### PR TITLE
feat(rolling-summary): CRD Issue 6 — Rolling Summary Service

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,6 +16,7 @@ import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.story_bible  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
+import afterworlds.persistence.orm.rolling_summary  # noqa: F401
 
 config = context.config
 

--- a/alembic/versions/0006_rolling_summary.py
+++ b/alembic/versions/0006_rolling_summary.py
@@ -1,0 +1,82 @@
+"""rolling_summaries table — CRD Issue 6.
+
+Creates the ``rolling_summaries`` table with:
+  - Coverage metadata columns: compressed_from_turn_id, compressed_through_turn_id
+    (both non-nullable FKs to turns.turn_id with RESTRICT on delete).
+  - version_number: monotonically increasing integer per story (starts at 1).
+  - is_current: boolean marking the single active row per story.
+  - UNIQUE constraint on (story_id, compressed_through_turn_id) — DB-layer
+    idempotency gate preventing duplicate coverage.
+  - Partial unique index on story_id WHERE is_current = 1 — SQLite-compatible
+    mechanism enforcing at most one current row per story.
+
+The partial index is created via op.execute() because Alembic's create_index()
+does not natively support a SQLite partial-index WHERE clause.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-17
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # rolling_summaries — compressed narrative history
+    # ------------------------------------------------------------------
+    op.create_table(
+        "rolling_summaries",
+        sa.Column("summary_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "story_id",
+            sa.String(36),
+            sa.ForeignKey("stories.story_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("text", sa.Text, nullable=False),
+        sa.Column(
+            "compressed_from_turn_id",
+            sa.String(36),
+            sa.ForeignKey("turns.turn_id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "compressed_through_turn_id",
+            sa.String(36),
+            sa.ForeignKey("turns.turn_id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("version_number", sa.Integer, nullable=False),
+        sa.Column("is_current", sa.Boolean, nullable=False, server_default="0"),
+        sa.Column("created_at", sa.String(64), nullable=False),
+        sa.UniqueConstraint(
+            "story_id",
+            "compressed_through_turn_id",
+            name="uq_rs_story_through_turn",
+        ),
+    )
+
+    # Partial unique index: at most one is_current = 1 row per story.
+    # SQLite supports partial indexes natively.  Alembic's create_index()
+    # does not accept a WHERE clause for SQLite, so op.execute() is used.
+    op.execute(
+        "CREATE UNIQUE INDEX uq_rs_current_per_story "
+        "ON rolling_summaries (story_id) "
+        "WHERE is_current = 1"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_rs_current_per_story")
+    op.drop_table("rolling_summaries")

--- a/docs/architecture/known_unknowns.md
+++ b/docs/architecture/known_unknowns.md
@@ -28,6 +28,7 @@ These were open questions during design. Decisions are recorded here for traceab
 | Business model and pricing | Metered hosted subscription with credits + BYOK perpetual license + first-year Cloud Services | See Item 8 in CRD and Design doc Section 8 |
 | Story Bible schema | Committed | Static / dynamic / provisional partitions, Events Ledger, Locked/Forbidden Facts; see Issue 4 |
 | Events Ledger tiered inclusion N value | 15 (configurable constant) | Resolved during Issue 4. Implemented as `EVENTS_LEDGER_N = 15` in `services/story_bible.py`. Tune with testing. See ADR-0005. |
+| Rolling summary compression trigger value (N turns) | Provisional N = 10 (configurable constant); empirical finalization deferred to Issue 8 | Escape hatch invoked during Issue 6: Context Builder not yet wired; stable-prefix-pressure evidence unavailable. Implemented as `ROLLING_SUMMARY_N = 10` in `services/rolling_summary.py`. Must be finalized in Issue 8 — not deferred past Issue 8. See ADR-0009. |
 | Significance flagging criteria for Events Ledger | Seven-value enum; six qualify for always-include | Resolved during Issue 4. Always-include: CHARACTER_DEATH, LOCKED_FACT_ESTABLISHED, MAJOR_PLOT_TURN, RELATIONSHIP_CHANGE, WORLD_STATE_CHANGE, FORBIDDEN_FACT_ESTABLISHED. ROUTINE is the only non-always-include value. See ADR-0005. |
 | Mode prompt contracts | Written | Versioned .md files in `/docs/prompts/`; see Item 6 in CRD |
 | BYOK commercial structure | Perpetual license + first year of Cloud Services included; optional annual renewal thereafter | License and services must not be collapsed in code or UX language |
@@ -73,16 +74,6 @@ These are genuinely open. Each has a designated resolution window. Do not resolv
 **Why it's open:** Route design is best decided once the service layer is stable. Premature route definitions create churn if underlying service contracts change during Issues 2–11.
 
 **What resolution requires:** Define route naming conventions, versioning strategy (e.g., `/api/v1/`), request/response payload shapes for core operations (create story, submit turn, retrieve state). Document before implementation begins.
-
----
-
-### Rolling summary compression trigger value (N turns)
-
-**Resolve during:** Issue 6. Starting value: 10 turns.
-
-**Why it's open:** The right trigger depends on average turn length, Story Bible growth rate, and acceptable context window pressure — all of which are empirically determined. 10 is a reasonable starting point based on cost model assumptions but must be validated with testing.
-
-**What resolution requires:** During Issue 6, implement the trigger as a configurable value (not a hardcoded constant). Run representative test scenarios. Document the final chosen value and the test evidence in an ADR.
 
 ---
 

--- a/docs/decisions/ADR-0009-rolling-summary-n-value.md
+++ b/docs/decisions/ADR-0009-rolling-summary-n-value.md
@@ -1,0 +1,145 @@
+# ADR-0009 — Rolling Summary Compression Trigger Value N
+
+**Status:** Accepted (provisional — empirical finalization deferred to Issue 8)
+**Date:** 2026-04-17
+**Issue:** CRD Issue 6 — Rolling Summary Service (GitHub #63)
+**Resolves Known Unknown:** "Rolling summary compression trigger value (N turns)"
+
+---
+
+## Context
+
+The Rolling Summary memory layer is compressed every N turns.  N is a
+designated Known Unknown from `known_unknowns.md` with the following
+resolution rule:
+
+> **Default rule:** N should be resolved during Issue 6.
+>
+> **Escape hatch:** if Issue 6 cannot produce meaningful stable-prefix-pressure
+> evidence because the Context Builder integration does not yet exist, the ADR
+> must say so explicitly.  In that case, the ADR must record:
+> - the configurable mechanism,
+> - the provisional value of 10,
+> - the specific reason empirical finalization could not be completed in Issue 6,
+> - that empirical finalization is deferred to Issue 8 only.
+
+This ADR invokes the escape hatch.
+
+---
+
+## Decision
+
+**Provisional N = 10.**
+
+Implemented as the module-level constant:
+
+```python
+ROLLING_SUMMARY_N: int = 10
+```
+
+in `src/afterworlds/services/rolling_summary.py`.
+
+N is exposed as a configurable value, not a hardcoded literal.  The
+`should_compress(story_turn_count, n=ROLLING_SUMMARY_N)` helper accepts an
+explicit `n` argument, making the trigger configurable in tests and
+adjustable without code changes once a config layer exists.
+
+---
+
+## Why Empirical Finalization Cannot Be Completed in Issue 6
+
+The right trigger value for N depends on:
+
+1. **Stable-prefix budget pressure:** how many tokens the Rolling Summary
+   typically consumes relative to the Story Bible and system prompt.  This
+   requires the Context Builder (Issue 8) to be wired so that a real
+   stable-prefix assembly can be measured with representative content.
+
+2. **Turn length distribution at steady state:** what a "normal" turn looks
+   like in each mode (RPG action, Branching beat, Writing exchange).  This
+   data only accumulates once the Writer path (Issue 9) is producing real
+   output.
+
+3. **Cache window economics:** a summary that fires too frequently wastes
+   generation cost; one that fires too rarely causes the Immediate layer
+   (recent turns verbatim) to overflow the available prefix budget.  The
+   cost model in the CRD (Item 8) estimates the stable prefix at 5k–24k
+   tokens and the rolling summary component at roughly 500–1,200 tokens —
+   but these figures are estimates, not measured values.
+
+At Issue 6, none of this evidence exists:
+
+- The Context Builder does not exist; no stable prefix has ever been
+  assembled end-to-end.
+- No Writer path produces real turns; turn length distribution is unknown.
+- ChromaDB integration (Issue 18) is not yet wired; retrieval overhead is
+  not measurable.
+
+Choosing N = 10 is consistent with the known_unknowns.md starting value.
+It is *empirically unsettled*, and this ADR says so explicitly rather than
+pretending the value is validated.
+
+---
+
+## Configurable Mechanism
+
+`ROLLING_SUMMARY_N` is defined as a plain integer constant at module scope.
+Callers and tests can:
+
+1. Import and assert the current value: `from afterworlds.services.rolling_summary import ROLLING_SUMMARY_N`.
+2. Pass a different `n` to `should_compress(count, n=custom_n)` to test
+   trigger behavior at any threshold without patching global state.
+3. Override the module constant in integration tests or configuration shims
+   without any code change to the service internals.
+
+The value is intentionally not buried in a constructor argument — it is a
+single module-level constant that is the single source of truth for the
+default trigger, matching the pattern of `EVENTS_LEDGER_N` in
+`services/story_bible.py`.
+
+---
+
+## Deferred Finalization — Issue 8 Only
+
+Empirical finalization of N is deferred to **Issue 8 (Context Builder)**,
+where:
+
+- The stable prefix is assembled end-to-end for the first time.
+- Token budgets for each memory layer can be measured against real content.
+- Cache hit rates under different N values can be estimated from the
+  pipeline cost model.
+- The tradeoff between compression frequency and stable-prefix token
+  pressure can be observed directly.
+
+**N must not be further deferred to Issue 12 or later.**  The known_unknowns.md
+escape hatch explicitly prohibits deferral past Issue 8.
+
+---
+
+## Alternatives Considered
+
+**N = 5 (more frequent compression):**
+More frequent summaries keep the Immediate layer shorter, reducing volatile
+suffix size.  But more frequent generation calls add cost and may produce
+lower-quality summaries over short turn windows.  Insufficient evidence to
+prefer this without stable-prefix measurement.
+
+**N = 20 (less frequent compression):**
+Allows longer verbatim turn histories before compression, which may improve
+summary quality.  But risks stable-prefix bloat if the rolling summary
+balloons to cover many turns' worth of content.  Again, insufficient evidence.
+
+**Hardcoded constant (not configurable):**
+Rejected per the issue spec requirement: "implement N as a configurable
+value, not a hardcoded literal."
+
+---
+
+## Consequences
+
+- `ROLLING_SUMMARY_N = 10` is the active trigger value from Issue 6 onward.
+- Issue 8 (Context Builder) must measure stable-prefix pressure with N = 10
+  and produce an updated ADR entry or an amendment to this ADR if the value
+  needs adjustment.
+- `known_unknowns.md` is updated to move the N-value item from Open to
+  Resolved (with this escape-hatch deferral noted).

--- a/src/afterworlds/models/rolling_summary.py
+++ b/src/afterworlds/models/rolling_summary.py
@@ -1,0 +1,44 @@
+"""Pydantic models for the Rolling Summary memory layer.
+
+The Rolling Summary is one of the six memory layers.  It is a compressed,
+auto-updated narrative history that lives in the stable prefix alongside the
+Story Bible.  It is structurally separate from:
+
+- The Story Bible (structured canon).
+- Retrieval Memory (semantic vector store).
+- Immediate layer (recent turns verbatim).
+
+These models represent persisted summary rows.  The service layer
+(:mod:`afterworlds.services.rolling_summary`) is responsible for trigger
+logic, generation, and retrieval.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class RollingSummary(BaseModel):
+    """One persisted rolling summary row.
+
+    Each row covers a closed, non-overlapping range of turns
+    [``compressed_from_turn_id`` … ``compressed_through_turn_id``].
+
+    ``version_number`` increases monotonically per story starting at 1.
+    ``is_current`` marks the single active row for the story; only one row
+    per story may carry ``is_current = True`` at any time.
+
+    Rows are append-only — prior summaries are never overwritten in place.
+    """
+
+    summary_id: UUID = Field(default_factory=uuid4)
+    story_id: UUID
+    text: str
+    compressed_from_turn_id: UUID
+    compressed_through_turn_id: UUID
+    version_number: int
+    is_current: bool = False
+    created_at: datetime

--- a/src/afterworlds/persistence/orm/rolling_summary.py
+++ b/src/afterworlds/persistence/orm/rolling_summary.py
@@ -1,0 +1,62 @@
+"""ORM model for the rolling_summaries table.
+
+ARCHITECTURE INVARIANT:
+  The rolling_summaries table is structurally separate from Story Bible tables
+  (prefix ``sb_``).  It carries no FK to any ``sb_*`` table.  It does carry
+  FKs to ``stories.story_id`` (the story hierarchy root) and to ``turns.turn_id``
+  (coverage anchors).  These are deliberate:
+
+  - ``story_id`` FK: every summary belongs to exactly one story.
+  - ``compressed_from_turn_id`` / ``compressed_through_turn_id`` FKs: each
+    summary's coverage range is anchored to real persisted Turn rows, making
+    coverage provenance readable from the row itself.
+
+Uniqueness constraints:
+  - ``(story_id, compressed_through_turn_id)`` — UNIQUE.  Prevents duplicate
+    coverage.  This is the DB-layer idempotency gate.
+  - One ``is_current = True`` row per story — enforced by a partial unique index
+    created in the Alembic migration via op.execute().  Service logic atomically
+    clears the previous current marker before setting the new one.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from afterworlds.persistence.orm.base import Base
+
+
+class RollingSummaryORM(Base):
+    """Persisted rolling summary row."""
+
+    __tablename__ = "rolling_summaries"
+
+    summary_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    story_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("stories.story_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    text: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    compressed_from_turn_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("turns.turn_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    compressed_through_turn_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("turns.turn_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    version_number: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    is_current: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=False)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "story_id",
+            "compressed_through_turn_id",
+            name="uq_rs_story_through_turn",
+        ),
+    )

--- a/src/afterworlds/persistence/orm/rolling_summary.py
+++ b/src/afterworlds/persistence/orm/rolling_summary.py
@@ -11,12 +11,15 @@ ARCHITECTURE INVARIANT:
     summary's coverage range is anchored to real persisted Turn rows, making
     coverage provenance readable from the row itself.
 
-Uniqueness constraints:
-  - ``(story_id, compressed_through_turn_id)`` — UNIQUE.  Prevents duplicate
-    coverage.  This is the DB-layer idempotency gate.
-  - One ``is_current = True`` row per story — enforced by a partial unique index
-    created in the Alembic migration via op.execute().  Service logic atomically
-    clears the previous current marker before setting the new one.
+Uniqueness constraints (enforced in both ORM metadata and Alembic migration):
+  - ``(story_id, compressed_through_turn_id)`` — UNIQUE (UniqueConstraint).
+    Prevents duplicate coverage.  This is the DB-layer idempotency gate.
+  - One ``is_current = True`` row per story — partial unique index on
+    ``(story_id) WHERE is_current = 1``.  Declared in ``__table_args__`` so
+    ``Base.metadata.create_all()`` enforces the same contract as the Alembic
+    migration path (migration 0006 mirrors this via op.execute()).  Service
+    logic atomically clears the previous current marker before setting the new
+    one so the index is never transiently violated within a single flush.
 """
 
 from __future__ import annotations
@@ -58,5 +61,15 @@ class RollingSummaryORM(Base):
             "story_id",
             "compressed_through_turn_id",
             name="uq_rs_story_through_turn",
+        ),
+        # Partial unique index: at most one is_current = True row per story.
+        # sqlite_where makes this a SQLite-native partial index so both the
+        # Alembic migration path (op.execute) and the create_all() path
+        # (used in tests) enforce the same constraint.
+        sa.Index(
+            "uq_rs_current_per_story",
+            "story_id",
+            unique=True,
+            sqlite_where=sa.text("is_current = 1"),
         ),
     )

--- a/src/afterworlds/services/rolling_summary.py
+++ b/src/afterworlds/services/rolling_summary.py
@@ -1,0 +1,276 @@
+"""Rolling Summary service — compression trigger, generation, and retrieval.
+
+This module implements the Rolling Summary memory layer (CRD Issue 6).
+
+The Rolling Summary is a compressed narrative history that fits within the
+stable prefix budget.  It sits between the Immediate layer (recent turns
+verbatim) and the Story Bible (structured canon):
+
+  Stable prefix:  [System + mode contract] [Story Bible] [Rolling summary]
+  Volatile suffix: [Recent turns verbatim] [Current input + intent]
+
+Design constraints from the issue spec:
+  - N is configurable (``ROLLING_SUMMARY_N``).  Start at 10.
+  - Summaries are append-only; prior rows are never overwritten.
+  - Idempotency is anchored to ``compressed_through_turn_id``, not to trigger
+    heuristics.  The DB enforces this via a UNIQUE constraint on
+    ``(story_id, compressed_through_turn_id)``.
+  - Exactly one row per story may be ``is_current = True`` at any time.
+    Enforced by a partial unique index (see migration 0006) and by service
+    logic that atomically clears the previous current marker.
+  - The summary generation callable is injected — no hardwired provider or
+    model.  For tests, a stub can be passed in.
+  - No prompt assembly, no Context Builder integration, no pipeline calls.
+
+N-value Known Unknown:
+  ``ROLLING_SUMMARY_N`` is the designated Known Unknown from
+  ``known_unknowns.md``.  Starting value is 10.  See ADR-0009 for the
+  escape-hatch rationale: empirical tuning requires the Context Builder
+  (Issue 8) and is deferred to that issue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from afterworlds.models.rolling_summary import RollingSummary
+from afterworlds.persistence.orm.rolling_summary import RollingSummaryORM
+
+# ---------------------------------------------------------------------------
+# Configurable constants
+# ---------------------------------------------------------------------------
+
+#: Compression trigger interval.  Every N turns, a new rolling summary is
+#: produced.  N = 10 is the starting value; tune with testing once the Context
+#: Builder (Issue 8) is in place.  See ADR-0009.
+ROLLING_SUMMARY_N: int = 10
+
+# ---------------------------------------------------------------------------
+# Generator type
+# ---------------------------------------------------------------------------
+
+#: Callable interface for the summary generator dependency.
+#:
+#: Arguments:
+#:   prior_summary (str | None): text of the current summary before this
+#:     compression, or None if this is the first compression for the story.
+#:   turn_texts (list[str]): ordered list of turn content strings for the
+#:     turns being compressed into this summary.
+#:
+#: Returns:
+#:   str: the generated summary text.
+SummaryGeneratorT = Callable[[str | None, list[str]], str]
+
+
+# ---------------------------------------------------------------------------
+# Trigger helper
+# ---------------------------------------------------------------------------
+
+
+def should_compress(story_turn_count: int, n: int = ROLLING_SUMMARY_N) -> bool:
+    """Return True if a compression should fire for the given total turn count.
+
+    Compression fires at multiples of N (N, 2N, 3N, …).  A count of zero
+    never triggers compression.
+
+    Args:
+        story_turn_count: total number of turns persisted for the story so far
+            (including the turn just added).
+        n: the compression interval.  Defaults to the module-level
+            ``ROLLING_SUMMARY_N`` constant.
+
+    Returns:
+        True if ``story_turn_count > 0`` and ``story_turn_count % n == 0``.
+    """
+    return story_turn_count > 0 and story_turn_count % n == 0
+
+
+# ---------------------------------------------------------------------------
+# ORM ↔ Pydantic conversion
+# ---------------------------------------------------------------------------
+
+
+def _orm_to_model(row: RollingSummaryORM) -> RollingSummary:
+    return RollingSummary(
+        summary_id=UUID(row.summary_id),
+        story_id=UUID(row.story_id),
+        text=row.text,
+        compressed_from_turn_id=UUID(row.compressed_from_turn_id),
+        compressed_through_turn_id=UUID(row.compressed_through_turn_id),
+        version_number=row.version_number,
+        is_current=row.is_current,
+        created_at=datetime.fromisoformat(row.created_at),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class RollingSummaryService:
+    """Service for the Rolling Summary memory layer.
+
+    Responsibilities:
+      - Compress a slice of turns into a new summary using an injected generator.
+      - Persist the new summary as an append-only row.
+      - Atomically manage the ``is_current`` marker.
+      - Retrieve the current summary or full history for a story.
+
+    Args:
+        session: SQLAlchemy session.
+        generator: callable that produces summary text from a prior summary
+            (or None) and a list of turn texts.  See :data:`SummaryGeneratorT`.
+    """
+
+    def __init__(self, session: Session, generator: SummaryGeneratorT) -> None:
+        self._session = session
+        self._generator = generator
+
+    # ------------------------------------------------------------------
+    # Compression
+    # ------------------------------------------------------------------
+
+    def compress(
+        self,
+        story_id: UUID,
+        from_turn_id: UUID,
+        through_turn_id: UUID,
+        turn_texts: list[str],
+    ) -> RollingSummary:
+        """Compress a turn slice into a new rolling summary.
+
+        Idempotent: if the current summary for this story already covers
+        ``through_turn_id``, the existing row is returned unchanged and the
+        generator is **not** called.  The DB unique constraint on
+        ``(story_id, compressed_through_turn_id)`` is the authoritative
+        idempotency gate; this service method also short-circuits on the
+        same condition before attempting a write.
+
+        The new row is inserted with ``is_current = True``.  The prior
+        current row (if any) is atomically flipped to ``is_current = False``
+        within the same flush so the DB partial unique index is never
+        transiently violated.
+
+        Args:
+            story_id: UUID of the story being compressed.
+            from_turn_id: UUID of the first Turn in the slice.
+            through_turn_id: UUID of the last Turn in the slice.
+            turn_texts: ordered list of turn content strings for the slice.
+
+        Returns:
+            The newly created (or pre-existing idempotent) :class:`RollingSummary`.
+
+        Raises:
+            IntegrityError: if the DB constraint is violated by a concurrent
+                writer (should not occur in normal single-writer usage).
+        """
+        sid = str(story_id)
+        through_id = str(through_turn_id)
+
+        # --- Idempotency short-circuit (service layer) ---
+        existing = (
+            self._session.execute(
+                select(RollingSummaryORM).where(
+                    RollingSummaryORM.story_id == sid,
+                    RollingSummaryORM.compressed_through_turn_id == through_id,
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if existing is not None:
+            return _orm_to_model(existing)
+
+        # --- Fetch prior summary text ---
+        prior = self.get_current_summary(story_id)
+        prior_text: str | None = prior.text if prior else None
+
+        # --- Determine next version number ---
+        next_version = (prior.version_number + 1) if prior else 1
+
+        # --- Generate new summary text ---
+        new_text = self._generator(prior_text, turn_texts)
+
+        # --- Atomically clear previous current marker ---
+        if prior is not None:
+            prior_row = self._session.get(RollingSummaryORM, str(prior.summary_id))
+            if prior_row is not None:
+                prior_row.is_current = False
+
+        # --- Persist new row ---
+        now = datetime.now(UTC).isoformat()
+        new_row = RollingSummaryORM(
+            summary_id=str(uuid4()),
+            story_id=sid,
+            text=new_text,
+            compressed_from_turn_id=str(from_turn_id),
+            compressed_through_turn_id=through_id,
+            version_number=next_version,
+            is_current=True,
+            created_at=now,
+        )
+        self._session.add(new_row)
+        try:
+            self._session.flush()
+        except IntegrityError:
+            self._session.rollback()
+            raise
+
+        return _orm_to_model(new_row)
+
+    # ------------------------------------------------------------------
+    # Retrieval
+    # ------------------------------------------------------------------
+
+    def get_current_summary(self, story_id: UUID) -> RollingSummary | None:
+        """Return the active current rolling summary, or None.
+
+        This is the method the Context Builder (Issue 8) will call when
+        assembling the stable prefix.
+
+        Returns:
+            The :class:`RollingSummary` for the current row, or ``None`` if no
+            summary has been compressed yet for this story.
+        """
+        row = (
+            self._session.execute(
+                select(RollingSummaryORM).where(
+                    RollingSummaryORM.story_id == str(story_id),
+                    RollingSummaryORM.is_current.is_(True),
+                )
+            )
+            .scalars()
+            .first()
+        )
+        return _orm_to_model(row) if row else None
+
+    def get_summary_history(self, story_id: UUID) -> list[RollingSummary]:
+        """Return all summaries for a story in creation order.
+
+        Includes historical (non-current) rows.  Intended for debugging and
+        regression investigation; not called by the Context Builder.
+
+        Returns:
+            List of :class:`RollingSummary` ordered by ``version_number``
+            ascending (creation order).
+        """
+        rows = (
+            self._session.execute(
+                select(RollingSummaryORM)
+                .where(RollingSummaryORM.story_id == str(story_id))
+                .order_by(
+                    RollingSummaryORM.version_number.asc(),
+                    RollingSummaryORM.summary_id.asc(),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [_orm_to_model(r) for r in rows]

--- a/src/afterworlds/services/rolling_summary.py
+++ b/src/afterworlds/services/rolling_summary.py
@@ -40,7 +40,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from afterworlds.models.rolling_summary import RollingSummary
+from afterworlds.persistence.orm.node import NodeORM, TurnORM
 from afterworlds.persistence.orm.rolling_summary import RollingSummaryORM
+from afterworlds.persistence.orm.story import ArcORM, ChapterORM
 
 # ---------------------------------------------------------------------------
 # Configurable constants
@@ -89,6 +91,43 @@ def should_compress(story_turn_count: int, n: int = ROLLING_SUMMARY_N) -> bool:
         True if ``story_turn_count > 0`` and ``story_turn_count % n == 0``.
     """
     return story_turn_count > 0 and story_turn_count % n == 0
+
+
+# ---------------------------------------------------------------------------
+# Coverage validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_turn_belongs_to_story(
+    session: Session, turn_id: UUID, story_id: UUID
+) -> None:
+    """Raise ValueError if the turn is not attributable to the story.
+
+    Resolves attribution via the full persisted lineage:
+    Turn → Node → Chapter → Arc → Story.  A turn with no Node link
+    (``node_id = NULL``) is correctly rejected — it has no story attribution.
+
+    Args:
+        session: active SQLAlchemy session.
+        turn_id: UUID of the Turn being validated.
+        story_id: UUID of the Story it must belong to.
+
+    Raises:
+        ValueError: if no lineage path from the turn to the story can be
+            found in the database.
+    """
+    row = session.execute(
+        select(TurnORM.turn_id)
+        .join(NodeORM, TurnORM.node_id == NodeORM.node_id)
+        .join(ChapterORM, NodeORM.chapter_id == ChapterORM.chapter_id)
+        .join(ArcORM, ChapterORM.arc_id == ArcORM.arc_id)
+        .where(TurnORM.turn_id == str(turn_id), ArcORM.story_id == str(story_id))
+    ).first()
+    if row is None:
+        raise ValueError(
+            f"Turn {turn_id} is not attributable to story {story_id} "
+            "via persisted Node lineage"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +215,8 @@ class RollingSummaryService:
             The newly created (or pre-existing idempotent) :class:`RollingSummary`.
 
         Raises:
+            ValueError: if ``from_turn_id`` or ``through_turn_id`` cannot be
+                attributed to ``story_id`` via persisted Node lineage.
             IntegrityError: re-raised only if the DB constraint is violated
                 but no conflicting row can be found (truly unexpected state).
         """
@@ -195,6 +236,10 @@ class RollingSummaryService:
         )
         if existing is not None:
             return _orm_to_model(existing)
+
+        # --- Validate coverage turns belong to this story ---
+        _validate_turn_belongs_to_story(self._session, from_turn_id, story_id)
+        _validate_turn_belongs_to_story(self._session, through_turn_id, story_id)
 
         # --- Fetch prior summary text ---
         prior = self.get_current_summary(story_id)

--- a/src/afterworlds/services/rolling_summary.py
+++ b/src/afterworlds/services/rolling_summary.py
@@ -16,8 +16,8 @@ Design constraints from the issue spec:
     heuristics.  The DB enforces this via a UNIQUE constraint on
     ``(story_id, compressed_through_turn_id)``.
   - Exactly one row per story may be ``is_current = True`` at any time.
-    Enforced by a partial unique index (see migration 0006) and by service
-    logic that atomically clears the previous current marker.
+    Enforced by a partial unique index (migration 0006 and ORM metadata) and
+    by service logic that atomically clears the previous current marker.
   - The summary generation callable is injected — no hardwired provider or
     model.  For tests, a stub can be passed in.
   - No prompt assembly, no Context Builder integration, no pipeline calls.
@@ -155,8 +155,16 @@ class RollingSummaryService:
 
         The new row is inserted with ``is_current = True``.  The prior
         current row (if any) is atomically flipped to ``is_current = False``
-        within the same flush so the DB partial unique index is never
+        within the same savepoint so the DB partial unique index is never
         transiently violated.
+
+        **Conflict handling:** all writes (the prior-current flip and the new
+        row insert) are executed inside a ``begin_nested()`` savepoint.  If a
+        concurrent writer wins the ``uq_rs_story_through_turn`` race between
+        the service-layer idempotency check and the flush, the savepoint is
+        rolled back automatically and the caller's outer transaction remains
+        intact.  The existing row written by the winner is re-queried and
+        returned.  The full session is never rolled back.
 
         Args:
             story_id: UUID of the story being compressed.
@@ -168,8 +176,8 @@ class RollingSummaryService:
             The newly created (or pre-existing idempotent) :class:`RollingSummary`.
 
         Raises:
-            IntegrityError: if the DB constraint is violated by a concurrent
-                writer (should not occur in normal single-writer usage).
+            IntegrityError: re-raised only if the DB constraint is violated
+                but no conflicting row can be found (truly unexpected state).
         """
         sid = str(story_id)
         through_id = str(through_turn_id)
@@ -198,13 +206,10 @@ class RollingSummaryService:
         # --- Generate new summary text ---
         new_text = self._generator(prior_text, turn_texts)
 
-        # --- Atomically clear previous current marker ---
-        if prior is not None:
-            prior_row = self._session.get(RollingSummaryORM, str(prior.summary_id))
-            if prior_row is not None:
-                prior_row.is_current = False
-
-        # --- Persist new row ---
+        # --- Persist: all writes inside a savepoint ---
+        # Both the prior-current flip and the new-row insert are inside the
+        # savepoint so a concurrent-write IntegrityError rolls back only this
+        # operation, leaving the caller's outer transaction intact.
         now = datetime.now(UTC).isoformat()
         new_row = RollingSummaryORM(
             summary_id=str(uuid4()),
@@ -216,12 +221,32 @@ class RollingSummaryService:
             is_current=True,
             created_at=now,
         )
-        self._session.add(new_row)
         try:
-            self._session.flush()
+            with self._session.begin_nested():
+                if prior is not None:
+                    prior_row = self._session.get(
+                        RollingSummaryORM, str(prior.summary_id)
+                    )
+                    if prior_row is not None:
+                        prior_row.is_current = False
+                self._session.add(new_row)
+                self._session.flush()
         except IntegrityError:
-            self._session.rollback()
-            raise
+            # Savepoint rolled back; outer transaction intact.
+            # Re-read the row that won the constraint race.
+            conflict_row = (
+                self._session.execute(
+                    select(RollingSummaryORM).where(
+                        RollingSummaryORM.story_id == sid,
+                        RollingSummaryORM.compressed_through_turn_id == through_id,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if conflict_row is not None:
+                return _orm_to_model(conflict_row)
+            raise  # unexpected — no conflicting row found
 
         return _orm_to_model(new_row)
 

--- a/tests/services/test_rolling_summary.py
+++ b/tests/services/test_rolling_summary.py
@@ -1,0 +1,714 @@
+"""Tests for the Rolling Summary service — CRD Issue 6 acceptance criteria.
+
+Coverage targets:
+  - Trigger threshold (should_compress): fires at N, 2N, 3N; not in between.
+  - Coverage metadata: compressed_from_turn_id, compressed_through_turn_id,
+    version_number populated on every row including the first.
+  - Idempotency anchored to compressed_through_turn_id (service layer).
+  - DB uniqueness constraint on (story_id, compressed_through_turn_id).
+  - Append-only versioning: prior rows preserved, version_number monotonic.
+  - Current-version invariant: exactly one is_current row per story.
+  - DB partial unique index rejects a second is_current=True row.
+  - Retrieval: get_current_summary returns None before first compression,
+    returns current row after; get_summary_history returns ordered history.
+  - Return types are structured typed payloads (RollingSummary, not ORM rows).
+  - Generator dependency is injected; no real network call in tests.
+  - N is readable from the module constant; changing it changes trigger
+    behavior.
+  - Configurability: should_compress(n=...) respects caller-supplied N.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+# ---------------------------------------------------------------------------
+# Import all ORMs so Base.metadata is fully populated
+# ---------------------------------------------------------------------------
+import afterworlds.persistence.orm.character_sheet  # noqa: F401
+import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.rolling_summary  # noqa: F401  — register ORM
+import afterworlds.persistence.orm.rules_package  # noqa: F401
+import afterworlds.persistence.orm.session_state  # noqa: F401
+import afterworlds.persistence.orm.state  # noqa: F401
+import afterworlds.persistence.orm.story  # noqa: F401
+import afterworlds.persistence.orm.story_bible  # noqa: F401
+from afterworlds.models.enums import IntentType, StoryMode
+from afterworlds.models.rolling_summary import RollingSummary
+from afterworlds.models.story import Story
+from afterworlds.persistence.crud.story import create_story
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.node import TurnORM
+from afterworlds.persistence.orm.rolling_summary import RollingSummaryORM
+from afterworlds.services.rolling_summary import (
+    ROLLING_SUMMARY_N,
+    RollingSummaryService,
+    should_compress,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def engine():  # type: ignore[no-untyped-def]
+    """In-memory SQLite engine with all tables created."""
+    eng = create_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    # Create the partial unique index (mirrors migration 0006 op.execute).
+    with eng.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_rs_current_per_story "
+                "ON rolling_summaries (story_id) WHERE is_current = 1"
+            )
+        )
+        conn.commit()
+    yield eng
+    Base.metadata.drop_all(eng)
+    eng.dispose()
+
+
+@pytest.fixture()
+def session(engine):  # type: ignore[no-untyped-def]
+    """SQLAlchemy session bound to the in-memory engine."""
+    factory = create_session_factory(engine)
+    sess = factory()
+    try:
+        yield sess
+    finally:
+        sess.close()
+
+
+@pytest.fixture()
+def story_id(session) -> UUID:  # type: ignore[no-untyped-def]
+    """Persist a minimal Story and return its UUID."""
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    story = Story(
+        title="Test Story", mode=StoryMode.RPG, created_at=now, updated_at=now
+    )
+    create_story(session, story)
+    session.commit()
+    return story.story_id
+
+
+def _make_turn(session, story_id: UUID, *, label: str = "t") -> UUID:  # type: ignore[no-untyped-def]
+    """Persist a minimal Turn row and return its UUID.
+
+    ``node_id`` is intentionally left as None — the FK is nullable and we do
+    not need a Node hierarchy to test rolling-summary coverage anchoring.
+    Foreign keys are enforced in tests (PRAGMA foreign_keys = ON), so the
+    Turn row must genuinely exist; Node ancestry is not required.
+
+    ``story_id`` is accepted for callsite clarity but is not stored on the
+    Turn row directly (Turns hang off Nodes, not Stories).  It is included
+    in the helper signature to make multi-story tests readable.
+    """
+    turn_id = str(uuid4())
+    now = datetime.now(UTC).isoformat()
+    session.add(
+        TurnORM(
+            turn_id=turn_id,
+            node_id=None,
+            user_input=f"Input {label}",
+            assistant_output=f"Output {label}",
+            timestamp=now,
+            intent_classification=IntentType.ACTION.value,
+        )
+    )
+    session.flush()
+    return UUID(turn_id)
+
+
+def _stub_generator(text_to_return: str = "summary text") -> MagicMock:
+    """Return a MagicMock that behaves as a SummaryGeneratorT."""
+    gen = MagicMock(return_value=text_to_return)
+    return gen
+
+
+def _make_service(session, generator=None):  # type: ignore[no-untyped-def]
+    """Return a RollingSummaryService with a stub generator."""
+    if generator is None:
+        generator = _stub_generator()
+    return RollingSummaryService(session, generator)
+
+
+# ===========================================================================
+# Trigger threshold tests — should_compress()
+# ===========================================================================
+
+
+class TestShouldCompress:
+    def test_fires_at_n(self) -> None:
+        assert should_compress(ROLLING_SUMMARY_N) is True
+
+    def test_fires_at_2n(self) -> None:
+        assert should_compress(ROLLING_SUMMARY_N * 2) is True
+
+    def test_fires_at_3n(self) -> None:
+        assert should_compress(ROLLING_SUMMARY_N * 3) is True
+
+    def test_does_not_fire_between_triggers(self) -> None:
+        for count in range(1, ROLLING_SUMMARY_N):
+            assert should_compress(count) is False, f"should not fire at {count}"
+
+    def test_does_not_fire_at_n_plus_1(self) -> None:
+        assert should_compress(ROLLING_SUMMARY_N + 1) is False
+
+    def test_does_not_fire_at_n_minus_1(self) -> None:
+        assert should_compress(ROLLING_SUMMARY_N - 1) is False
+
+    def test_does_not_fire_at_zero(self) -> None:
+        assert should_compress(0) is False
+
+    def test_n_constant_readable_from_module(self) -> None:
+        assert ROLLING_SUMMARY_N == 10
+
+    def test_caller_supplied_n_changes_trigger(self) -> None:
+        """Changing n in the call changes trigger behavior."""
+        assert should_compress(5, n=5) is True
+        assert should_compress(5, n=10) is False
+        assert should_compress(10, n=5) is True
+        assert should_compress(10, n=10) is True
+
+    def test_fires_at_each_multiple_of_n(self) -> None:
+        n = 7  # non-default N
+        for k in range(1, 6):
+            assert should_compress(n * k, n=n) is True
+        for offset in (1, 2, 3, 4, 5, 6):
+            assert should_compress(n + offset, n=n) is False
+
+
+# ===========================================================================
+# Coverage metadata tests
+# ===========================================================================
+
+
+class TestCoverageMetadata:
+    def test_from_and_through_populated_on_first_compression(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        result = svc.compress(story_id, t1, t10, ["text1", "text10"])
+
+        assert result.compressed_from_turn_id == t1
+        assert result.compressed_through_turn_id == t10
+
+    def test_version_number_starts_at_1(self, session, story_id: UUID) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        result = svc.compress(story_id, t1, t10, ["t"] * 10)
+
+        assert result.version_number == 1
+
+    def test_version_number_increments_monotonically(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        t21 = _make_turn(session, story_id, label="t21")
+        t30 = _make_turn(session, story_id, label="t30")
+        svc = _make_service(session)
+
+        r1 = svc.compress(story_id, t1, t10, ["t"] * 10)
+        session.commit()
+        r2 = svc.compress(story_id, t11, t20, ["t"] * 10)
+        session.commit()
+        r3 = svc.compress(story_id, t21, t30, ["t"] * 10)
+        session.commit()
+
+        assert r1.version_number == 1
+        assert r2.version_number == 2
+        assert r3.version_number == 3
+
+    def test_coverage_ids_are_non_nullable_on_every_row(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        result = svc.compress(story_id, t1, t10, ["text"])
+
+        assert result.compressed_from_turn_id is not None
+        assert result.compressed_through_turn_id is not None
+        assert isinstance(result.compressed_from_turn_id, UUID)
+        assert isinstance(result.compressed_through_turn_id, UUID)
+
+    def test_created_at_populated(self, session, story_id: UUID) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        result = svc.compress(story_id, t1, t10, ["text"])
+
+        assert isinstance(result.created_at, datetime)
+
+
+# ===========================================================================
+# Append-only versioning — prior rows preserved
+# ===========================================================================
+
+
+class TestAppendOnly:
+    def test_prior_summaries_preserved(self, session, story_id: UUID) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        svc = _make_service(session, _stub_generator("summary-v1"))
+
+        svc.compress(story_id, t1, t10, ["t"] * 10)
+        session.commit()
+
+        # Replace generator for second compression
+        svc._generator = _stub_generator("summary-v2")
+        svc.compress(story_id, t11, t20, ["t"] * 10)
+        session.commit()
+
+        history = svc.get_summary_history(story_id)
+        assert len(history) == 2
+        assert history[0].text == "summary-v1"
+        assert history[1].text == "summary-v2"
+
+    def test_three_compressions_preserve_all_rows(
+        self, session, story_id: UUID
+    ) -> None:
+        turns = [_make_turn(session, story_id, label=f"t{i}") for i in range(6)]
+        svc = _make_service(session)
+
+        svc.compress(story_id, turns[0], turns[1], ["t", "t"])
+        session.commit()
+        svc.compress(story_id, turns[2], turns[3], ["t", "t"])
+        session.commit()
+        svc.compress(story_id, turns[4], turns[5], ["t", "t"])
+        session.commit()
+
+        assert len(svc.get_summary_history(story_id)) == 3
+
+    def test_history_ordered_by_version_number(self, session, story_id: UUID) -> None:
+        turns = [_make_turn(session, story_id, label=f"t{i}") for i in range(4)]
+        svc = _make_service(session)
+
+        svc.compress(story_id, turns[0], turns[1], ["a", "b"])
+        session.commit()
+        svc.compress(story_id, turns[2], turns[3], ["c", "d"])
+        session.commit()
+
+        history = svc.get_summary_history(story_id)
+        assert history[0].version_number < history[1].version_number
+
+
+# ===========================================================================
+# Idempotency tests
+# ===========================================================================
+
+
+class TestIdempotency:
+    def test_second_compress_same_through_id_returns_existing(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        gen = _stub_generator("generated-text")
+        svc = _make_service(session, gen)
+
+        r1 = svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+        r2 = svc.compress(story_id, t1, t10, ["text"])
+
+        # Same summary returned; generator called only once.
+        assert r2.summary_id == r1.summary_id
+        gen.assert_called_once()
+
+    def test_no_duplicate_row_on_repeated_compress(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+        svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+
+        assert len(svc.get_summary_history(story_id)) == 1
+
+    def test_db_unique_constraint_rejects_duplicate_through_id(
+        self, session, story_id: UUID
+    ) -> None:
+        """Verify the DB constraint catches a duplicate even without service logic."""
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        now = datetime.now(UTC).isoformat()
+        sid = str(story_id)
+
+        row1 = RollingSummaryORM(
+            summary_id=str(uuid4()),
+            story_id=sid,
+            text="first",
+            compressed_from_turn_id=str(t1),
+            compressed_through_turn_id=str(t10),
+            version_number=1,
+            is_current=False,
+            created_at=now,
+        )
+        row2 = RollingSummaryORM(
+            summary_id=str(uuid4()),
+            story_id=sid,
+            text="second",
+            compressed_from_turn_id=str(t1),
+            compressed_through_turn_id=str(t10),  # same through_id — must fail
+            version_number=2,
+            is_current=False,
+            created_at=now,
+        )
+        session.add(row1)
+        session.flush()
+
+        session.add(row2)
+        with pytest.raises(IntegrityError):
+            session.flush()
+
+
+# ===========================================================================
+# Current-version invariant tests
+# ===========================================================================
+
+
+class TestCurrentVersionInvariant:
+    def test_first_compression_is_current(self, session, story_id: UUID) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        result = svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+
+        assert result.is_current is True
+
+    def test_only_latest_compression_is_current(self, session, story_id: UUID) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        svc = _make_service(session)
+
+        svc.compress(story_id, t1, t10, ["t"] * 10)
+        session.commit()
+        svc.compress(story_id, t11, t20, ["t"] * 10)
+        session.commit()
+
+        history = svc.get_summary_history(story_id)
+        assert history[0].is_current is False  # v1 no longer current
+        assert history[1].is_current is True  # v2 is current
+
+    def test_exactly_one_current_across_three_compressions(
+        self, session, story_id: UUID
+    ) -> None:
+        turns = [_make_turn(session, story_id, label=f"t{i}") for i in range(6)]
+        svc = _make_service(session)
+
+        svc.compress(story_id, turns[0], turns[1], ["t", "t"])
+        session.commit()
+        svc.compress(story_id, turns[2], turns[3], ["t", "t"])
+        session.commit()
+        svc.compress(story_id, turns[4], turns[5], ["t", "t"])
+        session.commit()
+
+        history = svc.get_summary_history(story_id)
+        current_rows = [r for r in history if r.is_current]
+        assert len(current_rows) == 1
+        assert current_rows[0].version_number == 3
+
+    def test_db_partial_index_rejects_second_current_row(
+        self, session, story_id: UUID
+    ) -> None:
+        """Verify the partial unique index catches a second is_current=True row."""
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        now = datetime.now(UTC).isoformat()
+        sid = str(story_id)
+
+        row1 = RollingSummaryORM(
+            summary_id=str(uuid4()),
+            story_id=sid,
+            text="first",
+            compressed_from_turn_id=str(t1),
+            compressed_through_turn_id=str(t10),
+            version_number=1,
+            is_current=True,
+            created_at=now,
+        )
+        row2 = RollingSummaryORM(
+            summary_id=str(uuid4()),
+            story_id=sid,
+            text="second",
+            compressed_from_turn_id=str(t11),
+            compressed_through_turn_id=str(t20),
+            version_number=2,
+            is_current=True,  # second current row — must fail
+            created_at=now,
+        )
+        session.add(row1)
+        session.flush()
+
+        session.add(row2)
+        with pytest.raises(IntegrityError):
+            session.flush()
+
+
+# ===========================================================================
+# Retrieval contract tests
+# ===========================================================================
+
+
+class TestRetrievalContract:
+    def test_get_current_summary_returns_none_before_any_compression(
+        self, session, story_id: UUID
+    ) -> None:
+        svc = _make_service(session)
+        result = svc.get_current_summary(story_id)
+        assert result is None
+
+    def test_get_current_summary_returns_summary_after_compression(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session, _stub_generator("my summary"))
+
+        svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+
+        result = svc.get_current_summary(story_id)
+        assert result is not None
+        assert result.text == "my summary"
+
+    def test_get_current_summary_returns_most_recent(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        svc = _make_service(session, _stub_generator("v1"))
+
+        svc.compress(story_id, t1, t10, ["t"] * 10)
+        session.commit()
+        svc._generator = _stub_generator("v2")
+        svc.compress(story_id, t11, t20, ["t"] * 10)
+        session.commit()
+
+        result = svc.get_current_summary(story_id)
+        assert result is not None
+        assert result.text == "v2"
+        assert result.version_number == 2
+
+    def test_get_current_summary_ignores_non_current_rows(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        svc = _make_service(session)
+
+        svc.compress(story_id, t1, t10, ["t"] * 10)
+        session.commit()
+        svc.compress(story_id, t11, t20, ["t"] * 10)
+        session.commit()
+
+        current = svc.get_current_summary(story_id)
+        assert current is not None
+        assert current.is_current is True
+        assert current.version_number == 2  # v1 is non-current and ignored
+
+    def test_get_current_summary_return_type_is_pydantic_model(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+
+        result = svc.get_current_summary(story_id)
+        assert isinstance(result, RollingSummary)
+        assert not isinstance(result, RollingSummaryORM)
+
+    def test_get_summary_history_returns_empty_before_any_compression(
+        self, session, story_id: UUID
+    ) -> None:
+        svc = _make_service(session)
+        history = svc.get_summary_history(story_id)
+        assert history == []
+
+    def test_get_summary_history_returns_all_in_creation_order(
+        self, session, story_id: UUID
+    ) -> None:
+        turns = [_make_turn(session, story_id, label=f"t{i}") for i in range(6)]
+        svc = _make_service(session, _stub_generator("text"))
+
+        svc.compress(story_id, turns[0], turns[1], ["a"])
+        session.commit()
+        svc.compress(story_id, turns[2], turns[3], ["b"])
+        session.commit()
+        svc.compress(story_id, turns[4], turns[5], ["c"])
+        session.commit()
+
+        history = svc.get_summary_history(story_id)
+        assert len(history) == 3
+        assert all(isinstance(r, RollingSummary) for r in history)
+        assert [r.version_number for r in history] == [1, 2, 3]
+
+    def test_get_summary_history_return_type_is_list_of_pydantic(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+
+        history = svc.get_summary_history(story_id)
+        assert isinstance(history, list)
+        assert all(isinstance(r, RollingSummary) for r in history)
+
+
+# ===========================================================================
+# Generator dependency tests
+# ===========================================================================
+
+
+class TestGeneratorDependency:
+    def test_generator_called_with_none_prior_on_first_compression(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        gen = _stub_generator("result")
+        svc = _make_service(session, gen)
+
+        svc.compress(story_id, t1, t10, ["text1", "text2"])
+        session.commit()
+
+        gen.assert_called_once_with(None, ["text1", "text2"])
+
+    def test_generator_called_with_prior_summary_text(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        t11 = _make_turn(session, story_id, label="t11")
+        t20 = _make_turn(session, story_id, label="t20")
+        gen = _stub_generator("v1")
+        svc = _make_service(session, gen)
+
+        svc.compress(story_id, t1, t10, ["turn-texts-1"])
+        session.commit()
+
+        gen2 = _stub_generator("v2")
+        svc._generator = gen2
+        svc.compress(story_id, t11, t20, ["turn-texts-2"])
+        session.commit()
+
+        # Second call receives the v1 text as the prior summary.
+        gen2.assert_called_once_with("v1", ["turn-texts-2"])
+
+    def test_generator_not_called_on_idempotent_repeat(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        gen = _stub_generator("result")
+        svc = _make_service(session, gen)
+
+        svc.compress(story_id, t1, t10, ["text"])
+        session.commit()
+        svc.compress(story_id, t1, t10, ["text"])  # repeat — no call
+
+        gen.assert_called_once()  # called only the first time
+
+    def test_generator_return_value_persisted_as_summary_text(
+        self, session, story_id: UUID
+    ) -> None:
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session, _stub_generator("persisted text"))
+
+        result = svc.compress(story_id, t1, t10, ["text"])
+
+        assert result.text == "persisted text"
+
+    def test_no_real_network_call_in_tests(self, session, story_id: UUID) -> None:
+        """The generator is a MagicMock — no real network call is made."""
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        gen = MagicMock(return_value="mock result")
+        svc = RollingSummaryService(session, gen)
+
+        svc.compress(story_id, t1, t10, ["turn text"])
+
+        # gen.assert_called_once() proves a real call was not made to any
+        # external service — the injected callable received the invocation.
+        gen.assert_called_once()
+
+
+# ===========================================================================
+# Multi-story isolation
+# ===========================================================================
+
+
+class TestMultiStoryIsolation:
+    def test_summaries_isolated_between_stories(self, session) -> None:
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        story_a = Story(title="A", mode=StoryMode.RPG, created_at=now, updated_at=now)
+        story_b = Story(title="B", mode=StoryMode.RPG, created_at=now, updated_at=now)
+        create_story(session, story_a)
+        create_story(session, story_b)
+        session.commit()
+
+        ta1 = _make_turn(session, story_a.story_id, label="a1")
+        ta10 = _make_turn(session, story_a.story_id, label="a10")
+        tb1 = _make_turn(session, story_b.story_id, label="b1")
+        tb10 = _make_turn(session, story_b.story_id, label="b10")
+
+        svc = _make_service(session, _stub_generator("story-A-summary"))
+        svc.compress(story_a.story_id, ta1, ta10, ["a"] * 10)
+        session.commit()
+
+        svc._generator = _stub_generator("story-B-summary")
+        svc.compress(story_b.story_id, tb1, tb10, ["b"] * 10)
+        session.commit()
+
+        current_a = svc.get_current_summary(story_a.story_id)
+        current_b = svc.get_current_summary(story_b.story_id)
+
+        assert current_a is not None
+        assert current_a.text == "story-A-summary"
+        assert current_b is not None
+        assert current_b.text == "story-B-summary"
+
+        assert svc.get_summary_history(story_a.story_id) == [current_a]
+        assert svc.get_summary_history(story_b.story_id) == [current_b]

--- a/tests/services/test_rolling_summary.py
+++ b/tests/services/test_rolling_summary.py
@@ -44,8 +44,9 @@ from afterworlds.models.story import Story
 from afterworlds.persistence.crud.story import create_story
 from afterworlds.persistence.database import create_engine, create_session_factory
 from afterworlds.persistence.orm.base import Base
-from afterworlds.persistence.orm.node import TurnORM
+from afterworlds.persistence.orm.node import NodeORM, TurnORM
 from afterworlds.persistence.orm.rolling_summary import RollingSummaryORM
+from afterworlds.persistence.orm.story import ArcORM, ChapterORM
 from afterworlds.services.rolling_summary import (
     ROLLING_SUMMARY_N,
     RollingSummaryService,
@@ -97,23 +98,43 @@ def story_id(session) -> UUID:  # type: ignore[no-untyped-def]
 
 
 def _make_turn(session, story_id: UUID, *, label: str = "t") -> UUID:  # type: ignore[no-untyped-def]
-    """Persist a minimal Turn row and return its UUID.
+    """Persist an Arc → Chapter → Node → Turn chain and return the Turn UUID.
 
-    ``node_id`` is intentionally left as None — the FK is nullable and we do
-    not need a Node hierarchy to test rolling-summary coverage anchoring.
-    Foreign keys are enforced in tests (PRAGMA foreign_keys = ON), so the
-    Turn row must genuinely exist; Node ancestry is not required.
+    Each call creates its own Arc, Chapter, and Node so the Turn is
+    unambiguously attributable to ``story_id`` via persisted Node lineage.
+    This satisfies the service-layer coverage validation added in the P1 fix:
+    ``compress()`` now verifies both coverage turns trace back to the given
+    story through the full lineage before persisting a new summary row.
 
-    ``story_id`` is accepted for callsite clarity but is not stored on the
-    Turn row directly (Turns hang off Nodes, not Stories).  It is included
-    in the helper signature to make multi-story tests readable.
+    Foreign keys are enforced in tests (``PRAGMA foreign_keys = ON``), so
+    all parent rows must exist in the DB.
     """
+    arc_id = str(uuid4())
+    chapter_id = str(uuid4())
+    node_id = str(uuid4())
     turn_id = str(uuid4())
     now = datetime.now(UTC).isoformat()
     session.add(
+        ArcORM(arc_id=arc_id, story_id=str(story_id), title=f"Arc-{label}", order=0)
+    )
+    session.add(
+        ChapterORM(chapter_id=chapter_id, arc_id=arc_id, title=f"Ch-{label}", order=0)
+    )
+    session.add(
+        NodeORM(
+            node_id=node_id,
+            chapter_id=chapter_id,
+            content=f"Content-{label}",
+            state_delta={},
+            branching_logic=[],
+            intent_type=IntentType.ACTION.value,
+            metadata_={},
+        )
+    )
+    session.add(
         TurnORM(
             turn_id=turn_id,
-            node_id=None,
+            node_id=node_id,
             user_input=f"Input {label}",
             assistant_output=f"Output {label}",
             timestamp=now,
@@ -669,6 +690,81 @@ class TestGeneratorDependency:
         # gen.assert_called_once() proves a real call was not made to any
         # external service — the injected callable received the invocation.
         gen.assert_called_once()
+
+
+# ===========================================================================
+# Coverage integrity — turns must belong to the given story
+# ===========================================================================
+
+
+class TestCoverageIntegrity:
+    """compress() validates that coverage turns trace back to the story."""
+
+    def test_from_turn_wrong_story_raises_value_error(
+        self, session, story_id: UUID
+    ) -> None:
+        """compress() rejects from_turn_id that belongs to a different story."""
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        other = Story(title="Other", mode=StoryMode.RPG, created_at=now, updated_at=now)
+        create_story(session, other)
+        session.commit()
+
+        from_turn = _make_turn(session, other.story_id, label="from")
+        through_turn = _make_turn(session, story_id, label="through")
+        svc = _make_service(session)
+
+        with pytest.raises(ValueError, match="is not attributable to story"):
+            svc.compress(story_id, from_turn, through_turn, ["text"])
+
+    def test_through_turn_wrong_story_raises_value_error(
+        self, session, story_id: UUID
+    ) -> None:
+        """compress() rejects through_turn_id that belongs to a different story."""
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        other = Story(title="Other", mode=StoryMode.RPG, created_at=now, updated_at=now)
+        create_story(session, other)
+        session.commit()
+
+        from_turn = _make_turn(session, story_id, label="from")
+        through_turn = _make_turn(session, other.story_id, label="through")
+        svc = _make_service(session)
+
+        with pytest.raises(ValueError, match="is not attributable to story"):
+            svc.compress(story_id, from_turn, through_turn, ["text"])
+
+    def test_orphan_from_turn_raises_value_error(self, session, story_id: UUID) -> None:
+        """compress() rejects an orphan turn (node_id=None) as from_turn_id."""
+        orphan_id = str(uuid4())
+        now = datetime.now(UTC).isoformat()
+        session.add(
+            TurnORM(
+                turn_id=orphan_id,
+                node_id=None,
+                user_input="orphan input",
+                assistant_output="orphan output",
+                timestamp=now,
+                intent_classification=IntentType.ACTION.value,
+            )
+        )
+        session.flush()
+
+        through_turn = _make_turn(session, story_id, label="through")
+        svc = _make_service(session)
+
+        with pytest.raises(ValueError, match="is not attributable to story"):
+            svc.compress(story_id, UUID(orphan_id), through_turn, ["text"])
+
+    def test_both_turns_correct_story_does_not_raise(
+        self, session, story_id: UUID
+    ) -> None:
+        """compress() succeeds when both turns are attributable to the given story."""
+        t1 = _make_turn(session, story_id, label="t1")
+        t10 = _make_turn(session, story_id, label="t10")
+        svc = _make_service(session)
+
+        result = svc.compress(story_id, t1, t10, ["text"])
+
+        assert result.story_id == story_id
 
 
 # ===========================================================================

--- a/tests/services/test_rolling_summary.py
+++ b/tests/services/test_rolling_summary.py
@@ -25,7 +25,6 @@ from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 # ---------------------------------------------------------------------------
@@ -60,18 +59,15 @@ from afterworlds.services.rolling_summary import (
 
 @pytest.fixture()
 def engine():  # type: ignore[no-untyped-def]
-    """In-memory SQLite engine with all tables created."""
+    """In-memory SQLite engine with all tables created.
+
+    The partial unique index ``uq_rs_current_per_story`` (one is_current row
+    per story) is now declared in ``RollingSummaryORM.__table_args__`` via a
+    ``sqlite_where`` Index, so ``create_all()`` creates it automatically.  No
+    manual DDL is required here.
+    """
     eng = create_engine("sqlite://")
     Base.metadata.create_all(eng)
-    # Create the partial unique index (mirrors migration 0006 op.execute).
-    with eng.connect() as conn:
-        conn.execute(
-            text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_rs_current_per_story "
-                "ON rolling_summaries (story_id) WHERE is_current = 1"
-            )
-        )
-        conn.commit()
     yield eng
     Base.metadata.drop_all(eng)
     eng.dispose()


### PR DESCRIPTION
## What was built

Rolling Summary service (CRD Issue 6 / GitHub #63) — the compressed narrative history layer of the six-layer memory architecture.

**Files added:**

| File | Purpose |
|---|---|
| `src/afterworlds/models/rolling_summary.py` | Pydantic model (`RollingSummary`) — typed payload returned by all retrieval methods |
| `src/afterworlds/persistence/orm/rolling_summary.py` | SQLAlchemy ORM model (`RollingSummaryORM`) with `__table_args__` uniqueness constraints and partial unique index |
| `alembic/versions/0006_rolling_summary.py` | Migration — creates `rolling_summaries` table, column FKs, UNIQUE constraint, and partial unique index |
| `src/afterworlds/services/rolling_summary.py` | Service: `ROLLING_SUMMARY_N`, `should_compress()`, `_validate_turn_belongs_to_story()`, `RollingSummaryService.compress()`, `.get_current_summary()`, `.get_summary_history()` |
| `tests/services/test_rolling_summary.py` | 43 tests across 9 test classes |
| `docs/decisions/ADR-0009-rolling-summary-n-value.md` | ADR resolving (via escape hatch) the N-value Known Unknown |

**Files modified:**

| File | Change |
|---|---|
| `alembic/env.py` | Import `rolling_summary` ORM so `Base.metadata` includes the new table |
| `docs/architecture/known_unknowns.md` | Moved N-value item from Open → Resolved; annotated with escape-hatch deferral to Issue 8 |
| `src/afterworlds/services/rolling_summary.py` | P1: added coverage-turn ownership validation; P2 bug fix: savepoint-based conflict recovery |
| `src/afterworlds/persistence/orm/rolling_summary.py` | P2 bug fix: mirrored partial unique index in ORM `__table_args__` |
| `tests/services/test_rolling_summary.py` | P1: rebuilt `_make_turn()` to create full Arc→Chapter→Node→Turn hierarchy; added `TestCoverageIntegrity` class |

---

## How this satisfies each acceptance criterion

**Compression fires at turn count N and does not fire between triggers.**
`should_compress(story_turn_count, n=ROLLING_SUMMARY_N)` returns `True` only when `story_turn_count > 0 and story_turn_count % n == 0`. Tested at N, 2N, 3N and all non-multiples from 1 to N−1.

**Each compression produces a new row with populated coverage metadata.**
`compress()` always writes `compressed_from_turn_id` (non-nullable FK), `compressed_through_turn_id` (non-nullable FK), and `version_number` (starts at 1, increments per compression per story). Tested including the first row.

**Prior summaries are preserved in SQLite; nothing is overwritten in place.**
`compress()` inserts a new row; it never updates the prior row's `text`. Tested across three sequential compressions: `get_summary_history()` returns all three rows.

**Idempotency anchored to coverage: running compression again for a story whose current summary already covers the same `compressed_through_turn_id` does not create a second row.**
Service-layer short-circuit returns the existing row and skips the generator call. Tested: generator called exactly once across two identical compress calls.

**DB-level coverage uniqueness: `(story_id, compressed_through_turn_id)` unique.**
`uq_rs_story_through_turn` UniqueConstraint in ORM `__table_args__` and in migration `op.create_table()`. Tested: direct ORM insert of a duplicate `through_turn_id` raises `IntegrityError`.

**DB-level current-row uniqueness: exactly one row per story may be marked current.**
Partial unique index `WHERE is_current = 1` created via `op.execute()` in migration 0006. Mirrored in `RollingSummaryORM.__table_args__` via `sa.Index('uq_rs_current_per_story', 'story_id', unique=True, sqlite_where=sa.text('is_current = 1'))` so `Base.metadata.create_all()` enforces the same constraint on both the migration path and the test/script path. Atomic flip: `compress()` sets prior `is_current = False` and inserts new `is_current = True` inside a single `begin_nested()` savepoint so the index is never transiently violated and the caller's outer transaction is preserved on conflict. Tested: direct ORM insert of a second `is_current = True` row raises `IntegrityError`.

**`get_current_summary(story_id)` returns structured typed payload or None.**
Returns `RollingSummary | None` — a Pydantic model, never a raw ORM row. Tested: `None` before any compression; correct `RollingSummary` after; most-recent across multiple compressions; non-current rows ignored; return type is explicitly asserted.

**`get_summary_history(story_id)` returns structured typed payload in creation order.**
Returns `list[RollingSummary]` ordered by `version_number ASC`. Tested: empty before any compression; correct ordered list across three compressions; all elements are `RollingSummary` instances.

**Summary generation call is invoked with correct prior summary and correct turn slice.**
Generator is called as `generator(prior_text, turn_texts)` — `prior_text=None` on first compression, the current summary's `text` on subsequent ones. Tested with `MagicMock.assert_called_once_with(...)`.

**N is exposed as a configurable value; changing it changes trigger behavior without code changes.**
`ROLLING_SUMMARY_N: int = 10` is a module-level constant importable by callers. `should_compress()` accepts an explicit `n` override. Tested: `ROLLING_SUMMARY_N == 10`; `should_compress(5, n=5) == True`; `should_compress(5, n=10) == False`.

**Coverage turns are validated against story ownership before persisting.**
`_validate_turn_belongs_to_story()` resolves each coverage turn's story attribution via the full persisted lineage (`Turn → Node → Chapter → Arc → Story`). Turns with `node_id=NULL` are correctly rejected. `ValueError` is raised with a descriptive message if attribution fails. Tested: wrong-story `from_turn_id`, wrong-story `through_turn_id`, orphan turn, passing case.

**No prompt assembly, no Context Builder integration, no pipeline invocation.**
Service has no imports from any Context Builder, pipeline, or prompt module. Enforced by code review.

---

## Test coverage summary

**43 new tests across 9 classes:**

| Class | Coverage |
|---|---|
| `TestShouldCompress` | 10 tests — fires at N/2N/3N; not between; zero; custom N; each multiple |
| `TestCoverageMetadata` | 5 tests — from/through populated on first row; version starts at 1; monotonic increments; non-nullable; created_at |
| `TestAppendOnly` | 3 tests — prior rows preserved; three compressions retain all rows; history ordered |
| `TestIdempotency` | 3 tests — service-layer idempotency; no duplicate rows; DB constraint raises IntegrityError |
| `TestCurrentVersionInvariant` | 4 tests — first is_current; only latest is_current; exactly one across three compressions; DB partial index rejects second is_current |
| `TestRetrievalContract` | 8 tests — None before compression; correct after; most-recent; ignores non-current; return type Pydantic; history empty/ordered/typed |
| `TestGeneratorDependency` | 5 tests — None prior on first; prior text on second; not called on idempotent repeat; return value persisted; no real network call |
| `TestCoverageIntegrity` | 4 tests — from_turn wrong story → ValueError; through_turn wrong story → ValueError; orphan turn → ValueError; both correct → succeeds |
| `TestMultiStoryIsolation` | 1 test — summaries isolated between stories |

**Full suite result:** 464 passed, 0 failed. Total coverage: **96.36%** (threshold: 80%).

New code coverage: `models/rolling_summary.py` 100%, `orm/rolling_summary.py` 100%, `services/rolling_summary.py` 92% (lines 279–294 are the `IntegrityError` re-raise path — the concurrent-writer safety branch not easily triggered in single-writer in-memory SQLite tests).

---

## Known Unknown — N-value

**Escape hatch invoked per ADR-0009.**

Empirical finalization of N requires stable-prefix pressure measurement, which is only possible once the Context Builder (Issue 8) is wired end-to-end. At Issue 6:
- No Context Builder exists.
- No Writer path produces real turns.
- No stable-prefix assembly has ever been measured.

ADR-0009 records: the configurable mechanism, the provisional value of 10, the specific reason empirical finalization could not be completed in Issue 6, and that finalization is deferred to Issue 8 only (not Issue 12 or later).

`known_unknowns.md` has been updated: the N-value item is moved from Open → Resolved with the escape-hatch deferral and ADR-0009 reference.

---

## Architecture Notes

No drift from design principles.

Specific decisions made within issue scope:

**Coverage FKs reference `turns.turn_id` with `RESTRICT` on delete.** Per the issue spec: rewind persistence semantics are not defined in current canon. The `RESTRICT` delete rule prevents removing turns that are referenced as coverage anchors, which is the safest choice given undefined rewind semantics. This does not make any claim about how rewind will be modeled.

**Partial unique index via `op.execute()` in migration; mirrored in ORM `__table_args__`.** SQLite supports partial unique indexes natively (`WHERE is_current = 1`). Alembic's `create_index()` does not accept a WHERE clause for SQLite, so the migration uses `op.execute()` for this constraint only. The ORM `__table_args__` also declares the index via `sa.Index('uq_rs_current_per_story', 'story_id', unique=True, sqlite_where=sa.text('is_current = 1'))` so `Base.metadata.create_all()` enforces the same contract without requiring any additional DDL. Both paths use the same index definition; the test `engine` fixture requires no manual DDL.

**`compress()` uses `begin_nested()` savepoint for conflict recovery.** The prior-current flip and the new row insert execute inside a single savepoint. On `IntegrityError`, only the savepoint rolls back; the caller's outer transaction remains intact. The conflict row is re-queried and returned idempotently. `IntegrityError` is re-raised only if no conflicting row can be found — indicating genuinely unexpected state. Pattern matches the established `begin_nested()` usage in `ingestion_service.py`.

**Coverage-turn ownership validated via persisted Node lineage (P1 fix).** `_validate_turn_belongs_to_story(session, turn_id, story_id)` resolves story attribution by traversing `Turn → Node → Chapter → Arc → Story` via three SQL JOINs. Turns with `node_id=NULL` are rejected by the INNER JOIN to `NodeORM`. The validation is called for both `from_turn_id` and `through_turn_id` after the idempotency short-circuit (existing idempotent rows do not need re-validation since their coverage was validated at write time). `_make_turn()` in tests was rebuilt to produce a full `Arc → Chapter → Node → Turn` chain; orphan turns no longer appear in coverage anchor fixtures.

**`should_compress` is a module-level function, not a method.** The trigger logic is purely mathematical (`count % n == 0`); it requires no DB access and no session. Making it a free function matches the `EVENTS_LEDGER_N` pattern in `services/story_bible.py` and makes it independently testable without a session fixture.

**P2 (concurrent duplicate generation) — boundary problem, not fixed in Issue 6.** Codex correctly identified that two concurrent callers can both pass the idempotency check, both call the generator, and one later loses the DB race. Row-level deduplication is preserved (only one row is written), but generation cost is not. Fixing this narrowly would require one of: (a) a pending/in-flight status column with a new state machine — schema addition outside Issue 6 scope; (b) application-level advisory locks — locking architecture not in Issue 6; (c) inserting a placeholder row and updating with generated text — breaks the append-only contract. None of these are a narrow fix within Issue 6. If the cost model makes duplicate generation significant once the Writer path (Issue 9) produces real workloads, this should be opened as a new issue with an explicit design decision.

**Rolling Summary is fully separate from Story Bible.** `rolling_summaries` has no FK to any `sb_*` table. The only shared FK is `story_id → stories.story_id`, which is explicitly permitted per the invariant (Story Bible carries the same FK). No import from `services/story_bible.py` or `models/story_bible.py` exists in the rolling summary module.

Closes #63
