### PR TITLE
feat(rules-package): CRD Issue 5a — Rules Package schema, ORM, service, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Agents must distinguish between:
 
 Trigger this check when:
 - the same PR receives repeated review/fix/re-review cycles,
-- the same file or function is revised across multiple review rounds,
+- the same file, function, query path, schema hotspot, or service hotspot is revised across multiple review rounds,
 - review feedback shifts from correctness defects to questions of semantics, ownership, architectural placement, or where behavior belongs,
 - a proposed fix would move behavior into an issue that does not clearly own it.
 
@@ -37,7 +37,27 @@ When triggered:
 
 Repeated review churn on one hotspot is a coordination signal, not just a coding task.
 
+## Hotspot audit rule
+
+If a PR has already gone through two or more review rounds on the same hotspot, do not keep issuing isolated patch comments indefinitely.
+
+Instead:
+1. Treat the hotspot as a defect family, not as unrelated one-off comments.
+2. Ask whether the implementation has addressed the whole defect class or only the latest symptom.
+3. Prefer one bundled hotspot audit over a long sequence of micro-fix comments.
+4. Evaluate likely sibling defects in the same area, including:
+   - nondeterministic selection or ordering,
+   - missing tie-breakers on precedence-based queries,
+   - package/scope/isolation leaks across related tables or services,
+   - missing integrity constraints for cross-table references,
+   - play-time reads that may behave inconsistently across equivalent inputs.
+5. If the remaining work is still concrete and in scope, request that the hotspot be fixed as a bundled pass.
+6. If the remaining work is no longer clearly concrete and in scope, switch to `[OWNER DECISION]:` handling instead of continuing the patch loop.
+
+The goal is to prevent infinite review churn on one hotspot while still catching real sibling defects in the same defect family.
+
 ## Comment labeling
 
 - Prefix any comment that requires a design, architectural, ethical, policy, or ownership judgment with `[OWNER DECISION]:` at the start of that comment.
 - If a review thread appears to have crossed from defect-fixing into boundary or ownership dispute, label the relevant comment with `[OWNER DECISION]:` rather than presenting it as an ordinary fix request.
+- If repeated comments on the same hotspot suggest a bundled hotspot audit is needed, say so explicitly rather than continuing to drip-feed one new patch comment per review round.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,21 +5,14 @@ Read it fully at the start of every session before taking any action.
 
 ## Project
 
-Afterworlds is an interactive storytelling platform built on the Sojourn Story
-State Machine. It lets users inhabit and continue narrative worlds across three
-modes: RPG, Branching, and Writing. The target users are called Sojourners.
-This is a solo-developer project operated under AfterworldsAI, LLC.
+Afterworlds is an interactive storytelling platform built on the Sojourn Story State Machine. It lets users inhabit and continue narrative worlds across three modes: RPG, Branching, and Writing. The target users are called Sojourners. This is a solo-developer project operated under AfterworldsAI, LLC.
 
-The authoritative design documents are in /docs/architecture/. Read them before
-making any architectural decision. If your implementation would deviate from
-anything in those documents, flag it in your PR description — do not resolve it
-silently.
+The authoritative design documents are in `/docs/architecture/`. Read them before making any architectural decision. If your implementation would deviate from anything in those documents, flag it in your PR description — do not resolve it silently.
 
 ## Language & Tooling
 
 - **Language:** Python 3.12 only
-- **Package management:** pip + virtualenv only — do not introduce Poetry, PDM,
-  uv, or any alternative dependency manager
+- **Package management:** pip + virtualenv only — do not introduce Poetry, PDM, uv, or any alternative dependency manager
 - **Testing:** pytest (minimum 80% coverage on new code)
 - **Type checking:** mypy strict mode — zero tolerance
 - **Formatting:** Black — zero tolerance
@@ -30,43 +23,28 @@ silently.
 ## Build & Test Commands
 
 ```bash
-# Create and activate virtualenv
 python -m venv venv
 venv\Scripts\activate        # Windows
 source venv/bin/activate     # Mac/Linux
 
-# Install dependencies
 pip install -e ".[dev]"
-
-# Run tests
 pytest
-
-# Type check
 mypy src/
-
-# Format
 black src/ tests/
-
-# Lint
 ruff check src/ tests/
-
-# Dependency audit
 pip-audit
 ```
 
 ## Architecture Principles — Non-Negotiable
 
-These must not be violated. Any code that breaks them is an architectural
-violation and must be flagged in the PR, not silently resolved.
+These must not be violated. Any code that breaks them is an architectural violation and must be flagged in the PR, not silently resolved.
 
-1. Story Bible is structurally separate from prose history
-2. Six memory layers have distinct roles: Immediate / Rolling Summary /
-   Story Bible / Rules Package / Retrieval Memory / Contradiction Checker
-3. Intent is classified before context is assembled
-4. Pipeline is staged: Planner → Writer → Extractor → Contradiction → Safety
-5. Extractor proposes canon updates — it does not write canon directly
-6. Stable prompt prefix is assembled once per turn and shared across all
-   passes for caching efficiency
+1. Story Bible is structurally separate from prose history.
+2. Six memory layers have distinct roles: Immediate / Rolling Summary / Story Bible / Rules Package / Retrieval Memory / Contradiction Checker.
+3. Intent is classified before context is assembled.
+4. Pipeline is staged: Planner → Writer → Extractor → Contradiction → Safety.
+5. Extractor proposes canon updates — it does not write canon directly.
+6. Stable prompt prefix is assembled once per turn and shared across all passes for caching efficiency.
 
 ## Repository & PR Rules
 
@@ -74,39 +52,51 @@ violation and must be flagged in the PR, not silently resolved.
 - No direct commits to main under any circumstances
 - Open a PR for every issue; PRs are not merged without Codex review passing
 - No PR merges with failing CI
-- Every PR description must include an **Architecture Notes** section:
-  either "No drift from design principles" or an explicit description of
-  any deviation and rationale
+- Every PR description must include an **Architecture Notes** section: either `No drift from design principles` or an explicit description of any deviation and rationale
 - Scope creep is a review failure — stay within issue boundaries
 
 ## Review-Loop Boundary Check
 
-If repeated review rounds on the same PR begin focusing on the same file or
-function, or if review feedback shifts from concrete defects to questions of
-ownership, semantics, architectural placement, or which issue should own a
-behavior, treat that as a boundary problem rather than “the next patch.”
+If repeated review rounds on the same PR begin focusing on the same file, function, query path, schema hotspot, or service hotspot, or if feedback shifts from concrete defects to questions of ownership, semantics, architectural placement, or which issue should own a behavior, treat that as a boundary problem rather than “the next patch.”
 
 When this happens:
 
 - Stop iterative fix/re-review cycling.
 - Classify the remaining feedback as:
-  - merge-blocking defect,
-  - issue-scope boundary problem,
-  - Known Unknown,
-  - non-blocking improvement.
+  - merge-blocking defect
+  - issue-scope boundary problem
+  - Known Unknown
+  - non-blocking improvement
 - Do not resolve boundary or ownership questions unilaterally in code.
-- Raise the issue explicitly in the PR description or PR comments under
-  **Architecture Notes**.
-- Pause for owner decision when the implementation appears to cross issue
-  scope, touch a Known Unknown, or require a new ownership rule.
+- Raise the issue explicitly in the PR description or PR comments under **Architecture Notes**.
+- Pause for owner decision when the implementation appears to cross issue scope, touch a Known Unknown, or require a new ownership rule.
 
-Do not keep patching a hotspot indefinitely just because a reviewer produced
-another comment. Repeated churn on the same hotspot is evidence that the PR may
-have crossed its intended boundary.
+Do not keep patching a hotspot indefinitely just because a reviewer produced another comment. Repeated churn on the same hotspot is evidence that the PR may have crossed its intended boundary.
+
+## Hotspot Review Escalation Rule
+
+If Codex or any reviewer produces repeated comments on the same hotspot across two or more review rounds, do not keep fixing comments one-by-one indefinitely.
+
+Instead:
+
+1. Stop and treat the hotspot as a defect family, not as isolated comments.
+2. Perform one bundled hotspot audit covering closely related sibling defects in the same area.
+3. Fix the concrete defect class in one pass, within the current issue scope.
+4. Re-request review only after the bundled hotspot pass is complete.
+5. If further review on the same hotspot still appears after that bundled pass, do not continue iterative patching automatically.
+6. Classify the remaining feedback as:
+   - merge-blocking defect
+   - scope/boundary problem
+   - Known Unknown
+   - non-blocking improvement
+7. Surface any scope/boundary problem explicitly in the PR Architecture Notes and pause for owner decision rather than silently extending scope.
+
+Repeated comments on one hotspot are a coordination signal. They are not, by themselves, an instruction to continue infinite patch/re-review cycling.
 
 ## Commit Format
 
-Conventional commits:  
+Conventional commits:
+
 `type(scope): description`
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
@@ -115,80 +105,56 @@ Example: `feat(story-bible): implement tiered inclusion policy for events ledger
 
 ## Known Unknowns — Do Not Resolve Silently
 
-See `/docs/architecture/known_unknowns.md`. If implementation touches a listed
-unknown, stop and flag it in the PR — do not resolve it unilaterally.
+See `/docs/architecture/known_unknowns.md`. If implementation touches a listed unknown, stop and flag it in the PR — do not resolve it unilaterally.
 
 ## Business Model Constraints — Architectural Invariants
 
-There is **one canonical five-pass pipeline** (Planner → Writer → Extractor →
-Contradiction → Safety) for all paying access paths. No commercial tier may
-remove core continuity functions. A degraded free-tier pipeline is not part
-of this product.
+There is **one canonical five-pass pipeline** (Planner → Writer → Extractor → Contradiction → Safety) for all paying access paths. No commercial tier may remove core continuity functions. A degraded free-tier pipeline is not part of this product.
 
-Access paths and their constraints:
+### Access paths and their constraints
 
-- **Hosted Subscription:** metered subscription with included monthly credits +
-  transparent top-ups. When credits are exhausted, the system stops or prompts
-  for top-up — it never silently degrades output quality or drops pipeline
-  passes.
-- **BYOK Perpetual License:** permanent product rights with full pipeline
-  parity. First year of Cloud Services included. BYOK is a first-class path —
-  not a fallback or reduced-function mode.
-- **BYOK Cloud Services Renewal:** optional annual renewal for ongoing hosted
-  services (storage, sync, backup, remote access, ingestion processing). The
-  perpetual license and the Cloud Services layer must not be collapsed in code
-  or entitlement logic.
-- **Starter Access (optional):** small paid entry package using the same full
-  pipeline and normal hosted credits. Not a free tier. Not a degraded path.
+- **Hosted Subscription:** metered subscription with included monthly credits + transparent top-ups. When credits are exhausted, the system stops or prompts for top-up — it never silently degrades output quality or drops pipeline passes.
+- **BYOK Perpetual License:** permanent product rights with full pipeline parity. First year of Cloud Services included. BYOK is a first-class path — not a fallback or reduced-function mode.
+- **BYOK Cloud Services Renewal:** optional annual renewal for ongoing hosted services (storage, sync, backup, remote access, ingestion processing). The perpetual license and the Cloud Services layer must not be collapsed in code or entitlement logic.
+- **Starter Access (optional):** small paid entry package using the same full pipeline and normal hosted credits. Not a free tier. Not a degraded path.
 
-Additional invariants:
+### Additional invariants
 
-- Extended TTL caching must be enabled by default wherever the provider
-  supports it — this is an economic requirement, not a preference
-- Stable prompt prefix is assembled once per turn and shared across all passes
-  — rebuilding it per pass is an architectural violation
-- Entitlement routing governs billing path, credit balance, Cloud Services
-  status, and storage/ingestion entitlements — never whether the core
-  continuity pipeline exists
-- BYOK non-renewal must preserve read/export/download access to owned work;
-  user content must never be held hostage as leverage for renewal
-- Top-up flows must be transparent and non-manipulative — no dark patterns,
-  no concealed overage behavior
+- Extended TTL caching must be enabled by default wherever the provider supports it — this is an economic requirement, not a preference.
+- Stable prompt prefix is assembled once per turn and shared across all passes — rebuilding it per pass is an architectural violation.
+- Entitlement routing governs billing path, credit balance, Cloud Services status, and storage/ingestion entitlements — never whether the core continuity pipeline exists.
+- BYOK non-renewal must preserve read/export/download access to owned work; user content must never be held hostage as leverage for renewal.
+- Top-up flows must be transparent and non-manipulative — no dark patterns, no concealed overage behavior.
 
 ## Note-Taking (Self-Improvement Loop)
 
-After each task, log any correction, preference, or pattern learned during
-that task. This is how the project accumulates institutional memory across
-sessions.
+After each task, log any correction, preference, or pattern learned during that task. This is how the project accumulates institutional memory across sessions.
 
-**Trigger conditions — log when:**
+### Trigger conditions — log when
 
 - You were corrected on an implementation decision
 - You discovered a behavioral pattern not covered by existing rules
 - You made an assumption that turned out to be wrong
 - You found a better approach than what the spec implied
 
-**Format:** one line, dated, plain language.  
+### Format
+
+One line, dated, plain language:
+
 `[YYYY-MM-DD] <lesson learned>`
 
-**Where to log:**
+### Where to log
 
 - Project-wide lessons go in the Lessons section below
 - Subsystem-specific lessons go in the relevant file in `/context/`
-- When three or more related lessons accumulate anywhere, create a new
-  context file in `/context/`, add it to the folder tree in the docs,
-  and note it below
+- When three or more related lessons accumulate anywhere, create a new context file in `/context/`, add it to the folder tree in the docs, and note it below
 
 ## Lessons
 
-[2026-04-02] Before committing, run the full local gate sequence on the exact branch head you plan to push: `black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest -q`. A green Black check alone does not mean the branch is CI-clean.
-
-[2026-04-02] When CI reports a specific file in a formatter or lint failure, verify that the file’s diff is actually staged and included in a pushed commit. A local fix is not complete until `git diff`, `git status`, and the commit contents confirm it was committed.
-
-[2026-04-02] When fixing a reported formatter or lint issue, inspect the files changed in the commit(s) being pushed. If CI complained about a file and that file is absent from the pushed commit summary, assume the fix did not reach GitHub.
-
-[2026-04-02] Pin Black to an exact version in dev dependencies to reduce avoidable CI/local drift, but do not assume version drift is the root cause without proof from the failing file, the actual commit contents, and the current CI run.
-
-[2026-04-07] CRD issue numbers (Issue 4, Issue 8, Issue 18, …) and GitHub issue numbers (#43, #44, #45, …) are different namespaces. Always write "CRD Issue N" for construction-readiness document references and "#N" for GitHub issue/ +PR references. Never use bare "Issue N" — every AI tool reviewed so far conflates the two sequences.
+- [2026-04-02] Before committing, run the full local gate sequence on the exact branch head you plan to push: `black src/ tests/ && ruff check src/ tests/ && mypy src/ && pytest -q`. A green Black check alone does not mean the branch is CI-clean.
+- [2026-04-02] When CI reports a specific file in a formatter or lint failure, verify that the file’s diff is actually staged and included in a pushed commit. A local fix is not complete until `git diff`, `git status`, and the commit contents confirm it was committed.
+- [2026-04-02] When fixing a reported formatter or lint issue, inspect the files changed in the commit(s) being pushed. If CI complained about a file and that file is absent from the pushed commit summary, assume the fix did not reach GitHub.
+- [2026-04-02] Pin Black to an exact version in dev dependencies to reduce avoidable CI/local drift, but do not assume version drift is the root cause without proof from the failing file, the actual commit contents, and the current CI run.
+- [2026-04-07] CRD issue numbers (Issue 4, Issue 8, Issue 18, …) and GitHub issue numbers (#43, #44, #45, …) are different namespaces. Always write `CRD Issue N` for construction-readiness document references and `#N` for GitHub issue/PR references. Never use bare `Issue N` — every AI tool reviewed so far conflates the two sequences.
 
 <!-- Claude Code appends dated one-line lessons here as they are learned -->

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -15,6 +15,7 @@ import afterworlds.persistence.orm.state  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.story_bible  # noqa: F401
+import afterworlds.persistence.orm.rules_package  # noqa: F401
 
 config = context.config
 

--- a/alembic/versions/0003_rules_package.py
+++ b/alembic/versions/0003_rules_package.py
@@ -1,0 +1,172 @@
+"""Rules Package schema — rp_* tables for CRD Issue 5a.
+
+Rules Package tables carry the ``rp_`` prefix to make their separation from
+Story Bible tables (``sb_``), session state, and story hierarchy structurally
+visible and machine-verifiable.
+
+Architecture invariant:
+  No ``rp_*`` table carries a FK to any Story Bible table, session state
+  table, or story hierarchy table (stories, arcs, chapters, nodes, turns).
+  ``rp_*`` tables may FK to other ``rp_*`` tables.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-09
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # rp_packages — top-level Rules Package metadata
+    # ------------------------------------------------------------------
+    op.create_table(
+        "rp_packages",
+        sa.Column("rules_package_id", sa.String(36), primary_key=True),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("system", sa.String(32), nullable=False),
+        sa.Column("version", sa.String(64), nullable=False),
+        sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
+        sa.Column(
+            "publication_status", sa.String(32), nullable=False, default="draft"
+        ),
+        sa.Column("published_at", sa.String(64), nullable=True),
+        sa.Column("created_at", sa.String(64), nullable=False),
+        sa.Column("updated_at", sa.String(64), nullable=False),
+    )
+
+    # ------------------------------------------------------------------
+    # rp_sources — source-document metadata within a package
+    # Immutable after creation.  category ≠ authority ordering.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "rp_sources",
+        sa.Column("source_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "rules_package_id",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("category", sa.String(32), nullable=False),
+        sa.Column("precedence_rank", sa.Integer, nullable=False),
+        sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
+        sa.Column("created_at", sa.String(64), nullable=False),
+    )
+
+    # ------------------------------------------------------------------
+    # rp_chunks — atomic rule text units (immutable after creation)
+    # source_id is non-nullable by design (ADR-0008).
+    # ------------------------------------------------------------------
+    op.create_table(
+        "rp_chunks",
+        sa.Column("chunk_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "rules_package_id",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_id",
+            sa.String(36),
+            sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("subsystem", sa.String(32), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("source_document", sa.Text, nullable=False),
+        sa.Column("source_locator_type", sa.String(32), nullable=False),
+        sa.Column("source_locator_value", sa.Text, nullable=False),
+        sa.Column("source_section_label", sa.Text, nullable=True),
+        sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
+        sa.Column("created_at", sa.String(64), nullable=False),
+    )
+
+    # ------------------------------------------------------------------
+    # rp_mechanical_entities — typed structured entity records
+    # source_id is non-nullable by design (ADR-0008).
+    # ------------------------------------------------------------------
+    op.create_table(
+        "rp_mechanical_entities",
+        sa.Column("entity_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "rules_package_id",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_id",
+            sa.String(36),
+            sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("entity_type", sa.String(32), nullable=False),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("structured_data", sa.JSON, nullable=False),
+        sa.Column("source_document", sa.Text, nullable=False),
+        sa.Column("source_locator_type", sa.String(32), nullable=False),
+        sa.Column("source_locator_value", sa.Text, nullable=False),
+        sa.Column("source_section_label", sa.Text, nullable=True),
+        sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
+        sa.Column("created_at", sa.String(64), nullable=False),
+    )
+
+    # ------------------------------------------------------------------
+    # rp_overrides — non-mutating layered override records
+    # Exactly one of target_chunk_id / target_entity_id must be set.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "rp_overrides",
+        sa.Column("override_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "rules_package_id",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "target_chunk_id",
+            sa.String(36),
+            sa.ForeignKey("rp_chunks.chunk_id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "target_entity_id",
+            sa.String(36),
+            sa.ForeignKey("rp_mechanical_entities.entity_id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("override_origin", sa.String(32), nullable=False),
+        sa.Column("override_operation", sa.String(32), nullable=False),
+        sa.Column("override_payload", sa.Text, nullable=False),
+        sa.Column("precedence", sa.Integer, nullable=False),
+        sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
+        sa.Column("created_at", sa.String(64), nullable=False),
+        sa.CheckConstraint(
+            "(target_chunk_id IS NULL AND target_entity_id IS NOT NULL)"
+            " OR (target_chunk_id IS NOT NULL AND target_entity_id IS NULL)",
+            name="ck_rp_overrides_exactly_one_target",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("rp_overrides")
+    op.drop_table("rp_mechanical_entities")
+    op.drop_table("rp_chunks")
+    op.drop_table("rp_sources")
+    op.drop_table("rp_packages")

--- a/alembic/versions/0003_rules_package.py
+++ b/alembic/versions/0003_rules_package.py
@@ -84,6 +84,9 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("source_id", sa.String(36), nullable=False),
+        sa.UniqueConstraint(
+            "rules_package_id", "chunk_id", name="uq_rp_chunks_package_chunk"
+        ),
         sa.ForeignKeyConstraint(
             ["rules_package_id", "source_id"],
             ["rp_sources.rules_package_id", "rp_sources.source_id"],
@@ -115,6 +118,11 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("source_id", sa.String(36), nullable=False),
+        sa.UniqueConstraint(
+            "rules_package_id",
+            "entity_id",
+            name="uq_rp_entities_package_entity",
+        ),
         sa.ForeignKeyConstraint(
             ["rules_package_id", "source_id"],
             ["rp_sources.rules_package_id", "rp_sources.source_id"],
@@ -145,18 +153,8 @@ def upgrade() -> None:
             sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column(
-            "target_chunk_id",
-            sa.String(36),
-            sa.ForeignKey("rp_chunks.chunk_id", ondelete="CASCADE"),
-            nullable=True,
-        ),
-        sa.Column(
-            "target_entity_id",
-            sa.String(36),
-            sa.ForeignKey("rp_mechanical_entities.entity_id", ondelete="CASCADE"),
-            nullable=True,
-        ),
+        sa.Column("target_chunk_id", sa.String(36), nullable=True),
+        sa.Column("target_entity_id", sa.String(36), nullable=True),
         sa.Column("override_origin", sa.String(32), nullable=False),
         sa.Column("override_operation", sa.String(32), nullable=False),
         sa.Column("override_payload", sa.Text, nullable=False),
@@ -167,6 +165,21 @@ def upgrade() -> None:
             "(target_chunk_id IS NULL AND target_entity_id IS NOT NULL)"
             " OR (target_chunk_id IS NOT NULL AND target_entity_id IS NULL)",
             name="ck_rp_overrides_exactly_one_target",
+        ),
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "target_chunk_id"],
+            ["rp_chunks.rules_package_id", "rp_chunks.chunk_id"],
+            ondelete="CASCADE",
+            name="fk_rp_overrides_package_chunk",
+        ),
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "target_entity_id"],
+            [
+                "rp_mechanical_entities.rules_package_id",
+                "rp_mechanical_entities.entity_id",
+            ],
+            ondelete="CASCADE",
+            name="fk_rp_overrides_package_entity",
         ),
     )
 

--- a/alembic/versions/0003_rules_package.py
+++ b/alembic/versions/0003_rules_package.py
@@ -38,9 +38,7 @@ def upgrade() -> None:
         sa.Column("system", sa.String(32), nullable=False),
         sa.Column("version", sa.String(64), nullable=False),
         sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
-        sa.Column(
-            "publication_status", sa.String(32), nullable=False, default="draft"
-        ),
+        sa.Column("publication_status", sa.String(32), nullable=False, default="draft"),
         sa.Column("published_at", sa.String(64), nullable=True),
         sa.Column("created_at", sa.String(64), nullable=False),
         sa.Column("updated_at", sa.String(64), nullable=False),
@@ -64,11 +62,17 @@ def upgrade() -> None:
         sa.Column("precedence_rank", sa.Integer, nullable=False),
         sa.Column("is_enabled", sa.Boolean, nullable=False, default=True),
         sa.Column("created_at", sa.String(64), nullable=False),
+        sa.UniqueConstraint(
+            "rules_package_id",
+            "source_id",
+            name="uq_rp_sources_package_source",
+        ),
     )
 
     # ------------------------------------------------------------------
     # rp_chunks — atomic rule text units (immutable after creation)
     # source_id is non-nullable by design (ADR-0008).
+    # Composite FK enforces that source_id belongs to the same package.
     # ------------------------------------------------------------------
     op.create_table(
         "rp_chunks",
@@ -79,11 +83,12 @@ def upgrade() -> None:
             sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column(
-            "source_id",
-            sa.String(36),
-            sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
-            nullable=False,
+        sa.Column("source_id", sa.String(36), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "source_id"],
+            ["rp_sources.rules_package_id", "rp_sources.source_id"],
+            ondelete="CASCADE",
+            name="fk_rp_chunks_package_source",
         ),
         sa.Column("subsystem", sa.String(32), nullable=False),
         sa.Column("content", sa.Text, nullable=False),
@@ -98,6 +103,7 @@ def upgrade() -> None:
     # ------------------------------------------------------------------
     # rp_mechanical_entities — typed structured entity records
     # source_id is non-nullable by design (ADR-0008).
+    # Composite FK enforces that source_id belongs to the same package.
     # ------------------------------------------------------------------
     op.create_table(
         "rp_mechanical_entities",
@@ -108,11 +114,12 @@ def upgrade() -> None:
             sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column(
-            "source_id",
-            sa.String(36),
-            sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
-            nullable=False,
+        sa.Column("source_id", sa.String(36), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "source_id"],
+            ["rp_sources.rules_package_id", "rp_sources.source_id"],
+            ondelete="CASCADE",
+            name="fk_rp_mechanical_entities_package_source",
         ),
         sa.Column("entity_type", sa.String(32), nullable=False),
         sa.Column("name", sa.Text, nullable=False),

--- a/docs/decisions/ADR-0007-rules-package-entity-patch-deferral.md
+++ b/docs/decisions/ADR-0007-rules-package-entity-patch-deferral.md
@@ -1,0 +1,49 @@
+# ADR-0007 — Rules Package: Entity-Targeting Override Patch Shape Deferral
+
+**Status:** Accepted  
+**Date:** 2026-04-09  
+**Issue:** CRD Issue 5a (Rules Package Schema and Data Model)
+
+## Context
+
+The `RuleOverride` model supports two target types:
+
+- **Chunk-targeting overrides** operate on `RuleChunk.content` (a plain text
+  field).  The payload shape is `ChunkOverridePayload` — a typed Pydantic
+  model with a single `content: str | None` field.  This shape is fully
+  defined and enforced in this issue.
+
+- **Entity-targeting overrides** operate on `MechanicalEntity.structured_data`,
+  which varies by entity type (`SpellEntity`, `ConditionEntity`, `StatBlockEntity`,
+  `ActionEntity`, `ItemEntity`).  A fully typed patch shape would require one
+  patch schema per entity type, with field-level merge semantics.
+
+In CRD Issue 5a, no downstream consumer (Context Builder, Adjudicator) yet
+requires entity override patch application.  Defining the patch shapes now
+would be speculative design with no validation feedback.
+
+## Decision
+
+Entity-targeting override structured patch shapes are **deferred** to the
+issue that first requires them.
+
+In this issue:
+
+- Entity-targeting `RuleOverride` records are valid and persist correctly.
+- The `override_payload` column stores `{"content": "<text>"}` as a plain
+  string for entity targets — the same `ChunkOverridePayload` JSON shape.
+- `AppliedEntity.override_ids_applied` records which overrides are active,
+  but the service does **not** apply them to `structured_data`.
+- `_apply_chunk_overrides` is a service-private method and is only called
+  for chunk targets.
+
+## Consequences
+
+- Entity override storage and retrieval work today.  Only application is
+  deferred.
+- The issue that first needs entity override application must define concrete
+  patch schemas (`SpellPatch`, `StatBlockPatch`, etc.) and update the service.
+- The `ADR-0007` marker appears in the `RuleOverride` and `ChunkOverridePayload`
+  docstrings as a breadcrumb to this decision.
+- No breaking schema changes are required when the patch shapes are defined:
+  `override_payload` is already `sa.Text` (free-form JSON string).

--- a/docs/decisions/ADR-0008-rules-package-source-id-non-nullability.md
+++ b/docs/decisions/ADR-0008-rules-package-source-id-non-nullability.md
@@ -1,0 +1,43 @@
+# ADR-0008 — Rules Package: source_id Non-Nullability on RuleChunk and MechanicalEntity
+
+**Status:** Accepted  
+**Date:** 2026-04-09  
+**Issue:** CRD Issue 5a (Rules Package Schema and Data Model)
+
+## Context
+
+`RuleChunk` and `MechanicalEntity` both carry a `source_id` field that
+references the `RuleSource` (source document) they were ingested from.
+
+The question was whether `source_id` should be nullable — permitting
+"orphaned" chunks or entities that are not associated with any named
+source document.
+
+## Decision
+
+`source_id` is **non-nullable** on both `rp_chunks` and `rp_mechanical_entities`.
+
+- Every chunk and every mechanical entity must belong to a named `RuleSource`
+  record within its package.
+- There is no legitimate use case for orphaned records in a d20 rules package:
+  every piece of rule text or structured entity comes from an identifiable
+  source document.
+- Traceability (knowing which book, supplement, or adventure a rule comes from)
+  is a first-class requirement of the Rules Package subsystem.
+
+## Consequences
+
+- **Ingestion (CRD Issue 5b):** The ingestion pipeline must create or identify
+  a `RuleSource` record before inserting any `RuleChunk` or `MechanicalEntity`.
+  If a source document is unknown at ingestion time, a default or placeholder
+  `RuleSource` record must be created rather than inserting with a null
+  `source_id`.
+- **Migration:** The `rp_chunks.source_id` and `rp_mechanical_entities.source_id`
+  columns carry `NOT NULL` constraints enforced at the database level.  Any
+  bulk-load path that omits `source_id` will fail at insert time, which is the
+  intended behaviour.
+- **Testing:** The schema separation invariant test (`test_schema_separation_invariant.py`)
+  does not need to verify non-nullability separately; it is verified directly
+  in `test_rules_package.py` (`TestSourceProvenance`).
+- **No nullable relaxation permitted** without a superseding ADR explaining
+  the edge case that cannot be handled by a placeholder source record.

--- a/src/afterworlds/models/enums.py
+++ b/src/afterworlds/models/enums.py
@@ -123,3 +123,125 @@ class ProposalStatus(StrEnum):
     PENDING = "pending"
     RATIFIED = "ratified"
     REJECTED = "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Rules Package enums
+# ---------------------------------------------------------------------------
+
+
+class RulesSystemEnum(StrEnum):
+    """Supported rule systems for a RulesPackage.
+
+    ``d20`` is the only v1 exemplar.  Additional systems slot in as additional
+    Rules Packages using the same schema without structural changes.
+    """
+
+    D20 = "d20"
+
+
+class PublicationStatusEnum(StrEnum):
+    """Publication lifecycle status for a RulesPackage.
+
+    ``draft`` — in progress, not visible to play-time queries.
+    ``published`` — released and available for play.
+    ``retired`` — no longer active; excluded from play-time queries.
+    """
+
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    RETIRED = "retired"
+
+
+class RuleSourceCategoryEnum(StrEnum):
+    """Classification of a source document within a RulesPackage.
+
+    This field classifies the *kind* of source document.  It does NOT
+    determine authority ordering.  Authority ordering within a package is
+    governed by ``RuleSource.precedence_rank``.  Do not infer winning-rule
+    behaviour from category alone.
+
+    ``adventure`` corresponds to what D&D players call a published adventure
+    module.  The term ``module`` is not used as a model or table name to
+    avoid overloading.
+    """
+
+    CORE_RULEBOOK = "core_rulebook"
+    SUPPLEMENT = "supplement"
+    ADVENTURE = "adventure"
+
+
+class RuleSubsystemEnum(StrEnum):
+    """Subsystem tag for scoping RuleChunk retrieval.
+
+    Used by the Context Builder to retrieve only the rule chunks relevant
+    to the current turn's needs (e.g. attack resolution, a spell lookup).
+    """
+
+    COMBAT = "combat"
+    SPELLS = "spells"
+    CONDITIONS = "conditions"
+    MOVEMENT = "movement"
+    ITEMS = "items"
+    CLASSES = "classes"
+    RACES = "races"
+    GENERAL = "general"
+
+
+class MechanicalEntityTypeEnum(StrEnum):
+    """Discriminated entity type for MechanicalEntity records.
+
+    Each value maps to a distinct typed Pydantic model:
+    ``spell`` → SpellEntity, ``condition`` → ConditionEntity,
+    ``stat_block`` → StatBlockEntity, ``action`` → ActionEntity,
+    ``item`` → ItemEntity.
+    """
+
+    CONDITION = "condition"
+    ACTION = "action"
+    SPELL = "spell"
+    ITEM = "item"
+    STAT_BLOCK = "stat_block"
+
+
+class OverrideOriginEnum(StrEnum):
+    """Origin classification for a RuleOverride.
+
+    ``house_rule`` — Sojourner-configured override for a play session.
+    ``package_patch`` — administrative correction to packaged content.
+    """
+
+    HOUSE_RULE = "house_rule"
+    PACKAGE_PATCH = "package_patch"
+
+
+class OverrideOperationEnum(StrEnum):
+    """Operation applied by a RuleOverride to its target record.
+
+    ``replace`` — replace target content with override content.
+    ``append`` — append override content to existing target content.
+    ``disable`` — disable the target record (excluded from active results).
+    """
+
+    REPLACE = "replace"
+    APPEND = "append"
+    DISABLE = "disable"
+
+
+class SourceLocatorTypeEnum(StrEnum):
+    """Type discriminator for the source locator on RuleChunk/MechanicalEntity.
+
+    Supports different source location schemes without forcing a rigid
+    document/section/anchor column triad on sources that may not have a
+    uniform page/section/anchor shape.
+
+    ``page`` — a page number (e.g. ``"p. 72"``).
+    ``heading_anchor`` — a heading identifier (e.g. ``"#spells-fireball"``).
+    ``section_path`` — a hierarchical section path (e.g. ``"Chapter 3 > Combat"``).
+    ``range`` — a page range (e.g. ``"pp. 72-74"``).
+    """
+
+    PAGE = "page"
+    HEADING_ANCHOR = "heading_anchor"
+    SECTION_PATH = "section_path"
+    RANGE = "range"

--- a/src/afterworlds/models/rules_package.py
+++ b/src/afterworlds/models/rules_package.py
@@ -12,10 +12,10 @@ Package is a standalone corpus with no cross-dependency on narrative state.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Self
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, model_validator
-from typing_extensions import Self
 
 from afterworlds.models.enums import (
     MechanicalEntityTypeEnum,
@@ -23,8 +23,8 @@ from afterworlds.models.enums import (
     OverrideOriginEnum,
     PublicationStatusEnum,
     RuleSourceCategoryEnum,
-    RuleSubsystemEnum,
     RulesSystemEnum,
+    RuleSubsystemEnum,
     SourceLocatorTypeEnum,
 )
 

--- a/src/afterworlds/models/rules_package.py
+++ b/src/afterworlds/models/rules_package.py
@@ -199,6 +199,16 @@ class RuleChunk(BaseModel):
     created_at: datetime
 
 
+# Mapping from entity_type discriminator to the expected structured_data type.
+_ENTITY_TYPE_TO_DATA_CLASS: dict[MechanicalEntityTypeEnum, type] = {
+    MechanicalEntityTypeEnum.SPELL: SpellEntity,
+    MechanicalEntityTypeEnum.CONDITION: ConditionEntity,
+    MechanicalEntityTypeEnum.STAT_BLOCK: StatBlockEntity,
+    MechanicalEntityTypeEnum.ACTION: ActionEntity,
+    MechanicalEntityTypeEnum.ITEM: ItemEntity,
+}
+
+
 # ---------------------------------------------------------------------------
 # Structured mechanical entity
 # ---------------------------------------------------------------------------
@@ -227,6 +237,18 @@ class MechanicalEntity(BaseModel):
     source_section_label: str | None = None
     is_enabled: bool = True
     created_at: datetime
+
+    @model_validator(mode="after")
+    def structured_data_matches_entity_type(self) -> Self:
+        """Ensure structured_data is the concrete type for entity_type."""
+        expected = _ENTITY_TYPE_TO_DATA_CLASS[self.entity_type]
+        if not isinstance(self.structured_data, expected):
+            raise ValueError(
+                f"structured_data type {type(self.structured_data).__name__!r} "
+                f"does not match entity_type {self.entity_type!r} "
+                f"(expected {expected.__name__!r})"
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/src/afterworlds/models/rules_package.py
+++ b/src/afterworlds/models/rules_package.py
@@ -28,7 +28,6 @@ from afterworlds.models.enums import (
     SourceLocatorTypeEnum,
 )
 
-
 # ---------------------------------------------------------------------------
 # Mechanical entity data models — one distinct typed model per entity_type
 # ---------------------------------------------------------------------------
@@ -104,7 +103,7 @@ class ChunkOverridePayload(BaseModel):
 
     Entity-targeting override patch semantics (structured patch shapes for
     StatBlockEntity, SpellEntity, etc.) are deferred.  In this issue,
-    entity-targeting overrides carry a plain ``{\"content\": ...}`` payload
+    entity-targeting overrides carry a plain ``{"content": ...}`` payload
     only.  See ADR-0007.
     """
 

--- a/src/afterworlds/models/rules_package.py
+++ b/src/afterworlds/models/rules_package.py
@@ -1,0 +1,330 @@
+"""Pydantic models for the Rules Package — mechanical canon subsystem.
+
+The Rules Package governs mechanical adjudication canon (rules, stats,
+entities).  It is structurally separate from the Story Bible, which governs
+narrative canon.
+
+Architecture invariant: no field in these models carries a reference to
+Story, Arc, Chapter, Node, Turn, or any Story Bible entity.  The Rules
+Package is a standalone corpus with no cross-dependency on narrative state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from afterworlds.models.enums import (
+    MechanicalEntityTypeEnum,
+    OverrideOperationEnum,
+    OverrideOriginEnum,
+    PublicationStatusEnum,
+    RuleSourceCategoryEnum,
+    RuleSubsystemEnum,
+    RulesSystemEnum,
+    SourceLocatorTypeEnum,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mechanical entity data models — one distinct typed model per entity_type
+# ---------------------------------------------------------------------------
+
+
+class SpellEntity(BaseModel):
+    """Typed data for a spell mechanical entity (d20 v1 shape).
+
+    Fields reflect what Issue 15 adjudication will need.
+    """
+
+    casting_time: str
+    range: str
+    duration: str
+    components: list[str] = Field(default_factory=list)
+    effect_description: str
+
+
+class ConditionEntity(BaseModel):
+    """Typed data for a condition mechanical entity."""
+
+    effects: list[str] = Field(default_factory=list)
+
+
+class StatBlockEntity(BaseModel):
+    """Typed data for a stat block mechanical entity (d20 v1 shape)."""
+
+    armor_class: int
+    hit_points: int
+    speed: str
+    strength: int
+    dexterity: int
+    constitution: int
+    intelligence: int
+    wisdom: int
+    charisma: int
+    actions: list[str] = Field(default_factory=list)
+
+
+class ActionEntity(BaseModel):
+    """Typed data for an action mechanical entity."""
+
+    action_type: str
+    description: str
+    attack_bonus: int | None = None
+    effect: str | None = None
+
+
+class ItemEntity(BaseModel):
+    """Typed data for an item mechanical entity (d20 v1 shape)."""
+
+    item_type: str
+    properties: list[str] = Field(default_factory=list)
+    weight: float | None = None
+    value: str | None = None
+
+
+# Union of all entity data types.  The sole source of truth for which
+# concrete models are valid for ``MechanicalEntity.structured_data``.
+EntityData = SpellEntity | ConditionEntity | StatBlockEntity | ActionEntity | ItemEntity
+
+
+# ---------------------------------------------------------------------------
+# Override payload model
+# ---------------------------------------------------------------------------
+
+
+class ChunkOverridePayload(BaseModel):
+    """Fully typed payload for chunk-targeting RuleOverride records.
+
+    For replace/append operations, ``content`` carries the replacement or
+    appended text.  For disable operations, ``content`` is None.
+
+    Entity-targeting override patch semantics (structured patch shapes for
+    StatBlockEntity, SpellEntity, etc.) are deferred.  In this issue,
+    entity-targeting overrides carry a plain ``{\"content\": ...}`` payload
+    only.  See ADR-0007.
+    """
+
+    content: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Source-document model — defined before RulesPackageDetail which references it
+# ---------------------------------------------------------------------------
+
+
+class RuleSource(BaseModel):
+    """Source-document metadata within a RulesPackage.
+
+    Records where rules came from to support traceability and explicit
+    authority ordering.  Source records are immutable after creation; all
+    layered changes go through ``RuleOverride``.
+
+    ``category`` classifies the source type.  ``precedence_rank`` determines
+    authority ordering within the package.  These are separate concerns —
+    do not infer winning-rule behaviour from ``category`` alone.
+    """
+
+    source_id: UUID = Field(default_factory=uuid4)
+    rules_package_id: UUID
+    name: str
+    category: RuleSourceCategoryEnum
+    precedence_rank: int
+    is_enabled: bool = True
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Core package models
+# ---------------------------------------------------------------------------
+
+
+class RulesPackage(BaseModel):
+    """Top-level Rules Package metadata record."""
+
+    rules_package_id: UUID = Field(default_factory=uuid4)
+    name: str
+    system: RulesSystemEnum
+    version: str
+    is_enabled: bool = True
+    publication_status: PublicationStatusEnum = PublicationStatusEnum.DRAFT
+    published_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class RulesPackageDetail(BaseModel):
+    """Full package metadata including its RuleSource records.
+
+    Returned by ``RulesPackageService.get_package_by_id``.
+    """
+
+    rules_package_id: UUID
+    name: str
+    system: RulesSystemEnum
+    version: str
+    is_enabled: bool
+    publication_status: PublicationStatusEnum
+    published_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    sources: list[RuleSource]
+
+
+# ---------------------------------------------------------------------------
+# Atomic rule chunk
+# ---------------------------------------------------------------------------
+
+
+class RuleChunk(BaseModel):
+    """Atomic unit of rule text within a RulesPackage.
+
+    Source provenance is required and non-nullable.  There are no orphaned
+    chunks — every chunk belongs to a named RuleSource.  Source records are
+    immutable after creation; layered changes go through RuleOverride.
+    """
+
+    chunk_id: UUID = Field(default_factory=uuid4)
+    rules_package_id: UUID
+    source_id: UUID  # Required; no orphaned chunks
+    subsystem: RuleSubsystemEnum
+    content: str
+    source_document: str  # Non-nullable provenance
+    source_locator_type: SourceLocatorTypeEnum
+    source_locator_value: str  # Non-nullable
+    source_section_label: str | None = None
+    is_enabled: bool = True
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Structured mechanical entity
+# ---------------------------------------------------------------------------
+
+
+class MechanicalEntity(BaseModel):
+    """Structured mechanical entity — typed, not a freeform blob.
+
+    ``structured_data`` holds a fully typed model for the given
+    ``entity_type``.  The service layer validates and deserialises to the
+    correct concrete type using ``entity_type`` as the discriminator.
+
+    Source records are immutable after creation; layered changes go through
+    RuleOverride.
+    """
+
+    entity_id: UUID = Field(default_factory=uuid4)
+    rules_package_id: UUID
+    source_id: UUID  # Required; no orphaned entities
+    entity_type: MechanicalEntityTypeEnum
+    name: str
+    structured_data: EntityData
+    source_document: str  # Non-nullable provenance
+    source_locator_type: SourceLocatorTypeEnum
+    source_locator_value: str  # Non-nullable
+    source_section_label: str | None = None
+    is_enabled: bool = True
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Non-mutating layered override
+# ---------------------------------------------------------------------------
+
+
+class RuleOverride(BaseModel):
+    """Non-mutating layered override record.
+
+    Source records (RuleChunk, MechanicalEntity) are never modified after
+    creation.  All layered changes are expressed as RuleOverride rows.
+
+    Exactly one of ``target_chunk_id`` or ``target_entity_id`` must be set.
+    This invariant is enforced at the model layer and in the database via a
+    check constraint.
+
+    Override precedence resolution lives in the service layer; callers do
+    not reimplement it.
+
+    Entity-targeting override patch semantics (structured patch shapes) are
+    deferred.  Entity-targeting overrides in this issue carry a plain content
+    payload only.  See ADR-0007.
+    """
+
+    override_id: UUID = Field(default_factory=uuid4)
+    rules_package_id: UUID
+    target_chunk_id: UUID | None = None
+    target_entity_id: UUID | None = None
+    override_origin: OverrideOriginEnum
+    override_operation: OverrideOperationEnum
+    # JSON-serialised payload.  For chunk targets: ChunkOverridePayload.
+    # For entity targets: {"content": "<text>"} (deferred typed patch shape).
+    override_payload: str
+    precedence: int
+    is_enabled: bool = True
+    created_at: datetime
+
+    @model_validator(mode="after")
+    def exactly_one_target(self) -> Self:
+        """Exactly one of target_chunk_id or target_entity_id must be set."""
+        chunk_set = self.target_chunk_id is not None
+        entity_set = self.target_entity_id is not None
+        if chunk_set == entity_set:
+            raise ValueError(
+                "Exactly one of target_chunk_id or target_entity_id must be set; "
+                f"got chunk={self.target_chunk_id!r}, entity={self.target_entity_id!r}"
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Service return types — stable named Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class ChunksResult(BaseModel):
+    """Return type for RulesPackageService.get_chunks_by_subsystem."""
+
+    package_id: UUID
+    subsystem: RuleSubsystemEnum
+    chunks: list[RuleChunk]
+
+
+class AppliedChunk(BaseModel):
+    """A rule chunk with active overrides applied in precedence order."""
+
+    chunk: RuleChunk
+    applied_content: str  # Content after override layering; empty if disabled
+    is_disabled: bool  # True when a disable override is active
+    override_ids_applied: list[UUID]
+
+
+class AppliedEntity(BaseModel):
+    """A mechanical entity with active overrides recorded.
+
+    Entity override patch semantics are deferred (see ADR-0007).  This
+    records which overrides are active; the Context Builder applies them
+    when structured patch shapes are defined in the issue that first
+    requires them.
+    """
+
+    entity: MechanicalEntity
+    override_ids_applied: list[UUID]
+
+
+class ActiveRuleSlice(BaseModel):
+    """Stable named typed payload returned by get_active_rule_slice.
+
+    This is the return type the Context Builder (Issue 8) will consume.
+    It contains rule chunks filtered by subsystem and specific mechanical
+    entities, with chunk override layering applied in precedence order.
+
+    Deterministic lookup against provided subsystem/entity references only.
+    Not a semantic search result — semantic retrieval belongs to Issue 18.
+    """
+
+    package_id: UUID
+    chunks: list[AppliedChunk]
+    entities: list[AppliedEntity]

--- a/src/afterworlds/persistence/orm/rules_package.py
+++ b/src/afterworlds/persistence/orm/rules_package.py
@@ -84,6 +84,9 @@ class RuleChunkORM(Base):
 
     __tablename__ = "rp_chunks"
     __table_args__ = (
+        sa.UniqueConstraint(
+            "rules_package_id", "chunk_id", name="uq_rp_chunks_package_chunk"
+        ),
         sa.ForeignKeyConstraint(
             ["rules_package_id", "source_id"],
             ["rp_sources.rules_package_id", "rp_sources.source_id"],
@@ -122,6 +125,11 @@ class MechanicalEntityORM(Base):
 
     __tablename__ = "rp_mechanical_entities"
     __table_args__ = (
+        sa.UniqueConstraint(
+            "rules_package_id",
+            "entity_id",
+            name="uq_rp_entities_package_entity",
+        ),
         sa.ForeignKeyConstraint(
             ["rules_package_id", "source_id"],
             ["rp_sources.rules_package_id", "rp_sources.source_id"],
@@ -164,6 +172,24 @@ class RuleOverrideORM(Base):
             " OR (target_chunk_id IS NOT NULL AND target_entity_id IS NULL)",
             name="ck_rp_overrides_exactly_one_target",
         ),
+        # Composite FKs enforce that target belongs to the same package as
+        # the override.  NULL target_chunk_id / target_entity_id is exempt
+        # from FK checking per SQL standard (the other column is set instead).
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "target_chunk_id"],
+            ["rp_chunks.rules_package_id", "rp_chunks.chunk_id"],
+            ondelete="CASCADE",
+            name="fk_rp_overrides_package_chunk",
+        ),
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "target_entity_id"],
+            [
+                "rp_mechanical_entities.rules_package_id",
+                "rp_mechanical_entities.entity_id",
+            ],
+            ondelete="CASCADE",
+            name="fk_rp_overrides_package_entity",
+        ),
     )
 
     override_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
@@ -172,16 +198,8 @@ class RuleOverrideORM(Base):
         sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
         nullable=False,
     )
-    target_chunk_id: Mapped[str | None] = mapped_column(
-        sa.String(36),
-        sa.ForeignKey("rp_chunks.chunk_id", ondelete="CASCADE"),
-        nullable=True,
-    )
-    target_entity_id: Mapped[str | None] = mapped_column(
-        sa.String(36),
-        sa.ForeignKey("rp_mechanical_entities.entity_id", ondelete="CASCADE"),
-        nullable=True,
-    )
+    target_chunk_id: Mapped[str | None] = mapped_column(sa.String(36), nullable=True)
+    target_entity_id: Mapped[str | None] = mapped_column(sa.String(36), nullable=True)
     override_origin: Mapped[str] = mapped_column(sa.String(32), nullable=False)
     override_operation: Mapped[str] = mapped_column(sa.String(32), nullable=False)
     # JSON-serialised payload string.

--- a/src/afterworlds/persistence/orm/rules_package.py
+++ b/src/afterworlds/persistence/orm/rules_package.py
@@ -52,6 +52,11 @@ class RuleSourceORM(Base):
     """
 
     __tablename__ = "rp_sources"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "rules_package_id", "source_id", name="uq_rp_sources_package_source"
+        ),
+    )
 
     source_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
     rules_package_id: Mapped[str] = mapped_column(
@@ -78,6 +83,14 @@ class RuleChunkORM(Base):
     """
 
     __tablename__ = "rp_chunks"
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "source_id"],
+            ["rp_sources.rules_package_id", "rp_sources.source_id"],
+            ondelete="CASCADE",
+            name="fk_rp_chunks_package_source",
+        ),
+    )
 
     chunk_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
     rules_package_id: Mapped[str] = mapped_column(
@@ -85,11 +98,7 @@ class RuleChunkORM(Base):
         sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
         nullable=False,
     )
-    source_id: Mapped[str] = mapped_column(
-        sa.String(36),
-        sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
-        nullable=False,
-    )
+    source_id: Mapped[str] = mapped_column(sa.String(36), nullable=False)
     subsystem: Mapped[str] = mapped_column(sa.String(32), nullable=False)
     content: Mapped[str] = mapped_column(sa.Text, nullable=False)
     source_document: Mapped[str] = mapped_column(sa.Text, nullable=False)
@@ -112,6 +121,14 @@ class MechanicalEntityORM(Base):
     """
 
     __tablename__ = "rp_mechanical_entities"
+    __table_args__ = (
+        sa.ForeignKeyConstraint(
+            ["rules_package_id", "source_id"],
+            ["rp_sources.rules_package_id", "rp_sources.source_id"],
+            ondelete="CASCADE",
+            name="fk_rp_mechanical_entities_package_source",
+        ),
+    )
 
     entity_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
     rules_package_id: Mapped[str] = mapped_column(
@@ -119,11 +136,7 @@ class MechanicalEntityORM(Base):
         sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
         nullable=False,
     )
-    source_id: Mapped[str] = mapped_column(
-        sa.String(36),
-        sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
-        nullable=False,
-    )
+    source_id: Mapped[str] = mapped_column(sa.String(36), nullable=False)
     entity_type: Mapped[str] = mapped_column(sa.String(32), nullable=False)
     name: Mapped[str] = mapped_column(sa.Text, nullable=False)
     structured_data: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)

--- a/src/afterworlds/persistence/orm/rules_package.py
+++ b/src/afterworlds/persistence/orm/rules_package.py
@@ -1,0 +1,180 @@
+"""ORM models for the Rules Package — mechanical canon subsystem.
+
+ARCHITECTURE INVARIANT:
+  Rules Package tables (prefix ``rp_``) are structurally separate from:
+  - Story Bible tables (prefix ``sb_``)
+  - Story hierarchy tables (stories, arcs, chapters, nodes, turns)
+  - Session state tables
+
+  No ``rp_*`` table carries a FK to any of the above.  Cross-subsystem
+  references (e.g. the character sheet's ``rules_package_id`` field) are
+  stored as plain strings without FK constraints, preserving the structural
+  independence of the Rules Package subsystem.
+
+  ``rp_*`` tables may carry FKs to other ``rp_*`` tables — this is
+  intra-subsystem cohesion, not cross-subsystem coupling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from afterworlds.persistence.orm.base import Base
+
+
+class RulesPackageORM(Base):
+    """Persisted RulesPackage row."""
+
+    __tablename__ = "rp_packages"
+
+    rules_package_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    name: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    system: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    version: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    is_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)
+    publication_status: Mapped[str] = mapped_column(
+        sa.String(32), nullable=False, default="draft"
+    )
+    published_at: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    updated_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class RuleSourceORM(Base):
+    """Persisted RuleSource row — immutable after creation.
+
+    ``category`` classifies the source type; ``precedence_rank`` determines
+    authority ordering.  These are separate concerns — do not infer
+    winning-rule behaviour from category alone.
+    """
+
+    __tablename__ = "rp_sources"
+
+    source_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    rules_package_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    category: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    precedence_rank: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    is_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class RuleChunkORM(Base):
+    """Persisted RuleChunk row — immutable after creation.
+
+    ``source_id`` is non-nullable by design: every chunk belongs to a named
+    source document.  Orphaned chunks (no source membership) are forbidden.
+    See ADR-0008.
+
+    Source provenance fields (``source_document``, ``source_locator_type``,
+    ``source_locator_value``) are non-nullable.
+    """
+
+    __tablename__ = "rp_chunks"
+
+    chunk_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    rules_package_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    subsystem: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    content: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    source_document: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    source_locator_type: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    source_locator_value: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    source_section_label: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    is_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class MechanicalEntityORM(Base):
+    """Persisted MechanicalEntity row — immutable after creation.
+
+    ``structured_data`` is a JSON column holding the typed entity data dict.
+    The service layer deserialises it to the correct typed Pydantic model
+    using ``entity_type`` as the discriminator.
+
+    ``source_id`` is non-nullable by design.  See ADR-0008.
+    Source provenance fields are non-nullable.
+    """
+
+    __tablename__ = "rp_mechanical_entities"
+
+    entity_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    rules_package_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_sources.source_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    entity_type: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    name: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    structured_data: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
+    source_document: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    source_locator_type: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    source_locator_value: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    source_section_label: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    is_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class RuleOverrideORM(Base):
+    """Persisted RuleOverride row — non-mutating layered override record.
+
+    Exactly one of ``target_chunk_id`` or ``target_entity_id`` must be set.
+    Enforced by a DB-level check constraint and the Pydantic model validator.
+
+    Override precedence resolution lives in the service layer.
+    """
+
+    __tablename__ = "rp_overrides"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "(target_chunk_id IS NULL AND target_entity_id IS NOT NULL)"
+            " OR (target_chunk_id IS NOT NULL AND target_entity_id IS NULL)",
+            name="ck_rp_overrides_exactly_one_target",
+        ),
+    )
+
+    override_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    rules_package_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_chunk_id: Mapped[str | None] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_chunks.chunk_id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    target_entity_id: Mapped[str | None] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_mechanical_entities.entity_id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    override_origin: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    override_operation: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    # JSON-serialised payload string.
+    # Chunk targets: serialised ChunkOverridePayload.
+    # Entity targets: {"content": "<text>"} — deferred structured patch shape.
+    override_payload: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    precedence: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    is_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -327,12 +327,20 @@ class RulesPackageService:
         if not enabled_source_ids:
             return None
 
-        stmt = select(MechanicalEntityORM).where(
-            MechanicalEntityORM.rules_package_id == str(package_id),
-            MechanicalEntityORM.entity_type == entity_type.value,
-            MechanicalEntityORM.name == name,
-            MechanicalEntityORM.is_enabled == True,  # noqa: E712
-            MechanicalEntityORM.source_id.in_(enabled_source_ids),
+        stmt = (
+            select(MechanicalEntityORM)
+            .join(
+                RuleSourceORM,
+                MechanicalEntityORM.source_id == RuleSourceORM.source_id,
+            )
+            .where(
+                MechanicalEntityORM.rules_package_id == str(package_id),
+                MechanicalEntityORM.entity_type == entity_type.value,
+                MechanicalEntityORM.name == name,
+                MechanicalEntityORM.is_enabled == True,  # noqa: E712
+                MechanicalEntityORM.source_id.in_(enabled_source_ids),
+            )
+            .order_by(RuleSourceORM.precedence_rank)
         )
         if source_id is not None:
             stmt = stmt.where(MechanicalEntityORM.source_id == str(source_id))

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -337,15 +337,18 @@ class RulesPackageService:
         if source_id is not None:
             stmt = stmt.where(MechanicalEntityORM.source_id == str(source_id))
 
-        row = self._session.execute(stmt).scalar_one_or_none()
+        row = self._session.execute(stmt).scalars().first()
         return _orm_to_entity(row) if row is not None else None
 
-    def get_overrides_for_chunk(self, chunk_id: UUID) -> list[RuleOverride]:
-        """Retrieve active overrides for a chunk, ordered by precedence."""
+    def get_overrides_for_chunk(
+        self, chunk_id: UUID, package_id: UUID
+    ) -> list[RuleOverride]:
+        """Retrieve active overrides for a chunk, scoped to its package."""
         rows = (
             self._session.execute(
                 select(RuleOverrideORM)
                 .where(
+                    RuleOverrideORM.rules_package_id == str(package_id),
                     RuleOverrideORM.target_chunk_id == str(chunk_id),
                     RuleOverrideORM.is_enabled == True,  # noqa: E712
                 )
@@ -356,12 +359,15 @@ class RulesPackageService:
         )
         return [_orm_to_override(r) for r in rows]
 
-    def get_overrides_for_entity(self, entity_id: UUID) -> list[RuleOverride]:
-        """Retrieve active overrides for an entity, ordered by precedence."""
+    def get_overrides_for_entity(
+        self, entity_id: UUID, package_id: UUID
+    ) -> list[RuleOverride]:
+        """Retrieve active overrides for an entity, scoped to its package."""
         rows = (
             self._session.execute(
                 select(RuleOverrideORM)
                 .where(
+                    RuleOverrideORM.rules_package_id == str(package_id),
                     RuleOverrideORM.target_entity_id == str(entity_id),
                     RuleOverrideORM.is_enabled == True,  # noqa: E712
                 )
@@ -436,7 +442,9 @@ class RulesPackageService:
                 include_non_published=include_non_published,
             )
             if entity is not None:
-                overrides = self.get_overrides_for_entity(entity.entity_id)
+                overrides = self.get_overrides_for_entity(
+                    entity.entity_id, entity.rules_package_id
+                )
                 applied_entities.append(
                     AppliedEntity(
                         entity=entity,
@@ -459,7 +467,7 @@ class RulesPackageService:
         - ``replace``: replaces current content with payload content.
         - ``append``: appends payload content to current content.
         """
-        overrides = self.get_overrides_for_chunk(chunk.chunk_id)
+        overrides = self.get_overrides_for_chunk(chunk.chunk_id, chunk.rules_package_id)
         content = chunk.content
         is_disabled = False
         applied_ids: list[UUID] = []

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -281,12 +281,18 @@ class RulesPackageService:
 
         chunk_rows = (
             self._session.execute(
-                select(RuleChunkORM).where(
+                select(RuleChunkORM)
+                .join(
+                    RuleSourceORM,
+                    RuleChunkORM.source_id == RuleSourceORM.source_id,
+                )
+                .where(
                     RuleChunkORM.rules_package_id == str(package_id),
                     RuleChunkORM.subsystem == subsystem.value,
                     RuleChunkORM.is_enabled == True,  # noqa: E712
                     RuleChunkORM.source_id.in_(enabled_source_ids),
                 )
+                .order_by(RuleSourceORM.precedence_rank, RuleChunkORM.chunk_id)
             )
             .scalars()
             .all()
@@ -340,7 +346,7 @@ class RulesPackageService:
                 MechanicalEntityORM.is_enabled == True,  # noqa: E712
                 MechanicalEntityORM.source_id.in_(enabled_source_ids),
             )
-            .order_by(RuleSourceORM.precedence_rank)
+            .order_by(RuleSourceORM.precedence_rank, MechanicalEntityORM.entity_id)
         )
         if source_id is not None:
             stmt = stmt.where(MechanicalEntityORM.source_id == str(source_id))
@@ -360,7 +366,7 @@ class RulesPackageService:
                     RuleOverrideORM.target_chunk_id == str(chunk_id),
                     RuleOverrideORM.is_enabled == True,  # noqa: E712
                 )
-                .order_by(RuleOverrideORM.precedence)
+                .order_by(RuleOverrideORM.precedence, RuleOverrideORM.override_id)
             )
             .scalars()
             .all()
@@ -379,7 +385,7 @@ class RulesPackageService:
                     RuleOverrideORM.target_entity_id == str(entity_id),
                     RuleOverrideORM.is_enabled == True,  # noqa: E712
                 )
-                .order_by(RuleOverrideORM.precedence)
+                .order_by(RuleOverrideORM.precedence, RuleOverrideORM.override_id)
             )
             .scalars()
             .all()
@@ -426,12 +432,18 @@ class RulesPackageService:
             subsystem_values = [s.value for s in subsystem_tags]
             chunk_rows = (
                 self._session.execute(
-                    select(RuleChunkORM).where(
+                    select(RuleChunkORM)
+                    .join(
+                        RuleSourceORM,
+                        RuleChunkORM.source_id == RuleSourceORM.source_id,
+                    )
+                    .where(
                         RuleChunkORM.rules_package_id == str(package_id),
                         RuleChunkORM.subsystem.in_(subsystem_values),
                         RuleChunkORM.is_enabled == True,  # noqa: E712
                         RuleChunkORM.source_id.in_(enabled_source_ids),
                     )
+                    .order_by(RuleSourceORM.precedence_rank, RuleChunkORM.chunk_id)
                 )
                 .scalars()
                 .all()

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -1,0 +1,497 @@
+"""Rules Package service — typed read surface for mechanical canon.
+
+This module provides the typed read interface that downstream issues
+(CRD Issue 5b ingestion, CRD Issue 8 Context Builder) depend on.
+
+Play-time queries
+-----------------
+Surface only published, enabled content.  Disabled packages, disabled
+sources, and their associated chunks/entities are excluded.
+
+Administrative / internal queries
+----------------------------------
+Pass ``include_non_published=True`` to access draft packages during
+ingestion validation and publication flow support (CRD Issue 5b).
+
+Source record immutability
+--------------------------
+Source records (RuleChunk, MechanicalEntity) are immutable after creation.
+All layered changes are expressed as RuleOverride rows.  No service method
+in this module modifies a source record.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import (
+    MechanicalEntityTypeEnum,
+    OverrideOperationEnum,
+    OverrideOriginEnum,
+    PublicationStatusEnum,
+    RuleSourceCategoryEnum,
+    RuleSubsystemEnum,
+    RulesSystemEnum,
+    SourceLocatorTypeEnum,
+)
+from afterworlds.models.rules_package import (
+    ActionEntity,
+    ActiveRuleSlice,
+    AppliedChunk,
+    AppliedEntity,
+    ChunkOverridePayload,
+    ChunksResult,
+    ConditionEntity,
+    EntityData,
+    ItemEntity,
+    MechanicalEntity,
+    RuleChunk,
+    RuleOverride,
+    RuleSource,
+    RulesPackageDetail,
+    SpellEntity,
+    StatBlockEntity,
+)
+from afterworlds.persistence.orm.rules_package import (
+    MechanicalEntityORM,
+    RuleChunkORM,
+    RuleOverrideORM,
+    RuleSourceORM,
+    RulesPackageORM,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers — ORM row → Pydantic model conversion
+# These are pure functions with no side effects.
+# ---------------------------------------------------------------------------
+
+
+def _orm_to_package_detail(
+    row: RulesPackageORM, sources: list[RuleSource]
+) -> RulesPackageDetail:
+    return RulesPackageDetail(
+        rules_package_id=UUID(row.rules_package_id),
+        name=row.name,
+        system=RulesSystemEnum(row.system),
+        version=row.version,
+        is_enabled=row.is_enabled,
+        publication_status=PublicationStatusEnum(row.publication_status),
+        published_at=(
+            datetime.fromisoformat(row.published_at) if row.published_at else None
+        ),
+        created_at=datetime.fromisoformat(row.created_at),
+        updated_at=datetime.fromisoformat(row.updated_at),
+        sources=sources,
+    )
+
+
+def _orm_to_source(row: RuleSourceORM) -> RuleSource:
+    return RuleSource(
+        source_id=UUID(row.source_id),
+        rules_package_id=UUID(row.rules_package_id),
+        name=row.name,
+        category=RuleSourceCategoryEnum(row.category),
+        precedence_rank=row.precedence_rank,
+        is_enabled=row.is_enabled,
+        created_at=datetime.fromisoformat(row.created_at),
+    )
+
+
+def _orm_to_chunk(row: RuleChunkORM) -> RuleChunk:
+    return RuleChunk(
+        chunk_id=UUID(row.chunk_id),
+        rules_package_id=UUID(row.rules_package_id),
+        source_id=UUID(row.source_id),
+        subsystem=RuleSubsystemEnum(row.subsystem),
+        content=row.content,
+        source_document=row.source_document,
+        source_locator_type=SourceLocatorTypeEnum(row.source_locator_type),
+        source_locator_value=row.source_locator_value,
+        source_section_label=row.source_section_label,
+        is_enabled=row.is_enabled,
+        created_at=datetime.fromisoformat(row.created_at),
+    )
+
+
+def _deserialize_entity_data(
+    entity_type: MechanicalEntityTypeEnum, data: dict[str, Any]
+) -> EntityData:
+    """Deserialise a structured_data dict to the correct typed entity model."""
+    if entity_type == MechanicalEntityTypeEnum.SPELL:
+        return SpellEntity.model_validate(data)
+    if entity_type == MechanicalEntityTypeEnum.CONDITION:
+        return ConditionEntity.model_validate(data)
+    if entity_type == MechanicalEntityTypeEnum.STAT_BLOCK:
+        return StatBlockEntity.model_validate(data)
+    if entity_type == MechanicalEntityTypeEnum.ACTION:
+        return ActionEntity.model_validate(data)
+    if entity_type == MechanicalEntityTypeEnum.ITEM:
+        return ItemEntity.model_validate(data)
+    raise ValueError(f"Unhandled entity type: {entity_type!r}")  # pragma: no cover
+
+
+def _orm_to_entity(row: MechanicalEntityORM) -> MechanicalEntity:
+    entity_type = MechanicalEntityTypeEnum(row.entity_type)
+    structured_data = _deserialize_entity_data(entity_type, row.structured_data)
+    return MechanicalEntity(
+        entity_id=UUID(row.entity_id),
+        rules_package_id=UUID(row.rules_package_id),
+        source_id=UUID(row.source_id),
+        entity_type=entity_type,
+        name=row.name,
+        structured_data=structured_data,
+        source_document=row.source_document,
+        source_locator_type=SourceLocatorTypeEnum(row.source_locator_type),
+        source_locator_value=row.source_locator_value,
+        source_section_label=row.source_section_label,
+        is_enabled=row.is_enabled,
+        created_at=datetime.fromisoformat(row.created_at),
+    )
+
+
+def _orm_to_override(row: RuleOverrideORM) -> RuleOverride:
+    return RuleOverride(
+        override_id=UUID(row.override_id),
+        rules_package_id=UUID(row.rules_package_id),
+        target_chunk_id=(
+            UUID(row.target_chunk_id) if row.target_chunk_id else None
+        ),
+        target_entity_id=(
+            UUID(row.target_entity_id) if row.target_entity_id else None
+        ),
+        override_origin=OverrideOriginEnum(row.override_origin),
+        override_operation=OverrideOperationEnum(row.override_operation),
+        override_payload=row.override_payload,
+        precedence=row.precedence,
+        is_enabled=row.is_enabled,
+        created_at=datetime.fromisoformat(row.created_at),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class RulesPackageService:
+    """Read-oriented service for the Rules Package subsystem.
+
+    Play-time methods surface only published, enabled content.
+    Administrative/internal callers may opt into draft reads via
+    ``include_non_published=True``.
+
+    Source records (RuleChunk, MechanicalEntity) are never modified by this
+    service.  All layered changes are expressed as RuleOverride rows.
+    """
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    # -- Accessibility helpers ----------------------------------------------
+
+    def _package_accessible(
+        self, row: RulesPackageORM, include_non_published: bool
+    ) -> bool:
+        """Return True if *row* is accessible under the given query policy."""
+        if not row.is_enabled:
+            return False
+        if not include_non_published:
+            return row.publication_status == PublicationStatusEnum.PUBLISHED.value
+        return True
+
+    def _enabled_source_ids_for_package(self, package_id: UUID) -> list[str]:
+        """Return string source IDs for all enabled sources in *package_id*."""
+        rows = (
+            self._session.execute(
+                select(RuleSourceORM.source_id).where(
+                    RuleSourceORM.rules_package_id == str(package_id),
+                    RuleSourceORM.is_enabled == True,  # noqa: E712
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows)
+
+    # -- Public read methods ------------------------------------------------
+
+    def get_package_by_id(
+        self,
+        package_id: UUID,
+        include_non_published: bool = False,
+    ) -> RulesPackageDetail | None:
+        """Fetch full package metadata including its RuleSource records.
+
+        Returns None if the package does not exist or is not accessible under
+        the current query policy.
+
+        Administrative/internal callers may pass ``include_non_published=True``
+        to access draft packages during ingestion validation and publication
+        flow support (CRD Issue 5b).
+        """
+        row = self._session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == str(package_id)
+            )
+        ).scalar_one_or_none()
+
+        if row is None:
+            return None
+        if not self._package_accessible(row, include_non_published):
+            return None
+
+        source_rows = (
+            self._session.execute(
+                select(RuleSourceORM)
+                .where(RuleSourceORM.rules_package_id == str(package_id))
+                .order_by(RuleSourceORM.precedence_rank)
+            )
+            .scalars()
+            .all()
+        )
+        sources = [_orm_to_source(src) for src in source_rows]
+        return _orm_to_package_detail(row, sources)
+
+    def get_chunks_by_subsystem(
+        self,
+        package_id: UUID,
+        subsystem: RuleSubsystemEnum,
+        include_non_published: bool = False,
+    ) -> ChunksResult:
+        """Retrieve rule chunks for a package/subsystem.
+
+        Respects package, RuleSource, and chunk enable/disable state.
+        Play-time (default): only published and enabled content is surfaced.
+        """
+        pkg_row = self._session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == str(package_id)
+            )
+        ).scalar_one_or_none()
+
+        if pkg_row is None or not self._package_accessible(
+            pkg_row, include_non_published
+        ):
+            return ChunksResult(
+                package_id=package_id, subsystem=subsystem, chunks=[]
+            )
+
+        enabled_source_ids = self._enabled_source_ids_for_package(package_id)
+        if not enabled_source_ids:
+            return ChunksResult(
+                package_id=package_id, subsystem=subsystem, chunks=[]
+            )
+
+        chunk_rows = (
+            self._session.execute(
+                select(RuleChunkORM).where(
+                    RuleChunkORM.rules_package_id == str(package_id),
+                    RuleChunkORM.subsystem == subsystem.value,
+                    RuleChunkORM.is_enabled == True,  # noqa: E712
+                    RuleChunkORM.source_id.in_(enabled_source_ids),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return ChunksResult(
+            package_id=package_id,
+            subsystem=subsystem,
+            chunks=[_orm_to_chunk(r) for r in chunk_rows],
+        )
+
+    def get_entity_by_type_and_name(
+        self,
+        package_id: UUID,
+        entity_type: MechanicalEntityTypeEnum,
+        name: str,
+        source_id: UUID | None = None,
+        include_non_published: bool = False,
+    ) -> MechanicalEntity | None:
+        """Retrieve a specific mechanical entity scoped to a package.
+
+        Optional ``source_id`` filter resolves ambiguity when the same name
+        exists across multiple RuleSource records within the package.
+
+        Returns None if not found or not accessible.
+        """
+        pkg_row = self._session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == str(package_id)
+            )
+        ).scalar_one_or_none()
+
+        if pkg_row is None or not self._package_accessible(
+            pkg_row, include_non_published
+        ):
+            return None
+
+        enabled_source_ids = self._enabled_source_ids_for_package(package_id)
+        if not enabled_source_ids:
+            return None
+
+        stmt = select(MechanicalEntityORM).where(
+            MechanicalEntityORM.rules_package_id == str(package_id),
+            MechanicalEntityORM.entity_type == entity_type.value,
+            MechanicalEntityORM.name == name,
+            MechanicalEntityORM.is_enabled == True,  # noqa: E712
+            MechanicalEntityORM.source_id.in_(enabled_source_ids),
+        )
+        if source_id is not None:
+            stmt = stmt.where(MechanicalEntityORM.source_id == str(source_id))
+
+        row = self._session.execute(stmt).scalar_one_or_none()
+        return _orm_to_entity(row) if row is not None else None
+
+    def get_overrides_for_chunk(self, chunk_id: UUID) -> list[RuleOverride]:
+        """Retrieve active overrides for a chunk, ordered by precedence."""
+        rows = (
+            self._session.execute(
+                select(RuleOverrideORM)
+                .where(
+                    RuleOverrideORM.target_chunk_id == str(chunk_id),
+                    RuleOverrideORM.is_enabled == True,  # noqa: E712
+                )
+                .order_by(RuleOverrideORM.precedence)
+            )
+            .scalars()
+            .all()
+        )
+        return [_orm_to_override(r) for r in rows]
+
+    def get_overrides_for_entity(self, entity_id: UUID) -> list[RuleOverride]:
+        """Retrieve active overrides for an entity, ordered by precedence."""
+        rows = (
+            self._session.execute(
+                select(RuleOverrideORM)
+                .where(
+                    RuleOverrideORM.target_entity_id == str(entity_id),
+                    RuleOverrideORM.is_enabled == True,  # noqa: E712
+                )
+                .order_by(RuleOverrideORM.precedence)
+            )
+            .scalars()
+            .all()
+        )
+        return [_orm_to_override(r) for r in rows]
+
+    def get_active_rule_slice(
+        self,
+        package_id: UUID,
+        subsystem_tags: list[RuleSubsystemEnum],
+        entity_refs: list[tuple[MechanicalEntityTypeEnum, str]],
+        include_non_published: bool = False,
+    ) -> ActiveRuleSlice:
+        """Assemble relevant rule chunks and entities for a turn context.
+
+        This is deterministic lookup against the provided subsystem tags and
+        entity references only.  Not a semantic search.  Semantic retrieval
+        belongs to CRD Issue 18.
+
+        Returns an ``ActiveRuleSlice`` with chunk override layering applied
+        in precedence order.  Disabled (``is_enabled=False``) chunks, sources,
+        and packages are excluded.  Override-disabled chunks appear with
+        ``is_disabled=True`` and empty ``applied_content``.
+
+        The return type ``ActiveRuleSlice`` is a stable named Pydantic model;
+        the Context Builder (CRD Issue 8) may depend on its shape.
+        """
+        pkg_row = self._session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == str(package_id)
+            )
+        ).scalar_one_or_none()
+
+        if pkg_row is None or not self._package_accessible(
+            pkg_row, include_non_published
+        ):
+            return ActiveRuleSlice(package_id=package_id, chunks=[], entities=[])
+
+        enabled_source_ids = self._enabled_source_ids_for_package(package_id)
+
+        # Collect and apply overrides to chunks for all requested subsystems
+        applied_chunks: list[AppliedChunk] = []
+        if subsystem_tags and enabled_source_ids:
+            subsystem_values = [s.value for s in subsystem_tags]
+            chunk_rows = (
+                self._session.execute(
+                    select(RuleChunkORM).where(
+                        RuleChunkORM.rules_package_id == str(package_id),
+                        RuleChunkORM.subsystem.in_(subsystem_values),
+                        RuleChunkORM.is_enabled == True,  # noqa: E712
+                        RuleChunkORM.source_id.in_(enabled_source_ids),
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for chunk_row in chunk_rows:
+                chunk = _orm_to_chunk(chunk_row)
+                applied_chunks.append(self._apply_chunk_overrides(chunk))
+
+        # Collect specific entities by (type, name) reference
+        applied_entities: list[AppliedEntity] = []
+        for etype, ename in entity_refs:
+            entity = self.get_entity_by_type_and_name(
+                package_id,
+                etype,
+                ename,
+                include_non_published=include_non_published,
+            )
+            if entity is not None:
+                overrides = self.get_overrides_for_entity(entity.entity_id)
+                applied_entities.append(
+                    AppliedEntity(
+                        entity=entity,
+                        override_ids_applied=[o.override_id for o in overrides],
+                    )
+                )
+
+        return ActiveRuleSlice(
+            package_id=package_id,
+            chunks=applied_chunks,
+            entities=applied_entities,
+        )
+
+    # -- Internal helpers ---------------------------------------------------
+
+    def _apply_chunk_overrides(self, chunk: RuleChunk) -> AppliedChunk:
+        """Apply active overrides to *chunk* in ascending precedence order.
+
+        - ``disable``: marks the chunk as disabled; stops further processing.
+        - ``replace``: replaces current content with payload content.
+        - ``append``: appends payload content to current content.
+        """
+        overrides = self.get_overrides_for_chunk(chunk.chunk_id)
+        content = chunk.content
+        is_disabled = False
+        applied_ids: list[UUID] = []
+
+        for override in overrides:
+            applied_ids.append(override.override_id)
+            if override.override_operation == OverrideOperationEnum.DISABLE:
+                is_disabled = True
+                break
+            elif override.override_operation == OverrideOperationEnum.REPLACE:
+                payload = ChunkOverridePayload.model_validate_json(
+                    override.override_payload
+                )
+                content = payload.content or ""
+            elif override.override_operation == OverrideOperationEnum.APPEND:
+                payload = ChunkOverridePayload.model_validate_json(
+                    override.override_payload
+                )
+                content = content + (payload.content or "")
+
+        return AppliedChunk(
+            chunk=chunk,
+            applied_content="" if is_disabled else content,
+            is_disabled=is_disabled,
+            override_ids_applied=applied_ids,
+        )

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -244,7 +244,10 @@ class RulesPackageService:
         source_rows = (
             self._session.execute(
                 select(RuleSourceORM)
-                .where(RuleSourceORM.rules_package_id == str(package_id))
+                .where(
+                    RuleSourceORM.rules_package_id == str(package_id),
+                    RuleSourceORM.is_enabled == True,  # noqa: E712
+                )
                 .order_by(RuleSourceORM.precedence_rank)
             )
             .scalars()

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -65,7 +65,6 @@ from afterworlds.persistence.orm.rules_package import (
     RulesPackageORM,
 )
 
-
 # ---------------------------------------------------------------------------
 # Module-level helpers — ORM row → Pydantic model conversion
 # These are pure functions with no side effects.
@@ -159,12 +158,8 @@ def _orm_to_override(row: RuleOverrideORM) -> RuleOverride:
     return RuleOverride(
         override_id=UUID(row.override_id),
         rules_package_id=UUID(row.rules_package_id),
-        target_chunk_id=(
-            UUID(row.target_chunk_id) if row.target_chunk_id else None
-        ),
-        target_entity_id=(
-            UUID(row.target_entity_id) if row.target_entity_id else None
-        ),
+        target_chunk_id=(UUID(row.target_chunk_id) if row.target_chunk_id else None),
+        target_entity_id=(UUID(row.target_entity_id) if row.target_entity_id else None),
         override_origin=OverrideOriginEnum(row.override_origin),
         override_operation=OverrideOperationEnum(row.override_operation),
         override_payload=row.override_payload,
@@ -278,15 +273,11 @@ class RulesPackageService:
         if pkg_row is None or not self._package_accessible(
             pkg_row, include_non_published
         ):
-            return ChunksResult(
-                package_id=package_id, subsystem=subsystem, chunks=[]
-            )
+            return ChunksResult(package_id=package_id, subsystem=subsystem, chunks=[])
 
         enabled_source_ids = self._enabled_source_ids_for_package(package_id)
         if not enabled_source_ids:
-            return ChunksResult(
-                package_id=package_id, subsystem=subsystem, chunks=[]
-            )
+            return ChunksResult(package_id=package_id, subsystem=subsystem, chunks=[])
 
         chunk_rows = (
             self._session.execute(

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -35,8 +35,8 @@ from afterworlds.models.enums import (
     OverrideOriginEnum,
     PublicationStatusEnum,
     RuleSourceCategoryEnum,
-    RuleSubsystemEnum,
     RulesSystemEnum,
+    RuleSubsystemEnum,
     SourceLocatorTypeEnum,
 )
 from afterworlds.models.rules_package import (

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -10,6 +10,7 @@ import pytest
 # Import all ORM models to ensure Base.metadata is fully populated
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401
 import afterworlds.persistence.orm.story  # noqa: F401

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -922,6 +922,40 @@ class TestGetEntityByTypeAndName:
         assert isinstance(result.structured_data, ConditionEntity)
         assert result.structured_data.effects == ["from_b"]
 
+    def test_no_source_id_uses_lowest_precedence_rank(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid1 = _insert_source(
+            session, package_id=pid, name="Source A", precedence_rank=1
+        )
+        sid2 = _insert_source(
+            session, package_id=pid, name="Source B", precedence_rank=2
+        )
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid1,
+            name="Blinded",
+            entity_type="condition",
+            structured_data={"effects": ["from_a"]},
+        )
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid2,
+            name="Blinded",
+            entity_type="condition",
+            structured_data={"effects": ["from_b"]},
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid), MechanicalEntityTypeEnum.CONDITION, "Blinded"
+        )
+        assert result is not None
+        assert isinstance(result.structured_data, ConditionEntity)
+        assert result.structured_data.effects == ["from_a"]
+
     def test_disabled_entity_not_returned(
         self, session: Session, svc: RulesPackageService
     ) -> None:

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -1,0 +1,1053 @@
+"""Tests for Rules Package schema, models, and service — CRD Issue 5a.
+
+Acceptance criteria verified:
+  AC-RP-001  rp_* table prefix — all five tables registered
+  AC-RP-002  No rp_* FK to non-rp_* tables (also in test_schema_separation_invariant)
+  AC-RP-003  Publication lifecycle — draft/retired not surfaced at play time
+  AC-RP-004  Source membership — disabled-source chunks/entities excluded
+  AC-RP-005  Source provenance — source_id non-nullable (ADR-0008)
+  AC-RP-006  Override non-mutation — source records unchanged by overrides
+  AC-RP-007  Override precedence — applied in ascending precedence order
+  AC-RP-008  Override target constraint — exactly one of chunk/entity
+  AC-RP-009  Entity type models — each enum value maps to a distinct typed model
+  AC-RP-010  get_active_rule_slice — correct chunks + entities + override layering
+  AC-RP-011  get_entity_by_type_and_name — package scoping and source_id filter
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+import afterworlds.persistence.orm.rules_package  # noqa: F401
+from afterworlds.models.enums import (
+    MechanicalEntityTypeEnum,
+    OverrideOperationEnum,
+    OverrideOriginEnum,
+    PublicationStatusEnum,
+    RuleSubsystemEnum,
+)
+from afterworlds.models.rules_package import (
+    ActionEntity,
+    ConditionEntity,
+    ItemEntity,
+    RuleOverride,
+    SpellEntity,
+    StatBlockEntity,
+)
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.rules_package import (
+    MechanicalEntityORM,
+    RuleChunkORM,
+    RuleOverrideORM,
+    RuleSourceORM,
+    RulesPackageORM,
+)
+from afterworlds.services.rules_package import RulesPackageService, _deserialize_entity_data
+
+
+# ---------------------------------------------------------------------------
+# Helpers — direct ORM row inserts for test setup
+# ---------------------------------------------------------------------------
+
+_NOW_ISO = datetime(2026, 4, 9, tzinfo=UTC).isoformat()
+
+
+def _insert_package(
+    session: Session,
+    *,
+    package_id: str | None = None,
+    name: str = "Test Package",
+    system: str = "d20",
+    version: str = "1.0",
+    is_enabled: bool = True,
+    publication_status: str = "published",
+    published_at: str | None = _NOW_ISO,
+) -> str:
+    pid = package_id or str(uuid4())
+    session.execute(
+        sa.insert(RulesPackageORM).values(
+            rules_package_id=pid,
+            name=name,
+            system=system,
+            version=version,
+            is_enabled=is_enabled,
+            publication_status=publication_status,
+            published_at=published_at,
+            created_at=_NOW_ISO,
+            updated_at=_NOW_ISO,
+        )
+    )
+    return pid
+
+
+def _insert_source(
+    session: Session,
+    *,
+    source_id: str | None = None,
+    package_id: str,
+    name: str = "Player's Handbook",
+    category: str = "core_rulebook",
+    precedence_rank: int = 1,
+    is_enabled: bool = True,
+) -> str:
+    sid = source_id or str(uuid4())
+    session.execute(
+        sa.insert(RuleSourceORM).values(
+            source_id=sid,
+            rules_package_id=package_id,
+            name=name,
+            category=category,
+            precedence_rank=precedence_rank,
+            is_enabled=is_enabled,
+            created_at=_NOW_ISO,
+        )
+    )
+    return sid
+
+
+def _insert_chunk(
+    session: Session,
+    *,
+    chunk_id: str | None = None,
+    package_id: str,
+    source_id: str,
+    subsystem: str = "combat",
+    content: str = "Attack action.",
+    is_enabled: bool = True,
+) -> str:
+    cid = chunk_id or str(uuid4())
+    session.execute(
+        sa.insert(RuleChunkORM).values(
+            chunk_id=cid,
+            rules_package_id=package_id,
+            source_id=source_id,
+            subsystem=subsystem,
+            content=content,
+            source_document="PHB",
+            source_locator_type="page",
+            source_locator_value="195",
+            source_section_label=None,
+            is_enabled=is_enabled,
+            created_at=_NOW_ISO,
+        )
+    )
+    return cid
+
+
+def _insert_entity(
+    session: Session,
+    *,
+    entity_id: str | None = None,
+    package_id: str,
+    source_id: str,
+    entity_type: str = "condition",
+    name: str = "Blinded",
+    structured_data: dict | None = None,
+    is_enabled: bool = True,
+) -> str:
+    eid = entity_id or str(uuid4())
+    if structured_data is None:
+        structured_data = {"effects": ["Cannot see"]}
+    session.execute(
+        sa.insert(MechanicalEntityORM).values(
+            entity_id=eid,
+            rules_package_id=package_id,
+            source_id=source_id,
+            entity_type=entity_type,
+            name=name,
+            structured_data=structured_data,
+            source_document="PHB",
+            source_locator_type="page",
+            source_locator_value="290",
+            source_section_label=None,
+            is_enabled=is_enabled,
+            created_at=_NOW_ISO,
+        )
+    )
+    return eid
+
+
+def _insert_override(
+    session: Session,
+    *,
+    override_id: str | None = None,
+    package_id: str,
+    target_chunk_id: str | None = None,
+    target_entity_id: str | None = None,
+    operation: str = "replace",
+    payload: dict | None = None,
+    precedence: int = 1,
+    is_enabled: bool = True,
+    origin: str = "house_rule",
+) -> str:
+    oid = override_id or str(uuid4())
+    if payload is None:
+        payload = {"content": "Replacement text."}
+    session.execute(
+        sa.insert(RuleOverrideORM).values(
+            override_id=oid,
+            rules_package_id=package_id,
+            target_chunk_id=target_chunk_id,
+            target_entity_id=target_entity_id,
+            override_origin=origin,
+            override_operation=operation,
+            override_payload=json.dumps(payload),
+            precedence=precedence,
+            is_enabled=is_enabled,
+            created_at=_NOW_ISO,
+        )
+    )
+    return oid
+
+
+# ---------------------------------------------------------------------------
+# Service fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def svc(session: Session) -> RulesPackageService:
+    return RulesPackageService(session)
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-001: rp_* table prefix
+# ---------------------------------------------------------------------------
+
+
+class TestRpTablePrefix:
+    def test_all_five_rp_tables_registered(self) -> None:
+        expected = {
+            "rp_packages",
+            "rp_sources",
+            "rp_chunks",
+            "rp_mechanical_entities",
+            "rp_overrides",
+        }
+        actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
+        assert expected == actual, (
+            f"Expected rp_* tables: {sorted(expected)}\nFound: {sorted(actual)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-002: All rp_* FKs stay within the rp_* namespace
+# ---------------------------------------------------------------------------
+
+
+class TestRpFkSeparation:
+    def test_all_rp_fks_stay_within_rp_namespace(self) -> None:
+        """Every FK from an rp_* table must target another rp_* table."""
+        violations: list[str] = []
+        for table_name, table in Base.metadata.tables.items():
+            if not table_name.startswith("rp_"):
+                continue
+            for fk in table.foreign_keys:
+                target = fk.column.table.name
+                if not target.startswith("rp_"):
+                    violations.append(
+                        f"  {table_name}.{fk.parent.name} → {target}.{fk.column.name}"
+                    )
+        assert not violations, (
+            "rp_* tables must not carry FK constraints to non-rp_* tables.\n"
+            "Violations:\n" + "\n".join(violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-005: Source provenance — source_id non-nullable at ORM level
+# ---------------------------------------------------------------------------
+
+
+class TestSourceProvenance:
+    def test_chunk_source_id_is_non_nullable(self) -> None:
+        col = RuleChunkORM.__table__.c["source_id"]
+        assert not col.nullable, (
+            "source_id on rp_chunks must be non-nullable (ADR-0008)"
+        )
+
+    def test_entity_source_id_is_non_nullable(self) -> None:
+        col = MechanicalEntityORM.__table__.c["source_id"]
+        assert not col.nullable, (
+            "source_id on rp_mechanical_entities must be non-nullable (ADR-0008)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-008: Override target constraint — Pydantic model validator
+# ---------------------------------------------------------------------------
+
+
+class TestRuleOverrideTargetConstraintPydantic:
+    def _base_kwargs(self, **overrides: object) -> dict:
+        base: dict = dict(
+            rules_package_id=uuid4(),
+            override_origin=OverrideOriginEnum.HOUSE_RULE,
+            override_operation=OverrideOperationEnum.REPLACE,
+            override_payload='{"content": "x"}',
+            precedence=1,
+            created_at=datetime(2026, 4, 9, tzinfo=UTC),
+        )
+        base.update(overrides)
+        return base
+
+    def test_chunk_target_only_is_valid(self) -> None:
+        RuleOverride(**self._base_kwargs(target_chunk_id=uuid4()))
+
+    def test_entity_target_only_is_valid(self) -> None:
+        RuleOverride(**self._base_kwargs(target_entity_id=uuid4()))
+
+    def test_both_targets_raises(self) -> None:
+        with pytest.raises(ValueError, match="Exactly one"):
+            RuleOverride(
+                **self._base_kwargs(
+                    target_chunk_id=uuid4(),
+                    target_entity_id=uuid4(),
+                )
+            )
+
+    def test_no_target_raises(self) -> None:
+        with pytest.raises(ValueError, match="Exactly one"):
+            RuleOverride(**self._base_kwargs())
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-008: Override target constraint — DB CHECK constraint
+# ---------------------------------------------------------------------------
+
+
+class TestRuleOverrideTargetConstraintDb:
+    def test_db_check_constraint_rejects_both_targets(
+        self, session: Session
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(session, package_id=pid, source_id=sid)
+        eid = _insert_entity(session, package_id=pid, source_id=sid)
+        session.commit()
+        with pytest.raises(sa.exc.IntegrityError):
+            session.execute(
+                sa.insert(RuleOverrideORM).values(
+                    override_id=str(uuid4()),
+                    rules_package_id=pid,
+                    target_chunk_id=cid,
+                    target_entity_id=eid,
+                    override_origin="house_rule",
+                    override_operation="replace",
+                    override_payload='{"content": "x"}',
+                    precedence=1,
+                    is_enabled=True,
+                    created_at=_NOW_ISO,
+                )
+            )
+            session.commit()
+
+    def test_db_check_constraint_rejects_no_target(
+        self, session: Session
+    ) -> None:
+        pid = _insert_package(session)
+        session.commit()
+        with pytest.raises(sa.exc.IntegrityError):
+            session.execute(
+                sa.insert(RuleOverrideORM).values(
+                    override_id=str(uuid4()),
+                    rules_package_id=pid,
+                    target_chunk_id=None,
+                    target_entity_id=None,
+                    override_origin="house_rule",
+                    override_operation="replace",
+                    override_payload='{"content": "x"}',
+                    precedence=1,
+                    is_enabled=True,
+                    created_at=_NOW_ISO,
+                )
+            )
+            session.commit()
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-009: Entity type models
+# ---------------------------------------------------------------------------
+
+
+class TestEntityTypeModels:
+    def test_spell_entity(self) -> None:
+        e = SpellEntity(
+            casting_time="1 action",
+            range="60 feet",
+            duration="Instantaneous",
+            components=["V", "S"],
+            effect_description="Deals 8d6 fire damage.",
+        )
+        assert e.casting_time == "1 action"
+        assert e.components == ["V", "S"]
+
+    def test_condition_entity(self) -> None:
+        e = ConditionEntity(effects=["Cannot see", "Disadvantage on attacks"])
+        assert len(e.effects) == 2
+
+    def test_stat_block_entity(self) -> None:
+        e = StatBlockEntity(
+            armor_class=15,
+            hit_points=52,
+            speed="30 ft.",
+            strength=16,
+            dexterity=12,
+            constitution=14,
+            intelligence=10,
+            wisdom=10,
+            charisma=8,
+            actions=["Multiattack", "Longsword"],
+        )
+        assert e.armor_class == 15
+
+    def test_action_entity(self) -> None:
+        e = ActionEntity(
+            action_type="melee",
+            description="Longsword attack",
+            attack_bonus=5,
+        )
+        assert e.attack_bonus == 5
+        assert e.effect is None
+
+    def test_item_entity(self) -> None:
+        e = ItemEntity(
+            item_type="weapon",
+            properties=["versatile"],
+            weight=3.0,
+            value="15 gp",
+        )
+        assert e.weight == 3.0
+
+    def test_each_enum_value_dispatches_to_distinct_typed_model(
+        self,
+    ) -> None:
+        """Every MechanicalEntityTypeEnum value must resolve to a typed model."""
+        type_to_data: dict[MechanicalEntityTypeEnum, dict] = {
+            MechanicalEntityTypeEnum.SPELL: {
+                "casting_time": "1 action",
+                "range": "60 feet",
+                "duration": "Instantaneous",
+                "effect_description": "Damage.",
+            },
+            MechanicalEntityTypeEnum.CONDITION: {"effects": ["stunned"]},
+            MechanicalEntityTypeEnum.STAT_BLOCK: {
+                "armor_class": 12,
+                "hit_points": 20,
+                "speed": "30 ft.",
+                "strength": 10,
+                "dexterity": 10,
+                "constitution": 10,
+                "intelligence": 10,
+                "wisdom": 10,
+                "charisma": 10,
+            },
+            MechanicalEntityTypeEnum.ACTION: {
+                "action_type": "bonus",
+                "description": "Cunning Action",
+            },
+            MechanicalEntityTypeEnum.ITEM: {"item_type": "armor"},
+        }
+        covered_types = set(type_to_data.keys())
+        all_types = set(MechanicalEntityTypeEnum)
+        assert covered_types == all_types, (
+            f"Missing coverage for: {all_types - covered_types}"
+        )
+        for etype, data in type_to_data.items():
+            result = _deserialize_entity_data(etype, data)
+            assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-003: Publication lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestPublicationLifecycle:
+    def test_draft_package_not_surfaced_at_play_time(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(
+            session, publication_status="draft", published_at=None
+        )
+        session.commit()
+        assert svc.get_package_by_id(UUID(pid)) is None
+
+    def test_published_package_surfaced_at_play_time(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session, publication_status="published")
+        session.commit()
+        result = svc.get_package_by_id(UUID(pid))
+        assert result is not None
+        assert result.publication_status == PublicationStatusEnum.PUBLISHED
+
+    def test_retired_package_not_surfaced_at_play_time(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session, publication_status="retired")
+        session.commit()
+        assert svc.get_package_by_id(UUID(pid)) is None
+
+    def test_draft_accessible_with_include_non_published(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(
+            session, publication_status="draft", published_at=None
+        )
+        session.commit()
+        result = svc.get_package_by_id(UUID(pid), include_non_published=True)
+        assert result is not None
+        assert result.publication_status == PublicationStatusEnum.DRAFT
+
+    def test_disabled_package_never_surfaced(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(
+            session, is_enabled=False, publication_status="published"
+        )
+        session.commit()
+        assert svc.get_package_by_id(UUID(pid)) is None
+        assert svc.get_package_by_id(UUID(pid), include_non_published=True) is None
+
+    def test_draft_chunks_not_surfaced_at_play_time(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(
+            session, publication_status="draft", published_at=None
+        )
+        sid = _insert_source(session, package_id=pid)
+        _insert_chunk(session, package_id=pid, source_id=sid)
+        session.commit()
+        result = svc.get_chunks_by_subsystem(UUID(pid), RuleSubsystemEnum.COMBAT)
+        assert result.chunks == []
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-004: Source membership — disabled source excludes its records
+# ---------------------------------------------------------------------------
+
+
+class TestSourceMembership:
+    def test_chunks_from_disabled_source_excluded(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        enabled_sid = _insert_source(
+            session,
+            package_id=pid,
+            name="Enabled",
+            is_enabled=True,
+            precedence_rank=1,
+        )
+        disabled_sid = _insert_source(
+            session,
+            package_id=pid,
+            name="Disabled",
+            is_enabled=False,
+            precedence_rank=2,
+        )
+        _insert_chunk(
+            session,
+            package_id=pid,
+            source_id=enabled_sid,
+            content="Enabled chunk.",
+        )
+        _insert_chunk(
+            session,
+            package_id=pid,
+            source_id=disabled_sid,
+            content="Disabled chunk.",
+        )
+        session.commit()
+        result = svc.get_chunks_by_subsystem(UUID(pid), RuleSubsystemEnum.COMBAT)
+        assert len(result.chunks) == 1
+        assert result.chunks[0].content == "Enabled chunk."
+
+    def test_entity_from_disabled_source_excluded(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        disabled_sid = _insert_source(session, package_id=pid, is_enabled=False)
+        _insert_entity(
+            session, package_id=pid, source_id=disabled_sid, name="Blinded"
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid), MechanicalEntityTypeEnum.CONDITION, "Blinded"
+        )
+        assert result is None
+
+    def test_no_enabled_sources_returns_empty_chunks(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        disabled_sid = _insert_source(session, package_id=pid, is_enabled=False)
+        _insert_chunk(session, package_id=pid, source_id=disabled_sid)
+        session.commit()
+        result = svc.get_chunks_by_subsystem(UUID(pid), RuleSubsystemEnum.COMBAT)
+        assert result.chunks == []
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-006: Override non-mutation — source records unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideNonMutation:
+    def test_original_chunk_row_unchanged_after_override(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Original."
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="replace",
+            payload={"content": "Replaced."},
+        )
+        session.commit()
+        row = session.get(RuleChunkORM, cid)
+        assert row is not None
+        assert row.content == "Original."
+
+    def test_chunk_model_carries_original_content(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Original."
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="replace",
+            payload={"content": "Replaced."},
+        )
+        session.commit()
+        result = svc.get_chunks_by_subsystem(UUID(pid), RuleSubsystemEnum.COMBAT)
+        assert len(result.chunks) == 1
+        assert result.chunks[0].content == "Original."
+
+    def test_active_rule_slice_applied_content_shows_replacement(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Original."
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="replace",
+            payload={"content": "Replaced."},
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert slice_.chunks[0].chunk.content == "Original."
+        assert slice_.chunks[0].applied_content == "Replaced."
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-007: Override precedence
+# ---------------------------------------------------------------------------
+
+
+class TestOverridePrecedence:
+    def test_overrides_applied_in_ascending_precedence_order(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Base."
+        )
+        # Insert higher precedence first to verify sorting, not insertion order
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " Two"},
+            precedence=2,
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="replace",
+            payload={"content": "One"},
+            precedence=1,
+        )
+        session.commit()
+        # precedence=1 replace: "Base." → "One"
+        # precedence=2 append:  "One" → "One Two"
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert slice_.chunks[0].applied_content == "One Two"
+
+    def test_disable_override_stops_further_processing(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Base."
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="disable",
+            payload={"content": None},
+            precedence=1,
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " MUST NOT APPEAR"},
+            precedence=2,
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert slice_.chunks[0].is_disabled is True
+        assert slice_.chunks[0].applied_content == ""
+        # Disable override was applied; append override was not
+        assert len(slice_.chunks[0].override_ids_applied) == 1
+
+    def test_disabled_override_row_is_skipped(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Base."
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="replace",
+            payload={"content": "Should not appear."},
+            precedence=1,
+            is_enabled=False,
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert slice_.chunks[0].applied_content == "Base."
+        assert slice_.chunks[0].override_ids_applied == []
+
+    def test_append_override_adds_to_content(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(
+            session, package_id=pid, source_id=sid, content="Base."
+        )
+        _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " Addendum."},
+            precedence=1,
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert slice_.chunks[0].applied_content == "Base. Addendum."
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-010: get_active_rule_slice
+# ---------------------------------------------------------------------------
+
+
+class TestGetActiveRuleSlice:
+    def test_returns_chunks_for_requested_subsystems_only(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        _insert_chunk(
+            session,
+            package_id=pid,
+            source_id=sid,
+            subsystem="combat",
+            content="Combat rule.",
+        )
+        _insert_chunk(
+            session,
+            package_id=pid,
+            source_id=sid,
+            subsystem="spells",
+            content="Spell rule.",
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert len(slice_.chunks) == 1
+        assert slice_.chunks[0].chunk.content == "Combat rule."
+
+    def test_returns_entities_for_requested_refs(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid,
+            entity_type="condition",
+            name="Blinded",
+            structured_data={"effects": ["Cannot see"]},
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid),
+            [],
+            [(MechanicalEntityTypeEnum.CONDITION, "Blinded")],
+        )
+        assert len(slice_.entities) == 1
+        assert slice_.entities[0].entity.name == "Blinded"
+
+    def test_nonexistent_package_returns_empty_slice(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        slice_ = svc.get_active_rule_slice(
+            uuid4(), [RuleSubsystemEnum.COMBAT], []
+        )
+        assert slice_.chunks == []
+        assert slice_.entities == []
+
+    def test_missing_entity_ref_not_included(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        _insert_source(session, package_id=pid)
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid),
+            [],
+            [(MechanicalEntityTypeEnum.CONDITION, "Nonexistent")],
+        )
+        assert slice_.entities == []
+
+    def test_entity_overrides_recorded_in_applied_entity(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        eid = _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid,
+            entity_type="condition",
+            name="Blinded",
+        )
+        oid = _insert_override(
+            session,
+            package_id=pid,
+            target_entity_id=eid,
+            operation="replace",
+            payload={"content": "House-ruled description."},
+        )
+        session.commit()
+        slice_ = svc.get_active_rule_slice(
+            UUID(pid),
+            [],
+            [(MechanicalEntityTypeEnum.CONDITION, "Blinded")],
+        )
+        assert len(slice_.entities) == 1
+        assert UUID(oid) in slice_.entities[0].override_ids_applied
+
+
+# ---------------------------------------------------------------------------
+# AC-RP-011: get_entity_by_type_and_name — scoping
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntityByTypeAndName:
+    def test_scoped_to_package(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid1 = _insert_package(session)
+        pid2 = _insert_package(session)
+        sid1 = _insert_source(session, package_id=pid1)
+        sid2 = _insert_source(session, package_id=pid2)
+        _insert_entity(
+            session,
+            package_id=pid1,
+            source_id=sid1,
+            name="Blinded",
+            entity_type="condition",
+            structured_data={"effects": ["pkg1"]},
+        )
+        _insert_entity(
+            session,
+            package_id=pid2,
+            source_id=sid2,
+            name="Blinded",
+            entity_type="condition",
+            structured_data={"effects": ["pkg2"]},
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid1), MechanicalEntityTypeEnum.CONDITION, "Blinded"
+        )
+        assert result is not None
+        assert isinstance(result.structured_data, ConditionEntity)
+        assert result.structured_data.effects == ["pkg1"]
+
+    def test_source_id_filter_resolves_ambiguity(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid1 = _insert_source(
+            session, package_id=pid, name="Source A", precedence_rank=1
+        )
+        sid2 = _insert_source(
+            session, package_id=pid, name="Source B", precedence_rank=2
+        )
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid1,
+            name="Blinded",
+            entity_type="condition",
+            structured_data={"effects": ["from_a"]},
+        )
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid2,
+            name="Blinded",
+            entity_type="condition",
+            structured_data={"effects": ["from_b"]},
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid),
+            MechanicalEntityTypeEnum.CONDITION,
+            "Blinded",
+            source_id=UUID(sid2),
+        )
+        assert result is not None
+        assert isinstance(result.structured_data, ConditionEntity)
+        assert result.structured_data.effects == ["from_b"]
+
+    def test_disabled_entity_not_returned(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid,
+            name="Blinded",
+            entity_type="condition",
+            is_enabled=False,
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid), MechanicalEntityTypeEnum.CONDITION, "Blinded"
+        )
+        assert result is None
+
+    def test_wrong_entity_type_returns_none(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid,
+            name="Blinded",
+            entity_type="condition",
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid), MechanicalEntityTypeEnum.SPELL, "Blinded"
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_package_by_id — sources are included and ordered by precedence
+# ---------------------------------------------------------------------------
+
+
+class TestGetPackageById:
+    def test_returns_sources_ordered_by_precedence(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        _insert_source(
+            session, package_id=pid, name="Supplement", precedence_rank=2
+        )
+        _insert_source(
+            session, package_id=pid, name="Core Rulebook", precedence_rank=1
+        )
+        session.commit()
+        result = svc.get_package_by_id(UUID(pid))
+        assert result is not None
+        assert [s.name for s in result.sources] == ["Core Rulebook", "Supplement"]
+
+    def test_nonexistent_package_returns_none(
+        self, svc: RulesPackageService
+    ) -> None:
+        assert svc.get_package_by_id(uuid4()) is None
+
+    def test_overrides_for_chunk_ordered_by_precedence(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(session, package_id=pid, source_id=sid)
+        oid1 = _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " B"},
+            precedence=2,
+        )
+        oid2 = _insert_override(
+            session,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " A"},
+            precedence=1,
+        )
+        session.commit()
+        overrides = svc.get_overrides_for_chunk(UUID(cid))
+        assert [str(o.override_id) for o in overrides] == [oid2, oid1]

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -48,8 +48,10 @@ from afterworlds.persistence.orm.rules_package import (
     RuleSourceORM,
     RulesPackageORM,
 )
-from afterworlds.services.rules_package import RulesPackageService, _deserialize_entity_data
-
+from afterworlds.services.rules_package import (
+    RulesPackageService,
+    _deserialize_entity_data,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers — direct ORM row inserts for test setup
@@ -231,9 +233,9 @@ class TestRpTablePrefix:
             "rp_overrides",
         }
         actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
-        assert expected == actual, (
-            f"Expected rp_* tables: {sorted(expected)}\nFound: {sorted(actual)}"
-        )
+        assert (
+            expected == actual
+        ), f"Expected rp_* tables: {sorted(expected)}\nFound: {sorted(actual)}"
 
 
 # ---------------------------------------------------------------------------
@@ -268,15 +270,15 @@ class TestRpFkSeparation:
 class TestSourceProvenance:
     def test_chunk_source_id_is_non_nullable(self) -> None:
         col = RuleChunkORM.__table__.c["source_id"]
-        assert not col.nullable, (
-            "source_id on rp_chunks must be non-nullable (ADR-0008)"
-        )
+        assert (
+            not col.nullable
+        ), "source_id on rp_chunks must be non-nullable (ADR-0008)"
 
     def test_entity_source_id_is_non_nullable(self) -> None:
         col = MechanicalEntityORM.__table__.c["source_id"]
-        assert not col.nullable, (
-            "source_id on rp_mechanical_entities must be non-nullable (ADR-0008)"
-        )
+        assert (
+            not col.nullable
+        ), "source_id on rp_mechanical_entities must be non-nullable (ADR-0008)"
 
 
 # ---------------------------------------------------------------------------
@@ -323,9 +325,7 @@ class TestRuleOverrideTargetConstraintPydantic:
 
 
 class TestRuleOverrideTargetConstraintDb:
-    def test_db_check_constraint_rejects_both_targets(
-        self, session: Session
-    ) -> None:
+    def test_db_check_constraint_rejects_both_targets(self, session: Session) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
         cid = _insert_chunk(session, package_id=pid, source_id=sid)
@@ -348,9 +348,7 @@ class TestRuleOverrideTargetConstraintDb:
             )
             session.commit()
 
-    def test_db_check_constraint_rejects_no_target(
-        self, session: Session
-    ) -> None:
+    def test_db_check_constraint_rejects_no_target(self, session: Session) -> None:
         pid = _insert_package(session)
         session.commit()
         with pytest.raises(sa.exc.IntegrityError):
@@ -456,9 +454,9 @@ class TestEntityTypeModels:
         }
         covered_types = set(type_to_data.keys())
         all_types = set(MechanicalEntityTypeEnum)
-        assert covered_types == all_types, (
-            f"Missing coverage for: {all_types - covered_types}"
-        )
+        assert (
+            covered_types == all_types
+        ), f"Missing coverage for: {all_types - covered_types}"
         for etype, data in type_to_data.items():
             result = _deserialize_entity_data(etype, data)
             assert result is not None
@@ -473,9 +471,7 @@ class TestPublicationLifecycle:
     def test_draft_package_not_surfaced_at_play_time(
         self, session: Session, svc: RulesPackageService
     ) -> None:
-        pid = _insert_package(
-            session, publication_status="draft", published_at=None
-        )
+        pid = _insert_package(session, publication_status="draft", published_at=None)
         session.commit()
         assert svc.get_package_by_id(UUID(pid)) is None
 
@@ -498,9 +494,7 @@ class TestPublicationLifecycle:
     def test_draft_accessible_with_include_non_published(
         self, session: Session, svc: RulesPackageService
     ) -> None:
-        pid = _insert_package(
-            session, publication_status="draft", published_at=None
-        )
+        pid = _insert_package(session, publication_status="draft", published_at=None)
         session.commit()
         result = svc.get_package_by_id(UUID(pid), include_non_published=True)
         assert result is not None
@@ -509,9 +503,7 @@ class TestPublicationLifecycle:
     def test_disabled_package_never_surfaced(
         self, session: Session, svc: RulesPackageService
     ) -> None:
-        pid = _insert_package(
-            session, is_enabled=False, publication_status="published"
-        )
+        pid = _insert_package(session, is_enabled=False, publication_status="published")
         session.commit()
         assert svc.get_package_by_id(UUID(pid)) is None
         assert svc.get_package_by_id(UUID(pid), include_non_published=True) is None
@@ -519,9 +511,7 @@ class TestPublicationLifecycle:
     def test_draft_chunks_not_surfaced_at_play_time(
         self, session: Session, svc: RulesPackageService
     ) -> None:
-        pid = _insert_package(
-            session, publication_status="draft", published_at=None
-        )
+        pid = _insert_package(session, publication_status="draft", published_at=None)
         sid = _insert_source(session, package_id=pid)
         _insert_chunk(session, package_id=pid, source_id=sid)
         session.commit()
@@ -575,9 +565,7 @@ class TestSourceMembership:
     ) -> None:
         pid = _insert_package(session)
         disabled_sid = _insert_source(session, package_id=pid, is_enabled=False)
-        _insert_entity(
-            session, package_id=pid, source_id=disabled_sid, name="Blinded"
-        )
+        _insert_entity(session, package_id=pid, source_id=disabled_sid, name="Blinded")
         session.commit()
         result = svc.get_entity_by_type_and_name(
             UUID(pid), MechanicalEntityTypeEnum.CONDITION, "Blinded"
@@ -606,9 +594,7 @@ class TestOverrideNonMutation:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Original."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Original.")
         _insert_override(
             session,
             package_id=pid,
@@ -626,9 +612,7 @@ class TestOverrideNonMutation:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Original."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Original.")
         _insert_override(
             session,
             package_id=pid,
@@ -646,9 +630,7 @@ class TestOverrideNonMutation:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Original."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Original.")
         _insert_override(
             session,
             package_id=pid,
@@ -657,9 +639,7 @@ class TestOverrideNonMutation:
             payload={"content": "Replaced."},
         )
         session.commit()
-        slice_ = svc.get_active_rule_slice(
-            UUID(pid), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(UUID(pid), [RuleSubsystemEnum.COMBAT], [])
         assert slice_.chunks[0].chunk.content == "Original."
         assert slice_.chunks[0].applied_content == "Replaced."
 
@@ -675,9 +655,7 @@ class TestOverridePrecedence:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Base."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Base.")
         # Insert higher precedence first to verify sorting, not insertion order
         _insert_override(
             session,
@@ -698,9 +676,7 @@ class TestOverridePrecedence:
         session.commit()
         # precedence=1 replace: "Base." → "One"
         # precedence=2 append:  "One" → "One Two"
-        slice_ = svc.get_active_rule_slice(
-            UUID(pid), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(UUID(pid), [RuleSubsystemEnum.COMBAT], [])
         assert slice_.chunks[0].applied_content == "One Two"
 
     def test_disable_override_stops_further_processing(
@@ -708,9 +684,7 @@ class TestOverridePrecedence:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Base."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Base.")
         _insert_override(
             session,
             package_id=pid,
@@ -728,9 +702,7 @@ class TestOverridePrecedence:
             precedence=2,
         )
         session.commit()
-        slice_ = svc.get_active_rule_slice(
-            UUID(pid), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(UUID(pid), [RuleSubsystemEnum.COMBAT], [])
         assert slice_.chunks[0].is_disabled is True
         assert slice_.chunks[0].applied_content == ""
         # Disable override was applied; append override was not
@@ -741,9 +713,7 @@ class TestOverridePrecedence:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Base."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Base.")
         _insert_override(
             session,
             package_id=pid,
@@ -754,9 +724,7 @@ class TestOverridePrecedence:
             is_enabled=False,
         )
         session.commit()
-        slice_ = svc.get_active_rule_slice(
-            UUID(pid), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(UUID(pid), [RuleSubsystemEnum.COMBAT], [])
         assert slice_.chunks[0].applied_content == "Base."
         assert slice_.chunks[0].override_ids_applied == []
 
@@ -765,9 +733,7 @@ class TestOverridePrecedence:
     ) -> None:
         pid = _insert_package(session)
         sid = _insert_source(session, package_id=pid)
-        cid = _insert_chunk(
-            session, package_id=pid, source_id=sid, content="Base."
-        )
+        cid = _insert_chunk(session, package_id=pid, source_id=sid, content="Base.")
         _insert_override(
             session,
             package_id=pid,
@@ -777,9 +743,7 @@ class TestOverridePrecedence:
             precedence=1,
         )
         session.commit()
-        slice_ = svc.get_active_rule_slice(
-            UUID(pid), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(UUID(pid), [RuleSubsystemEnum.COMBAT], [])
         assert slice_.chunks[0].applied_content == "Base. Addendum."
 
 
@@ -809,9 +773,7 @@ class TestGetActiveRuleSlice:
             content="Spell rule.",
         )
         session.commit()
-        slice_ = svc.get_active_rule_slice(
-            UUID(pid), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(UUID(pid), [RuleSubsystemEnum.COMBAT], [])
         assert len(slice_.chunks) == 1
         assert slice_.chunks[0].chunk.content == "Combat rule."
 
@@ -840,9 +802,7 @@ class TestGetActiveRuleSlice:
     def test_nonexistent_package_returns_empty_slice(
         self, session: Session, svc: RulesPackageService
     ) -> None:
-        slice_ = svc.get_active_rule_slice(
-            uuid4(), [RuleSubsystemEnum.COMBAT], []
-        )
+        slice_ = svc.get_active_rule_slice(uuid4(), [RuleSubsystemEnum.COMBAT], [])
         assert slice_.chunks == []
         assert slice_.entities == []
 
@@ -1010,20 +970,14 @@ class TestGetPackageById:
         self, session: Session, svc: RulesPackageService
     ) -> None:
         pid = _insert_package(session)
-        _insert_source(
-            session, package_id=pid, name="Supplement", precedence_rank=2
-        )
-        _insert_source(
-            session, package_id=pid, name="Core Rulebook", precedence_rank=1
-        )
+        _insert_source(session, package_id=pid, name="Supplement", precedence_rank=2)
+        _insert_source(session, package_id=pid, name="Core Rulebook", precedence_rank=1)
         session.commit()
         result = svc.get_package_by_id(UUID(pid))
         assert result is not None
         assert [s.name for s in result.sources] == ["Core Rulebook", "Supplement"]
 
-    def test_nonexistent_package_returns_none(
-        self, svc: RulesPackageService
-    ) -> None:
+    def test_nonexistent_package_returns_none(self, svc: RulesPackageService) -> None:
         assert svc.get_package_by_id(uuid4()) is None
 
     def test_overrides_for_chunk_ordered_by_precedence(

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -1003,5 +1003,5 @@ class TestGetPackageById:
             precedence=1,
         )
         session.commit()
-        overrides = svc.get_overrides_for_chunk(UUID(cid))
+        overrides = svc.get_overrides_for_chunk(UUID(cid), UUID(pid))
         assert [str(o.override_id) for o in overrides] == [oid2, oid1]

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -1039,3 +1039,166 @@ class TestGetPackageById:
         session.commit()
         overrides = svc.get_overrides_for_chunk(UUID(cid), UUID(pid))
         assert [str(o.override_id) for o in overrides] == [oid2, oid1]
+
+
+# ---------------------------------------------------------------------------
+# Deterministic ordering — chunk list, entity resolution, override ordering
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicOrdering:
+    def test_chunks_ordered_by_source_precedence_then_chunk_id(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        """Chunks from lower precedence_rank sources appear first; within a
+        source, chunks are ordered by chunk_id for stable iteration."""
+        pid = _insert_package(session)
+        sid_low = _insert_source(
+            session, package_id=pid, name="Core", precedence_rank=1
+        )
+        sid_high = _insert_source(
+            session, package_id=pid, name="Supplement", precedence_rank=2
+        )
+        # Insert in reverse order to confirm ordering is not insertion-based.
+        cid_b = _insert_chunk(
+            session,
+            package_id=pid,
+            source_id=sid_low,
+            content="Core chunk B",
+            chunk_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        )
+        cid_a = _insert_chunk(
+            session,
+            package_id=pid,
+            source_id=sid_low,
+            content="Core chunk A",
+            chunk_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        )
+        cid_supp = _insert_chunk(
+            session, package_id=pid, source_id=sid_high, content="Supplement chunk"
+        )
+        session.commit()
+        result = svc.get_chunks_by_subsystem(UUID(pid), RuleSubsystemEnum.COMBAT)
+        ids = [str(c.chunk_id) for c in result.chunks]
+        # Core (rank 1) chunks before Supplement (rank 2); within Core, UUID order.
+        assert ids.index(cid_a) < ids.index(cid_b)
+        assert ids.index(cid_b) < ids.index(cid_supp)
+
+    def test_entity_resolution_tie_break_by_entity_id(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        """When two sources share the same precedence_rank, entity_id is the
+        stable tie-breaker — the lexicographically smaller entity_id wins."""
+        pid = _insert_package(session)
+        sid1 = _insert_source(
+            session, package_id=pid, name="Source A", precedence_rank=1
+        )
+        sid2 = _insert_source(
+            session, package_id=pid, name="Source B", precedence_rank=1
+        )
+        eid_first = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        eid_second = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid2,
+            name="Blinded",
+            entity_type="condition",
+            entity_id=eid_second,
+            structured_data={"effects": ["second"]},
+        )
+        _insert_entity(
+            session,
+            package_id=pid,
+            source_id=sid1,
+            name="Blinded",
+            entity_type="condition",
+            entity_id=eid_first,
+            structured_data={"effects": ["first"]},
+        )
+        session.commit()
+        result = svc.get_entity_by_type_and_name(
+            UUID(pid), MechanicalEntityTypeEnum.CONDITION, "Blinded"
+        )
+        assert result is not None
+        assert str(result.entity_id) == eid_first
+
+    def test_override_tie_break_by_override_id(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        """When two overrides share the same precedence, override_id is the
+        stable tie-breaker — lexicographically smaller override_id is applied
+        first."""
+        pid = _insert_package(session)
+        sid = _insert_source(session, package_id=pid)
+        cid = _insert_chunk(session, package_id=pid, source_id=sid)
+        oid_first = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        oid_second = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        _insert_override(
+            session,
+            override_id=oid_second,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " second"},
+            precedence=1,
+        )
+        _insert_override(
+            session,
+            override_id=oid_first,
+            package_id=pid,
+            target_chunk_id=cid,
+            operation="append",
+            payload={"content": " first"},
+            precedence=1,
+        )
+        session.commit()
+        overrides = svc.get_overrides_for_chunk(UUID(cid), UUID(pid))
+        assert [str(o.override_id) for o in overrides] == [oid_first, oid_second]
+
+
+# ---------------------------------------------------------------------------
+# Package-consistency constraints — schema-level enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPackageConsistencyConstraints:
+    def test_cross_package_chunk_override_rejected_by_schema(
+        self, session: Session
+    ) -> None:
+        """An override row whose rules_package_id does not match the targeted
+        chunk's rules_package_id must be rejected by the composite FK."""
+        pid_a = _insert_package(session, name="Package A")
+        pid_b = _insert_package(session, name="Package B")
+        _insert_source(session, package_id=pid_a)
+        sid_b = _insert_source(session, package_id=pid_b)
+        cid_b = _insert_chunk(session, package_id=pid_b, source_id=sid_b)
+        session.commit()
+        # Insert override belonging to pkg_A but targeting a chunk from pkg_B.
+        with pytest.raises(sa.exc.IntegrityError):
+            _insert_override(
+                session,
+                package_id=pid_a,
+                target_chunk_id=cid_b,
+            )
+            session.commit()
+
+    def test_cross_package_entity_override_rejected_by_schema(
+        self, session: Session
+    ) -> None:
+        """An override row whose rules_package_id does not match the targeted
+        entity's rules_package_id must be rejected by the composite FK."""
+        pid_a = _insert_package(session, name="Package A")
+        pid_b = _insert_package(session, name="Package B")
+        _insert_source(session, package_id=pid_a)
+        sid_b = _insert_source(session, package_id=pid_b)
+        eid_b = _insert_entity(session, package_id=pid_b, source_id=sid_b)
+        session.commit()
+        with pytest.raises(sa.exc.IntegrityError):
+            _insert_override(
+                session,
+                package_id=pid_a,
+                target_chunk_id=None,
+                target_entity_id=eid_b,
+            )
+            session.commit()

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -36,6 +36,7 @@ from afterworlds.models.rules_package import (
     ActionEntity,
     ConditionEntity,
     ItemEntity,
+    MechanicalEntity,
     RuleOverride,
     SpellEntity,
     StatBlockEntity,
@@ -1202,3 +1203,89 @@ class TestPackageConsistencyConstraints:
                 target_entity_id=eid_b,
             )
             session.commit()
+
+
+# ---------------------------------------------------------------------------
+# get_package_by_id — disabled sources excluded from returned detail
+# ---------------------------------------------------------------------------
+
+
+class TestGetPackageByIdDisabledSources:
+    def test_disabled_source_excluded_from_package_detail(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        """get_package_by_id must not include disabled sources in the returned
+        RulesPackageDetail.sources list."""
+        pid = _insert_package(session)
+        _insert_source(session, package_id=pid, name="Active Source", is_enabled=True)
+        _insert_source(
+            session, package_id=pid, name="Disabled Source", is_enabled=False
+        )
+        session.commit()
+
+        result = svc.get_package_by_id(UUID(pid))
+
+        assert result is not None
+        assert [s.name for s in result.sources] == ["Active Source"]
+
+    def test_package_with_all_sources_disabled_returns_empty_sources(
+        self, session: Session, svc: RulesPackageService
+    ) -> None:
+        """A package with every source disabled returns an empty sources list."""
+        pid = _insert_package(session)
+        _insert_source(session, package_id=pid, is_enabled=False)
+        session.commit()
+
+        result = svc.get_package_by_id(UUID(pid))
+
+        assert result is not None
+        assert result.sources == []
+
+
+# ---------------------------------------------------------------------------
+# MechanicalEntity — structured_data type must match entity_type
+# ---------------------------------------------------------------------------
+
+
+class TestMechanicalEntityTypeConsistency:
+    def test_mismatched_structured_data_raises(self) -> None:
+        """Constructing a MechanicalEntity with structured_data whose type does
+        not match entity_type must raise a ValidationError."""
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="does not match entity_type"):
+            MechanicalEntity(
+                rules_package_id=uuid4(),
+                source_id=uuid4(),
+                entity_type=MechanicalEntityTypeEnum.SPELL,
+                name="Fireball",
+                structured_data=ConditionEntity(effects=["burning"]),
+                source_document="PHB",
+                source_locator_type="page",
+                source_locator_value="241",
+                created_at=datetime.now(UTC),
+            )
+
+    def test_matching_structured_data_accepted(self) -> None:
+        """A MechanicalEntity with correctly typed structured_data must
+        construct without error."""
+        entity = MechanicalEntity(
+            rules_package_id=uuid4(),
+            source_id=uuid4(),
+            entity_type=MechanicalEntityTypeEnum.SPELL,
+            name="Fireball",
+            structured_data=SpellEntity(
+                casting_time="1 action",
+                range="150 feet",
+                duration="Instantaneous",
+                components=["V", "S", "M"],
+                effect_description="8d6 fire damage.",
+            ),
+            source_document="PHB",
+            source_locator_type="page",
+            source_locator_value="241",
+            created_at=datetime.now(UTC),
+        )
+        assert entity.entity_type == MechanicalEntityTypeEnum.SPELL
+        assert isinstance(entity.structured_data, SpellEntity)

--- a/tests/services/test_schema_separation_invariant.py
+++ b/tests/services/test_schema_separation_invariant.py
@@ -1,19 +1,24 @@
-"""CI invariant test: Story Bible tables are structurally separate from prose
-history tables.
+"""CI invariant tests: structural separation of Story Bible and Rules Package.
 
-Architecture invariant (Issue 4):
+Architecture invariant (CRD Issue 4):
   No ``sb_*`` table may carry a ForeignKey constraint that references any
   prose history table (nodes, turns, arcs, chapters).
 
   Story Bible tables reference ``stories`` (the top-level hierarchy) which
   is explicitly permitted.  Provenance references to turns are stored as
   plain strings — not FK constraints.
+
+Architecture invariant (CRD Issue 5a):
+  No ``rp_*`` table may carry a ForeignKey constraint that references any
+  non-``rp_*`` table.  Cross-subsystem references (e.g. character sheet
+  ``rules_package_id``) must use plain strings without FK constraints.
 """
 
 from __future__ import annotations
 
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401
 import afterworlds.persistence.orm.story  # noqa: F401
@@ -25,8 +30,14 @@ _PROSE_HISTORY_TABLES: frozenset[str] = frozenset(
     {"nodes", "turns", "arcs", "chapters"}
 )
 
-# All Story Bible table names carry this prefix.
+# Table prefix constants
 _SB_PREFIX = "sb_"
+_RP_PREFIX = "rp_"
+
+
+# ---------------------------------------------------------------------------
+# Story Bible structural invariants (CRD Issue 4)
+# ---------------------------------------------------------------------------
 
 
 def test_story_bible_tables_exist_with_sb_prefix() -> None:
@@ -107,3 +118,48 @@ def test_source_turn_id_is_not_a_fk_constraint() -> None:
             f"{table_name}.source_turn_id must not be a FK to turns; "
             "it is a plain provenance string."
         )
+
+
+# ---------------------------------------------------------------------------
+# Rules Package structural invariants (CRD Issue 5a)
+# ---------------------------------------------------------------------------
+
+
+def test_rules_package_tables_exist_with_rp_prefix() -> None:
+    """All five Rules Package tables must be registered with the rp_ prefix."""
+    expected = {
+        "rp_packages",
+        "rp_sources",
+        "rp_chunks",
+        "rp_mechanical_entities",
+        "rp_overrides",
+    }
+    actual = {name for name in Base.metadata.tables if name.startswith(_RP_PREFIX)}
+    assert (
+        expected == actual
+    ), f"Expected rp_* tables: {sorted(expected)}\nFound: {sorted(actual)}"
+
+
+def test_no_rp_table_fk_to_non_rp_tables() -> None:
+    """No rp_* table may carry a FK that references a non-rp_* table.
+
+    rp_* tables may reference other rp_* tables (intra-subsystem cohesion).
+    All cross-subsystem references must be plain strings without FK
+    constraints, preserving structural independence of the Rules Package.
+    """
+    violations: list[str] = []
+
+    for table_name, table in Base.metadata.tables.items():
+        if not table_name.startswith(_RP_PREFIX):
+            continue
+        for fk in table.foreign_keys:
+            target_table = fk.column.table.name
+            if not target_table.startswith(_RP_PREFIX):
+                violations.append(
+                    f"  {table_name}.{fk.parent.name} → {target_table}.{fk.column.name}"
+                )
+
+    assert not violations, (
+        "rp_* tables must not carry FK constraints to non-rp_* tables.\n"
+        "Violations found:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
Closes #54

## Summary

Implements CRD Issue 5a — Rules Package Schema and Data Model in full.

- **Enums** (`src/afterworlds/models/enums.py`): 8 new `StrEnum` classes — `RulesSystemEnum`, `PublicationStatusEnum`, `RuleSourceCategoryEnum`, `RuleSubsystemEnum`, `MechanicalEntityTypeEnum`, `OverrideOriginEnum`, `OverrideOperationEnum`, `SourceLocatorTypeEnum`.
- **Pydantic models** (`src/afterworlds/models/rules_package.py`): Full typed model layer — `RulesPackage`, `RulesPackageDetail`, `RuleSource`, `RuleChunk`, `MechanicalEntity`, `RuleOverride` (with `@model_validator` exactly-one-target constraint), five distinct entity data types (`SpellEntity`, `ConditionEntity`, `StatBlockEntity`, `ActionEntity`, `ItemEntity`), `ChunkOverridePayload`, and stable named service return types `ActiveRuleSlice`, `AppliedChunk`, `AppliedEntity`, `ChunksResult`.
- **ORM** (`src/afterworlds/persistence/orm/rules_package.py`): Five `rp_*` tables — `rp_packages`, `rp_sources`, `rp_chunks`, `rp_mechanical_entities`, `rp_overrides`. `rp_overrides` carries a DB CHECK constraint enforcing exactly-one-target. `source_id` is non-nullable on `rp_chunks` and `rp_mechanical_entities` (ADR-0008). All PKs `String(36)`, datetimes `String(64)`, structured entity data `sa.JSON`.
- **Service** (`src/afterworlds/services/rules_package.py`): Read-only service — `get_package_by_id`, `get_chunks_by_subsystem`, `get_entity_by_type_and_name`, `get_overrides_for_chunk`, `get_overrides_for_entity`, `get_active_rule_slice`. Play-time queries surface only published+enabled content. `include_non_published=True` opt-in for ingestion/admin use. Override layering (replace/append/disable in ascending precedence+id order) applied in `_apply_chunk_overrides`. Deterministic lookup only — no semantic search.
- **Migration** (`alembic/versions/0003_rules_package.py`): Creates all five `rp_*` tables; `revision="0003"`, `down_revision="0002"`.
- **Tests** (`tests/services/test_rules_package.py`): 45 tests covering all 11 acceptance criteria plus the full integrity/determinism hotspot (see Architecture Notes).
- **Schema separation invariants** (`tests/services/test_schema_separation_invariant.py`): Extended with two new CI invariant tests — `test_rules_package_tables_exist_with_rp_prefix` and `test_no_rp_table_fk_to_non_rp_tables`.
- **ADR-0007** (`docs/decisions/ADR-0007-rules-package-entity-patch-deferral.md`): Entity-targeting override structured patch shapes deferred; entity overrides carry `{"content": "..."}` payload only in this issue.
- **ADR-0008** (`docs/decisions/ADR-0008-rules-package-source-id-non-nullability.md`): `source_id` non-nullable on `rp_chunks` and `rp_mechanical_entities`; ingestion must assign a `RuleSource` before inserting chunks or entities.

## Architecture Notes

**No drift from design principles.** Specific invariants confirmed:

1. **Story Bible / Rules Package structural separation** — `rp_*` tables carry no FK to `sb_*` tables, story hierarchy tables (`stories`, `arcs`, `chapters`, `nodes`, `turns`), or session state. Intra-subsystem FKs are permitted and correct. CI invariant test enforces this mechanically.

2. **`rp_` prefix** — all five tables use the `rp_` prefix, machine-verifiable by CI test.

3. **Extractor proposes, does not write canon directly** — the service is read-only; write operations land in CRD Issue 5b.

4. **Stable prompt prefix / caching** — `ActiveRuleSlice` is the stable named Pydantic model the Context Builder (CRD Issue 8) will consume.

5. **`character_sheet.rules_package_id`** — already `sa.Text` (no FK), compatible with `rp_packages.rules_package_id`.

**Two ADRs introduced:** ADR-0007 (entity patch shape deferral) and ADR-0008 (source_id non-nullability).

### Hotspot audit — integrity and determinism defect class (commits after initial review)

A bundled Codex review triggered a full audit of the Rules Package ORM/service hotspot. Five concrete defects in the same family were identified and resolved:

| # | Location | Defect | Fix |
|---|---|---|---|
| 1 | `get_chunks_by_subsystem` | No `ORDER BY` — chunk list is non-deterministic; Context Builder (CRD Issue 8) depends on stable ordering | JOIN `RuleSourceORM`; order by `(precedence_rank, chunk_id)` |
| 2 | `get_entity_by_type_and_name` | No tie-breaker on equal `precedence_rank` — still non-deterministic when two sources share a rank | Add `entity_id` as secondary sort key |
| 3 | `get_overrides_for_chunk` | No tie-breaker on equal `precedence` — `_apply_chunk_overrides` application order is non-deterministic at equal precedence | Add `override_id` as secondary sort key |
| 4 | `get_overrides_for_entity` | Same as #3 | Same fix |
| 5 | `rp_overrides.target_chunk_id / target_entity_id` | Simple FK validated existence but not package membership — cross-package override target accepted at schema level | Add `UniqueConstraint(rules_package_id, chunk_id)` to `rp_chunks` and `UniqueConstraint(rules_package_id, entity_id)` to `rp_mechanical_entities`; replace simple FKs on `rp_overrides` with composite `ForeignKeyConstraint` so a cross-package target is rejected at the schema level. Service-level `rules_package_id` filter (from earlier fix) is retained as defence-in-depth. |

`get_active_rule_slice` chunk query receives the same JOIN + ORDER BY treatment as `get_chunks_by_subsystem`.

**Tests added for the hotspot:**
- `test_chunks_ordered_by_source_precedence_then_chunk_id`
- `test_entity_resolution_tie_break_by_entity_id`
- `test_override_tie_break_by_override_id`
- `test_cross_package_chunk_override_rejected_by_schema`
- `test_cross_package_entity_override_rejected_by_schema`

### Remaining classification — nothing merge-blocking

| Item | Classification | Notes |
|---|---|---|
| Should equal `precedence_rank` be prohibited per package? | Non-blocking improvement | Current fix (tie-break by `entity_id`) is correct and deterministic. Prohibiting via `UniqueConstraint(rules_package_id, precedence_rank)` would be a policy decision for the owner. Not required for correctness. |
| Should equal override `precedence` on the same target be prohibited? | Non-blocking improvement | Current fix (tie-break by `override_id`) is correct and deterministic. A uniqueness constraint would be a policy decision. Not required for correctness. |
| Entity override patch shape (`StatBlockPatch`, `SpellPatch`, etc.) | Known Unknown / deferred | Documented in ADR-0007. Deferred to the issue that first requires structured entity patching. No schema change needed when that issue lands. |
| Semantic retrieval (which chunks are relevant to a given turn) | Out of scope (CRD Issue 18) | `get_active_rule_slice` is deterministic tag-based lookup only, as specified in 5a. |

## Test plan

- [x] `pytest tests/services/test_rules_package.py` — 45 tests, all acceptance criteria + hotspot
- [x] `pytest tests/services/test_schema_separation_invariant.py` — CI invariants including rp_* separation
- [x] `mypy src/` — strict mode, zero issues
- [x] `black src/ tests/` — zero issues
- [x] `ruff check src/ tests/` — zero issues
- [x] `pip-audit` — dependency scan gate (runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)