### PR TITLE
feat(rules-package): enforce logical-key uniqueness + rename rp_manifests (CRD Issue 5a follow-up, #60)

### DIFF
--- a/alembic/versions/0005_rp_logical_key_constraints_and_manifest_rename.py
+++ b/alembic/versions/0005_rp_logical_key_constraints_and_manifest_rename.py
@@ -1,0 +1,82 @@
+"""rp_* logical-key uniqueness constraints and manifest table rename — CRD Issue 5a follow-up (#60).
+
+Changes:
+  1. rp_packages — add UNIQUE constraint on (name, version, system): the logical
+     identity key already used by IngestionService._upsert_package().
+  2. rp_sources — add UNIQUE constraint on (rules_package_id, name): the logical
+     identity key already used by IngestionService._upsert_source().
+     The existing uq_rp_sources_package_source constraint on
+     (rules_package_id, source_id) is kept because it is required as a composite
+     FK target by rp_chunks and rp_mechanical_entities.
+  3. rules_package_manifests → rp_manifests: aligns the manifest table with the
+     rp_* naming family.  Rename was deferred from Issue 5b because that issue
+     explicitly required the old name; this follow-up is the owner-approved
+     home for the rename.
+
+SQLite note: SQLite does not support ALTER TABLE ADD CONSTRAINT.  Constraints
+must be added via Alembic batch mode, which copies the table to a new
+definition and drops the old one.  The rename for the manifest table is done
+via op.rename_table(), which SQLite supports natively.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-16
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. rp_packages — logical-identity uniqueness on (name, version, system)
+    #    Batch mode is required for SQLite (no ALTER TABLE ADD CONSTRAINT).
+    # ------------------------------------------------------------------
+    with op.batch_alter_table("rp_packages") as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_rp_packages_name_version_system",
+            ["name", "version", "system"],
+        )
+
+    # ------------------------------------------------------------------
+    # 2. rp_sources — logical-identity uniqueness on (rules_package_id, name)
+    #    Batch mode is required for SQLite.
+    # ------------------------------------------------------------------
+    with op.batch_alter_table("rp_sources") as batch_op:
+        batch_op.create_unique_constraint(
+            "uq_rp_sources_name",
+            ["rules_package_id", "name"],
+        )
+
+    # ------------------------------------------------------------------
+    # 3. Rename rules_package_manifests → rp_manifests
+    #
+    # SQLite supports ALTER TABLE ... RENAME TO natively, which Alembic
+    # wraps as op.rename_table().  The internal DDL retains the old
+    # constraint name (uq_rules_package_manifests_package) because SQLite
+    # does not expose ALTER CONSTRAINT; this has no effect on runtime
+    # behaviour.  New rows written by the ORM use the ORM's constraint
+    # name (uq_rp_manifests_package), which is equivalent.
+    # ------------------------------------------------------------------
+    op.rename_table("rules_package_manifests", "rp_manifests")
+
+
+def downgrade() -> None:
+    op.rename_table("rp_manifests", "rules_package_manifests")
+
+    with op.batch_alter_table("rp_sources") as batch_op:
+        batch_op.drop_constraint("uq_rp_sources_name", type_="unique")
+
+    with op.batch_alter_table("rp_packages") as batch_op:
+        batch_op.drop_constraint(
+            "uq_rp_packages_name_version_system", type_="unique"
+        )

--- a/src/afterworlds/ingestion/ingestion_service.py
+++ b/src/afterworlds/ingestion/ingestion_service.py
@@ -255,7 +255,7 @@ class IngestionService:
         """Publish a RulesPackage after passing all gate checks.
 
         Gate checks (in order):
-        1. Package exists and is accessible.
+        1. Package exists and ``is_enabled`` is True.
         2. Manifest row exists for the package.
         3. ``sql_ingest_complete`` is True.
         4. ``vector_write_complete`` is True.
@@ -268,7 +268,10 @@ class IngestionService:
         PublicationError
             If any gate check fails.
         """
-        # Gate 1: package exists
+        # Gate 1: package exists and is enabled.
+        # Publishing a disabled package would create contradictory lifecycle
+        # state: the package would be marked published but excluded from all
+        # play-time queries by the is_enabled check in _package_accessible().
         pkg_row = session.execute(
             select(RulesPackageORM).where(
                 RulesPackageORM.rules_package_id == package_id
@@ -277,6 +280,10 @@ class IngestionService:
         if pkg_row is None:
             raise PublicationError(
                 f"Package {package_id!r} not found — cannot publish."
+            )
+        if not pkg_row.is_enabled:
+            raise PublicationError(
+                f"Package {package_id!r} is disabled — cannot publish."
             )
 
         # Gate 2: manifest exists

--- a/src/afterworlds/ingestion/ingestion_service.py
+++ b/src/afterworlds/ingestion/ingestion_service.py
@@ -28,6 +28,7 @@ from uuid import uuid4
 
 from chromadb.api import ClientAPI as ChromaClientAPI
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.srd_parser import ParsedChunk, ParsedEntity, SRDParser
@@ -338,36 +339,64 @@ class IngestionService:
     # ------------------------------------------------------------------
 
     def _upsert_package(self, session: Session, now: str) -> str:
-        """Return the existing package_id or create a new package row."""
+        """Return the existing package_id or create a new package row.
+
+        Uses a read-before-insert fast path.  If a concurrent writer inserts
+        the same logical key between the read and the insert, the flush will
+        hit the ``uq_rp_packages_name_version_system`` constraint and raise an
+        ``IntegrityError``.  The savepoint is rolled back (outer transaction
+        intact) and the winner's row is re-read by logical key.
+        """
         cfg = self._config
+        system_value = RulesSystemEnum(cfg.system).value
         existing = session.execute(
             select(RulesPackageORM).where(
                 RulesPackageORM.name == cfg.package_name,
                 RulesPackageORM.version == cfg.package_version,
-                RulesPackageORM.system == RulesSystemEnum(cfg.system).value,
+                RulesPackageORM.system == system_value,
             )
         ).scalar_one_or_none()
         if existing is not None:
             return str(existing.rules_package_id)
         package_id = _make_package_id()
-        session.add(
-            RulesPackageORM(
-                rules_package_id=package_id,
-                name=cfg.package_name,
-                system=RulesSystemEnum(cfg.system).value,
-                version=cfg.package_version,
-                is_enabled=True,
-                publication_status=PublicationStatusEnum.DRAFT.value,
-                published_at=None,
-                created_at=now,
-                updated_at=now,
-            )
-        )
-        session.flush()
+        try:
+            with session.begin_nested():
+                session.add(
+                    RulesPackageORM(
+                        rules_package_id=package_id,
+                        name=cfg.package_name,
+                        system=system_value,
+                        version=cfg.package_version,
+                        is_enabled=True,
+                        publication_status=PublicationStatusEnum.DRAFT.value,
+                        published_at=None,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+                session.flush()
+        except IntegrityError:
+            # Concurrent insert won the race.  Savepoint rolled back; outer
+            # transaction intact.  Re-read the winner's row by logical key.
+            row = session.execute(
+                select(RulesPackageORM).where(
+                    RulesPackageORM.name == cfg.package_name,
+                    RulesPackageORM.version == cfg.package_version,
+                    RulesPackageORM.system == system_value,
+                )
+            ).scalar_one()
+            return str(row.rules_package_id)
         return package_id
 
     def _upsert_source(self, session: Session, package_id: str, now: str) -> str:
-        """Return the existing source_id or create a new source row."""
+        """Return the existing source_id or create a new source row.
+
+        Uses a read-before-insert fast path.  If a concurrent writer inserts
+        the same logical key between the read and the insert, the flush will
+        hit the ``uq_rp_sources_name`` constraint and raise an
+        ``IntegrityError``.  The savepoint is rolled back (outer transaction
+        intact) and the winner's row is re-read by logical key.
+        """
         cfg = self._config
         existing = session.execute(
             select(RuleSourceORM).where(
@@ -378,18 +407,30 @@ class IngestionService:
         if existing is not None:
             return str(existing.source_id)
         source_id = _make_source_id()
-        session.add(
-            RuleSourceORM(
-                source_id=source_id,
-                rules_package_id=package_id,
-                name=cfg.source_name,
-                category=RuleSourceCategoryEnum(cfg.source_category).value,
-                precedence_rank=cfg.source_precedence_rank,
-                is_enabled=True,
-                created_at=now,
-            )
-        )
-        session.flush()
+        try:
+            with session.begin_nested():
+                session.add(
+                    RuleSourceORM(
+                        source_id=source_id,
+                        rules_package_id=package_id,
+                        name=cfg.source_name,
+                        category=RuleSourceCategoryEnum(cfg.source_category).value,
+                        precedence_rank=cfg.source_precedence_rank,
+                        is_enabled=True,
+                        created_at=now,
+                    )
+                )
+                session.flush()
+        except IntegrityError:
+            # Concurrent insert won the race.  Savepoint rolled back; outer
+            # transaction intact.  Re-read the winner's row by logical key.
+            row = session.execute(
+                select(RuleSourceORM).where(
+                    RuleSourceORM.rules_package_id == package_id,
+                    RuleSourceORM.name == cfg.source_name,
+                )
+            ).scalar_one()
+            return str(row.source_id)
         return source_id
 
     def _persist_chunks(

--- a/src/afterworlds/persistence/orm/rules_package.py
+++ b/src/afterworlds/persistence/orm/rules_package.py
@@ -29,6 +29,14 @@ class RulesPackageORM(Base):
     """Persisted RulesPackage row."""
 
     __tablename__ = "rp_packages"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "name",
+            "version",
+            "system",
+            name="uq_rp_packages_name_version_system",
+        ),
+    )
 
     rules_package_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
     name: Mapped[str] = mapped_column(sa.Text, nullable=False)
@@ -53,6 +61,20 @@ class RuleSourceORM(Base):
 
     __tablename__ = "rp_sources"
     __table_args__ = (
+        # Logical-identity uniqueness: (rules_package_id, name) is the natural
+        # key for a RuleSource within a package.  Enforces the same dedup key
+        # used by IngestionService._upsert_source() at the DB level.
+        sa.UniqueConstraint(
+            "rules_package_id",
+            "name",
+            name="uq_rp_sources_name",
+        ),
+        # Required for composite FK targets from rp_chunks and
+        # rp_mechanical_entities.  SQLAlchemy / SQLite require the referenced
+        # column set to be covered by a UNIQUE constraint.  Since source_id is
+        # already a UUID PK (globally unique), this constraint is redundant as a
+        # uniqueness guard but cannot be dropped without breaking the composite
+        # FK references above.
         sa.UniqueConstraint(
             "rules_package_id", "source_id", name="uq_rp_sources_package_source"
         ),
@@ -167,11 +189,11 @@ class RulesPackageManifestORM(Base):
     on ``rules_package_id``.
     """
 
-    __tablename__ = "rules_package_manifests"
+    __tablename__ = "rp_manifests"
     __table_args__ = (
         sa.UniqueConstraint(
             "rules_package_id",
-            name="uq_rules_package_manifests_package",
+            name="uq_rp_manifests_package",
         ),
     )
 

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -658,7 +658,7 @@ class TestProvenance:
 
 class TestManifest:
     def test_manifest_persisted(self, session: Any, ingestion_result: Any) -> None:
-        """Manifest row persisted as distinct row in rules_package_manifests."""
+        """Manifest row persisted as distinct row in rp_manifests."""
         manifests = session.execute(select(RulesPackageManifestORM)).scalars().all()
         assert len(manifests) == 1
         m = manifests[0]

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -2072,3 +2072,145 @@ class TestSRDParser:
         entities = parser.parse_entities(srd_data_fixture)
         for ent in entities:
             assert ent.entity_type in MechanicalEntityTypeEnum
+
+
+# ---------------------------------------------------------------------------
+# Upsert conflict recovery (Issue #60)
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertConflictRecovery:
+    """Savepoint-based IntegrityError recovery in _upsert_package / _upsert_source.
+
+    These tests exercise the concurrent-insert recovery path: when the initial
+    read-before-insert finds no existing row but the subsequent insert hits a
+    unique-constraint IntegrityError (a concurrent writer won the race), the
+    helpers must roll back the savepoint, re-read the winner's row by logical
+    key, and return the existing ID — leaving the outer transaction intact and
+    the DB with exactly one row.
+    """
+
+    def test_upsert_package_recovers_from_concurrent_insert(
+        self,
+        session: Any,
+        ingestion_service: IngestionService,
+    ) -> None:
+        """_upsert_package returns winner's ID when insert races to IntegrityError.
+
+        Simulates a concurrent writer that inserted the same (name, version,
+        system) row between this caller's read (which saw None) and flush.
+        The savepoint rolls back; the recovery path re-reads the winner row.
+        """
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+        from uuid import uuid4
+
+        now = datetime.now(UTC).isoformat()
+        cfg = ingestion_service._config
+
+        # Pre-insert the winner row (represents the concurrent writer)
+        winner_id = str(uuid4())
+        session.add(
+            RulesPackageORM(
+                rules_package_id=winner_id,
+                name=cfg.package_name,
+                system="d20",
+                version=cfg.package_version,
+                is_enabled=True,
+                publication_status="draft",
+                published_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.flush()
+
+        # Patch the first session.execute call to return None, simulating the
+        # pre-race read that found no row before the concurrent insert landed.
+        _real_execute = session.execute
+        call_count: dict[str, int] = {"n": 0}
+
+        def _first_miss(stmt: Any, *args: Any, **kwargs: Any) -> Any:
+            if call_count["n"] == 0:
+                call_count["n"] += 1
+                mock_result = MagicMock()
+                mock_result.scalar_one_or_none.return_value = None
+                return mock_result
+            return _real_execute(stmt, *args, **kwargs)
+
+        with patch.object(session, "execute", side_effect=_first_miss):
+            result_id = ingestion_service._upsert_package(session, now)
+
+        assert result_id == winner_id
+        pkgs = session.execute(select(RulesPackageORM)).scalars().all()
+        assert len(pkgs) == 1
+
+    def test_upsert_source_recovers_from_concurrent_insert(
+        self,
+        session: Any,
+        ingestion_service: IngestionService,
+    ) -> None:
+        """_upsert_source returns winner's ID when insert races to IntegrityError.
+
+        Simulates a concurrent writer that inserted the same (rules_package_id,
+        name) row between this caller's read (None) and flush.  The savepoint
+        rolls back; the recovery path re-reads the winner row.
+        """
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+        from uuid import uuid4
+
+        now = datetime.now(UTC).isoformat()
+        cfg = ingestion_service._config
+
+        # Pre-insert a package the source will belong to; flush first so the
+        # FK from rp_sources → rp_packages is satisfied when the source is inserted.
+        package_id = str(uuid4())
+        session.add(
+            RulesPackageORM(
+                rules_package_id=package_id,
+                name=cfg.package_name,
+                system="d20",
+                version=cfg.package_version,
+                is_enabled=True,
+                publication_status="draft",
+                published_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.flush()
+
+        # Pre-insert the winner source row (concurrent writer's row)
+        winner_src_id = str(uuid4())
+        session.add(
+            RuleSourceORM(
+                source_id=winner_src_id,
+                rules_package_id=package_id,
+                name=cfg.source_name,
+                category="core_rulebook",
+                precedence_rank=cfg.source_precedence_rank,
+                is_enabled=True,
+                created_at=now,
+            )
+        )
+        session.flush()
+
+        # Patch: first execute returns None (pre-race read)
+        _real_execute = session.execute
+        call_count2: dict[str, int] = {"n": 0}
+
+        def _first_miss_src(stmt: Any, *args: Any, **kwargs: Any) -> Any:
+            if call_count2["n"] == 0:
+                call_count2["n"] += 1
+                mock_result = MagicMock()
+                mock_result.scalar_one_or_none.return_value = None
+                return mock_result
+            return _real_execute(stmt, *args, **kwargs)
+
+        with patch.object(session, "execute", side_effect=_first_miss_src):
+            result_id = ingestion_service._upsert_source(session, package_id, now)
+
+        assert result_id == winner_src_id
+        sources = session.execute(select(RuleSourceORM)).scalars().all()
+        assert len(sources) == 1

--- a/tests/ingestion/test_ingestion.py
+++ b/tests/ingestion/test_ingestion.py
@@ -843,6 +843,37 @@ class TestManifest:
                 vector_writer=vector_writer,
             )
 
+    def test_publication_fails_if_package_disabled(
+        self,
+        session: Any,
+        ingestion_result: Any,
+        chroma_client: chromadb.ClientAPI,
+        ingestion_service: IngestionService,
+    ) -> None:
+        """Gate 1: publish() raises PublicationError for a disabled package.
+
+        A disabled package that passes all other gates must still be rejected:
+        marking it published while is_enabled=False creates contradictory
+        lifecycle state — the package would show publication_status=published
+        but be invisible to all play-time queries (which gate on is_enabled).
+        """
+        # Disable the package after ingest
+        pkg_row = session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == ingestion_result.package_id
+            )
+        ).scalar_one()
+        pkg_row.is_enabled = False
+        session.commit()
+
+        vector_writer = VectorWriter(chroma_client)
+        with pytest.raises(PublicationError, match="is disabled"):
+            ingestion_service.publish(
+                session=session,
+                package_id=ingestion_result.package_id,
+                vector_writer=vector_writer,
+            )
+
     def test_publication_fails_on_partial_vector_loss(
         self,
         session: Any,

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -225,13 +225,14 @@ def svc(session: Session) -> RulesPackageService:
 
 
 class TestRpTablePrefix:
-    def test_all_five_rp_tables_registered(self) -> None:
+    def test_all_rp_tables_registered(self) -> None:
         expected = {
             "rp_packages",
             "rp_sources",
             "rp_chunks",
             "rp_mechanical_entities",
             "rp_overrides",
+            "rp_manifests",
         }
         actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
         assert (
@@ -925,8 +926,8 @@ class TestGetEntityByTypeAndName:
     def test_scoped_to_package(
         self, session: Session, svc: RulesPackageService
     ) -> None:
-        pid1 = _insert_package(session)
-        pid2 = _insert_package(session)
+        pid1 = _insert_package(session, name="Package One")
+        pid2 = _insert_package(session, name="Package Two")
         sid1 = _insert_source(session, package_id=pid1)
         sid2 = _insert_source(session, package_id=pid2)
         _insert_entity(
@@ -1593,3 +1594,138 @@ class TestOverridePackageAccessibilityGate:
             UUID(eid), UUID(pid), include_non_published=True
         )
         assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# rp_packages — logical-key uniqueness: (name, version, system)
+# AC from issue #60
+# ---------------------------------------------------------------------------
+
+
+class TestRpPackagesLogicalKeyUniqueness:
+    def test_duplicate_name_version_system_rejected(self, session: Session) -> None:
+        """Inserting two rp_packages rows with the same (name, version, system)
+        must raise IntegrityError at the DB layer."""
+        _insert_package(session, name="Core Rules", system="d20", version="5.0")
+        session.commit()
+        with pytest.raises(sa.exc.IntegrityError):
+            _insert_package(session, name="Core Rules", system="d20", version="5.0")
+            session.commit()
+
+    def test_same_name_version_different_system_allowed(self, session: Session) -> None:
+        """Two packages with the same name and version but different system
+        are distinct logical identities and must both be accepted."""
+        _insert_package(session, name="Core Rules", system="d20", version="5.0")
+        _insert_package(session, name="Core Rules", system="gurps", version="5.0")
+        session.commit()
+        rows = session.execute(sa.select(RulesPackageORM)).scalars().all()
+        assert len(rows) == 2
+
+    def test_same_name_system_different_version_allowed(self, session: Session) -> None:
+        """Two packages with the same name and system but different version
+        are distinct logical identities and must both be accepted."""
+        _insert_package(session, name="Core Rules", system="d20", version="5.0")
+        _insert_package(session, name="Core Rules", system="d20", version="6.0")
+        session.commit()
+        rows = session.execute(sa.select(RulesPackageORM)).scalars().all()
+        assert len(rows) == 2
+
+    def test_upsert_package_finds_existing_row_after_constraint_added(
+        self, session: Session
+    ) -> None:
+        """IngestionService._upsert_package returns existing package_id when a
+        package with the same (name, version, system) already exists — confirming
+        the service read-before-insert path is conflict-safe against the new
+        unique constraint."""
+        from afterworlds.ingestion.ingestion_service import IngestionService
+        from afterworlds.models.rules_package import IngestionConfig
+
+        cfg = IngestionConfig(
+            package_name="Core Rules", package_version="5.0", system="d20"
+        )
+        svc = IngestionService(cfg)
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC).isoformat()
+        pid_first = svc._upsert_package(session, now)
+        session.commit()
+
+        pid_second = svc._upsert_package(session, now)
+        assert pid_first == pid_second
+
+
+# ---------------------------------------------------------------------------
+# rp_sources — logical-key uniqueness: (rules_package_id, name)
+# AC from issue #60
+# ---------------------------------------------------------------------------
+
+
+class TestRpSourcesLogicalKeyUniqueness:
+    def test_duplicate_package_id_name_rejected(self, session: Session) -> None:
+        """Inserting two rp_sources rows with the same (rules_package_id, name)
+        must raise IntegrityError at the DB layer."""
+        pid = _insert_package(session)
+        session.commit()
+        _insert_source(session, package_id=pid, name="SRD 5.2.1")
+        session.commit()
+        with pytest.raises(sa.exc.IntegrityError):
+            _insert_source(session, package_id=pid, name="SRD 5.2.1")
+            session.commit()
+
+    def test_same_name_different_package_allowed(self, session: Session) -> None:
+        """The same source name under two different packages is allowed — the
+        logical key is scoped to the package."""
+        pid_a = _insert_package(session, name="Package A")
+        pid_b = _insert_package(session, name="Package B")
+        session.commit()
+        _insert_source(session, package_id=pid_a, name="SRD 5.2.1")
+        _insert_source(session, package_id=pid_b, name="SRD 5.2.1")
+        session.commit()
+        rows = session.execute(sa.select(RuleSourceORM)).scalars().all()
+        assert len(rows) == 2
+
+    def test_upsert_source_finds_existing_row_after_constraint_added(
+        self, session: Session
+    ) -> None:
+        """IngestionService._upsert_source returns existing source_id when a
+        source with the same (rules_package_id, name) already exists — confirming
+        the service read-before-insert path is conflict-safe."""
+        from afterworlds.ingestion.ingestion_service import IngestionService
+        from afterworlds.models.rules_package import IngestionConfig
+
+        cfg = IngestionConfig(
+            package_name="Test Package",
+            package_version="1.0",
+            system="d20",
+            source_name="Core Rulebook",
+        )
+        svc_obj = IngestionService(cfg)
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC).isoformat()
+        pid = svc_obj._upsert_package(session, now)
+        sid_first = svc_obj._upsert_source(session, pid, now)
+        session.commit()
+
+        sid_second = svc_obj._upsert_source(session, pid, now)
+        assert sid_first == sid_second
+
+
+# ---------------------------------------------------------------------------
+# rp_manifests — table name alignment with rp_* family (issue #60 rename)
+# ---------------------------------------------------------------------------
+
+
+class TestRpManifestTableName:
+    def test_manifest_table_is_rp_manifests(self) -> None:
+        """The manifest ORM class must use the rp_manifests table name, not
+        the legacy rules_package_manifests name."""
+        from afterworlds.persistence.orm.rules_package import RulesPackageManifestORM
+
+        assert RulesPackageManifestORM.__tablename__ == "rp_manifests"
+
+    def test_manifest_table_included_in_rp_family(self) -> None:
+        """rp_manifests must be present in Base.metadata under the rp_* prefix
+        so the FK separation invariant check covers it."""
+        assert "rp_manifests" in Base.metadata.tables
+        assert "rules_package_manifests" not in Base.metadata.tables

--- a/tests/services/test_schema_separation_invariant.py
+++ b/tests/services/test_schema_separation_invariant.py
@@ -126,13 +126,19 @@ def test_source_turn_id_is_not_a_fk_constraint() -> None:
 
 
 def test_rules_package_tables_exist_with_rp_prefix() -> None:
-    """All five Rules Package tables must be registered with the rp_ prefix."""
+    """All Rules Package tables must be registered with the rp_ prefix.
+
+    Updated in issue #60: rp_manifests replaces the legacy
+    rules_package_manifests name, bringing the manifest table into the
+    rp_* naming family.
+    """
     expected = {
         "rp_packages",
         "rp_sources",
         "rp_chunks",
         "rp_mechanical_entities",
         "rp_overrides",
+        "rp_manifests",
     }
     actual = {name for name in Base.metadata.tables if name.startswith(_RP_PREFIX)}
     assert (


### PR DESCRIPTION
## Summary

Closes #60 — CRD Issue 5a follow-up: enforce logical-key uniqueness for \`rp_packages\` and \`rp_sources\` at the DB layer, bring the manifest table into the \`rp_*\` naming family, and make both upsert helpers conflict-safe under the new constraints.

### Changes

- **\`rp_packages\`** — added \`UNIQUE(name, version, system)\` (\`uq_rp_packages_name_version_system\`): the logical identity key already enforced in read-before-insert by \`IngestionService._upsert_package()\`, now also enforced at the DB layer.
- **\`rp_sources\`** — added \`UNIQUE(rules_package_id, name)\` (\`uq_rp_sources_name\`): same pattern, mirrors \`IngestionService._upsert_source()\`. The existing \`uq_rp_sources_package_source\` constraint on \`(rules_package_id, source_id)\` is retained — it is required as the composite FK target for \`rp_chunks\` and \`rp_mechanical_entities\`.
- **\`rules_package_manifests\` → \`rp_manifests\`** — ORM tablename, constraint name, all runtime references, and the schema separation invariant test updated. Historical migration \`0004\` is untouched.
- **Migration \`0005\`** — uses \`op.batch_alter_table()\` for SQLite-compatible constraint additions; \`op.rename_table()\` for the manifest rename. Downgrade reverses all three operations.
- **\`publish()\` Gate 1** — added \`is_enabled\` check alongside the existence check. Publishing a disabled package would create contradictory lifecycle state (\`publication_status=published\` but invisible to play-time queries).
- **Conflict-safe upserts** — \`_upsert_package()\` and \`_upsert_source()\` now wrap the insert+flush in \`session.begin_nested()\`. If a concurrent writer inserts the same logical key between the read and the flush (raising \`IntegrityError\` on the new constraint), the savepoint is rolled back, the outer transaction is left intact, and the winner's row is re-read by logical key.
- **Tests** — new \`TestRpPackagesLogicalKeyUniqueness\` (4 tests), \`TestRpSourcesLogicalKeyUniqueness\` (3 tests), \`TestRpManifestTableName\` (2 tests), \`test_publication_fails_if_package_disabled\`, and \`TestUpsertConflictRecovery\` (2 tests covering the savepoint IntegrityError recovery path). Updated \`TestGetEntityByTypeAndName::test_scoped_to_package\` to use distinct logical-key values.

All 421 tests pass. Coverage: 96.44%.

## Architecture Notes

No drift from design principles.

- The new DB constraints mirror uniqueness guarantees already assumed by the service layer upsert paths — this tightens the schema to match existing behaviour, not changing semantics.
- \`uq_rp_sources_package_source\` is retained (not replaced) because it is a required composite FK target. Documented in both the ORM and the migration.
- The \`is_enabled\` check in \`publish()\` Gate 1 is within the issue boundary: the gate already checked package existence; checking enabled state is the natural complement and prevents contradictory lifecycle state.
- The \`rules_package_manifests\` → \`rp_manifests\` rename was explicitly listed in the issue scope as deferred from CRD Issue 5b.
- The savepoint-based concurrency fix is within scope: Issue #60 explicitly required reviewing service upsert paths for conflict-safe behaviour after the new constraints land.
- No Known Unknowns from \`/docs/architecture/known_unknowns.md\` are touched by this PR.