### PR TITLE
feat(extractor): implement standalone Extractor pass — CRD Issue 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,9 @@ jobs:
         # CVE-2026-4539: ReDoS in pygments AdlLexer (pygments/lexers/archetype.py).
         # Affects pygments <=2.19.2. No patched release exists upstream as of 2026-03-27.
         # Remove --ignore-vuln once pygments ships a fix and the dep is updated.
-        run: pip-audit --ignore-vuln CVE-2026-4539
+        # CVE-2026-3219: vulnerability in pip affecting versions through 26.0.1.
+        # No patched pip release exists upstream yet. This CI job upgrades pip before
+        # auditing, so we are temporarily ignoring this CVE to keep the audit gate
+        # usable. Remove this ignore once pip ships a fixed release and CI is pinned
+        # or upgraded to that version.
+        run: pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219

--- a/alembic/versions/0008_event_kind.py
+++ b/alembic/versions/0008_event_kind.py
@@ -1,0 +1,41 @@
+"""sb_events.event_kind — CRD Issue 10.
+
+Adds a ``event_kind`` column to the ``sb_events`` table.  This column stores
+the functional classification of an event (e.g. ``death``, ``location_change``)
+as defined by ``EventKind`` in ``models/enums.py``.
+
+Pre-Issue-10 rows receive ``server_default="routine"`` so existing data is
+backfilled without a separate data migration.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-25
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008"
+down_revision: Union[str, None] = "0007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sb_events",
+        sa.Column(
+            "event_kind",
+            sa.String(64),
+            nullable=False,
+            server_default="routine",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sb_events", "event_kind")

--- a/docs/decisions/ADR-0011-extractor-design-decisions.md
+++ b/docs/decisions/ADR-0011-extractor-design-decisions.md
@@ -1,0 +1,216 @@
+# ADR-0011 — Extractor Pass Design Decisions (CRD Issue 10)
+
+**Status:** Accepted
+**Date:** 2026-04-25
+**Issue:** CRD Issue 10 — Extractor Classification Policy
+**Scope:** Tool-use output schema; EVENT proposal type; cast-name resolution;
+  pass-forward content; cross-pass cache reuse
+
+---
+
+## Decision 1 — Anthropic Tool Use for Structured Extraction Output
+
+### Context
+
+The Extractor pass must produce structured, typed proposal output (locked facts,
+soft facts, transient states, unresolved threads, events).  Options:
+
+1. **Tool use (`tool_choice` forced)** — model always calls the extraction tool;
+   response is a `ToolUseBlock` with a validated JSON input dict.
+2. **Prose JSON** — model returns a JSON blob inside a text response; service
+   parses it.
+3. **Separate classification calls** — one LLM call per category.
+
+### Decision
+
+**Option 1: Anthropic tool use with `tool_choice={"type": "tool", "name":
+"propose_story_bible_updates"}` to force a single tool call per Extractor pass.**
+
+The `EXTRACT_TOOL_SPEC` in `pipeline/extractor/caller.py` defines five typed
+array fields: `locked_facts`, `soft_facts`, `transient_states`,
+`unresolved_threads`, `events`.  All are optional (`required: []`) so the model
+can omit categories where nothing was found.
+
+### Rationale
+
+- Tool use eliminates fragile JSON-in-prose parsing.
+- `tool_choice={"type": "tool", "name": ...}` forces the model to always call
+  the tool, producing a deterministic response shape.  No "I found nothing"
+  prose to parse.
+- A single tool call covers all five categories in one pass, minimising latency
+  and token cost.
+- Fail-closed: if the response contains no matching `ToolUseBlock`, the service
+  raises `ExtractorPassError` rather than silently emitting empty proposals.
+
+### Consequences
+
+- `parse_tool_input()` in `caller.py` scans content blocks for a `ToolUseBlock`
+  whose `.name` matches `EXTRACT_TOOL_NAME` and returns `.input` as a dict.
+- Responses that contain only `TextBlock` (model ignores tool_choice) raise
+  `ExtractorPassError`.
+- The `ExtractorModelCaller` protocol and `AnthropicExtractorCaller` class
+  mirror the `WriterModelCaller` pattern for injection and testability.
+
+---
+
+## Decision 2 — EVENT Added to ProposalType
+
+### Context
+
+The Events Ledger (`sb_events`) is part of the Story Bible.  The Extractor must
+be able to propose new events as part of its extraction pass.  The existing four
+`ProposalType` values (`LOCKED_FACT`, `SOFT_FACT`, `TRANSIENT_STATE`,
+`UNRESOLVED_THREAD`) do not cover append-only ledger entries.
+
+Options:
+
+1. **Add `ProposalType.EVENT`** — a dedicated routing value; `ratify_update()`
+   extended to create the `SBEventORM` row on ratification.
+2. **Reuse `TRANSIENT_STATE`** — events encoded as transient-state proposals with
+   `target_entity_type="event"`.  Service detects and routes accordingly.
+
+### Decision
+
+**Option 1: `ProposalType.EVENT` added to `models/enums.py`.**
+
+`StoryBibleService.ratify_update()` extended with an `EVENT` branch that creates
+an `SBEventORM` row and marks the proposal RATIFIED.  Events auto-commit (no
+`confirmed=True` required).
+
+### Rationale
+
+- Events are a first-class Story Bible entity type; treating them as a subtype
+  of `TRANSIENT_STATE` creates a leaky abstraction and forces the service to
+  inspect `proposed_value` internals to determine routing.
+- An explicit `ProposalType.EVENT` keeps routing logic in the enum discriminant,
+  not in `proposed_value` interpretation.
+- Events are always auto-committed (the Events Ledger is append-only; even
+  `character_death` events are recorded immediately).  A dedicated enum value
+  makes this policy explicit in code rather than implicit in a convention.
+
+### Consequences
+
+- `ProposalType.EVENT` is a new wire value (`"event"`) in the SQLite
+  `sb_provisional_staging.proposal_type` column.  Rows from Issues 1–9 will
+  not have this value; the column has no CHECK constraint limiting values so
+  existing rows are unaffected.
+- `ratify_update()` handles the new branch before the `else` clause that covers
+  `SOFT_FACT` / `TRANSIENT_STATE`.
+- Tests verify that event ratification creates a row in `sb_events`.
+
+---
+
+## Decision 3 — Cast-Name Resolution via AssembledContext
+
+### Context
+
+The Extractor LLM returns character names (e.g. `"Aldric"`) not UUIDs.  To
+apply soft-fact and transient-state updates to live dynamic fields, the service
+must resolve names to `cast_id` UUIDs.
+
+Options:
+
+1. **Use `AssembledContext.stable_prefix.story_bible_context.cast`** — the cast
+   tuple is already in memory from the Context Builder pass; no extra DB query.
+2. **Query the DB by name** — add a `find_cast_by_name()` method to
+   `StoryBibleService` and query at extraction time.
+
+### Decision
+
+**Option 1: resolve character names from `AssembledContext` at extraction time.**
+
+`_build_cast_name_map()` in `service.py` builds a `dict[str, UUID]` keyed on
+lowercase character name from `built_context.stable_prefix.story_bible_context.cast`.
+
+### Rationale
+
+- The `AssembledContext` is already in memory; the cast is the authoritative
+  snapshot used by the Writer.  No extra DB query for what is already available.
+- Case-insensitive matching (`name.lower()`) tolerates LLM capitalisation drift.
+- If the name does not resolve, the proposal is still staged and ratified; only
+  the dynamic-field application is skipped (not raised).  The RATIFIED proposal
+  remains in the staging table for future review.
+
+### Consequences
+
+- `proposed_value` for cast-update proposals stores both `character_name` (for
+  human traceability) and `entity_id` (resolved UUID, or `None` if not found).
+- If a character is added to the Story Bible after context assembly (by a
+  previous Extractor pass in the same session), the name map will not contain
+  the new entry.  This is acceptable in Issue 10 standalone; pipeline
+  orchestration (Issue 12) will manage pass ordering.
+- `target_entity_id` on the proposal is `None` for unresolvable names; the
+  dynamic-field update is skipped without error.
+
+---
+
+## Decision 4 — Cross-Pass Cache Reuse: Deferred to Issue 12
+
+### Context
+
+The CRD requires that the five pipeline passes share the same stable-prefix
+cache entry.  The Extractor uses a different system prompt than the Writer
+(extractor.md vs. mode prompt), which means the two passes produce different
+Anthropic cache keys.
+
+### Decision
+
+**Defer full cross-pass cache sharing to Issue 12 (pipeline orchestration).**
+
+The Issue 10 Extractor renders the stable-prefix user-message blocks in
+byte-for-byte identical order to the Writer's `PromptRenderer`, placing the
+cache breakpoint on the same (last) stable-prefix block.  The system-prompt
+block differs, which busts cross-pass sharing under the Anthropic caching model
+(cache key includes system).
+
+### Rationale
+
+- Issue 12 owns pipeline orchestration and is the correct place to evaluate
+  whether all five passes can share a single system-prompt tier or whether the
+  stable-prefix is cached only within a single pass's lifetime.
+- The Issue 10 Extractor produces stable within-pass caching (second call with
+  the same Story Bible hits the same cache).  The tradeoff is accepted and
+  documented.
+- Full cross-pass system-prompt unification would require either (a) a shared
+  system prompt across all passes (changing the Writer's behaviour) or (b) a
+  provider feature that caches only the user-message tier independently of the
+  system tier.  Neither is decided here.
+
+### Consequences
+
+- Pass-forward text from the Extractor adds ~2,000–2,500 uncached tokens per
+  turn to subsequent passes, consistent with the CRD cost-model estimate.
+- Issue 12 must revisit system-prompt sharing and decide whether a unified
+  pass-agnostic system prompt is feasible.  This is noted as a Known Unknown
+  that Issue 12 must address.
+
+---
+
+## Decision 5 — Extractor Does Not Commit to DB; Session Managed by Service
+
+### Context
+
+The Writer service calls `session.commit()` after persisting the Turn.  The
+Extractor makes multiple staging and ratification writes.
+
+### Decision
+
+**`ExtractorService.extract()` calls `session.commit()` once at the end of the
+pass, after all staging and ratification writes are complete.**
+
+### Rationale
+
+- A single commit at the end is atomic: either all proposals stage-and-ratify
+  together or none do.  This prevents partial state (ratified proposals without
+  corresponding staging rows) from reaching the DB on error.
+- Mirrors the Writer's single-commit pattern for consistency.
+- The pipeline (Issue 12) may choose to manage session lifecycle across all
+  five passes; Issue 10 commits its own pass following the Issue 9 precedent.
+
+### Consequences
+
+- If `extract()` raises `ExtractorPassError` after some staging writes but
+  before commit, the session is left dirty.  The caller is responsible for
+  rollback.  Issue 12 must handle this in pipeline error recovery.
+- All staging and ratification writes are flushed (but not committed) during the
+  pass; ORM object state is consistent within the session before commit.

--- a/docs/decisions/ADR-0011-extractor-design-decisions.md
+++ b/docs/decisions/ADR-0011-extractor-design-decisions.md
@@ -3,148 +3,252 @@
 **Status:** Accepted
 **Date:** 2026-04-25
 **Issue:** CRD Issue 10 — Extractor Classification Policy
-**Scope:** Tool-use output schema; EVENT proposal type; cast-name resolution;
-  pass-forward content; cross-pass cache reuse
+**Scope:** Tool-use output schema; proposal model; transaction ownership;
+  natural-key resolution; EventKind taxonomy; writable-field allowlists;
+  events bypass staging; cross-pass cache reuse
 
 ---
 
-## Decision 1 — Anthropic Tool Use for Structured Extraction Output
+## Decision 1 — Anthropic Tool Use with Discriminated Union Schema
 
 ### Context
 
-The Extractor pass must produce structured, typed proposal output (locked facts,
-soft facts, transient states, unresolved threads, events).  Options:
+The Extractor pass must produce structured, typed proposal output.  Options:
 
-1. **Tool use (`tool_choice` forced)** — model always calls the extraction tool;
-   response is a `ToolUseBlock` with a validated JSON input dict.
-2. **Prose JSON** — model returns a JSON blob inside a text response; service
-   parses it.
-3. **Separate classification calls** — one LLM call per category.
+1. **Tool use with discriminated union** — model calls `propose_canon_updates`
+   once with a `proposals` array; each element is tagged by `kind`.
+2. **Tool use with flat parallel arrays** — separate arrays per category
+   (`locked_facts`, `soft_facts`, etc.).
+3. **Prose JSON** — model returns a JSON blob in text; service parses it.
 
 ### Decision
 
-**Option 1: Anthropic tool use with `tool_choice={"type": "tool", "name":
-"propose_story_bible_updates"}` to force a single tool call per Extractor pass.**
+**Option 1: `propose_canon_updates` with a `proposals: [{oneOf discriminated-union}]`
+array, forced via `tool_choice={"type": "tool", "name": "propose_canon_updates"}`.**
 
-The `EXTRACT_TOOL_SPEC` in `pipeline/extractor/caller.py` defines five typed
-array fields: `locked_facts`, `soft_facts`, `transient_states`,
-`unresolved_threads`, `events`.  All are optional (`required: []`) so the model
-can omit categories where nothing was found.
+The `EXTRACT_TOOL_SPEC` in `pipeline/extractor/caller.py` defines a single
+`proposals` array whose items are a `oneOf` discriminated union keyed on `kind`:
+`locked_fact`, `soft_fact`, `transient_state`, `unresolved_thread`, `event`.
 
 ### Rationale
 
+- A single array is easier to extend (add a new `kind` variant without touching
+  the schema shape).
+- The discriminated union makes kind membership explicit at the schema level —
+  no implicit inference from which array a proposal appears in.
 - Tool use eliminates fragile JSON-in-prose parsing.
-- `tool_choice={"type": "tool", "name": ...}` forces the model to always call
-  the tool, producing a deterministic response shape.  No "I found nothing"
-  prose to parse.
-- A single tool call covers all five categories in one pass, minimising latency
-  and token cost.
 - Fail-closed: if the response contains no matching `ToolUseBlock`, the service
-  raises `ExtractorPassError` rather than silently emitting empty proposals.
+  raises `ExtractorPassError`.
 
 ### Consequences
 
-- `parse_tool_input()` in `caller.py` scans content blocks for a `ToolUseBlock`
-  whose `.name` matches `EXTRACT_TOOL_NAME` and returns `.input` as a dict.
-- Responses that contain only `TextBlock` (model ignores tool_choice) raise
-  `ExtractorPassError`.
-- The `ExtractorModelCaller` protocol and `AnthropicExtractorCaller` class
-  mirror the `WriterModelCaller` pattern for injection and testability.
+- `parse_tool_input()` in `caller.py` extracts the tool-use block.
+- `ExtractorProposalSet.model_validate(tool_input)` validates the full proposal
+  list using the Pydantic discriminated union in `models/extractor.py`.
+- The flat-array design (from prior Issue 10 iteration) is retired; any existing
+  data was never committed to production.
 
 ---
 
-## Decision 2 — EVENT Added to ProposalType
+## Decision 2 — EventProposal Bypasses Staging; ProposalType.EVENT Removed
 
 ### Context
 
-The Events Ledger (`sb_events`) is part of the Story Bible.  The Extractor must
-be able to propose new events as part of its extraction pass.  The existing four
-`ProposalType` values (`LOCKED_FACT`, `SOFT_FACT`, `TRANSIENT_STATE`,
-`UNRESOLVED_THREAD`) do not cover append-only ledger entries.
-
-Options:
-
-1. **Add `ProposalType.EVENT`** — a dedicated routing value; `ratify_update()`
-   extended to create the `SBEventORM` row on ratification.
-2. **Reuse `TRANSIENT_STATE`** — events encoded as transient-state proposals with
-   `target_entity_type="event"`.  Service detects and routes accordingly.
+Events are append-only ledger entries.  The prior design staged events as
+`ProposalType.EVENT` rows in `sb_provisional_staging`, then ratified them.
+Issue 10 as posted requires events to go directly to `add_event` without a
+staging row.
 
 ### Decision
 
-**Option 1: `ProposalType.EVENT` added to `models/enums.py`.**
+**Events bypass the provisional staging table entirely.**
 
-`StoryBibleService.ratify_update()` extended with an `EVENT` branch that creates
-an `SBEventORM` row and marks the proposal RATIFIED.  Events auto-commit (no
-`confirmed=True` required).
+`route_extractor_proposals()` calls `add_event()` directly for `EventProposal`
+instances.  No `SBProvisionalStagingORM` row is created.  `ProposalType.EVENT`
+is removed from the `ProposalType` enum.
 
 ### Rationale
 
-- Events are a first-class Story Bible entity type; treating them as a subtype
-  of `TRANSIENT_STATE` creates a leaky abstraction and forces the service to
-  inspect `proposed_value` internals to determine routing.
-- An explicit `ProposalType.EVENT` keeps routing logic in the enum discriminant,
-  not in `proposed_value` interpretation.
-- Events are always auto-committed (the Events Ledger is append-only; even
-  `character_death` events are recorded immediately).  A dedicated enum value
-  makes this policy explicit in code rather than implicit in a convention.
+- Events are always auto-committed (the Events Ledger is append-only).
+- A staging row adds latency and a join without providing a rollback path that
+  matters for append-only data.
+- Removing `ProposalType.EVENT` keeps the enum truthful: the four remaining
+  values all have provisional staging rows; events do not.
 
 ### Consequences
 
-- `ProposalType.EVENT` is a new wire value (`"event"`) in the SQLite
-  `sb_provisional_staging.proposal_type` column.  Rows from Issues 1–9 will
-  not have this value; the column has no CHECK constraint limiting values so
-  existing rows are unaffected.
-- `ratify_update()` handles the new branch before the `else` clause that covers
-  `SOFT_FACT` / `TRANSIENT_STATE`.
-- Tests verify that event ratification creates a row in `sb_events`.
+- `ExtractorRoutingSummary.event_ids` carries the `event_id` UUIDs of the
+  `sb_events` rows, not proposal IDs.
+- Tests verify that no staging row exists after an event proposal (bypass test).
+- `ratify_update()` no longer handles `ProposalType.EVENT`.
 
 ---
 
-## Decision 3 — Cast-Name Resolution via AssembledContext
+## Decision 3 — Fail-Loud Natural-Key Resolution
 
 ### Context
 
-The Extractor LLM returns character names (e.g. `"Aldric"`) not UUIDs.  To
-apply soft-fact and transient-state updates to live dynamic fields, the service
-must resolve names to `cast_id` UUIDs.
-
-Options:
-
-1. **Use `AssembledContext.stable_prefix.story_bible_context.cast`** — the cast
-   tuple is already in memory from the Context Builder pass; no extra DB query.
-2. **Query the DB by name** — add a `find_cast_by_name()` method to
-   `StoryBibleService` and query at extraction time.
+The Extractor LLM returns character names and relationship keys, not UUIDs.
+The prior design silently skipped field updates when a name was unresolvable.
+Issue 10 as posted requires the entire routing transaction to fail on any
+unresolvable natural key.
 
 ### Decision
 
-**Option 1: resolve character names from `AssembledContext` at extraction time.**
+**Resolution failure raises `EntityNotFoundError` and aborts the transaction.**
 
-`_build_cast_name_map()` in `service.py` builds a `dict[str, UUID]` keyed on
-lowercase character name from `built_context.stable_prefix.story_bible_context.cast`.
+`StoryBibleService.find_character_by_name()` raises `EntityNotFoundError` if no
+active cast entry matches the name (case-insensitive).  `_parse_relationship_natural_key()`
+raises `ValueError` on bad delimiter format.  Both propagate through
+`route_extractor_proposals()` and are caught in `ExtractorService.extract()` as
+`ExtractorPassError`, leaving no DB state committed.
 
 ### Rationale
 
-- The `AssembledContext` is already in memory; the cast is the authoritative
-  snapshot used by the Writer.  No extra DB query for what is already available.
-- Case-insensitive matching (`name.lower()`) tolerates LLM capitalisation drift.
-- If the name does not resolve, the proposal is still staged and ratified; only
-  the dynamic-field application is skipped (not raised).  The RATIFIED proposal
-  remains in the staging table for future review.
+- Strict fail-loud matches the posted spec acceptance criteria.
+- Silent skip could leave partial state (some proposals applied, others not)
+  within the same turn — harder to reason about and audit.
+- If strictness proves operationally undesirable, it can be relaxed in a later
+  issue.  Starting strict is safer than starting permissive.
 
 ### Consequences
 
-- `proposed_value` for cast-update proposals stores both `character_name` (for
-  human traceability) and `entity_id` (resolved UUID, or `None` if not found).
-- If a character is added to the Story Bible after context assembly (by a
-  previous Extractor pass in the same session), the name map will not contain
-  the new entry.  This is acceptable in Issue 10 standalone; pipeline
-  orchestration (Issue 12) will manage pass ordering.
-- `target_entity_id` on the proposal is `None` for unresolvable names; the
-  dynamic-field update is skipped without error.
+- The operator-facing error message includes the unresolvable name.
+- `EntityNotFoundError` and `ValueError` are caught in `ExtractorService.extract()`
+  and re-raised as `ExtractorPassError`.
+- No partial DB state is committed when routing fails.
 
 ---
 
-## Decision 4 — Cross-Pass Cache Reuse: Deferred to Issue 12
+## Decision 4 — TargetDomain + Writable-Field Allowlists
+
+### Context
+
+The Extractor may target three domains: CHARACTER, RELATIONSHIP, WORLD.  Each
+domain has a distinct natural-key convention and a distinct set of fields that
+may be updated.
+
+### Decision
+
+**`TargetDomain` enum (CHARACTER, WORLD, RELATIONSHIP) and
+`StoryBibleService.get_writable_fields(target_domain)` are the single sources of truth.**
+
+- CHARACTER: `_CAST_DYNAMIC_FIELDS` = `{current_location, current_status, is_alive, notes}`
+- RELATIONSHIP: `{current_status_description}`
+- WORLD: `frozenset()` — not supported in v1; always fails field validation.
+
+### Rationale
+
+- A method on `StoryBibleService` owns the allowlist so the routing logic
+  (`route_extractor_proposals`) does not duplicate policy knowledge.
+- WORLD is a `frozenset()` (always-fail) rather than a separate code branch,
+  so adding v1 world-state fields later only requires updating the method.
+
+### Consequences
+
+- Any proposal targeting `WORLD` domain raises `ValueError` (no writable fields)
+  and aborts the transaction.
+- The relationship allowlist is narrow (one field) to match what the schema and
+  ORM currently support.
+
+---
+
+## Decision 5 — Relationship Natural-Key Format
+
+### Context
+
+Relationships are directional (subject → object).  The Extractor must identify
+which relationship to update using character names.
+
+### Decision
+
+**Natural key format: `"<Subject> -> <Object>"` — exactly one ` -> ` delimiter
+(space, dash, greater-than, space).**
+
+`_parse_relationship_natural_key()` splits on `" -> "` and requires exactly two
+parts.  Zero or more than one delimiter raises `ValueError`, which aborts the
+transaction via the fail-loud resolution contract.
+
+### Rationale
+
+- A four-character fixed delimiter is unambiguous for any character name that
+  does not itself contain ` -> `.
+- Splitting on a fixed string (not a regex) is simple and readable.
+- The format is documented in `extractor.md` so the LLM prompt mirrors it.
+
+### Consequences
+
+- Character names containing ` -> ` would produce a parse error; this is
+  acceptable since no canon character names include that sequence.
+
+---
+
+## Decision 6 — EventKind Taxonomy Added
+
+### Context
+
+Events in the Events Ledger lacked a functional classification beyond
+`significance`.  Downstream passes (summarisation, retrieval filtering) need a
+machine-readable classification of what *kind* of event occurred.
+
+### Decision
+
+**`EventKind` enum added to `models/enums.py` with eleven values:**
+LOCATION_CHANGE, INVENTORY_GAIN, INVENTORY_LOSS, NPC_INTRODUCTION,
+STATUS_CHANGE, RELATIONSHIP_CHANGE, SCENE_TRANSITION, PLOT_REVEAL,
+OATH_OR_PROMISE, DEATH, ROUTINE.
+
+`event_kind` is a required field on the `Event` Pydantic model and a non-nullable
+column (`server_default="routine"`) on `sb_events` (migration 0008).
+
+### Rationale
+
+- `significance` is a policy-tier field (for the tiered inclusion policy).
+  `event_kind` is a functional-type field (for filtering, summarisation, display).
+  The two are orthogonal; collapsing them into one field would create a
+  mixed-semantics column.
+- Making `event_kind` required on the model ensures new events are always
+  classified; `server_default="routine"` backfills pre-Issue-10 rows safely.
+
+### Consequences
+
+- All callers that construct `Event` must supply `event_kind`.
+- Test fixtures (`make_event`, context-builder tests) updated to include `event_kind`.
+- Migration 0008 must run before the application processes any turn.
+
+---
+
+## Decision 7 — Transaction Ownership: route_extractor_proposals Commits
+
+### Context
+
+The Writer service calls `session.commit()` after persisting the Turn.  The
+Extractor makes multiple staging and direct canon writes per turn.
+
+### Decision
+
+**`StoryBibleService.route_extractor_proposals()` calls `self._session.commit()`
+once at the end of the pass.  `ExtractorService.extract()` does NOT touch the
+session.**
+
+### Rationale
+
+- A single commit at the end is atomic: all proposals stage-and-apply together
+  or none do.
+- Removes session management from `ExtractorService`, which is a pipeline-layer
+  concern, not a service-layer concern.
+- Mirrors the Writer's single-commit pattern for consistency.
+
+### Consequences
+
+- If `route_extractor_proposals()` raises before commit, the session is dirty.
+  The caller (`ExtractorService.extract()`) is responsible for rollback.
+- Issue 12 (pipeline orchestration) must handle session lifecycle across all
+  five passes and decide whether to use a single session or per-pass sessions.
+
+---
+
+## Decision 8 — Cross-Pass Cache Reuse: Deferred to Issue 12
 
 ### Context
 
@@ -166,51 +270,10 @@ block differs, which busts cross-pass sharing under the Anthropic caching model
 ### Rationale
 
 - Issue 12 owns pipeline orchestration and is the correct place to evaluate
-  whether all five passes can share a single system-prompt tier or whether the
-  stable-prefix is cached only within a single pass's lifetime.
-- The Issue 10 Extractor produces stable within-pass caching (second call with
-  the same Story Bible hits the same cache).  The tradeoff is accepted and
-  documented.
-- Full cross-pass system-prompt unification would require either (a) a shared
-  system prompt across all passes (changing the Writer's behaviour) or (b) a
-  provider feature that caches only the user-message tier independently of the
-  system tier.  Neither is decided here.
+  whether all five passes can share a single system-prompt tier.
+- The Issue 10 Extractor produces stable within-pass caching.
 
 ### Consequences
 
-- Pass-forward text from the Extractor adds ~2,000–2,500 uncached tokens per
-  turn to subsequent passes, consistent with the CRD cost-model estimate.
-- Issue 12 must revisit system-prompt sharing and decide whether a unified
-  pass-agnostic system prompt is feasible.  This is noted as a Known Unknown
-  that Issue 12 must address.
-
----
-
-## Decision 5 — Extractor Does Not Commit to DB; Session Managed by Service
-
-### Context
-
-The Writer service calls `session.commit()` after persisting the Turn.  The
-Extractor makes multiple staging and ratification writes.
-
-### Decision
-
-**`ExtractorService.extract()` calls `session.commit()` once at the end of the
-pass, after all staging and ratification writes are complete.**
-
-### Rationale
-
-- A single commit at the end is atomic: either all proposals stage-and-ratify
-  together or none do.  This prevents partial state (ratified proposals without
-  corresponding staging rows) from reaching the DB on error.
-- Mirrors the Writer's single-commit pattern for consistency.
-- The pipeline (Issue 12) may choose to manage session lifecycle across all
-  five passes; Issue 10 commits its own pass following the Issue 9 precedent.
-
-### Consequences
-
-- If `extract()` raises `ExtractorPassError` after some staging writes but
-  before commit, the session is left dirty.  The caller is responsible for
-  rollback.  Issue 12 must handle this in pipeline error recovery.
-- All staging and ratification writes are flushed (but not committed) during the
-  pass; ORM object state is consistent within the session before commit.
+- Issue 12 must revisit system-prompt sharing.  This is a Known Unknown that
+  Issue 12 must address.

--- a/docs/prompts/extractor.md
+++ b/docs/prompts/extractor.md
@@ -12,44 +12,86 @@ appears at the end of the conversation, marked `[WRITER OUTPUT]`.
 
 ## What you produce
 
-Call `propose_story_bible_updates` exactly once, reporting all narrative updates you
-identify. If nothing changed, call it with all empty arrays. You MUST call the tool —
-do not return plain text.
+Call `propose_canon_updates` exactly once with a single `proposals` array containing
+every update you identify. Use an empty array if nothing changed. You MUST call the
+tool — do not return plain text.
+
+Each proposal is a discriminated-union object with a `kind` field:
+
+| kind | purpose |
+|---|---|
+| `locked_fact` | Irreversible fact requiring Sojourner confirmation |
+| `soft_fact` | State change with low-confidence flag (auto-commits) |
+| `transient_state` | Volatile state change (auto-commits immediately) |
+| `unresolved_thread` | Open plot question not resolved this beat |
+| `event` | Significant narrative moment for the Events Ledger |
 
 ## Classification criteria
 
-**locked_facts** — Irreversible, high-stakes facts that cannot be undone: a named
+**locked_fact** — Irreversible, high-stakes facts that cannot be undone: a named
 character dies, a kingdom falls, a long-kept secret is revealed in a way that cannot
 be taken back. These require explicit Sojourner confirmation before becoming permanent
 canon. Be conservative: only extract facts that are clearly and explicitly established
 in the prose, not implied or speculative.
 
-**soft_facts** — Character or world state changes that appear real but carry some
+**soft_fact** — Character or world state changes that appear real but carry some
 uncertainty (e.g., a character's attitude visibly shifts, a character acquires new
-knowledge). Auto-committed with a low-confidence flag so the Sojourner can review.
-Only cover fields: `current_location`, `current_status`, `is_alive`, `notes`.
+knowledge). Auto-committed with a low-confidence flag for Sojourner review.
 
-**transient_states** — Volatile state that is expected to change frequently:
-a character's current location, whether they are conscious, their immediate status.
-Auto-committed immediately. Same field list as soft_facts.
+**transient_state** — Volatile state that is expected to change frequently: a
+character's current location, whether they are conscious, their immediate status.
+Auto-committed immediately. Use for the same fields as `soft_fact`.
 
-**unresolved_threads** — New plot threads, mysteries, or open questions that the
-prose introduces but does not resolve in this beat. One thread per distinct open
-question.
+**unresolved_thread** — New plot threads, mysteries, or open questions the prose
+introduces but does not resolve in this beat. One entry per distinct open question.
 
-**events** — Significant narrative moments worth recording in the Events Ledger.
-Use character names exactly as they appear in the Story Bible cast list. Choose
-significance carefully:
+**event** — Significant narrative moments worth recording in the Events Ledger.
+
+## Target domains and natural-key conventions
+
+`soft_fact` and `transient_state` proposals require `target_domain` and
+`target_natural_key`:
+
+| domain | natural_key format | writable fields |
+|---|---|---|
+| `character` | Character name (e.g. `"Aldric"`) | `current_location`, `current_status`, `is_alive`, `notes` |
+| `relationship` | `"<Subject> -> <Object>"` (e.g. `"Aldric -> Mira"`) | `current_status_description` |
+| `world` | (not supported in v1 — do not use) | (none) |
+
+Use character names exactly as they appear in the Story Bible cast list. The
+service resolves names case-insensitively, but exact-casing from the cast list is
+preferred. For relationships, use exactly one ` -> ` delimiter (space, dash,
+greater-than, space).
+
+## EventKind values
+
+Every `event` proposal requires an `event_kind` classification:
+
+| event_kind | when to use |
+|---|---|
+| `location_change` | A character moves to a new location |
+| `inventory_gain` | A character acquires an item |
+| `inventory_loss` | A character loses or gives up an item |
+| `npc_introduction` | A new named character is introduced |
+| `status_change` | A character's condition or status changes |
+| `relationship_change` | A relationship between characters changes meaningfully |
+| `scene_transition` | The scene or setting shifts |
+| `plot_reveal` | A hidden fact or secret comes to light |
+| `oath_or_promise` | A character makes a binding commitment |
+| `death` | A character dies |
+| `routine` | A minor action with no lasting narrative consequence |
+
+## EventSignificance values
 
 | significance | when to use |
 |---|---|
-| `routine` | minor action, nothing lasting |
-| `character_death` | a named character dies |
-| `locked_fact_established` | an irreversible fact becomes canon |
-| `major_plot_turn` | a major narrative turning point |
-| `relationship_change` | a relationship between characters changes meaningfully |
-| `world_state_change` | the world state changes in a lasting, observable way |
-| `forbidden_fact_established` | a forbidden fact becomes directly relevant |
+| `routine` | Minor action, nothing lasting |
+| `character_death` | A named character dies |
+| `locked_fact_established` | An irreversible fact becomes canon |
+| `major_plot_turn` | A major narrative turning point |
+| `relationship_change` | A relationship changes meaningfully |
+| `world_state_change` | The world state changes in a lasting, observable way |
+| `forbidden_fact_established` | A forbidden fact becomes directly relevant |
 
 ## Rules
 
@@ -57,7 +99,9 @@ significance carefully:
    speculate, or hallucinate updates.
 2. Do not re-extract facts already visible in the Story Bible unless they changed
    in this beat.
-3. If nothing changed in a category, leave that array empty.
+3. Use an empty proposals array when nothing changed — never omit the tool call.
 4. Use character names exactly as they appear in the Story Bible cast list.
 5. For `is_alive`: only extract `false` when the prose explicitly shows a character
    dying in this beat — not when death is feared or threatened.
+6. The routing service will fail the entire turn if a character name or relationship
+   key cannot be resolved. Double-check names against the cast list before proposing.

--- a/docs/prompts/extractor.md
+++ b/docs/prompts/extractor.md
@@ -1,0 +1,63 @@
+# Extractor — Story Bible Update Classifier
+
+You are the Extractor, the third pass in the Sojourn narrative pipeline. Your sole
+responsibility is to analyze the Writer's prose and identify every narrative state
+change that should be proposed for the Story Bible.
+
+## What you receive
+
+The assembled context shows you the current Story Bible: world rules, cast, locked
+facts, forbidden facts, active events, and plot threads. The Writer's prose output
+appears at the end of the conversation, marked `[WRITER OUTPUT]`.
+
+## What you produce
+
+Call `propose_story_bible_updates` exactly once, reporting all narrative updates you
+identify. If nothing changed, call it with all empty arrays. You MUST call the tool —
+do not return plain text.
+
+## Classification criteria
+
+**locked_facts** — Irreversible, high-stakes facts that cannot be undone: a named
+character dies, a kingdom falls, a long-kept secret is revealed in a way that cannot
+be taken back. These require explicit Sojourner confirmation before becoming permanent
+canon. Be conservative: only extract facts that are clearly and explicitly established
+in the prose, not implied or speculative.
+
+**soft_facts** — Character or world state changes that appear real but carry some
+uncertainty (e.g., a character's attitude visibly shifts, a character acquires new
+knowledge). Auto-committed with a low-confidence flag so the Sojourner can review.
+Only cover fields: `current_location`, `current_status`, `is_alive`, `notes`.
+
+**transient_states** — Volatile state that is expected to change frequently:
+a character's current location, whether they are conscious, their immediate status.
+Auto-committed immediately. Same field list as soft_facts.
+
+**unresolved_threads** — New plot threads, mysteries, or open questions that the
+prose introduces but does not resolve in this beat. One thread per distinct open
+question.
+
+**events** — Significant narrative moments worth recording in the Events Ledger.
+Use character names exactly as they appear in the Story Bible cast list. Choose
+significance carefully:
+
+| significance | when to use |
+|---|---|
+| `routine` | minor action, nothing lasting |
+| `character_death` | a named character dies |
+| `locked_fact_established` | an irreversible fact becomes canon |
+| `major_plot_turn` | a major narrative turning point |
+| `relationship_change` | a relationship between characters changes meaningfully |
+| `world_state_change` | the world state changes in a lasting, observable way |
+| `forbidden_fact_established` | a forbidden fact becomes directly relevant |
+
+## Rules
+
+1. Extract only what is explicitly present in the Writer's prose. Do not infer,
+   speculate, or hallucinate updates.
+2. Do not re-extract facts already visible in the Story Bible unless they changed
+   in this beat.
+3. If nothing changed in a category, leave that array empty.
+4. Use character names exactly as they appear in the Story Bible cast list.
+5. For `is_alive`: only extract `false` when the prose explicitly shows a character
+   dying in this beat — not when death is feared or threatened.

--- a/docs/prompts/extractor.md
+++ b/docs/prompts/extractor.md
@@ -58,6 +58,10 @@ introduces but does not resolve in this beat. One entry per distinct open questi
 | `relationship` | `"<Subject> -> <Object>"` (e.g. `"Aldric -> Mira"`) | `current_status_description` |
 | `world` | (not supported in v1 — do not use) | (none) |
 
+`proposed_value` is a JSON string for text fields and a JSON boolean (`true`/`false`) for
+`is_alive`. Do not use a string `"true"` or `"false"` for `is_alive` — pass the boolean
+directly.
+
 Use character names exactly as they appear in the Story Bible cast list. The
 service resolves names case-insensitively, but exact-casing from the cast list is
 preferred. For relationships, use exactly one ` -> ` delimiter (space, dash,

--- a/src/afterworlds/models/enums.py
+++ b/src/afterworlds/models/enums.py
@@ -142,13 +142,15 @@ class ThreadStatus(StrEnum):
 class ProposalType(StrEnum):
     """Extractor route classification for a provisional staging entry.
 
-    Mirrors the four routes in the Extractor Update Policy (design.md §4).
+    Mirrors the four routes in the Extractor Update Policy (design.md §4) plus
+    EVENT, added for the Events Ledger auto-commit path (CRD Issue 10).
     """
 
     LOCKED_FACT = "locked_fact"
     SOFT_FACT = "soft_fact"
     TRANSIENT_STATE = "transient_state"
     UNRESOLVED_THREAD = "unresolved_thread"
+    EVENT = "event"
 
 
 class ProposalStatus(StrEnum):

--- a/src/afterworlds/models/enums.py
+++ b/src/afterworlds/models/enums.py
@@ -142,15 +142,15 @@ class ThreadStatus(StrEnum):
 class ProposalType(StrEnum):
     """Extractor route classification for a provisional staging entry.
 
-    Mirrors the four routes in the Extractor Update Policy (design.md §4) plus
-    EVENT, added for the Events Ledger auto-commit path (CRD Issue 10).
+    Mirrors the four routes in the Extractor Update Policy (design.md §4).
+    EVENT proposals bypass staging and go directly to ``add_event``; there is
+    no ``ProposalType.EVENT`` value.
     """
 
     LOCKED_FACT = "locked_fact"
     SOFT_FACT = "soft_fact"
     TRANSIENT_STATE = "transient_state"
     UNRESOLVED_THREAD = "unresolved_thread"
-    EVENT = "event"
 
 
 class ProposalStatus(StrEnum):
@@ -159,6 +159,39 @@ class ProposalStatus(StrEnum):
     PENDING = "pending"
     RATIFIED = "ratified"
     REJECTED = "rejected"
+
+
+class TargetDomain(StrEnum):
+    """Domain of a proposal's target entity — used by the Extractor routing layer.
+
+    Determines the natural-key format and writable-field allowlist applied by
+    ``StoryBibleService.route_extractor_proposals()``.
+    """
+
+    CHARACTER = "character"
+    WORLD = "world"
+    RELATIONSHIP = "relationship"
+
+
+class EventKind(StrEnum):
+    """Functional classification of an Events Ledger entry.
+
+    Used by the Extractor to classify the type of event being proposed,
+    enabling downstream filtering and summarisation without reparsing prose.
+    The canonical set is defined here; ``extractor.md`` mirrors it.
+    """
+
+    LOCATION_CHANGE = "location_change"
+    INVENTORY_GAIN = "inventory_gain"
+    INVENTORY_LOSS = "inventory_loss"
+    NPC_INTRODUCTION = "npc_introduction"
+    STATUS_CHANGE = "status_change"
+    RELATIONSHIP_CHANGE = "relationship_change"
+    SCENE_TRANSITION = "scene_transition"
+    PLOT_REVEAL = "plot_reveal"
+    OATH_OR_PROMISE = "oath_or_promise"
+    DEATH = "death"
+    ROUTINE = "routine"
 
 
 # ---------------------------------------------------------------------------

--- a/src/afterworlds/models/extractor.py
+++ b/src/afterworlds/models/extractor.py
@@ -21,7 +21,7 @@ class SoftFactProposal(BaseModel):
     target_domain: TargetDomain
     target_natural_key: str
     target_field: str
-    proposed_value: str
+    proposed_value: bool | str
     rationale: str | None = None
 
 
@@ -30,7 +30,7 @@ class TransientStateProposal(BaseModel):
     target_domain: TargetDomain
     target_natural_key: str
     target_field: str
-    proposed_value: str
+    proposed_value: bool | str
     rationale: str | None = None
 
 
@@ -60,7 +60,7 @@ ExtractorProposal = Annotated[
 
 
 class ExtractorProposalSet(BaseModel):
-    proposals: list[ExtractorProposal] = Field(default_factory=list)
+    proposals: list[ExtractorProposal]
 
 
 class ExtractorRoutingSummary(BaseModel):

--- a/src/afterworlds/models/extractor.py
+++ b/src/afterworlds/models/extractor.py
@@ -1,0 +1,83 @@
+"""Extractor proposal types and result types — CRD Issue 10."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from afterworlds.models.enums import EventKind, EventSignificance, TargetDomain
+
+
+class LockedFactProposal(BaseModel):
+    kind: Literal["locked_fact"] = "locked_fact"
+    fact_text: str
+    rationale: str | None = None
+
+
+class SoftFactProposal(BaseModel):
+    kind: Literal["soft_fact"] = "soft_fact"
+    target_domain: TargetDomain
+    target_natural_key: str
+    target_field: str
+    proposed_value: str
+    rationale: str | None = None
+
+
+class TransientStateProposal(BaseModel):
+    kind: Literal["transient_state"] = "transient_state"
+    target_domain: TargetDomain
+    target_natural_key: str
+    target_field: str
+    proposed_value: str
+    rationale: str | None = None
+
+
+class UnresolvedThreadProposal(BaseModel):
+    kind: Literal["unresolved_thread"] = "unresolved_thread"
+    description: str
+    rationale: str | None = None
+
+
+class EventProposal(BaseModel):
+    kind: Literal["event"] = "event"
+    event_kind: EventKind
+    description: str
+    significance: EventSignificance
+    related_entity_natural_keys: list[str] = Field(default_factory=list)
+    rationale: str | None = None
+
+
+ExtractorProposal = Annotated[
+    LockedFactProposal
+    | SoftFactProposal
+    | TransientStateProposal
+    | UnresolvedThreadProposal
+    | EventProposal,
+    Field(discriminator="kind"),
+]
+
+
+class ExtractorProposalSet(BaseModel):
+    proposals: list[ExtractorProposal] = Field(default_factory=list)
+
+
+class ExtractorRoutingSummary(BaseModel):
+    locked_fact_staged_ids: list[UUID]
+    soft_fact_staged_ids: list[UUID]
+    transient_state_staged_ids: list[UUID]
+    unresolved_thread_staged_ids: list[UUID]
+    event_ids: list[UUID]
+
+
+__all__ = [
+    "LockedFactProposal",
+    "SoftFactProposal",
+    "TransientStateProposal",
+    "UnresolvedThreadProposal",
+    "EventProposal",
+    "ExtractorProposal",
+    "ExtractorProposalSet",
+    "ExtractorRoutingSummary",
+]

--- a/src/afterworlds/models/story_bible.py
+++ b/src/afterworlds/models/story_bible.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from afterworlds.models.enums import (
     CastRole,
+    EventKind,
     EventSignificance,
     ProposalStatus,
     ProposalType,
@@ -129,6 +130,7 @@ class Event(BaseModel):
     story_id: UUID
     description: str
     significance: EventSignificance
+    event_kind: EventKind
     # Provenance: traceability only; not a FK to the turns table.
     source_turn_id: str | None = None
     is_active: bool = True

--- a/src/afterworlds/persistence/orm/story_bible.py
+++ b/src/afterworlds/persistence/orm/story_bible.py
@@ -145,6 +145,9 @@ class SBEventORM(Base):
     )
     description: Mapped[str] = mapped_column(sa.Text, nullable=False)
     significance: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    event_kind: Mapped[str] = mapped_column(
+        sa.String(64), nullable=False, server_default="routine"
+    )
     # Provenance — plain string, NOT a FK to turns. Traceability only.
     source_turn_id: Mapped[str | None] = mapped_column(sa.String(36), nullable=True)
     is_active: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, default=True)

--- a/src/afterworlds/pipeline/extractor/__init__.py
+++ b/src/afterworlds/pipeline/extractor/__init__.py
@@ -1,0 +1,1 @@
+"""Extractor pipeline pass — CRD Issue 10."""

--- a/src/afterworlds/pipeline/extractor/caller.py
+++ b/src/afterworlds/pipeline/extractor/caller.py
@@ -25,144 +25,193 @@ from afterworlds.pipeline.extractor.config import ExtractorConfig
 # Tool specification
 # ---------------------------------------------------------------------------
 
-EXTRACT_TOOL_NAME: str = "propose_story_bible_updates"
+EXTRACT_TOOL_NAME: str = "propose_canon_updates"
+
+_SOFT_TRANSIENT_PROPERTIES: dict[str, Any] = {
+    "target_domain": {
+        "type": "string",
+        "enum": ["character", "world", "relationship"],
+        "description": "Entity domain the update targets.",
+    },
+    "target_natural_key": {
+        "type": "string",
+        "description": (
+            "Character name for the 'character' domain; "
+            "'<Subject> -> <Object>' for the 'relationship' domain."
+        ),
+    },
+    "target_field": {
+        "type": "string",
+        "description": (
+            "Field to update.  "
+            "Character allowlist: current_location, current_status, is_alive, notes.  "
+            "Relationship allowlist: current_status_description."
+        ),
+    },
+    "proposed_value": {
+        "type": "string",
+        "description": "New field value as a string.",
+    },
+    "rationale": {
+        "type": "string",
+        "description": "Why this change is warranted.",
+    },
+}
+
+_SOFT_TRANSIENT_REQUIRED: list[str] = [
+    "kind",
+    "target_domain",
+    "target_natural_key",
+    "target_field",
+    "proposed_value",
+]
 
 #: Tool specification passed to the Anthropic API.
 EXTRACT_TOOL_SPEC: dict[str, Any] = {
     "name": EXTRACT_TOOL_NAME,
     "description": (
-        "Report all narrative canon updates proposed for this turn. "
-        "Call this tool exactly once, reporting every update you identify. "
-        "Use empty arrays for categories where nothing was found."
+        "Report all narrative canon updates proposed for this turn as a single "
+        "discriminated-union array.  Call this tool exactly once.  Use an empty "
+        "proposals array when nothing was extracted."
     ),
     "input_schema": {
         "type": "object",
         "properties": {
-            "locked_facts": {
+            "proposals": {
                 "type": "array",
-                "description": (
-                    "Irreversible facts established in this beat that require "
-                    "Sojourner confirmation before becoming permanent canon."
-                ),
+                "description": "All narrative canon updates proposed for this turn.",
                 "items": {
-                    "type": "object",
-                    "properties": {
-                        "fact_text": {
-                            "type": "string",
-                            "description": "The irreversible fact, stated plainly.",
-                        }
-                    },
-                    "required": ["fact_text"],
-                },
-            },
-            "soft_facts": {
-                "type": "array",
-                "description": (
-                    "Character or world state changes that auto-commit with a "
-                    "low-confidence flag so the Sojourner can review them."
-                ),
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "character_name": {
-                            "type": "string",
+                    "oneOf": [
+                        {
+                            "type": "object",
                             "description": (
-                                "Exact character name from the Story Bible cast list."
+                                "An irreversible fact established this beat.  "
+                                "Requires Sojourner confirmation before becoming canon."
                             ),
+                            "properties": {
+                                "kind": {"type": "string", "const": "locked_fact"},
+                                "fact_text": {
+                                    "type": "string",
+                                    "description": (
+                                        "The irreversible fact, stated plainly."
+                                    ),
+                                },
+                                "rationale": {
+                                    "type": "string",
+                                    "description": "Why this fact is irreversible.",
+                                },
+                            },
+                            "required": ["kind", "fact_text"],
                         },
-                        "field_name": {
-                            "type": "string",
-                            "enum": [
-                                "current_location",
-                                "current_status",
-                                "is_alive",
-                                "notes",
-                            ],
-                            "description": "Which dynamic field changed.",
-                        },
-                        "new_value": {
-                            "description": "The new field value.",
-                        },
-                    },
-                    "required": ["character_name", "field_name", "new_value"],
-                },
-            },
-            "transient_states": {
-                "type": "array",
-                "description": (
-                    "Volatile state changes (current location, active quest, etc.) "
-                    "that auto-commit immediately without a review flag."
-                ),
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "character_name": {
-                            "type": "string",
+                        {
+                            "type": "object",
                             "description": (
-                                "Exact character name from the Story Bible cast list."
+                                "A character or world state change proposed with a "
+                                "low-confidence flag for Sojourner review."
                             ),
+                            "properties": {
+                                "kind": {"type": "string", "const": "soft_fact"},
+                                **_SOFT_TRANSIENT_PROPERTIES,
+                            },
+                            "required": _SOFT_TRANSIENT_REQUIRED,
                         },
-                        "field_name": {
-                            "type": "string",
-                            "enum": [
-                                "current_location",
-                                "current_status",
-                                "is_alive",
-                                "notes",
+                        {
+                            "type": "object",
+                            "description": (
+                                "A volatile state change that auto-commits immediately "
+                                "without a Sojourner review flag."
+                            ),
+                            "properties": {
+                                "kind": {"type": "string", "const": "transient_state"},
+                                **_SOFT_TRANSIENT_PROPERTIES,
+                            },
+                            "required": _SOFT_TRANSIENT_REQUIRED,
+                        },
+                        {
+                            "type": "object",
+                            "description": (
+                                "A new unresolved plot thread introduced this beat."
+                            ),
+                            "properties": {
+                                "kind": {
+                                    "type": "string",
+                                    "const": "unresolved_thread",
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": (
+                                        "Brief description of the open thread."
+                                    ),
+                                },
+                                "rationale": {"type": "string"},
+                            },
+                            "required": ["kind", "description"],
+                        },
+                        {
+                            "type": "object",
+                            "description": (
+                                "A significant narrative moment for the Events Ledger."
+                            ),
+                            "properties": {
+                                "kind": {"type": "string", "const": "event"},
+                                "event_kind": {
+                                    "type": "string",
+                                    "enum": [
+                                        "location_change",
+                                        "inventory_gain",
+                                        "inventory_loss",
+                                        "npc_introduction",
+                                        "status_change",
+                                        "relationship_change",
+                                        "scene_transition",
+                                        "plot_reveal",
+                                        "oath_or_promise",
+                                        "death",
+                                        "routine",
+                                    ],
+                                    "description": (
+                                        "Functional classification of the event."
+                                    ),
+                                },
+                                "description": {
+                                    "type": "string",
+                                    "description": "What happened, stated plainly.",
+                                },
+                                "significance": {
+                                    "type": "string",
+                                    "enum": [
+                                        "routine",
+                                        "character_death",
+                                        "locked_fact_established",
+                                        "major_plot_turn",
+                                        "relationship_change",
+                                        "world_state_change",
+                                        "forbidden_fact_established",
+                                    ],
+                                    "description": (
+                                        "Significance for tiered inclusion policy."
+                                    ),
+                                },
+                                "related_entity_natural_keys": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": (
+                                        "Character names or 'Subject -> Object' keys "
+                                        "involved in this event."
+                                    ),
+                                },
+                                "rationale": {"type": "string"},
+                            },
+                            "required": [
+                                "kind",
+                                "event_kind",
+                                "description",
+                                "significance",
                             ],
-                            "description": "Which dynamic field changed.",
                         },
-                        "new_value": {
-                            "description": "The new field value.",
-                        },
-                    },
-                    "required": ["character_name", "field_name", "new_value"],
+                    ]
                 },
-            },
-            "unresolved_threads": {
-                "type": "array",
-                "description": (
-                    "New plot threads or open questions introduced in the prose "
-                    "that are not resolved within this beat."
-                ),
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "type": "string",
-                            "description": "Brief description of the open thread.",
-                        }
-                    },
-                    "required": ["description"],
-                },
-            },
-            "events": {
-                "type": "array",
-                "description": "Significant narrative moments for the Events Ledger.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "type": "string",
-                            "description": "What happened, stated plainly.",
-                        },
-                        "significance": {
-                            "type": "string",
-                            "enum": [
-                                "routine",
-                                "character_death",
-                                "locked_fact_established",
-                                "major_plot_turn",
-                                "relationship_change",
-                                "world_state_change",
-                                "forbidden_fact_established",
-                            ],
-                            "description": "Significance for tiered inclusion policy.",
-                        },
-                    },
-                    "required": ["description", "significance"],
-                },
-            },
+            }
         },
         "required": [],
     },

--- a/src/afterworlds/pipeline/extractor/caller.py
+++ b/src/afterworlds/pipeline/extractor/caller.py
@@ -49,8 +49,12 @@ _SOFT_TRANSIENT_PROPERTIES: dict[str, Any] = {
         ),
     },
     "proposed_value": {
-        "type": "string",
-        "description": "New field value as a string.",
+        "oneOf": [{"type": "string"}, {"type": "boolean"}],
+        "description": (
+            "New field value. "
+            "Use a string for text fields (current_location, current_status, notes); "
+            "use a JSON boolean (true/false) for is_alive."
+        ),
     },
     "rationale": {
         "type": "string",
@@ -213,7 +217,7 @@ EXTRACT_TOOL_SPEC: dict[str, Any] = {
                 },
             }
         },
-        "required": [],
+        "required": ["proposals"],
     },
 }
 

--- a/src/afterworlds/pipeline/extractor/caller.py
+++ b/src/afterworlds/pipeline/extractor/caller.py
@@ -311,20 +311,26 @@ def parse_tool_input(response: Message) -> dict[str, Any]:
             f"Unexpected response type from provider: {type(response).__name__}"
         )
 
-    for block in response.content:
-        if isinstance(block, ToolUseBlock) and block.name == EXTRACT_TOOL_NAME:
-            raw: Any = block.input
-            if not isinstance(raw, dict):
-                raise ExtractorPassError(
-                    f"Tool input is not a dict; got {type(raw).__name__}"
-                )
-            return raw
-
-    raise ExtractorPassError(
-        f"Provider response contains no '{EXTRACT_TOOL_NAME}' tool-use block. "
-        "stop_reason was: "
-        f"{getattr(response, 'stop_reason', '<unknown>')!r}"
-    )
+    matching = [
+        block
+        for block in response.content
+        if isinstance(block, ToolUseBlock) and block.name == EXTRACT_TOOL_NAME
+    ]
+    if not matching:
+        raise ExtractorPassError(
+            f"Provider response contains no '{EXTRACT_TOOL_NAME}' tool-use block. "
+            "stop_reason was: "
+            f"{getattr(response, 'stop_reason', '<unknown>')!r}"
+        )
+    if len(matching) > 1:
+        raise ExtractorPassError(
+            f"Provider response contains {len(matching)} '{EXTRACT_TOOL_NAME}' "
+            "tool-use blocks; expected exactly one."
+        )
+    raw: Any = matching[0].input
+    if not isinstance(raw, dict):
+        raise ExtractorPassError(f"Tool input is not a dict; got {type(raw).__name__}")
+    return raw
 
 
 __all__ = [

--- a/src/afterworlds/pipeline/extractor/caller.py
+++ b/src/afterworlds/pipeline/extractor/caller.py
@@ -1,0 +1,288 @@
+"""Extractor model caller protocol and default Anthropic implementation — CRD Issue 10.
+
+The Extractor uses Anthropic tool use to obtain structured proposal output.
+``tool_choice={"type": "tool", "name": EXTRACT_TOOL_NAME}`` forces the model
+to always call the extraction tool, eliminating prose-parsing ambiguity.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol
+
+import anthropic
+from anthropic.types import (
+    CacheControlEphemeralParam,
+    Message,
+    MessageParam,
+    TextBlockParam,
+    ToolUseBlock,
+)
+
+from afterworlds.pipeline.extractor.config import ExtractorConfig
+
+# ---------------------------------------------------------------------------
+# Tool specification
+# ---------------------------------------------------------------------------
+
+EXTRACT_TOOL_NAME: str = "propose_story_bible_updates"
+
+#: Tool specification passed to the Anthropic API.
+EXTRACT_TOOL_SPEC: dict[str, Any] = {
+    "name": EXTRACT_TOOL_NAME,
+    "description": (
+        "Report all narrative canon updates proposed for this turn. "
+        "Call this tool exactly once, reporting every update you identify. "
+        "Use empty arrays for categories where nothing was found."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "locked_facts": {
+                "type": "array",
+                "description": (
+                    "Irreversible facts established in this beat that require "
+                    "Sojourner confirmation before becoming permanent canon."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "fact_text": {
+                            "type": "string",
+                            "description": "The irreversible fact, stated plainly.",
+                        }
+                    },
+                    "required": ["fact_text"],
+                },
+            },
+            "soft_facts": {
+                "type": "array",
+                "description": (
+                    "Character or world state changes that auto-commit with a "
+                    "low-confidence flag so the Sojourner can review them."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "character_name": {
+                            "type": "string",
+                            "description": (
+                                "Exact character name from the Story Bible cast list."
+                            ),
+                        },
+                        "field_name": {
+                            "type": "string",
+                            "enum": [
+                                "current_location",
+                                "current_status",
+                                "is_alive",
+                                "notes",
+                            ],
+                            "description": "Which dynamic field changed.",
+                        },
+                        "new_value": {
+                            "description": "The new field value.",
+                        },
+                    },
+                    "required": ["character_name", "field_name", "new_value"],
+                },
+            },
+            "transient_states": {
+                "type": "array",
+                "description": (
+                    "Volatile state changes (current location, active quest, etc.) "
+                    "that auto-commit immediately without a review flag."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "character_name": {
+                            "type": "string",
+                            "description": (
+                                "Exact character name from the Story Bible cast list."
+                            ),
+                        },
+                        "field_name": {
+                            "type": "string",
+                            "enum": [
+                                "current_location",
+                                "current_status",
+                                "is_alive",
+                                "notes",
+                            ],
+                            "description": "Which dynamic field changed.",
+                        },
+                        "new_value": {
+                            "description": "The new field value.",
+                        },
+                    },
+                    "required": ["character_name", "field_name", "new_value"],
+                },
+            },
+            "unresolved_threads": {
+                "type": "array",
+                "description": (
+                    "New plot threads or open questions introduced in the prose "
+                    "that are not resolved within this beat."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "description": "Brief description of the open thread.",
+                        }
+                    },
+                    "required": ["description"],
+                },
+            },
+            "events": {
+                "type": "array",
+                "description": "Significant narrative moments for the Events Ledger.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string",
+                            "description": "What happened, stated plainly.",
+                        },
+                        "significance": {
+                            "type": "string",
+                            "enum": [
+                                "routine",
+                                "character_death",
+                                "locked_fact_established",
+                                "major_plot_turn",
+                                "relationship_change",
+                                "world_state_change",
+                                "forbidden_fact_established",
+                            ],
+                            "description": "Significance for tiered inclusion policy.",
+                        },
+                    },
+                    "required": ["description", "significance"],
+                },
+            },
+        },
+        "required": [],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Payload type alias
+# ---------------------------------------------------------------------------
+
+ExtractorPayload = dict[str, object]
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class ExtractorModelCaller(Protocol):
+    """Protocol for the Extractor model invocation seam."""
+
+    def __call__(self, payload: ExtractorPayload) -> Message:
+        """Invoke the model with the extraction payload and return the response."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Default Anthropic implementation
+# ---------------------------------------------------------------------------
+
+
+class AnthropicExtractorCaller:
+    """Default ExtractorModelCaller wired to the Anthropic Python SDK.
+
+    Forces tool use via ``tool_choice={"type": "tool", "name": ...}`` so the
+    model always returns a structured ToolUseBlock rather than prose.
+    """
+
+    def __init__(self, config: ExtractorConfig) -> None:
+        self._config = config
+
+    def __call__(self, payload: ExtractorPayload) -> Message:
+        api_key = self._config.get_api_key()
+        client = anthropic.Anthropic(api_key=api_key)
+
+        system_blocks: list[TextBlockParam] = payload["system"]  # type: ignore[assignment]
+        messages: list[MessageParam] = payload["messages"]  # type: ignore[assignment]
+        model: str = payload["model"]  # type: ignore[assignment]
+        max_tokens: int = payload["max_tokens"]  # type: ignore[assignment]
+        tools: list[Any] = payload["tools"]  # type: ignore[assignment]
+        tool_choice: dict[str, Any] = payload["tool_choice"]  # type: ignore[assignment]
+
+        return client.messages.create(  # type: ignore[call-overload, no-any-return]
+            model=model,
+            max_tokens=max_tokens,
+            system=system_blocks,
+            messages=messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            stream=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timing wrapper
+# ---------------------------------------------------------------------------
+
+
+def timed_call(
+    caller: ExtractorModelCaller,
+    payload: ExtractorPayload,
+) -> tuple[Message, int]:
+    """Call the model caller and return (response, latency_ms)."""
+    start = time.monotonic()
+    response = caller(payload)
+    latency_ms = int((time.monotonic() - start) * 1000)
+    return response, latency_ms
+
+
+def parse_tool_input(response: Message) -> dict[str, Any]:
+    """Extract the tool-use input dict from an Anthropic Message.
+
+    Scans the content blocks for a ToolUseBlock whose name matches
+    ``EXTRACT_TOOL_NAME`` and returns its ``input`` dict.
+
+    Raises:
+        ExtractorPassError: if no matching tool-use block is found or the
+            response envelope is malformed.
+    """
+    from afterworlds.pipeline.extractor.models import ExtractorPassError
+
+    if not isinstance(response, Message):
+        raise ExtractorPassError(
+            f"Unexpected response type from provider: {type(response).__name__}"
+        )
+
+    for block in response.content:
+        if isinstance(block, ToolUseBlock) and block.name == EXTRACT_TOOL_NAME:
+            raw: Any = block.input
+            if not isinstance(raw, dict):
+                raise ExtractorPassError(
+                    f"Tool input is not a dict; got {type(raw).__name__}"
+                )
+            return raw
+
+    raise ExtractorPassError(
+        f"Provider response contains no '{EXTRACT_TOOL_NAME}' tool-use block. "
+        "stop_reason was: "
+        f"{getattr(response, 'stop_reason', '<unknown>')!r}"
+    )
+
+
+__all__ = [
+    "EXTRACT_TOOL_NAME",
+    "EXTRACT_TOOL_SPEC",
+    "ExtractorPayload",
+    "ExtractorModelCaller",
+    "AnthropicExtractorCaller",
+    "timed_call",
+    "parse_tool_input",
+    "CacheControlEphemeralParam",
+    "TextBlockParam",
+    "MessageParam",
+]

--- a/src/afterworlds/pipeline/extractor/config.py
+++ b/src/afterworlds/pipeline/extractor/config.py
@@ -1,0 +1,65 @@
+"""Extractor pass configuration — CRD Issue 10.
+
+The Extractor is a small/fast model pass per the CRD cost model (Item 8).
+Configuration follows the same env-var pattern as WriterConfig.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_DEFAULT_EXTRACTOR_MODEL: str = "claude-haiku-4-5-20251001"
+
+#: Max tokens for an Extractor response.  The tool-use output is structured JSON,
+#: so 1024 tokens is generous; the prose budget is not relevant here.
+EXTRACTOR_MAX_TOKENS: int = 1024
+
+
+@dataclass
+class ExtractorConfig:
+    """Configuration for the Extractor pass.
+
+    Attributes:
+        model: Anthropic model identifier.  Defaults to the Haiku-tier model per
+            the CRD small/fast model assignment for the Extractor pass.
+        api_key_env: Name of the environment variable holding the Anthropic API key.
+        extended_ttl: When True, the cache breakpoint uses ``ttl="1h"``.
+            Must be True by default — CRD Item 14 invariant #9.
+    """
+
+    model: str = _DEFAULT_EXTRACTOR_MODEL
+    api_key_env: str = "ANTHROPIC_API_KEY"
+    extended_ttl: bool = True
+
+    @classmethod
+    def from_env(cls) -> ExtractorConfig:
+        """Build an ExtractorConfig from environment variables.
+
+        Environment variables:
+            AFTERWORLDS_EXTRACTOR_MODEL: overrides the default model identifier.
+            AFTERWORLDS_EXTRACTOR_API_KEY_ENV: overrides the env-var name for the key.
+            AFTERWORLDS_EXTRACTOR_EXTENDED_TTL: set to "false", "0", or "no" to
+                disable extended TTL (not recommended; defaults to True).
+        """
+        model = os.environ.get("AFTERWORLDS_EXTRACTOR_MODEL", _DEFAULT_EXTRACTOR_MODEL)
+        api_key_env = os.environ.get(
+            "AFTERWORLDS_EXTRACTOR_API_KEY_ENV", "ANTHROPIC_API_KEY"
+        )
+        ttl_str = os.environ.get("AFTERWORLDS_EXTRACTOR_EXTENDED_TTL", "true").lower()
+        extended_ttl = ttl_str not in ("0", "false", "no")
+        return cls(model=model, api_key_env=api_key_env, extended_ttl=extended_ttl)
+
+    def get_api_key(self) -> str:
+        """Return the API key from the configured environment variable.
+
+        Raises:
+            ValueError: if the configured env var is not set or empty.
+        """
+        key = os.environ.get(self.api_key_env, "")
+        if not key:
+            raise ValueError(
+                f"Anthropic API key env var {self.api_key_env!r} is not set. "
+                "Set it before calling the Extractor service."
+            )
+        return key

--- a/src/afterworlds/pipeline/extractor/models.py
+++ b/src/afterworlds/pipeline/extractor/models.py
@@ -4,36 +4,23 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
-from afterworlds.models.story_bible import ProvisionalProposal
+from afterworlds.models.extractor import ExtractorProposalSet, ExtractorRoutingSummary
 
 
 class ExtractorResult(BaseModel):
     """Typed return value from ExtractorService.extract().
 
     Attributes:
-        proposals: All proposals staged during this pass (both pending and
-            auto-committed).
-        pending_proposals: Subset of proposals still in PENDING status —
-            locked-fact proposals that require Sojourner confirmation.
-        auto_committed: Proposals that were staged and immediately ratified
-            (soft facts, transient states, events, unresolved threads).
-        pass_forward_content: Text summary of Extractor findings, added to the
-            PassForwardLedger by the pipeline (Issue 12) for downstream passes.
-        model_identifier: Provider and model string, e.g.
-            ``"anthropic:claude-haiku-4-5-20251001"``.
-        latency_ms: Wall-clock latency of the provider call in milliseconds.
+        proposal_set: All proposals extracted from the LLM response.
+        routed: IDs of staged / created entries, grouped by proposal kind.
         input_token_count: Uncached input tokens consumed, when reported.
         output_token_count: Output tokens generated, when reported.
         cache_read_token_count: Cache-hit tokens, when reported.
         cache_creation_token_count: Cache-write tokens, when reported.
     """
 
-    proposals: list[ProvisionalProposal]
-    pending_proposals: list[ProvisionalProposal]
-    auto_committed: list[ProvisionalProposal]
-    pass_forward_content: str
-    model_identifier: str
-    latency_ms: int
+    proposal_set: ExtractorProposalSet
+    routed: ExtractorRoutingSummary
     input_token_count: int | None
     output_token_count: int | None
     cache_read_token_count: int | None
@@ -47,6 +34,8 @@ class ExtractorPassError(Exception):
       - No tool_use block in the provider response.
       - Tool name mismatch or malformed tool input.
       - Underlying provider exception.
+      - Natural-key resolution failure (EntityNotFoundError or ValueError
+        from routing) — the entire turn is aborted with no DB state committed.
 
     The original cause is preserved as ``__cause__`` via standard Python
     exception chaining (``raise ExtractorPassError(...) from original``).

--- a/src/afterworlds/pipeline/extractor/models.py
+++ b/src/afterworlds/pipeline/extractor/models.py
@@ -1,0 +1,53 @@
+"""Extractor pass result and error types — CRD Issue 10."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from afterworlds.models.story_bible import ProvisionalProposal
+
+
+class ExtractorResult(BaseModel):
+    """Typed return value from ExtractorService.extract().
+
+    Attributes:
+        proposals: All proposals staged during this pass (both pending and
+            auto-committed).
+        pending_proposals: Subset of proposals still in PENDING status —
+            locked-fact proposals that require Sojourner confirmation.
+        auto_committed: Proposals that were staged and immediately ratified
+            (soft facts, transient states, events, unresolved threads).
+        pass_forward_content: Text summary of Extractor findings, added to the
+            PassForwardLedger by the pipeline (Issue 12) for downstream passes.
+        model_identifier: Provider and model string, e.g.
+            ``"anthropic:claude-haiku-4-5-20251001"``.
+        latency_ms: Wall-clock latency of the provider call in milliseconds.
+        input_token_count: Uncached input tokens consumed, when reported.
+        output_token_count: Output tokens generated, when reported.
+        cache_read_token_count: Cache-hit tokens, when reported.
+        cache_creation_token_count: Cache-write tokens, when reported.
+    """
+
+    proposals: list[ProvisionalProposal]
+    pending_proposals: list[ProvisionalProposal]
+    auto_committed: list[ProvisionalProposal]
+    pass_forward_content: str
+    model_identifier: str
+    latency_ms: int
+    input_token_count: int | None
+    output_token_count: int | None
+    cache_read_token_count: int | None
+    cache_creation_token_count: int | None
+
+
+class ExtractorPassError(Exception):
+    """Raised when the Extractor pass cannot produce a usable result.
+
+    Fail-closed: no silent fallback, no default stub.  Covers:
+      - No tool_use block in the provider response.
+      - Tool name mismatch or malformed tool input.
+      - Underlying provider exception.
+
+    The original cause is preserved as ``__cause__`` via standard Python
+    exception chaining (``raise ExtractorPassError(...) from original``).
+    """

--- a/src/afterworlds/pipeline/extractor/service.py
+++ b/src/afterworlds/pipeline/extractor/service.py
@@ -1,22 +1,17 @@
 """Extractor service — CRD Issue 10.
 
 Extractor pass: receives AssembledContext + writer_output, calls the LLM using
-Anthropic tool use to extract structured narrative proposals, stages every
-proposal through StoryBibleService, auto-commits soft facts, transient states,
-events, and unresolved threads, and stages locked-fact proposals as PENDING for
-Sojourner confirmation.
+Anthropic tool use to extract structured narrative proposals, and routes all
+proposals through StoryBibleService.route_extractor_proposals() in a single
+transactional call.
 
 Architectural invariants enforced here:
-  - The Extractor NEVER writes to the Story Bible without first calling
-    StoryBibleService.stage_proposed_update().  Every canon write is preceded
-    by a staged proposal; ratification and application happen after staging.
-  - Locked-fact proposals remain PENDING; they are never ratified without
-    explicit Sojourner confirmation (confirmed=True).
-  - Soft facts, transient states, unresolved threads, and events are auto-
-    ratified immediately after staging.
-  - Soft-fact and transient-state proposals that resolve to a known cast
-    entry are applied to the live dynamic field via StoryBibleService.
-    Unresolvable proposals remain RATIFIED but unapplied (logged, not raised).
+  - The Extractor does not commit or manage the DB session.
+    StoryBibleService.route_extractor_proposals() owns the transaction.
+  - Natural-key resolution failures are fatal: the entire turn is aborted with
+    no DB state committed (EntityNotFoundError → ExtractorPassError).
+  - Locked-fact proposals are staged as PENDING; they require explicit
+    Sojourner confirmation before becoming canon.
   - The Extractor does not create Nodes or Turns; it does not call
     IntentClassifierService, RollingSummaryService, or RulesPackageService.
   - All writes are routed through StoryBibleService; no direct ORM access.
@@ -26,10 +21,8 @@ Architectural invariants enforced here:
 
 from __future__ import annotations
 
-import contextlib
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID
 
 from anthropic.types import (
@@ -45,8 +38,7 @@ from afterworlds.models.context import (
     _render_rule_slice,
     _render_story_bible_context,
 )
-from afterworlds.models.enums import EventSignificance, ProposalType
-from afterworlds.models.story_bible import ProvisionalProposal
+from afterworlds.models.extractor import ExtractorProposalSet
 from afterworlds.pipeline.extractor.caller import (
     EXTRACT_TOOL_NAME,
     EXTRACT_TOOL_SPEC,
@@ -105,15 +97,14 @@ class ExtractorService:
       1. Render an Anthropic Messages payload from AssembledContext + writer_output.
       2. Invoke the provider via the injected caller (forced tool use).
       3. Parse the ToolUseBlock response.
-      4. Stage all proposals via StoryBibleService.stage_proposed_update().
-      5. Auto-ratify soft facts, transient states, unresolved threads, and events.
-      6. Apply soft-fact and transient-state updates to live cast fields where
-         the character name resolves to a known cast entry.
-      7. Leave locked-fact proposals as PENDING for Sojourner confirmation.
-      8. Return a typed ExtractorResult.
+      4. Validate the tool input against ExtractorProposalSet.
+      5. Delegate all routing and DB writes to
+         StoryBibleService.route_extractor_proposals() — single transactional call.
+      6. Return a typed ExtractorResult.
 
     Args:
-        session: SQLAlchemy session (used indirectly via StoryBibleService).
+        session: SQLAlchemy session (held for compatibility; session management
+            is owned by StoryBibleService.route_extractor_proposals).
         story_bible_service: StoryBibleService instance for all Story Bible
             writes.  Injected so tests can pass a real or spy instance.
         config: Extractor configuration.  Defaults to ExtractorConfig.from_env().
@@ -138,9 +129,9 @@ class ExtractorService:
     def extract(
         self,
         built_context: AssembledContext,
-        story_id: UUID,
         writer_output: str,
-        source_turn_id: str | None = None,
+        story_id: UUID,
+        turn_id: UUID,
     ) -> ExtractorResult:
         """Execute one Extractor pass and return a typed result.
 
@@ -148,23 +139,32 @@ class ExtractorService:
             built_context: AssembledContext produced by the Context Builder.
                 The Extractor reuses the same stable prefix as the Writer so
                 the Anthropic cache breakpoint is in the same position.
-            story_id: UUID of the story this turn belongs to.
             writer_output: The prose produced by the Writer pass this turn.
-            source_turn_id: Optional string UUID of the persisted Turn, used as
-                provenance on all proposals created this pass.
+            story_id: UUID of the story this turn belongs to.
+            turn_id: UUID of the persisted Turn, used as provenance on all
+                proposals and canon writes created this pass.
 
         Returns:
-            ExtractorResult with all staged proposals, token metrics, and a
-            pass_forward_content summary for downstream pipeline passes.
+            ExtractorResult with the validated proposal set, routing summary,
+            and token metrics.
 
         Raises:
             ExtractorPassError: if the provider call fails, the response
-                contains no tool-use block, or the tool input is malformed.
+                contains no tool-use block, the tool input fails schema
+                validation, or natural-key resolution fails during routing
+                (no DB state is committed in the latter case).
         """
+        ctx_story_id = built_context.stable_prefix.story_bible_context.story_id
+        if ctx_story_id != story_id:
+            raise ExtractorPassError(
+                f"built_context story_id {ctx_story_id} does not match "
+                f"story_id {story_id}."
+            )
+
         payload = self._render(built_context, writer_output)
 
         try:
-            response, latency_ms = timed_call(self._caller, payload)
+            response, _latency_ms = timed_call(self._caller, payload)
         except Exception as exc:
             raise ExtractorPassError(f"Extractor provider call failed: {exc}") from exc
 
@@ -177,173 +177,31 @@ class ExtractorService:
                 f"Extractor response parsing failed: {exc}"
             ) from exc
 
-        cast_name_map = _build_cast_name_map(built_context)
+        try:
+            proposal_set = ExtractorProposalSet.model_validate(tool_input)
+        except Exception as exc:
+            raise ExtractorPassError(
+                f"Extractor tool input failed schema validation: {exc}"
+            ) from exc
 
-        all_proposals: list[ProvisionalProposal] = []
-        pending: list[ProvisionalProposal] = []
-        auto_committed: list[ProvisionalProposal] = []
-
-        # ── Locked facts — stage only, leave PENDING ──────────────────────
-        for item in _iter_list(tool_input, "locked_facts"):
-            fact_text = str(item.get("fact_text", "")).strip()
-            if not fact_text:
-                continue
-            proposal = ProvisionalProposal(
-                story_id=story_id,
-                proposal_type=ProposalType.LOCKED_FACT,
-                proposed_value={"fact_text": fact_text},
-                source_turn_id=source_turn_id,
-                created_at=datetime.now(UTC),
+        try:
+            routed = self._sbs.route_extractor_proposals(
+                story_id, turn_id, proposal_set
             )
-            staged = self._sbs.stage_proposed_update(story_id, proposal)
-            all_proposals.append(staged)
-            pending.append(staged)
-
-        # ── Soft facts — stage + ratify + apply ───────────────────────────
-        for item in _iter_list(tool_input, "soft_facts"):
-            staged_ratified = self._stage_and_ratify_cast_update(
-                story_id,
-                item,
-                ProposalType.SOFT_FACT,
-                cast_name_map,
-                source_turn_id,
-            )
-            if staged_ratified is not None:
-                all_proposals.append(staged_ratified)
-                auto_committed.append(staged_ratified)
-
-        # ── Transient states — stage + ratify + apply ─────────────────────
-        for item in _iter_list(tool_input, "transient_states"):
-            staged_ratified = self._stage_and_ratify_cast_update(
-                story_id,
-                item,
-                ProposalType.TRANSIENT_STATE,
-                cast_name_map,
-                source_turn_id,
-            )
-            if staged_ratified is not None:
-                all_proposals.append(staged_ratified)
-                auto_committed.append(staged_ratified)
-
-        # ── Unresolved threads — stage + ratify (creates thread row) ──────
-        for item in _iter_list(tool_input, "unresolved_threads"):
-            description = str(item.get("description", "")).strip()
-            if not description:
-                continue
-            proposal = ProvisionalProposal(
-                story_id=story_id,
-                proposal_type=ProposalType.UNRESOLVED_THREAD,
-                proposed_value={"description": description},
-                source_turn_id=source_turn_id,
-                created_at=datetime.now(UTC),
-            )
-            staged = self._sbs.stage_proposed_update(story_id, proposal)
-            ratified = self._sbs.ratify_update(staged.proposal_id)
-            all_proposals.append(ratified)
-            auto_committed.append(ratified)
-
-        # ── Events — stage + ratify (creates event row) ───────────────────
-        for item in _iter_list(tool_input, "events"):
-            description = str(item.get("description", "")).strip()
-            significance_raw = str(
-                item.get("significance", EventSignificance.ROUTINE.value)
-            ).strip()
-            if not description:
-                continue
-            # Coerce unknown significance values to ROUTINE rather than failing.
-            try:
-                EventSignificance(significance_raw)
-            except ValueError:
-                significance_raw = EventSignificance.ROUTINE.value
-            proposal = ProvisionalProposal(
-                story_id=story_id,
-                proposal_type=ProposalType.EVENT,
-                proposed_value={
-                    "description": description,
-                    "significance": significance_raw,
-                },
-                source_turn_id=source_turn_id,
-                created_at=datetime.now(UTC),
-            )
-            staged = self._sbs.stage_proposed_update(story_id, proposal)
-            ratified = self._sbs.ratify_update(staged.proposal_id)
-            all_proposals.append(ratified)
-            auto_committed.append(ratified)
-
-        self._session.commit()
-
-        pass_forward = _render_pass_forward(pending, auto_committed)
+        except (EntityNotFoundError, ValueError) as exc:
+            raise ExtractorPassError(
+                f"Extractor routing failed — no DB state committed: {exc}"
+            ) from exc
 
         usage = response.usage
         return ExtractorResult(
-            proposals=all_proposals,
-            pending_proposals=pending,
-            auto_committed=auto_committed,
-            pass_forward_content=pass_forward,
-            model_identifier=f"anthropic:{response.model}",
-            latency_ms=latency_ms,
+            proposal_set=proposal_set,
+            routed=routed,
             input_token_count=usage.input_tokens,
             output_token_count=usage.output_tokens,
             cache_read_token_count=usage.cache_read_input_tokens,
             cache_creation_token_count=usage.cache_creation_input_tokens,
         )
-
-    # -----------------------------------------------------------------------
-    # Private: staging helpers
-    # -----------------------------------------------------------------------
-
-    def _stage_and_ratify_cast_update(
-        self,
-        story_id: UUID,
-        item: dict[str, Any],
-        proposal_type: ProposalType,
-        cast_name_map: dict[str, UUID],
-        source_turn_id: str | None,
-    ) -> ProvisionalProposal | None:
-        """Stage a cast-field update proposal, ratify it, and apply the change.
-
-        Returns the ratified ProvisionalProposal, or None if the item was empty
-        or had no fact_text / description.  Never raises; unresolvable proposals
-        are staged and ratified without applying the field update.
-        """
-        char_name = str(item.get("character_name", "")).strip()
-        field_name = str(item.get("field_name", "")).strip()
-        new_value: Any = item.get("new_value")
-        if not char_name or not field_name:
-            return None
-
-        cast_id = cast_name_map.get(char_name.lower())
-        proposed_value: dict[str, Any] = {
-            "entity_type": "cast_entry",
-            "character_name": char_name,
-            "entity_id": str(cast_id) if cast_id is not None else None,
-            "field_name": field_name,
-            "new_value": new_value,
-        }
-        proposal = ProvisionalProposal(
-            story_id=story_id,
-            proposal_type=proposal_type,
-            target_entity_type="cast_entry",
-            target_entity_id=str(cast_id) if cast_id is not None else None,
-            proposed_value=proposed_value,
-            source_turn_id=source_turn_id,
-            created_at=datetime.now(UTC),
-        )
-        staged = self._sbs.stage_proposed_update(story_id, proposal)
-        ratified = self._sbs.ratify_update(staged.proposal_id)
-
-        # Apply the field update to live canon if the entity is resolvable.
-        if cast_id is not None:
-            with contextlib.suppress(ValueError, EntityNotFoundError):
-                self._sbs.update_dynamic_field(
-                    story_id,
-                    cast_id,
-                    field_name,
-                    new_value,
-                    source_turn_id=source_turn_id,
-                )
-
-        return ratified
 
     # -----------------------------------------------------------------------
     # Private: prompt rendering
@@ -430,17 +288,6 @@ class ExtractorService:
 # ---------------------------------------------------------------------------
 
 
-def _build_cast_name_map(built_context: AssembledContext) -> dict[str, UUID]:
-    """Build a lowercase-name → cast_id map from the assembled context.
-
-    Case-insensitive so the LLM's name capitalisation doesn't prevent matching.
-    """
-    return {
-        entry.name.lower(): entry.cast_id
-        for entry in built_context.stable_prefix.story_bible_context.cast
-    }
-
-
 def _collect_stable_texts(built_context: AssembledContext) -> list[str]:
     """Return stable-prefix section texts in canonical Issue 8 order.
 
@@ -464,53 +311,3 @@ def _collect_stable_texts(built_context: AssembledContext) -> list[str]:
         texts.append(retrieval_text)
 
     return texts
-
-
-def _iter_list(tool_input: dict[str, Any], key: str) -> list[dict[str, Any]]:
-    """Safely extract a list of dicts from the tool input under ``key``."""
-    raw = tool_input.get(key, [])
-    if not isinstance(raw, list):
-        return []
-    return [item for item in raw if isinstance(item, dict)]
-
-
-def _render_pass_forward(
-    pending: list[ProvisionalProposal],
-    auto_committed: list[ProvisionalProposal],
-) -> str:
-    """Render the Extractor's pass-forward summary for downstream passes."""
-    lines: list[str] = ["[EXTRACTOR SUMMARY]"]
-
-    if pending:
-        lines.append(f"Locked-fact proposals pending confirmation: {len(pending)}")
-        for p in pending:
-            fact = p.proposed_value.get("fact_text", "<unknown>")
-            lines.append(f"  - {fact}")
-
-    if auto_committed:
-        lines.append(f"Auto-committed proposals: {len(auto_committed)}")
-        for p in auto_committed:
-            lines.append(f"  - [{p.proposal_type.value}] {_proposal_summary(p)}")
-
-    if not pending and not auto_committed:
-        lines.append("No narrative updates extracted this turn.")
-
-    return "\n".join(lines)
-
-
-def _proposal_summary(proposal: ProvisionalProposal) -> str:
-    """Return a one-line summary of a proposal for pass-forward output."""
-    pv = proposal.proposed_value
-    ptype = proposal.proposal_type
-
-    if ptype == ProposalType.UNRESOLVED_THREAD:
-        return str(pv.get("description", "<no description>"))
-    if ptype == ProposalType.EVENT:
-        sig = str(pv.get("significance", "?"))
-        return f"{pv.get('description', '<no description>')} [{sig}]"
-    if ptype in (ProposalType.SOFT_FACT, ProposalType.TRANSIENT_STATE):
-        char = str(pv.get("character_name", "?"))
-        field = str(pv.get("field_name", "?"))
-        val = pv.get("new_value", "?")
-        return f"{char}.{field} = {val!r}"
-    return str(pv)

--- a/src/afterworlds/pipeline/extractor/service.py
+++ b/src/afterworlds/pipeline/extractor/service.py
@@ -1,0 +1,516 @@
+"""Extractor service — CRD Issue 10.
+
+Extractor pass: receives AssembledContext + writer_output, calls the LLM using
+Anthropic tool use to extract structured narrative proposals, stages every
+proposal through StoryBibleService, auto-commits soft facts, transient states,
+events, and unresolved threads, and stages locked-fact proposals as PENDING for
+Sojourner confirmation.
+
+Architectural invariants enforced here:
+  - The Extractor NEVER writes to the Story Bible without first calling
+    StoryBibleService.stage_proposed_update().  Every canon write is preceded
+    by a staged proposal; ratification and application happen after staging.
+  - Locked-fact proposals remain PENDING; they are never ratified without
+    explicit Sojourner confirmation (confirmed=True).
+  - Soft facts, transient states, unresolved threads, and events are auto-
+    ratified immediately after staging.
+  - Soft-fact and transient-state proposals that resolve to a known cast
+    entry are applied to the live dynamic field via StoryBibleService.
+    Unresolvable proposals remain RATIFIED but unapplied (logged, not raised).
+  - The Extractor does not create Nodes or Turns; it does not call
+    IntentClassifierService, RollingSummaryService, or RulesPackageService.
+  - All writes are routed through StoryBibleService; no direct ORM access.
+  - ExtractorResult is a typed Pydantic model.  ExtractorPassError is a
+    typed exception.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+from uuid import UUID
+
+from anthropic.types import (
+    CacheControlEphemeralParam,
+    MessageParam,
+    TextBlockParam,
+)
+from sqlalchemy.orm import Session
+
+from afterworlds.models.context import (
+    AssembledContext,
+    _render_retrieval_memory,
+    _render_rule_slice,
+    _render_story_bible_context,
+)
+from afterworlds.models.enums import EventSignificance, ProposalType
+from afterworlds.models.story_bible import ProvisionalProposal
+from afterworlds.pipeline.extractor.caller import (
+    EXTRACT_TOOL_NAME,
+    EXTRACT_TOOL_SPEC,
+    AnthropicExtractorCaller,
+    ExtractorModelCaller,
+    ExtractorPayload,
+    parse_tool_input,
+    timed_call,
+)
+from afterworlds.pipeline.extractor.config import (
+    EXTRACTOR_MAX_TOKENS,
+    ExtractorConfig,
+)
+from afterworlds.pipeline.extractor.models import ExtractorPassError, ExtractorResult
+from afterworlds.services.story_bible import EntityNotFoundError, StoryBibleService
+
+# ---------------------------------------------------------------------------
+# Prompt loading
+# ---------------------------------------------------------------------------
+
+_PROMPT_DIR: Path = Path(__file__).parents[4] / "docs" / "prompts"
+
+
+class UnknownPromptError(ValueError):
+    """Raised when the extractor prompt file is missing."""
+
+
+def load_extractor_prompt() -> str:
+    """Load the versioned Extractor system prompt from docs/prompts/extractor.md."""
+    prompt_path = _PROMPT_DIR / "extractor.md"
+    try:
+        return prompt_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise UnknownPromptError(
+            f"Extractor prompt file not found at {prompt_path}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# TTL constants (mirrors WriterConfig)
+# ---------------------------------------------------------------------------
+
+_TTL_EXTENDED: Literal["1h"] = "1h"
+_TTL_DEFAULT: Literal["5m"] = "5m"
+
+
+# ---------------------------------------------------------------------------
+# ExtractorService
+# ---------------------------------------------------------------------------
+
+
+class ExtractorService:
+    """Extractor pass service.
+
+    Responsibilities:
+      1. Render an Anthropic Messages payload from AssembledContext + writer_output.
+      2. Invoke the provider via the injected caller (forced tool use).
+      3. Parse the ToolUseBlock response.
+      4. Stage all proposals via StoryBibleService.stage_proposed_update().
+      5. Auto-ratify soft facts, transient states, unresolved threads, and events.
+      6. Apply soft-fact and transient-state updates to live cast fields where
+         the character name resolves to a known cast entry.
+      7. Leave locked-fact proposals as PENDING for Sojourner confirmation.
+      8. Return a typed ExtractorResult.
+
+    Args:
+        session: SQLAlchemy session (used indirectly via StoryBibleService).
+        story_bible_service: StoryBibleService instance for all Story Bible
+            writes.  Injected so tests can pass a real or spy instance.
+        config: Extractor configuration.  Defaults to ExtractorConfig.from_env().
+        caller: Injectable model caller.  Defaults to AnthropicExtractorCaller.
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        story_bible_service: StoryBibleService,
+        config: ExtractorConfig | None = None,
+        caller: ExtractorModelCaller | None = None,
+    ) -> None:
+        self._session = session
+        self._sbs = story_bible_service
+        self._config = config or ExtractorConfig.from_env()
+        self._caller: ExtractorModelCaller = caller or AnthropicExtractorCaller(
+            self._config
+        )
+        self._system_prompt: str = load_extractor_prompt()
+
+    def extract(
+        self,
+        built_context: AssembledContext,
+        story_id: UUID,
+        writer_output: str,
+        source_turn_id: str | None = None,
+    ) -> ExtractorResult:
+        """Execute one Extractor pass and return a typed result.
+
+        Args:
+            built_context: AssembledContext produced by the Context Builder.
+                The Extractor reuses the same stable prefix as the Writer so
+                the Anthropic cache breakpoint is in the same position.
+            story_id: UUID of the story this turn belongs to.
+            writer_output: The prose produced by the Writer pass this turn.
+            source_turn_id: Optional string UUID of the persisted Turn, used as
+                provenance on all proposals created this pass.
+
+        Returns:
+            ExtractorResult with all staged proposals, token metrics, and a
+            pass_forward_content summary for downstream pipeline passes.
+
+        Raises:
+            ExtractorPassError: if the provider call fails, the response
+                contains no tool-use block, or the tool input is malformed.
+        """
+        payload = self._render(built_context, writer_output)
+
+        try:
+            response, latency_ms = timed_call(self._caller, payload)
+        except Exception as exc:
+            raise ExtractorPassError(f"Extractor provider call failed: {exc}") from exc
+
+        try:
+            tool_input = parse_tool_input(response)
+        except ExtractorPassError:
+            raise
+        except Exception as exc:
+            raise ExtractorPassError(
+                f"Extractor response parsing failed: {exc}"
+            ) from exc
+
+        cast_name_map = _build_cast_name_map(built_context)
+
+        all_proposals: list[ProvisionalProposal] = []
+        pending: list[ProvisionalProposal] = []
+        auto_committed: list[ProvisionalProposal] = []
+
+        # ── Locked facts — stage only, leave PENDING ──────────────────────
+        for item in _iter_list(tool_input, "locked_facts"):
+            fact_text = str(item.get("fact_text", "")).strip()
+            if not fact_text:
+                continue
+            proposal = ProvisionalProposal(
+                story_id=story_id,
+                proposal_type=ProposalType.LOCKED_FACT,
+                proposed_value={"fact_text": fact_text},
+                source_turn_id=source_turn_id,
+                created_at=datetime.now(UTC),
+            )
+            staged = self._sbs.stage_proposed_update(story_id, proposal)
+            all_proposals.append(staged)
+            pending.append(staged)
+
+        # ── Soft facts — stage + ratify + apply ───────────────────────────
+        for item in _iter_list(tool_input, "soft_facts"):
+            staged_ratified = self._stage_and_ratify_cast_update(
+                story_id,
+                item,
+                ProposalType.SOFT_FACT,
+                cast_name_map,
+                source_turn_id,
+            )
+            if staged_ratified is not None:
+                all_proposals.append(staged_ratified)
+                auto_committed.append(staged_ratified)
+
+        # ── Transient states — stage + ratify + apply ─────────────────────
+        for item in _iter_list(tool_input, "transient_states"):
+            staged_ratified = self._stage_and_ratify_cast_update(
+                story_id,
+                item,
+                ProposalType.TRANSIENT_STATE,
+                cast_name_map,
+                source_turn_id,
+            )
+            if staged_ratified is not None:
+                all_proposals.append(staged_ratified)
+                auto_committed.append(staged_ratified)
+
+        # ── Unresolved threads — stage + ratify (creates thread row) ──────
+        for item in _iter_list(tool_input, "unresolved_threads"):
+            description = str(item.get("description", "")).strip()
+            if not description:
+                continue
+            proposal = ProvisionalProposal(
+                story_id=story_id,
+                proposal_type=ProposalType.UNRESOLVED_THREAD,
+                proposed_value={"description": description},
+                source_turn_id=source_turn_id,
+                created_at=datetime.now(UTC),
+            )
+            staged = self._sbs.stage_proposed_update(story_id, proposal)
+            ratified = self._sbs.ratify_update(staged.proposal_id)
+            all_proposals.append(ratified)
+            auto_committed.append(ratified)
+
+        # ── Events — stage + ratify (creates event row) ───────────────────
+        for item in _iter_list(tool_input, "events"):
+            description = str(item.get("description", "")).strip()
+            significance_raw = str(
+                item.get("significance", EventSignificance.ROUTINE.value)
+            ).strip()
+            if not description:
+                continue
+            # Coerce unknown significance values to ROUTINE rather than failing.
+            try:
+                EventSignificance(significance_raw)
+            except ValueError:
+                significance_raw = EventSignificance.ROUTINE.value
+            proposal = ProvisionalProposal(
+                story_id=story_id,
+                proposal_type=ProposalType.EVENT,
+                proposed_value={
+                    "description": description,
+                    "significance": significance_raw,
+                },
+                source_turn_id=source_turn_id,
+                created_at=datetime.now(UTC),
+            )
+            staged = self._sbs.stage_proposed_update(story_id, proposal)
+            ratified = self._sbs.ratify_update(staged.proposal_id)
+            all_proposals.append(ratified)
+            auto_committed.append(ratified)
+
+        self._session.commit()
+
+        pass_forward = _render_pass_forward(pending, auto_committed)
+
+        usage = response.usage
+        return ExtractorResult(
+            proposals=all_proposals,
+            pending_proposals=pending,
+            auto_committed=auto_committed,
+            pass_forward_content=pass_forward,
+            model_identifier=f"anthropic:{response.model}",
+            latency_ms=latency_ms,
+            input_token_count=usage.input_tokens,
+            output_token_count=usage.output_tokens,
+            cache_read_token_count=usage.cache_read_input_tokens,
+            cache_creation_token_count=usage.cache_creation_input_tokens,
+        )
+
+    # -----------------------------------------------------------------------
+    # Private: staging helpers
+    # -----------------------------------------------------------------------
+
+    def _stage_and_ratify_cast_update(
+        self,
+        story_id: UUID,
+        item: dict[str, Any],
+        proposal_type: ProposalType,
+        cast_name_map: dict[str, UUID],
+        source_turn_id: str | None,
+    ) -> ProvisionalProposal | None:
+        """Stage a cast-field update proposal, ratify it, and apply the change.
+
+        Returns the ratified ProvisionalProposal, or None if the item was empty
+        or had no fact_text / description.  Never raises; unresolvable proposals
+        are staged and ratified without applying the field update.
+        """
+        char_name = str(item.get("character_name", "")).strip()
+        field_name = str(item.get("field_name", "")).strip()
+        new_value: Any = item.get("new_value")
+        if not char_name or not field_name:
+            return None
+
+        cast_id = cast_name_map.get(char_name.lower())
+        proposed_value: dict[str, Any] = {
+            "entity_type": "cast_entry",
+            "character_name": char_name,
+            "entity_id": str(cast_id) if cast_id is not None else None,
+            "field_name": field_name,
+            "new_value": new_value,
+        }
+        proposal = ProvisionalProposal(
+            story_id=story_id,
+            proposal_type=proposal_type,
+            target_entity_type="cast_entry",
+            target_entity_id=str(cast_id) if cast_id is not None else None,
+            proposed_value=proposed_value,
+            source_turn_id=source_turn_id,
+            created_at=datetime.now(UTC),
+        )
+        staged = self._sbs.stage_proposed_update(story_id, proposal)
+        ratified = self._sbs.ratify_update(staged.proposal_id)
+
+        # Apply the field update to live canon if the entity is resolvable.
+        if cast_id is not None:
+            with contextlib.suppress(ValueError, EntityNotFoundError):
+                self._sbs.update_dynamic_field(
+                    story_id,
+                    cast_id,
+                    field_name,
+                    new_value,
+                    source_turn_id=source_turn_id,
+                )
+
+        return ratified
+
+    # -----------------------------------------------------------------------
+    # Private: prompt rendering
+    # -----------------------------------------------------------------------
+
+    def _render(
+        self,
+        built_context: AssembledContext,
+        writer_output: str,
+    ) -> ExtractorPayload:
+        """Render the AssembledContext + writer_output into an Extractor payload.
+
+        Cache breakpoint placement:
+          - The stable-prefix content blocks are rendered in the canonical
+            Issue 8 order with the cache_control marker on the last block.
+          - The writer output block and volatile suffix blocks carry no marker.
+          - This mirrors the Writer renderer so the Anthropic cache can
+            potentially share the stable-prefix region across passes.
+        """
+        cache_control = CacheControlEphemeralParam(
+            type="ephemeral",
+            ttl=_TTL_EXTENDED if self._config.extended_ttl else _TTL_DEFAULT,
+        )
+
+        stable_texts = _collect_stable_texts(built_context)
+        user_blocks: list[TextBlockParam] = []
+
+        if stable_texts:
+            for text in stable_texts[:-1]:
+                user_blocks.append(TextBlockParam(type="text", text=text))
+            user_blocks.append(
+                TextBlockParam(
+                    type="text",
+                    text=stable_texts[-1],
+                    cache_control=cache_control,
+                )
+            )
+
+        # Pass-forward ledger from prior passes (empty in Issue 10 standalone).
+        ledger_text = built_context.pass_forward_ledger.render()
+        if ledger_text:
+            user_blocks.append(TextBlockParam(type="text", text=ledger_text))
+
+        # Volatile suffix: recent turns + current input + intent.
+        vs = built_context.volatile_suffix
+        for turn in vs.recent_turns:
+            user_blocks.append(
+                TextBlockParam(
+                    type="text",
+                    text=(
+                        f"Player: {turn.user_input}\n"
+                        f"Narrator: {turn.assistant_output}"
+                    ),
+                )
+            )
+        user_blocks.append(
+            TextBlockParam(
+                type="text",
+                text=vs.current_input,
+            )
+        )
+
+        # Writer output — appended after the volatile suffix so the stable
+        # prefix cache breakpoint is not perturbed.
+        user_blocks.append(
+            TextBlockParam(
+                type="text",
+                text=f"[WRITER OUTPUT]\n{writer_output}",
+            )
+        )
+
+        return {
+            "model": self._config.model,
+            "max_tokens": EXTRACTOR_MAX_TOKENS,
+            "system": [TextBlockParam(type="text", text=self._system_prompt)],
+            "messages": [MessageParam(role="user", content=user_blocks)],
+            "tools": [EXTRACT_TOOL_SPEC],
+            "tool_choice": {"type": "tool", "name": EXTRACT_TOOL_NAME},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_cast_name_map(built_context: AssembledContext) -> dict[str, UUID]:
+    """Build a lowercase-name → cast_id map from the assembled context.
+
+    Case-insensitive so the LLM's name capitalisation doesn't prevent matching.
+    """
+    return {
+        entry.name.lower(): entry.cast_id
+        for entry in built_context.stable_prefix.story_bible_context.cast
+    }
+
+
+def _collect_stable_texts(built_context: AssembledContext) -> list[str]:
+    """Return stable-prefix section texts in canonical Issue 8 order.
+
+    Mirrors PromptRenderer._collect_stable_prefix_texts() so the Extractor's
+    user-message blocks are byte-for-byte identical to the Writer's, maximising
+    the chance of cross-pass cache reuse.
+    """
+    texts: list[str] = []
+    sp = built_context.stable_prefix
+
+    texts.append(_render_story_bible_context(sp.story_bible_context))
+
+    if sp.rolling_summary_text is not None:
+        texts.append(sp.rolling_summary_text)
+
+    if sp.rules_package_slice is not None:
+        texts.append(_render_rule_slice(sp.rules_package_slice))
+
+    retrieval_text = _render_retrieval_memory(sp.retrieval_memory)
+    if retrieval_text:
+        texts.append(retrieval_text)
+
+    return texts
+
+
+def _iter_list(tool_input: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    """Safely extract a list of dicts from the tool input under ``key``."""
+    raw = tool_input.get(key, [])
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _render_pass_forward(
+    pending: list[ProvisionalProposal],
+    auto_committed: list[ProvisionalProposal],
+) -> str:
+    """Render the Extractor's pass-forward summary for downstream passes."""
+    lines: list[str] = ["[EXTRACTOR SUMMARY]"]
+
+    if pending:
+        lines.append(f"Locked-fact proposals pending confirmation: {len(pending)}")
+        for p in pending:
+            fact = p.proposed_value.get("fact_text", "<unknown>")
+            lines.append(f"  - {fact}")
+
+    if auto_committed:
+        lines.append(f"Auto-committed proposals: {len(auto_committed)}")
+        for p in auto_committed:
+            lines.append(f"  - [{p.proposal_type.value}] {_proposal_summary(p)}")
+
+    if not pending and not auto_committed:
+        lines.append("No narrative updates extracted this turn.")
+
+    return "\n".join(lines)
+
+
+def _proposal_summary(proposal: ProvisionalProposal) -> str:
+    """Return a one-line summary of a proposal for pass-forward output."""
+    pv = proposal.proposed_value
+    ptype = proposal.proposal_type
+
+    if ptype == ProposalType.UNRESOLVED_THREAD:
+        return str(pv.get("description", "<no description>"))
+    if ptype == ProposalType.EVENT:
+        sig = str(pv.get("significance", "?"))
+        return f"{pv.get('description', '<no description>')} [{sig}]"
+    if ptype in (ProposalType.SOFT_FACT, ProposalType.TRANSIENT_STATE):
+        char = str(pv.get("character_name", "?"))
+        field = str(pv.get("field_name", "?"))
+        val = pv.get("new_value", "?")
+        return f"{char}.{field} = {val!r}"
+    return str(pv)

--- a/src/afterworlds/pipeline/extractor/service.py
+++ b/src/afterworlds/pipeline/extractor/service.py
@@ -260,7 +260,10 @@ class ExtractorService:
         user_blocks.append(
             TextBlockParam(
                 type="text",
-                text=vs.current_input,
+                text=(
+                    f"Player: {vs.current_input}\n"
+                    f"[Intent: {vs.classified_intent.intent_type.value}]"
+                ),
             )
         )
 

--- a/src/afterworlds/services/story_bible.py
+++ b/src/afterworlds/services/story_bible.py
@@ -102,6 +102,17 @@ _CAST_DYNAMIC_FIELDS: frozenset[str] = frozenset(
     {"current_location", "current_status", "is_alive", "notes"}
 )
 
+#: Required Python type per (domain-value, field) pair.
+#: Enforced by the routing layer before any canon write.
+#: bool is NOT a subclass of str, so isinstance checks are unambiguous.
+_FIELD_VALUE_TYPES: dict[tuple[str, str], type] = {
+    ("character", "is_alive"): bool,
+    ("character", "current_location"): str,
+    ("character", "current_status"): str,
+    ("character", "notes"): str,
+    ("relationship", "current_status_description"): str,
+}
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -870,6 +881,12 @@ class StoryBibleService:
                         f"Writable fields: {sorted(writable) if writable else '(none)'}"
                     )
 
+                _check_field_value_type(
+                    proposal.target_domain,
+                    proposal.target_field,
+                    proposal.proposed_value,
+                )
+
                 if proposal.target_domain == TargetDomain.CHARACTER:
                     entity_uuid = self.find_character_by_name(
                         story_id, proposal.target_natural_key
@@ -1225,6 +1242,27 @@ class StoryBibleService:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _check_field_value_type(
+    target_domain: TargetDomain,
+    target_field: str,
+    proposed_value: bool | str,
+) -> None:
+    """Raise ValueError if proposed_value's Python type is wrong for target_field.
+
+    Called by route_extractor_proposals before any staging or canon write so that
+    a type mismatch aborts the entire transaction rather than reaching the ORM.
+    """
+    expected = _FIELD_VALUE_TYPES.get((target_domain.value, target_field))
+    if expected is None:
+        return  # unknown field — the writable-field check already handles this
+    if not isinstance(proposed_value, expected):
+        raise ValueError(
+            f"Field '{target_field}' in domain '{target_domain.value}' requires "
+            f"a {expected.__name__} value; "
+            f"got {type(proposed_value).__name__!r}."
+        )
 
 
 def _set_cast_column(row: SBCastEntryORM, col_name: str, value: object) -> None:

--- a/src/afterworlds/services/story_bible.py
+++ b/src/afterworlds/services/story_bible.py
@@ -737,29 +737,6 @@ class StoryBibleService:
         self._session.flush()
         return _proposal_orm_to_model(row)
 
-    def get_pending_proposals(self, story_id: UUID) -> list[ProvisionalProposal]:
-        """Return all active PENDING proposals for a story.
-
-        Surfaces locked-fact proposals that require Sojourner confirmation before
-        they can be ratified.  Also returns any other proposal that arrived in
-        PENDING state (e.g. unresolvable soft-fact or transient-state proposals
-        queued by the Extractor service for manual review).
-        """
-        rows = (
-            self._session.execute(
-                select(SBProvisionalStagingORM)
-                .where(
-                    SBProvisionalStagingORM.story_id == str(story_id),
-                    SBProvisionalStagingORM.status == ProposalStatus.PENDING.value,
-                    SBProvisionalStagingORM.is_active.is_(True),
-                )
-                .order_by(SBProvisionalStagingORM.created_at.asc())
-            )
-            .scalars()
-            .all()
-        )
-        return [_proposal_orm_to_model(r) for r in rows]
-
     def list_pending_locked_fact_proposals(
         self, story_id: UUID
     ) -> list[ProvisionalProposal]:

--- a/src/afterworlds/services/story_bible.py
+++ b/src/afterworlds/services/story_bible.py
@@ -21,14 +21,25 @@ import json
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import (
+    EventKind,
     EventSignificance,
     ProposalStatus,
     ProposalType,
+    TargetDomain,
     ThreadStatus,
+)
+from afterworlds.models.extractor import (
+    EventProposal,
+    ExtractorProposalSet,
+    ExtractorRoutingSummary,
+    LockedFactProposal,
+    SoftFactProposal,
+    TransientStateProposal,
+    UnresolvedThreadProposal,
 )
 from afterworlds.models.story_bible import (
     CastEntry,
@@ -183,6 +194,7 @@ def _event_orm_to_model(row: SBEventORM) -> Event:
         story_id=UUID(row.story_id),
         description=row.description,
         significance=EventSignificance(row.significance),
+        event_kind=EventKind(row.event_kind),
         source_turn_id=row.source_turn_id,
         is_active=row.is_active,
         created_at=datetime.fromisoformat(row.created_at),
@@ -571,6 +583,7 @@ class StoryBibleService:
             story_id=str(story_id),
             description=event.description,
             significance=event.significance.value,
+            event_kind=event.event_kind.value,
             source_turn_id=event.source_turn_id,
             is_active=True,
             created_at=event.created_at.isoformat(),
@@ -623,11 +636,13 @@ class StoryBibleService:
         - ``unresolved_thread``: creates an ``UnresolvedThread`` in
           ``sb_unresolved_threads``.
         - ``soft_fact`` / ``transient_state``: marks the proposal
-          ``RATIFIED`` only.  Applying ``proposed_value`` to live canon is
-          the responsibility of the Extractor service (CRD Issue 10), which
-          reads ``RATIFIED`` proposals and routes them to the appropriate
-          canon update path.  ``StoryBibleService`` does not auto-apply
-          these proposal types.
+          ``RATIFIED`` only.  Dynamic field application is performed by
+          ``route_extractor_proposals``; these proposal types arriving here
+          are treated as already-applied audit rows.
+
+        Events are not ratified through this method; ``EventProposal``
+        instances bypass staging and go directly to ``add_event`` via
+        ``route_extractor_proposals``.
 
         Raises ``EntityNotFoundError`` if the proposal does not exist.
         """
@@ -692,41 +707,10 @@ class StoryBibleService:
             )
             self._session.add(thread_row)
 
-        elif ptype == ProposalType.EVENT:
-            description = row.proposed_value.get("description", "")
-            significance_str = row.proposed_value.get(
-                "significance", EventSignificance.ROUTINE.value
-            )
-            if not description:
-                raise ValueError(
-                    f"Proposal {proposal_id} is missing required 'description' "
-                    "in proposed_value; cannot write blank event entry."
-                )
-            try:
-                significance = EventSignificance(significance_str)
-            except ValueError as exc:
-                raise ValueError(
-                    f"Proposal {proposal_id} has unrecognised significance "
-                    f"'{significance_str}'."
-                ) from exc
-            row.status = ProposalStatus.RATIFIED.value
-            event_row = SBEventORM(
-                event_id=str(uuid4()),
-                story_id=row.story_id,
-                description=description,
-                significance=significance.value,
-                source_turn_id=row.source_turn_id,
-                is_active=True,
-                created_at=now,
-            )
-            self._session.add(event_row)
-
         else:
             # soft_fact / transient_state: mark RATIFIED only.
-            # Applying proposed_value to live canon is the responsibility of
-            # the Extractor service (CRD Issue 10).  This ratification step
-            # records Sojourner approval; the Extractor reads RATIFIED
-            # proposals and routes them to the appropriate canon update path.
+            # Dynamic field application is handled by route_extractor_proposals;
+            # these proposals arrive here as already-applied audit rows.
             row.status = ProposalStatus.RATIFIED.value
 
         self._session.flush()
@@ -775,6 +759,287 @@ class StoryBibleService:
             .all()
         )
         return [_proposal_orm_to_model(r) for r in rows]
+
+    def list_pending_locked_fact_proposals(
+        self, story_id: UUID
+    ) -> list[ProvisionalProposal]:
+        """Return active PENDING LOCKED_FACT proposals for a story.
+
+        These are the proposals that require Sojourner confirmation before the
+        locked fact becomes canon.  Other proposal types are excluded.
+        """
+        rows = (
+            self._session.execute(
+                select(SBProvisionalStagingORM)
+                .where(
+                    SBProvisionalStagingORM.story_id == str(story_id),
+                    SBProvisionalStagingORM.proposal_type
+                    == ProposalType.LOCKED_FACT.value,
+                    SBProvisionalStagingORM.status == ProposalStatus.PENDING.value,
+                    SBProvisionalStagingORM.is_active.is_(True),
+                )
+                .order_by(SBProvisionalStagingORM.created_at.asc())
+            )
+            .scalars()
+            .all()
+        )
+        return [_proposal_orm_to_model(r) for r in rows]
+
+    def get_writable_fields(self, target_domain: TargetDomain) -> frozenset[str]:
+        """Return the set of writable field names for a target domain.
+
+        CHARACTER domain exposes the dynamic field allowlist.
+        RELATIONSHIP domain exposes ``current_status_description`` only.
+        WORLD domain is not writable in v1 — returns an empty frozenset.
+        """
+        if target_domain == TargetDomain.CHARACTER:
+            return _CAST_DYNAMIC_FIELDS
+        elif target_domain == TargetDomain.RELATIONSHIP:
+            return frozenset({"current_status_description"})
+        else:
+            return frozenset()
+
+    def find_character_by_name(self, story_id: UUID, name: str) -> UUID:
+        """Return the cast_id for a character matching ``name`` (case-insensitive).
+
+        Raises ``EntityNotFoundError`` if no active cast entry matches.
+        """
+        rows = (
+            self._session.execute(
+                select(SBCastEntryORM).where(
+                    SBCastEntryORM.story_id == str(story_id),
+                    func.lower(SBCastEntryORM.static_name) == name.lower(),
+                    SBCastEntryORM.is_active.is_(True),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not rows:
+            raise EntityNotFoundError(
+                f"No active cast entry with name {name!r} found in story {story_id}."
+            )
+        return UUID(rows[0].cast_id)
+
+    def route_extractor_proposals(
+        self,
+        story_id: UUID,
+        turn_id: UUID,
+        proposal_set: ExtractorProposalSet,
+    ) -> ExtractorRoutingSummary:
+        """Route all Extractor proposals transactionally.
+
+        Owns the DB transaction: commits on success, leaves the session dirty on
+        error (caller is responsible for rollback).  All proposals are processed
+        before commit; any resolution failure raises ``EntityNotFoundError`` or
+        ``ValueError`` and aborts the entire batch with no DB state changes.
+
+        Routing policy:
+        - ``LockedFactProposal``: staged as PENDING — requires Sojourner
+          confirmation via ``ratify_update`` before becoming canon.
+        - ``SoftFactProposal`` / ``TransientStateProposal``: natural key resolved,
+          dynamic field applied, staged as RATIFIED audit row.
+        - ``UnresolvedThreadProposal``: canonical thread created, staged as
+          RATIFIED audit row.
+        - ``EventProposal``: written directly to ``sb_events`` via ``add_event``;
+          no staging row created.
+        """
+        locked_fact_staged_ids: list[UUID] = []
+        soft_fact_staged_ids: list[UUID] = []
+        transient_state_staged_ids: list[UUID] = []
+        unresolved_thread_staged_ids: list[UUID] = []
+        event_ids: list[UUID] = []
+
+        now = _now_iso()
+        turn_id_str = str(turn_id)
+        story_id_str = str(story_id)
+
+        for proposal in proposal_set.proposals:
+            if isinstance(proposal, LockedFactProposal):
+                proposal_id = uuid4()
+                staging_row = SBProvisionalStagingORM(
+                    proposal_id=str(proposal_id),
+                    story_id=story_id_str,
+                    proposal_type=ProposalType.LOCKED_FACT.value,
+                    proposed_value={"fact_text": proposal.fact_text},
+                    source_turn_id=turn_id_str,
+                    status=ProposalStatus.PENDING.value,
+                    requires_confirmation=True,
+                    is_active=True,
+                    created_at=now,
+                )
+                self._session.add(staging_row)
+                self._session.flush()
+                locked_fact_staged_ids.append(proposal_id)
+
+            elif isinstance(proposal, (SoftFactProposal, TransientStateProposal)):
+                is_soft = isinstance(proposal, SoftFactProposal)
+                ptype = (
+                    ProposalType.SOFT_FACT if is_soft else ProposalType.TRANSIENT_STATE
+                )
+
+                writable = self.get_writable_fields(proposal.target_domain)
+                if proposal.target_field not in writable:
+                    raise ValueError(
+                        f"Field '{proposal.target_field}' is not writable for domain "
+                        f"'{proposal.target_domain}'. "
+                        f"Writable fields: {sorted(writable) if writable else '(none)'}"
+                    )
+
+                if proposal.target_domain == TargetDomain.CHARACTER:
+                    entity_uuid = self.find_character_by_name(
+                        story_id, proposal.target_natural_key
+                    )
+                    self.update_dynamic_field(
+                        story_id,
+                        entity_uuid,
+                        proposal.target_field,
+                        proposal.proposed_value,
+                        source_turn_id=turn_id_str,
+                    )
+                    entity_id_str = str(entity_uuid)
+
+                else:
+                    subject_name, object_name = _parse_relationship_natural_key(
+                        proposal.target_natural_key
+                    )
+                    subject_uuid = self.find_character_by_name(story_id, subject_name)
+                    object_uuid = self.find_character_by_name(story_id, object_name)
+                    rel_row = self._find_relationship_row(
+                        story_id, subject_uuid, object_uuid
+                    )
+                    self._update_relationship_field(
+                        rel_row,
+                        proposal.target_field,
+                        proposal.proposed_value,
+                        turn_id_str,
+                    )
+                    entity_id_str = rel_row.relationship_id
+
+                proposal_id = uuid4()
+                audit_row = SBProvisionalStagingORM(
+                    proposal_id=str(proposal_id),
+                    story_id=story_id_str,
+                    proposal_type=ptype.value,
+                    target_entity_id=entity_id_str,
+                    proposed_value={
+                        "target_domain": proposal.target_domain.value,
+                        "target_natural_key": proposal.target_natural_key,
+                        "target_field": proposal.target_field,
+                        "proposed_value": proposal.proposed_value,
+                    },
+                    source_turn_id=turn_id_str,
+                    status=ProposalStatus.RATIFIED.value,
+                    requires_confirmation=False,
+                    is_active=True,
+                    created_at=now,
+                )
+                self._session.add(audit_row)
+                self._session.flush()
+
+                if is_soft:
+                    soft_fact_staged_ids.append(proposal_id)
+                else:
+                    transient_state_staged_ids.append(proposal_id)
+
+            elif isinstance(proposal, UnresolvedThreadProposal):
+                thread_id = uuid4()
+                thread_row = SBUnresolvedThreadORM(
+                    thread_id=str(thread_id),
+                    story_id=story_id_str,
+                    description=proposal.description,
+                    source_turn_id=turn_id_str,
+                    status=ThreadStatus.OPEN.value,
+                    is_active=True,
+                    created_at=now,
+                )
+                self._session.add(thread_row)
+
+                proposal_id = uuid4()
+                audit_row = SBProvisionalStagingORM(
+                    proposal_id=str(proposal_id),
+                    story_id=story_id_str,
+                    proposal_type=ProposalType.UNRESOLVED_THREAD.value,
+                    proposed_value={"description": proposal.description},
+                    source_turn_id=turn_id_str,
+                    status=ProposalStatus.RATIFIED.value,
+                    requires_confirmation=False,
+                    is_active=True,
+                    created_at=now,
+                )
+                self._session.add(audit_row)
+                self._session.flush()
+                unresolved_thread_staged_ids.append(proposal_id)
+
+            elif isinstance(proposal, EventProposal):
+                event = Event(
+                    story_id=story_id,
+                    description=proposal.description,
+                    significance=proposal.significance,
+                    event_kind=proposal.event_kind,
+                    source_turn_id=turn_id_str,
+                    created_at=datetime.now(UTC),
+                )
+                saved = self.add_event(story_id, event)
+                event_ids.append(saved.event_id)
+
+        self._session.commit()
+        return ExtractorRoutingSummary(
+            locked_fact_staged_ids=locked_fact_staged_ids,
+            soft_fact_staged_ids=soft_fact_staged_ids,
+            transient_state_staged_ids=transient_state_staged_ids,
+            unresolved_thread_staged_ids=unresolved_thread_staged_ids,
+            event_ids=event_ids,
+        )
+
+    def _find_relationship_row(
+        self,
+        story_id: UUID,
+        subject_uuid: UUID,
+        object_uuid: UUID,
+    ) -> SBRelationshipLedgerORM:
+        row = (
+            self._session.execute(
+                select(SBRelationshipLedgerORM).where(
+                    SBRelationshipLedgerORM.story_id == str(story_id),
+                    SBRelationshipLedgerORM.subject_cast_id == str(subject_uuid),
+                    SBRelationshipLedgerORM.object_cast_id == str(object_uuid),
+                    SBRelationshipLedgerORM.is_active.is_(True),
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if row is None:
+            raise EntityNotFoundError(
+                f"No active relationship from '{subject_uuid}' to '{object_uuid}' "
+                f"in story {story_id}."
+            )
+        return row
+
+    def _update_relationship_field(
+        self,
+        row: SBRelationshipLedgerORM,
+        field: str,
+        value: str,
+        source_turn_id: str,
+    ) -> None:
+        if not hasattr(row, field):
+            raise ValueError(f"SBRelationshipLedgerORM has no attribute '{field}'.")
+        old_val = getattr(row, field)
+        history_row = SBDynamicFieldHistoryORM(
+            history_id=str(uuid4()),
+            entity_type="relationship_ledger",
+            entity_id=row.relationship_id,
+            field_name=field,
+            old_value=json.dumps(old_val) if old_val is not None else None,
+            changed_at=_now_iso(),
+            source_turn_id=source_turn_id,
+        )
+        self._session.add(history_row)
+        setattr(row, field, value)
+        row.updated_at = _now_iso()
+        self._session.flush()
 
     # ------------------------------------------------------------------
     # Domain-specific creation helpers
@@ -977,3 +1242,25 @@ def _set_cast_column(row: SBCastEntryORM, col_name: str, value: object) -> None:
     if not hasattr(row, col_name):
         raise ValueError(f"SBCastEntryORM has no attribute '{col_name}'.")
     setattr(row, col_name, value)
+
+
+def _parse_relationship_natural_key(key: str) -> tuple[str, str]:
+    """Parse a ``'<subject> -> <object>'`` relationship natural key.
+
+    The delimiter is exactly the four-character sequence `` -> `` (space, dash,
+    greater-than, space).  Zero or more than one delimiter raises ``ValueError``,
+    which the caller translates to a transaction failure.
+    """
+    parts = key.split(" -> ")
+    if len(parts) != 2:
+        raise ValueError(
+            f"Relationship natural key must contain exactly one ' -> ' delimiter; "
+            f"got {key!r}."
+        )
+    subject, obj = parts[0].strip(), parts[1].strip()
+    if not subject or not obj:
+        raise ValueError(
+            f"Relationship natural key subject and object must be non-empty; "
+            f"got {key!r}."
+        )
+    return subject, obj

--- a/src/afterworlds/services/story_bible.py
+++ b/src/afterworlds/services/story_bible.py
@@ -1011,7 +1011,7 @@ class StoryBibleService:
         self,
         row: SBRelationshipLedgerORM,
         field: str,
-        value: str,
+        value: bool | str,
         source_turn_id: str,
     ) -> None:
         if not hasattr(row, field):

--- a/src/afterworlds/services/story_bible.py
+++ b/src/afterworlds/services/story_bible.py
@@ -692,6 +692,35 @@ class StoryBibleService:
             )
             self._session.add(thread_row)
 
+        elif ptype == ProposalType.EVENT:
+            description = row.proposed_value.get("description", "")
+            significance_str = row.proposed_value.get(
+                "significance", EventSignificance.ROUTINE.value
+            )
+            if not description:
+                raise ValueError(
+                    f"Proposal {proposal_id} is missing required 'description' "
+                    "in proposed_value; cannot write blank event entry."
+                )
+            try:
+                significance = EventSignificance(significance_str)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Proposal {proposal_id} has unrecognised significance "
+                    f"'{significance_str}'."
+                ) from exc
+            row.status = ProposalStatus.RATIFIED.value
+            event_row = SBEventORM(
+                event_id=str(uuid4()),
+                story_id=row.story_id,
+                description=description,
+                significance=significance.value,
+                source_turn_id=row.source_turn_id,
+                is_active=True,
+                created_at=now,
+            )
+            self._session.add(event_row)
+
         else:
             # soft_fact / transient_state: mark RATIFIED only.
             # Applying proposed_value to live canon is the responsibility of
@@ -723,6 +752,29 @@ class StoryBibleService:
         row.status = ProposalStatus.REJECTED.value
         self._session.flush()
         return _proposal_orm_to_model(row)
+
+    def get_pending_proposals(self, story_id: UUID) -> list[ProvisionalProposal]:
+        """Return all active PENDING proposals for a story.
+
+        Surfaces locked-fact proposals that require Sojourner confirmation before
+        they can be ratified.  Also returns any other proposal that arrived in
+        PENDING state (e.g. unresolvable soft-fact or transient-state proposals
+        queued by the Extractor service for manual review).
+        """
+        rows = (
+            self._session.execute(
+                select(SBProvisionalStagingORM)
+                .where(
+                    SBProvisionalStagingORM.story_id == str(story_id),
+                    SBProvisionalStagingORM.status == ProposalStatus.PENDING.value,
+                    SBProvisionalStagingORM.is_active.is_(True),
+                )
+                .order_by(SBProvisionalStagingORM.created_at.asc())
+            )
+            .scalars()
+            .all()
+        )
+        return [_proposal_orm_to_model(r) for r in rows]
 
     # ------------------------------------------------------------------
     # Domain-specific creation helpers

--- a/src/afterworlds/services/story_bible.py
+++ b/src/afterworlds/services/story_bible.py
@@ -779,7 +779,8 @@ class StoryBibleService:
     def find_character_by_name(self, story_id: UUID, name: str) -> UUID:
         """Return the cast_id for a character matching ``name`` (case-insensitive).
 
-        Raises ``EntityNotFoundError`` if no active cast entry matches.
+        Raises ``EntityNotFoundError`` if no active cast entry matches or if
+        multiple active entries match (ambiguous — caller cannot safely pick one).
         """
         rows = (
             self._session.execute(
@@ -795,6 +796,12 @@ class StoryBibleService:
         if not rows:
             raise EntityNotFoundError(
                 f"No active cast entry with name {name!r} found in story {story_id}."
+            )
+        if len(rows) > 1:
+            raise EntityNotFoundError(
+                f"Ambiguous character name {name!r}: {len(rows)} active cast entries "
+                f"match case-insensitively in story {story_id}. "
+                "Natural-key resolution requires a unique match."
             )
         return UUID(rows[0].cast_id)
 
@@ -975,7 +982,7 @@ class StoryBibleService:
         subject_uuid: UUID,
         object_uuid: UUID,
     ) -> SBRelationshipLedgerORM:
-        row = (
+        rows = (
             self._session.execute(
                 select(SBRelationshipLedgerORM).where(
                     SBRelationshipLedgerORM.story_id == str(story_id),
@@ -985,14 +992,20 @@ class StoryBibleService:
                 )
             )
             .scalars()
-            .first()
+            .all()
         )
-        if row is None:
+        if not rows:
             raise EntityNotFoundError(
                 f"No active relationship from '{subject_uuid}' to '{object_uuid}' "
                 f"in story {story_id}."
             )
-        return row
+        if len(rows) > 1:
+            raise EntityNotFoundError(
+                f"Ambiguous relationship: {len(rows)} active rows from "
+                f"'{subject_uuid}' to '{object_uuid}' in story {story_id}. "
+                "Natural-key resolution requires a unique match."
+            )
+        return rows[0]
 
     def _update_relationship_field(
         self,

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -1230,6 +1230,44 @@ class TestErrorHandling:
                 _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
             )
 
+    def test_multiple_tool_use_blocks_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Response with >1 matching tool-use blocks raises ExtractorPassError."""
+        story_id, cast_id = story_and_cast
+
+        duplicate_block_response = Message(
+            id="msg_dup_tool",
+            type="message",
+            role="assistant",
+            content=[
+                ToolUseBlock(
+                    type="tool_use",
+                    id="toolu_dup_01",
+                    name=EXTRACT_TOOL_NAME,
+                    input={"proposals": []},
+                ),
+                ToolUseBlock(
+                    type="tool_use",
+                    id="toolu_dup_02",
+                    name=EXTRACT_TOOL_NAME,
+                    input={"proposals": []},
+                ),
+            ],
+            model="claude-haiku-4-5-20251001",
+            stop_reason="tool_use",
+            stop_sequence=None,
+            usage=Usage(input_tokens=10, output_tokens=5),
+        )
+        fake = _make_fake_caller(duplicate_block_response)
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError, match="2"):
+            service.extract(
+                _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+            )
+
 
 # ---------------------------------------------------------------------------
 # Boolean proposed_value (is_alive)
@@ -1768,3 +1806,59 @@ class TestTransactionBoundary:
         assert (
             staging_rows == []
         ), "Partial DB state was committed — transaction boundary violated"
+
+
+# ---------------------------------------------------------------------------
+# Renderer — volatile suffix intent block
+# ---------------------------------------------------------------------------
+
+
+class TestRendererVolatileSuffix:
+    def test_intent_included_in_volatile_suffix(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """_render() must include classified_intent after current_input.
+
+        The volatile suffix block must contain both 'Player:' and '[Intent:'
+        so the Extractor model sees the same intent annotation as the Writer.
+        """
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response())
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+        )
+
+        assert len(fake.captured) == 1  # type: ignore[attr-defined]
+        payload = fake.captured[0]  # type: ignore[attr-defined]
+        messages = payload["messages"]
+        user_content: list[dict[str, Any]] = messages[0]["content"]
+
+        intent_blocks = [b for b in user_content if "[Intent:" in b.get("text", "")]
+        assert len(intent_blocks) == 1, "Expected exactly one block with [Intent:]"
+        intent_block_text: str = intent_blocks[0]["text"]
+        assert "Player: I push open the door." in intent_block_text
+        assert "[Intent: in_character_action]" in intent_block_text
+
+    def test_intent_block_precedes_writer_output(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """The intent block appears before [WRITER OUTPUT] in the payload."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response())
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+        )
+
+        user_content: list[dict[str, Any]] = fake.captured[0]["messages"][0][
+            "content"
+        ]  # type: ignore[attr-defined]
+        texts = [b.get("text", "") for b in user_content]
+        intent_idx = next(i for i, t in enumerate(texts) if "[Intent:" in t)
+        writer_idx = next(i for i, t in enumerate(texts) if "[WRITER OUTPUT]" in t)
+        assert intent_idx < writer_idx, "Intent block must precede writer output"

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -1307,6 +1307,102 @@ class TestBooleanProposedValue:
         assert entry is not None
         assert entry.is_alive is True
 
+    def test_boolean_for_string_field_raises(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Boolean proposed_value for current_location raises ExtractorPassError."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_location",
+                            "proposed_value": False,
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
+    def test_boolean_for_notes_raises(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Boolean proposed_value for notes raises ExtractorPassError; no DB state."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "transient_state",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "notes",
+                            "proposed_value": False,
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
+    def test_boolean_for_relationship_field_raises(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """Boolean for current_status_description raises ExtractorPassError."""
+        story_id, aldric_cast_id, _mira_cast_id = story_with_relationship
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "Aldric -> Mira",
+                            "target_field": "current_status_description",
+                            "proposed_value": False,
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, aldric_cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
 
 # ---------------------------------------------------------------------------
 # Shared fixture — relationship seeding

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -1,51 +1,22 @@
 """Unit tests for ExtractorService — CRD Issue 10.
 
-Coverage targets:
-
-Classification routing — one test per proposal kind:
-  - test_locked_fact_staged_pending
-  - test_soft_fact_staged_id_returned
-  - test_transient_state_staged_id_returned
-  - test_unresolved_thread_staged_id_returned
-  - test_event_id_returned
-
-Field application:
-  - test_soft_fact_applied_to_cast_dynamic_field
-  - test_transient_state_applied_to_cast_dynamic_field
-
-Audit trail (direct-write prevention):
-  - test_soft_fact_has_ratified_staging_row
-  - test_transient_state_has_ratified_staging_row
-  - test_unresolved_thread_has_ratified_staging_row
-  - test_event_bypasses_staging_table
-
-Database entries:
-  - test_unresolved_thread_creates_thread_row
-  - test_event_creates_event_row_with_event_kind
-
-Fail-loud unresolvable name (strict per Issue 10):
-  - test_unresolvable_character_name_raises_extractor_pass_error
-  - test_unresolvable_name_leaves_no_db_state
-
-Story-id guard:
-  - test_story_id_mismatch_raises_extractor_pass_error
-
-Empty tool response:
-  - test_empty_tool_response_produces_empty_result
-
-list_pending_locked_fact_proposals:
-  - test_list_pending_locked_fact_proposals_returns_locked_facts
-  - test_list_pending_excludes_auto_committed_proposals
-
-Token metrics:
-  - test_token_metrics_propagated
-  - test_cache_metrics_none_when_not_reported
-
-Error handling:
-  - test_provider_exception_raises_extractor_pass_error
-  - test_no_tool_use_block_raises_extractor_pass_error
-  - test_fake_caller_receives_tool_spec_with_new_name
-  - test_result_is_typed_extractor_result
+Test classes
+------------
+TestLockedFactRouting       — locked_fact staging and DB row
+TestSoftFactRouting         — soft_fact staging, field application, audit row
+TestTransientStateRouting   — transient_state staging, field application, audit row
+TestUnresolvedThreadRouting — thread row, audit row
+TestEventRouting            — event bypass, event_kind column, event_id matching
+TestUnresolvableCharacter   — fail-loud on unknown character name; no DB state
+TestStoryIdGuard            — built_context / story_id mismatch guard
+TestEmptyToolResponse       — empty proposals array handling
+TestListPendingLockedFactProposals — list_pending_locked_fact_proposals contract
+TestTokenMetrics            — all four token counts; None when omitted
+TestErrorHandling           — provider exception, missing tool block, payload shape
+TestRelationshipDomain      — RELATIONSHIP success; malformed-key variants;
+                              unresolvable subject/object; no DB state on failure
+TestWorldDomain             — world domain always raises; no DB state
+TestTransactionBoundary     — all-or-nothing commit: partial failure → zero rows
 """
 
 from __future__ import annotations

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -1,0 +1,1061 @@
+"""Unit tests for ExtractorService — CRD Issue 10.
+
+Coverage targets (from the Issue 10 test requirements):
+
+Classification routing — one test per proposal category:
+  - test_locked_fact_staged_pending
+  - test_soft_fact_auto_ratified
+  - test_transient_state_auto_ratified
+  - test_unresolved_thread_creates_thread_row
+  - test_event_creates_event_row
+
+Direct-write prevention (architectural invariant — CRD Item 12):
+  - test_all_proposals_staged_before_canon_is_touched
+
+Auto-commit behaviour:
+  - test_soft_fact_applied_to_cast_dynamic_field
+  - test_transient_state_applied_to_cast_dynamic_field
+  - test_unresolvable_character_name_still_ratifies_proposal
+  - test_empty_tool_response_produces_empty_result
+
+Pass-forward content:
+  - test_pass_forward_mentions_pending_locked_fact
+  - test_pass_forward_mentions_auto_committed_event
+  - test_pass_forward_empty_when_no_proposals
+
+Token metrics:
+  - test_token_metrics_propagated
+  - test_cache_metrics_none_when_not_reported
+
+Error handling:
+  - test_provider_exception_raises_extractor_pass_error
+  - test_no_tool_use_block_raises_extractor_pass_error
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import pytest
+from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
+
+import afterworlds.persistence.orm.character_sheet  # noqa: F401
+import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.rules_package  # noqa: F401
+import afterworlds.persistence.orm.session_state  # noqa: F401
+import afterworlds.persistence.orm.state  # noqa: F401
+import afterworlds.persistence.orm.story  # noqa: F401
+import afterworlds.persistence.orm.story_bible  # noqa: F401
+from afterworlds.models.context import (
+    AssembledContext,
+    PassForwardLedger,
+    RetrievalMemoryPayload,
+    StablePrefix,
+    VolatileSuffix,
+)
+from afterworlds.models.enums import (
+    CastRole,
+    IntentType,
+    ProposalStatus,
+    ProposalType,
+    StoryMode,
+)
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.story import Arc, Chapter, Story
+from afterworlds.models.story_bible import CastEntry, StoryBibleContext
+from afterworlds.persistence.crud.node import create_node
+from afterworlds.persistence.crud.story import create_arc, create_chapter, create_story
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.story_bible import (
+    SBEventORM,
+    SBProvisionalStagingORM,
+    SBUnresolvedThreadORM,
+)
+from afterworlds.pipeline.extractor.caller import EXTRACT_TOOL_NAME, ExtractorPayload
+from afterworlds.pipeline.extractor.config import ExtractorConfig
+from afterworlds.pipeline.extractor.models import ExtractorPassError, ExtractorResult
+from afterworlds.pipeline.extractor.service import ExtractorService
+from afterworlds.services.story_bible import StoryBibleService
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def engine():  # type: ignore[no-untyped-def]
+    eng = create_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    yield eng
+    Base.metadata.drop_all(eng)
+    eng.dispose()
+
+
+@pytest.fixture()
+def session(engine):  # type: ignore[no-untyped-def]
+    factory = create_session_factory(engine)
+    sess = factory()
+    try:
+        yield sess
+    finally:
+        sess.close()
+
+
+@pytest.fixture()
+def story_and_cast(session):  # type: ignore[no-untyped-def]
+    """Seed a Story + Arc + Chapter + Node + cast entry; return (story_id, cast_id)."""
+    from afterworlds.models.node import Node
+
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    story = Story(
+        title="Extractor Test Story",
+        mode=StoryMode.BRANCHING,
+        created_at=now,
+        updated_at=now,
+    )
+    create_story(session, story)
+
+    arc = Arc(story_id=story.story_id, title="Arc One", order=1)
+    create_arc(session, arc)
+
+    chapter = Chapter(arc_id=arc.arc_id, title="Chapter One", order=1)
+    create_chapter(session, chapter)
+
+    node = Node(
+        chapter_id=chapter.chapter_id,
+        content="",
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+    )
+    create_node(session, node)
+
+    sbs = StoryBibleService(session)
+    cast_entry = CastEntry(
+        story_id=story.story_id,
+        name="Aldric",
+        role=CastRole.PROTAGONIST,
+        current_location="The Crossroads Inn",
+        created_at=now,
+    )
+    saved = sbs.add_cast_entry(story.story_id, cast_entry)
+    session.commit()
+
+    return story.story_id, saved.cast_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> ExtractorConfig:
+    return ExtractorConfig(
+        model="claude-haiku-test",
+        api_key_env="ANTHROPIC_API_KEY",
+        extended_ttl=True,
+    )
+
+
+def _make_assembled(story_id: UUID, cast_id: UUID | None = None) -> AssembledContext:
+    cast: tuple[CastEntry, ...] = ()
+    if cast_id is not None:
+        cast = (
+            CastEntry(
+                cast_id=cast_id,
+                story_id=story_id,
+                name="Aldric",
+                role=CastRole.PROTAGONIST,
+                current_location="The Crossroads Inn",
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        )
+    ctx = StoryBibleContext(
+        story_id=story_id,
+        setting=None,
+        cast=cast,
+        locked_facts=(),
+        forbidden_facts=(),
+        relationship_ledger=(),
+        active_plot_threads=(),
+        events=(),
+    )
+    sp = StablePrefix(
+        system_prompt="You are the story architect.",
+        story_bible_context=ctx,
+        rolling_summary_text=None,
+        rules_package_slice=None,
+        retrieval_memory=RetrievalMemoryPayload(),
+    )
+    icr = IntentClassificationResult(
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        confidence=0.90,
+        raw_input="I push open the door.",
+        ambiguous=False,
+    )
+    vs = VolatileSuffix(
+        recent_turns=[],
+        current_input="I push open the door.",
+        classified_intent=icr,
+    )
+    return AssembledContext(
+        stable_prefix=sp,
+        volatile_suffix=vs,
+        pass_forward_ledger=PassForwardLedger(),
+    )
+
+
+def _fake_tool_response(
+    tool_input: dict[str, Any] | None = None,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_read_input_tokens: int | None = None,
+    cache_creation_input_tokens: int | None = None,
+) -> Message:
+    return Message(
+        id="msg_fake_extractor",
+        type="message",
+        role="assistant",
+        content=[
+            ToolUseBlock(
+                type="tool_use",
+                id="toolu_fake_01",
+                name=EXTRACT_TOOL_NAME,
+                input=tool_input if tool_input is not None else {},
+            )
+        ],
+        model="claude-haiku-4-5-20251001",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        usage=Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+        ),
+    )
+
+
+def _make_fake_caller(  # type: ignore[no-untyped-def]
+    response: Message | None = None,
+    raise_exc: Exception | None = None,
+):
+    captured: list[ExtractorPayload] = []
+
+    def caller(payload: ExtractorPayload) -> Message:
+        captured.append(payload)
+        if raise_exc is not None:
+            raise raise_exc
+        return response or _fake_tool_response()
+
+    caller.captured = captured  # type: ignore[attr-defined]
+    return caller
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — locked facts
+# ---------------------------------------------------------------------------
+
+
+class TestLockedFactRouting:
+    def test_locked_fact_staged_pending(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A locked-fact proposal is staged with PENDING status."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {"locked_facts": [{"fact_text": "The king has been assassinated."}]}
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The king falls dead."
+        )
+
+        assert len(result.pending_proposals) == 1
+        proposal = result.pending_proposals[0]
+        assert proposal.proposal_type == ProposalType.LOCKED_FACT
+        assert proposal.status == ProposalStatus.PENDING
+        assert proposal.requires_confirmation is True
+        assert "king" in proposal.proposed_value.get("fact_text", "").lower()
+
+    def test_locked_fact_not_in_auto_committed(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Locked-fact proposals are NOT in auto_committed."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {"locked_facts": [{"fact_text": "The keep is destroyed."}]}
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The keep crumbles."
+        )
+
+        assert not any(
+            p.proposal_type == ProposalType.LOCKED_FACT for p in result.auto_committed
+        )
+
+    def test_locked_fact_remains_in_staging_area(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """After extract(), a PENDING proposal row exists in the staging table."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {"locked_facts": [{"fact_text": "The bridge is destroyed."}]}
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The bridge falls."
+        )
+
+        rows = (
+            session.query(SBProvisionalStagingORM)
+            .filter_by(status=ProposalStatus.PENDING.value)
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].proposal_type == ProposalType.LOCKED_FACT.value
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — soft facts
+# ---------------------------------------------------------------------------
+
+
+class TestSoftFactRouting:
+    def test_soft_fact_auto_ratified(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A soft-fact proposal is RATIFIED."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "soft_facts": [
+                        {
+                            "character_name": "Aldric",
+                            "field_name": "current_status",
+                            "new_value": "injured",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "Aldric is cut by a blade."
+        )
+
+        assert len(result.auto_committed) == 1
+        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
+        assert result.auto_committed[0].proposal_type == ProposalType.SOFT_FACT
+
+    def test_soft_fact_applied_to_cast_dynamic_field(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A soft-fact update is applied to the cast entry's dynamic field."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "soft_facts": [
+                        {
+                            "character_name": "Aldric",
+                            "field_name": "current_location",
+                            "new_value": "The Dark Tower",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id), story_id, "Aldric enters the tower."
+        )
+
+        entry = sbs.get_character(story_id, cast_id)
+        assert entry is not None
+        assert entry.current_location == "The Dark Tower"
+
+    def test_soft_fact_staged_before_field_applied(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Staging row exists for the soft fact (direct-write prevention invariant)."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "soft_facts": [
+                        {
+                            "character_name": "Aldric",
+                            "field_name": "current_status",
+                            "new_value": "exhausted",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            story_id,
+            "Aldric collapses exhausted.",
+        )
+
+        rows = (
+            session.query(SBProvisionalStagingORM)
+            .filter_by(
+                proposal_type=ProposalType.SOFT_FACT.value,
+                status=ProposalStatus.RATIFIED.value,
+            )
+            .all()
+        )
+        assert len(rows) == 1, "No staging row found — direct-write invariant violated"
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — transient states
+# ---------------------------------------------------------------------------
+
+
+class TestTransientStateRouting:
+    def test_transient_state_auto_ratified(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A transient-state proposal is RATIFIED."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "transient_states": [
+                        {
+                            "character_name": "Aldric",
+                            "field_name": "current_location",
+                            "new_value": "Forest Path",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id),
+            story_id,
+            "Aldric walks the forest path.",
+        )
+
+        assert len(result.auto_committed) == 1
+        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
+        assert result.auto_committed[0].proposal_type == ProposalType.TRANSIENT_STATE
+
+    def test_transient_state_applied_to_cast_dynamic_field(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A transient-state update is applied to the cast entry's dynamic field."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "transient_states": [
+                        {
+                            "character_name": "Aldric",
+                            "field_name": "current_location",
+                            "new_value": "The Market Square",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            story_id,
+            "Aldric reaches the market.",
+        )
+
+        entry = sbs.get_character(story_id, cast_id)
+        assert entry is not None
+        assert entry.current_location == "The Market Square"
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — unresolved threads
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvedThreadRouting:
+    def test_unresolved_thread_auto_ratified(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """An unresolved-thread proposal is RATIFIED."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "unresolved_threads": [
+                        {"description": "Who left the hooded figure at the inn?"}
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "A hooded figure watches."
+        )
+
+        assert len(result.auto_committed) == 1
+        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
+        assert result.auto_committed[0].proposal_type == ProposalType.UNRESOLVED_THREAD
+
+    def test_unresolved_thread_creates_thread_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Ratifying an unresolved-thread proposal creates a thread row."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "unresolved_threads": [
+                        {"description": "Where is the missing artefact hidden?"}
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The artefact is gone."
+        )
+
+        rows = (
+            session.query(SBUnresolvedThreadORM).filter_by(story_id=str(story_id)).all()
+        )
+        assert len(rows) == 1
+        assert "artefact" in rows[0].description.lower()
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — events
+# ---------------------------------------------------------------------------
+
+
+class TestEventRouting:
+    def test_event_auto_ratified(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """An event proposal is RATIFIED."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "events": [
+                        {
+                            "description": "Aldric crossed the Thornbridge.",
+                            "significance": "routine",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id),
+            story_id,
+            "Aldric crosses the bridge.",
+        )
+
+        assert len(result.auto_committed) == 1
+        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
+        assert result.auto_committed[0].proposal_type == ProposalType.EVENT
+
+    def test_event_creates_event_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Ratifying an event proposal creates a row in sb_events."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "events": [
+                        {
+                            "description": "Aldric slew the Night Warden.",
+                            "significance": "major_plot_turn",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            story_id,
+            "The Night Warden falls.",
+        )
+
+        rows = session.query(SBEventORM).filter_by(story_id=str(story_id)).all()
+        assert len(rows) == 1
+        assert "night warden" in rows[0].description.lower()
+        assert rows[0].significance == "major_plot_turn"
+
+    def test_event_with_character_death_significance(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """character_death significance is stored correctly."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "events": [
+                        {
+                            "description": "Aldric is slain.",
+                            "significance": "character_death",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(_make_assembled(story_id, cast_id), story_id, "Aldric falls.")
+
+        rows = session.query(SBEventORM).filter_by(story_id=str(story_id)).all()
+        assert len(rows) == 1
+        assert rows[0].significance == "character_death"
+
+
+# ---------------------------------------------------------------------------
+# Direct-write prevention — architectural invariant
+# ---------------------------------------------------------------------------
+
+
+class TestDirectWritePrevention:
+    def test_all_auto_committed_proposals_have_staging_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Every auto-committed update has a corresponding RATIFIED staging row.
+
+        This is the architectural invariant: the Extractor CANNOT write to canon
+        without first staging a proposal.  We verify it by confirming that for
+        each auto-committed proposal returned in ExtractorResult, a matching row
+        exists in the provisional staging table with RATIFIED status.
+        """
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "transient_states": [
+                        {
+                            "character_name": "Aldric",
+                            "field_name": "current_location",
+                            "new_value": "The Vault",
+                        }
+                    ],
+                    "events": [
+                        {
+                            "description": "Aldric found the vault.",
+                            "significance": "routine",
+                        }
+                    ],
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "Aldric enters the vault."
+        )
+
+        # For every auto-committed proposal, a RATIFIED staging row must exist.
+        ratified_ids = {
+            str(row.proposal_id)
+            for row in session.query(SBProvisionalStagingORM)
+            .filter_by(status=ProposalStatus.RATIFIED.value)
+            .all()
+        }
+        for p in result.auto_committed:
+            assert str(p.proposal_id) in ratified_ids, (
+                f"Proposal {p.proposal_id} ({p.proposal_type.value}) was "
+                "auto-committed without a staging row — direct-write invariant violated"
+            )
+
+    def test_no_auto_committed_proposals_without_staging_for_locked_facts(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Locked facts are NOT in auto_committed — they require confirmation."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {"locked_facts": [{"fact_text": "The throne is vacant forever."}]}
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The throne stands empty."
+        )
+
+        # Locked facts must be PENDING, not auto-committed.
+        assert all(p.status == ProposalStatus.PENDING for p in result.pending_proposals)
+        assert len(result.auto_committed) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unresolvable character name
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvableCharacter:
+    def test_unresolvable_name_still_ratifies_proposal(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Soft-fact for unknown character name is RATIFIED without error."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "soft_facts": [
+                        {
+                            "character_name": "UnknownHero",
+                            "field_name": "current_location",
+                            "new_value": "Somewhere",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The unknown hero walks."
+        )
+
+        # Proposal is staged and ratified even without a resolvable cast entry.
+        assert len(result.auto_committed) == 1
+        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
+        # The real cast entry is unchanged.
+        entry = sbs.get_character(story_id, cast_id)
+        assert entry is not None
+        assert entry.current_location == "The Crossroads Inn"
+
+
+# ---------------------------------------------------------------------------
+# Empty tool response
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyToolResponse:
+    def test_empty_tool_response_produces_empty_result(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """When the model proposes nothing, all lists are empty."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response({}))
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "Nothing changed."
+        )
+
+        assert result.proposals == []
+        assert result.pending_proposals == []
+        assert result.auto_committed == []
+
+    def test_empty_result_pass_forward_says_no_updates(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Pass-forward content says no updates when the model finds nothing."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response({}))
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "Nothing changed."
+        )
+
+        assert "no narrative updates" in result.pass_forward_content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Pass-forward content
+# ---------------------------------------------------------------------------
+
+
+class TestPassForwardContent:
+    def test_pass_forward_mentions_pending_locked_fact(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Pass-forward content references pending locked-fact proposals."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {"locked_facts": [{"fact_text": "The emperor is dead."}]}
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "The emperor falls."
+        )
+
+        assert "emperor" in result.pass_forward_content.lower()
+        assert "pending" in result.pass_forward_content.lower()
+
+    def test_pass_forward_mentions_auto_committed_event(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Pass-forward content references auto-committed events."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "events": [
+                        {
+                            "description": "Aldric found the hidden door.",
+                            "significance": "routine",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), story_id, "A door appears."
+        )
+
+        assert "event" in result.pass_forward_content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Token metrics
+# ---------------------------------------------------------------------------
+
+
+class TestTokenMetrics:
+    def test_token_metrics_propagated(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """ExtractorResult surfaces all four token counts when reported."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {},
+                input_tokens=200,
+                output_tokens=80,
+                cache_read_input_tokens=150,
+                cache_creation_input_tokens=50,
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+        assert result.input_token_count == 200
+        assert result.output_token_count == 80
+        assert result.cache_read_token_count == 150
+        assert result.cache_creation_token_count == 50
+
+    def test_cache_metrics_none_when_not_reported(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Cache token fields are None when the provider omits them."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {},
+                input_tokens=100,
+                output_tokens=40,
+                cache_read_input_tokens=None,
+                cache_creation_input_tokens=None,
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+        assert result.cache_read_token_count is None
+        assert result.cache_creation_token_count is None
+
+    def test_model_identifier_format(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """model_identifier is formatted as 'anthropic:<model_string>'."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response())
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+        assert result.model_identifier.startswith("anthropic:")
+        assert "haiku" in result.model_identifier
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_provider_exception_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A provider exception is wrapped in ExtractorPassError."""
+        story_id, cast_id = story_and_cast
+        original_exc = ConnectionError("network failure")
+        fake = _make_fake_caller(raise_exc=original_exc)
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError) as exc_info:
+            service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+        assert exc_info.value.__cause__ is original_exc
+
+    def test_no_tool_use_block_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Response with no tool-use block raises ExtractorPassError."""
+        story_id, cast_id = story_and_cast
+
+        text_only_response = Message(
+            id="msg_text",
+            type="message",
+            role="assistant",
+            content=[TextBlock(type="text", text="I extracted nothing.")],
+            model="claude-haiku-4-5-20251001",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage=Usage(input_tokens=10, output_tokens=5),
+        )
+        fake = _make_fake_caller(text_only_response)
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+    def test_fake_caller_receives_tool_spec(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """The injected caller receives a payload with the extraction tool spec."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response())
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+        assert len(fake.captured) == 1  # type: ignore[attr-defined]
+        payload = fake.captured[0]  # type: ignore[attr-defined]
+        assert "tools" in payload
+        tools = payload["tools"]
+        assert isinstance(tools, list)
+        assert len(tools) == 1
+        assert tools[0]["name"] == EXTRACT_TOOL_NAME
+
+    def test_result_is_typed_extractor_result(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """extract() returns a typed ExtractorResult, not a raw dict."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(_fake_tool_response())
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+
+        assert isinstance(result, ExtractorResult)
+
+
+# ---------------------------------------------------------------------------
+# StoryBibleService.get_pending_proposals
+# ---------------------------------------------------------------------------
+
+
+class TestGetPendingProposals:
+    def test_get_pending_proposals_returns_locked_facts(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """get_pending_proposals() returns the staged locked-fact proposals."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {"locked_facts": [{"fact_text": "The wall has fallen."}]}
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(_make_assembled(story_id, cast_id), story_id, "The wall falls.")
+
+        pending = sbs.get_pending_proposals(story_id)
+        assert len(pending) == 1
+        assert pending[0].proposal_type == ProposalType.LOCKED_FACT
+
+    def test_get_pending_proposals_empty_after_all_auto_committed(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """get_pending_proposals() is empty when only auto-committed proposals exist."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "events": [
+                        {
+                            "description": "A small skirmish occurred.",
+                            "significance": "routine",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id), story_id, "A fight breaks out."
+        )
+
+        pending = sbs.get_pending_proposals(story_id)
+        assert pending == []

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -76,11 +76,16 @@ from afterworlds.models.enums import (
     IntentType,
     ProposalStatus,
     ProposalType,
+    RelationshipType,
     StoryMode,
 )
 from afterworlds.models.intent_classification import IntentClassificationResult
 from afterworlds.models.story import Arc, Chapter, Story
-from afterworlds.models.story_bible import CastEntry, StoryBibleContext
+from afterworlds.models.story_bible import (
+    CastEntry,
+    RelationshipLedger,
+    StoryBibleContext,
+)
 from afterworlds.persistence.crud.node import create_node
 from afterworlds.persistence.crud.story import create_arc, create_chapter, create_story
 from afterworlds.persistence.database import create_engine, create_session_factory
@@ -88,6 +93,7 @@ from afterworlds.persistence.orm.base import Base
 from afterworlds.persistence.orm.story_bible import (
     SBEventORM,
     SBProvisionalStagingORM,
+    SBRelationshipLedgerORM,
     SBUnresolvedThreadORM,
 )
 from afterworlds.pipeline.extractor.caller import EXTRACT_TOOL_NAME, ExtractorPayload
@@ -1176,3 +1182,321 @@ class TestErrorHandling:
         )
 
         assert isinstance(result, ExtractorResult)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture — relationship seeding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def story_with_relationship(session, story_and_cast):  # type: ignore[no-untyped-def]
+    """Extend story_and_cast with a second cast entry 'Mira' and 'Aldric -> Mira'."""
+    story_id, aldric_cast_id = story_and_cast
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+
+    sbs = StoryBibleService(session)
+    mira_entry = CastEntry(
+        story_id=story_id,
+        name="Mira",
+        role=CastRole.SUPPORTING,
+        created_at=now,
+    )
+    mira_saved = sbs.add_cast_entry(story_id, mira_entry)
+
+    relationship = RelationshipLedger(
+        story_id=story_id,
+        subject_cast_id=aldric_cast_id,
+        object_cast_id=mira_saved.cast_id,
+        relationship_type=RelationshipType.ALLY,
+        current_status_description="Cautious allies",
+        created_at=now,
+        updated_at=now,
+    )
+    sbs.add_relationship(story_id, relationship)
+    session.commit()
+
+    return story_id, aldric_cast_id, mira_saved.cast_id
+
+
+# ---------------------------------------------------------------------------
+# Relationship domain
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipDomain:
+    def test_relationship_soft_fact_updates_status_description(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """RELATIONSHIP soft_fact updates current_status_description and leaves a
+        RATIFIED audit row."""
+        story_id, aldric_cast_id, mira_cast_id = story_with_relationship
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "Aldric -> Mira",
+                            "target_field": "current_status_description",
+                            "proposed_value": "tense allies",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, aldric_cast_id),
+            "Aldric eyes Mira with suspicion.",
+            story_id,
+            _turn_id(),
+        )
+
+        assert len(result.routed.soft_fact_staged_ids) == 1
+
+        rel_row = (
+            session.query(SBRelationshipLedgerORM)
+            .filter_by(
+                story_id=str(story_id),
+                subject_cast_id=str(aldric_cast_id),
+                object_cast_id=str(mira_cast_id),
+                is_active=True,
+            )
+            .one()
+        )
+        assert rel_row.current_status_description == "tense allies"
+
+        audit_rows = (
+            session.query(SBProvisionalStagingORM)
+            .filter_by(
+                proposal_type=ProposalType.SOFT_FACT.value,
+                status=ProposalStatus.RATIFIED.value,
+            )
+            .all()
+        )
+        assert len(audit_rows) == 1
+
+    def test_relationship_malformed_key_no_delimiter_raises(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """Relationship key with no ' -> ' delimiter raises ExtractorPassError."""
+        story_id, aldric_cast_id, _mira_cast_id = story_with_relationship
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "AldricMira",
+                            "target_field": "current_status_description",
+                            "proposed_value": "allies",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, aldric_cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+    def test_relationship_malformed_key_two_delimiters_raises(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """Relationship key with two ' -> ' delimiters raises ExtractorPassError."""
+        story_id, aldric_cast_id, _mira_cast_id = story_with_relationship
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "Aldric -> Mira -> Vex",
+                            "target_field": "current_status_description",
+                            "proposed_value": "allies",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, aldric_cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+    def test_relationship_unresolvable_subject_raises(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """Unresolvable subject name raises ExtractorPassError with no DB state."""
+        story_id, aldric_cast_id, _mira_cast_id = story_with_relationship
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "UnknownPerson -> Mira",
+                            "target_field": "current_status_description",
+                            "proposed_value": "allies",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, aldric_cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
+    def test_relationship_unresolvable_object_raises(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """Unresolvable object name raises ExtractorPassError with no DB state."""
+        story_id, aldric_cast_id, _mira_cast_id = story_with_relationship
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "Aldric -> UnknownPerson",
+                            "target_field": "current_status_description",
+                            "proposed_value": "allies",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, aldric_cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
+
+# ---------------------------------------------------------------------------
+# World domain
+# ---------------------------------------------------------------------------
+
+
+class TestWorldDomain:
+    def test_world_domain_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """world domain raises ExtractorPassError; no DB state committed."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "world",
+                            "target_natural_key": "some_key",
+                            "target_field": "any_field",
+                            "proposed_value": "whatever",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
+
+# ---------------------------------------------------------------------------
+# Transaction boundary (all-or-nothing invariant)
+# ---------------------------------------------------------------------------
+
+
+class TestTransactionBoundary:
+    def test_partial_failure_leaves_no_db_state(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """locked_fact (succeeds flush) + soft_fact with unknown name (fails) →
+        zero rows after rollback; proves the all-or-nothing transaction boundary."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "locked_fact",
+                            "fact_text": "The fortress gates are sealed forever.",
+                        },
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "UnknownName",
+                            "target_field": "current_location",
+                            "proposed_value": "Somewhere",
+                        },
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id),
+                "The gates seal. UnknownName walks away.",
+                story_id,
+                _turn_id(),
+            )
+
+        # After rollback the locked_fact's flush must not have been committed.
+        session.rollback()
+        staging_rows = session.query(SBProvisionalStagingORM).all()
+        assert (
+            staging_rows == []
+        ), "Partial DB state was committed — transaction boundary violated"

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -1,27 +1,41 @@
 """Unit tests for ExtractorService — CRD Issue 10.
 
-Coverage targets (from the Issue 10 test requirements):
+Coverage targets:
 
-Classification routing — one test per proposal category:
+Classification routing — one test per proposal kind:
   - test_locked_fact_staged_pending
-  - test_soft_fact_auto_ratified
-  - test_transient_state_auto_ratified
-  - test_unresolved_thread_creates_thread_row
-  - test_event_creates_event_row
+  - test_soft_fact_staged_id_returned
+  - test_transient_state_staged_id_returned
+  - test_unresolved_thread_staged_id_returned
+  - test_event_id_returned
 
-Direct-write prevention (architectural invariant — CRD Item 12):
-  - test_all_proposals_staged_before_canon_is_touched
-
-Auto-commit behaviour:
+Field application:
   - test_soft_fact_applied_to_cast_dynamic_field
   - test_transient_state_applied_to_cast_dynamic_field
-  - test_unresolvable_character_name_still_ratifies_proposal
+
+Audit trail (direct-write prevention):
+  - test_soft_fact_has_ratified_staging_row
+  - test_transient_state_has_ratified_staging_row
+  - test_unresolved_thread_has_ratified_staging_row
+  - test_event_bypasses_staging_table
+
+Database entries:
+  - test_unresolved_thread_creates_thread_row
+  - test_event_creates_event_row_with_event_kind
+
+Fail-loud unresolvable name (strict per Issue 10):
+  - test_unresolvable_character_name_raises_extractor_pass_error
+  - test_unresolvable_name_leaves_no_db_state
+
+Story-id guard:
+  - test_story_id_mismatch_raises_extractor_pass_error
+
+Empty tool response:
   - test_empty_tool_response_produces_empty_result
 
-Pass-forward content:
-  - test_pass_forward_mentions_pending_locked_fact
-  - test_pass_forward_mentions_auto_committed_event
-  - test_pass_forward_empty_when_no_proposals
+list_pending_locked_fact_proposals:
+  - test_list_pending_locked_fact_proposals_returns_locked_facts
+  - test_list_pending_excludes_auto_committed_proposals
 
 Token metrics:
   - test_token_metrics_propagated
@@ -30,13 +44,15 @@ Token metrics:
 Error handling:
   - test_provider_exception_raises_extractor_pass_error
   - test_no_tool_use_block_raises_extractor_pass_error
+  - test_fake_caller_receives_tool_spec_with_new_name
+  - test_result_is_typed_extractor_result
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
@@ -222,7 +238,7 @@ def _fake_tool_response(
                 type="tool_use",
                 id="toolu_fake_01",
                 name=EXTRACT_TOOL_NAME,
-                input=tool_input if tool_input is not None else {},
+                input=tool_input if tool_input is not None else {"proposals": []},
             )
         ],
         model="claude-haiku-4-5-20251001",
@@ -253,6 +269,10 @@ def _make_fake_caller(  # type: ignore[no-untyped-def]
     return caller
 
 
+def _turn_id() -> UUID:
+    return uuid4()
+
+
 # ---------------------------------------------------------------------------
 # Classification routing — locked facts
 # ---------------------------------------------------------------------------
@@ -262,93 +282,15 @@ class TestLockedFactRouting:
     def test_locked_fact_staged_pending(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """A locked-fact proposal is staged with PENDING status."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {"locked_facts": [{"fact_text": "The king has been assassinated."}]}
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The king falls dead."
-        )
-
-        assert len(result.pending_proposals) == 1
-        proposal = result.pending_proposals[0]
-        assert proposal.proposal_type == ProposalType.LOCKED_FACT
-        assert proposal.status == ProposalStatus.PENDING
-        assert proposal.requires_confirmation is True
-        assert "king" in proposal.proposed_value.get("fact_text", "").lower()
-
-    def test_locked_fact_not_in_auto_committed(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """Locked-fact proposals are NOT in auto_committed."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {"locked_facts": [{"fact_text": "The keep is destroyed."}]}
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The keep crumbles."
-        )
-
-        assert not any(
-            p.proposal_type == ProposalType.LOCKED_FACT for p in result.auto_committed
-        )
-
-    def test_locked_fact_remains_in_staging_area(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """After extract(), a PENDING proposal row exists in the staging table."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {"locked_facts": [{"fact_text": "The bridge is destroyed."}]}
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The bridge falls."
-        )
-
-        rows = (
-            session.query(SBProvisionalStagingORM)
-            .filter_by(status=ProposalStatus.PENDING.value)
-            .all()
-        )
-        assert len(rows) == 1
-        assert rows[0].proposal_type == ProposalType.LOCKED_FACT.value
-
-
-# ---------------------------------------------------------------------------
-# Classification routing — soft facts
-# ---------------------------------------------------------------------------
-
-
-class TestSoftFactRouting:
-    def test_soft_fact_auto_ratified(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """A soft-fact proposal is RATIFIED."""
+        """A locked-fact proposal produces a staged_id and a PENDING staging row."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "soft_facts": [
+                    "proposals": [
                         {
-                            "character_name": "Aldric",
-                            "field_name": "current_status",
-                            "new_value": "injured",
+                            "kind": "locked_fact",
+                            "fact_text": "The king is assassinated.",
                         }
                     ]
                 }
@@ -358,12 +300,93 @@ class TestSoftFactRouting:
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "Aldric is cut by a blade."
+            _make_assembled(story_id, cast_id),
+            "The king falls dead.",
+            story_id,
+            _turn_id(),
         )
 
-        assert len(result.auto_committed) == 1
-        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
-        assert result.auto_committed[0].proposal_type == ProposalType.SOFT_FACT
+        assert len(result.routed.locked_fact_staged_ids) == 1
+        assert result.routed.soft_fact_staged_ids == []
+        assert result.routed.event_ids == []
+
+        rows = (
+            session.query(SBProvisionalStagingORM)
+            .filter_by(
+                proposal_type=ProposalType.LOCKED_FACT.value,
+                status=ProposalStatus.PENDING.value,
+            )
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].requires_confirmation is True
+        assert "king" in rows[0].proposed_value.get("fact_text", "").lower()
+
+    def test_locked_fact_staged_id_matches_db_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """The staged_id returned matches the DB row's proposal_id."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {"kind": "locked_fact", "fact_text": "The bridge is destroyed."}
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id),
+            "The bridge falls.",
+            story_id,
+            _turn_id(),
+        )
+
+        staged_id = result.routed.locked_fact_staged_ids[0]
+        row = session.get(SBProvisionalStagingORM, str(staged_id))
+        assert row is not None
+        assert row.status == ProposalStatus.PENDING.value
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — soft facts
+# ---------------------------------------------------------------------------
+
+
+class TestSoftFactRouting:
+    def test_soft_fact_staged_id_returned(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A soft-fact proposal returns a staged_id."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_status",
+                            "proposed_value": "injured",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id), "Aldric is cut.", story_id, _turn_id()
+        )
+
+        assert len(result.routed.soft_fact_staged_ids) == 1
+        assert result.routed.locked_fact_staged_ids == []
 
     def test_soft_fact_applied_to_cast_dynamic_field(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
@@ -373,40 +396,13 @@ class TestSoftFactRouting:
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "soft_facts": [
+                    "proposals": [
                         {
-                            "character_name": "Aldric",
-                            "field_name": "current_location",
-                            "new_value": "The Dark Tower",
-                        }
-                    ]
-                }
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        service.extract(
-            _make_assembled(story_id, cast_id), story_id, "Aldric enters the tower."
-        )
-
-        entry = sbs.get_character(story_id, cast_id)
-        assert entry is not None
-        assert entry.current_location == "The Dark Tower"
-
-    def test_soft_fact_staged_before_field_applied(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """Staging row exists for the soft fact (direct-write prevention invariant)."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {
-                    "soft_facts": [
-                        {
-                            "character_name": "Aldric",
-                            "field_name": "current_status",
-                            "new_value": "exhausted",
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_location",
+                            "proposed_value": "The Dark Tower",
                         }
                     ]
                 }
@@ -417,8 +413,43 @@ class TestSoftFactRouting:
 
         service.extract(
             _make_assembled(story_id, cast_id),
+            "Aldric enters the tower.",
             story_id,
+            _turn_id(),
+        )
+
+        entry = sbs.get_character(story_id, cast_id)
+        assert entry is not None
+        assert entry.current_location == "The Dark Tower"
+
+    def test_soft_fact_has_ratified_staging_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A RATIFIED audit staging row exists for each soft-fact update."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_status",
+                            "proposed_value": "exhausted",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id),
             "Aldric collapses exhausted.",
+            story_id,
+            _turn_id(),
         )
 
         rows = (
@@ -429,7 +460,7 @@ class TestSoftFactRouting:
             )
             .all()
         )
-        assert len(rows) == 1, "No staging row found — direct-write invariant violated"
+        assert len(rows) == 1, "No audit staging row — direct-write invariant violated"
 
 
 # ---------------------------------------------------------------------------
@@ -438,19 +469,21 @@ class TestSoftFactRouting:
 
 
 class TestTransientStateRouting:
-    def test_transient_state_auto_ratified(  # type: ignore[no-untyped-def]
+    def test_transient_state_staged_id_returned(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """A transient-state proposal is RATIFIED."""
+        """A transient-state proposal returns a staged_id."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "transient_states": [
+                    "proposals": [
                         {
-                            "character_name": "Aldric",
-                            "field_name": "current_location",
-                            "new_value": "Forest Path",
+                            "kind": "transient_state",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_location",
+                            "proposed_value": "Forest Path",
                         }
                     ]
                 }
@@ -461,13 +494,12 @@ class TestTransientStateRouting:
 
         result = service.extract(
             _make_assembled(story_id, cast_id),
-            story_id,
             "Aldric walks the forest path.",
+            story_id,
+            _turn_id(),
         )
 
-        assert len(result.auto_committed) == 1
-        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
-        assert result.auto_committed[0].proposal_type == ProposalType.TRANSIENT_STATE
+        assert len(result.routed.transient_state_staged_ids) == 1
 
     def test_transient_state_applied_to_cast_dynamic_field(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
@@ -477,11 +509,13 @@ class TestTransientStateRouting:
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "transient_states": [
+                    "proposals": [
                         {
-                            "character_name": "Aldric",
-                            "field_name": "current_location",
-                            "new_value": "The Market Square",
+                            "kind": "transient_state",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_location",
+                            "proposed_value": "The Market Square",
                         }
                     ]
                 }
@@ -492,56 +526,31 @@ class TestTransientStateRouting:
 
         service.extract(
             _make_assembled(story_id, cast_id),
-            story_id,
             "Aldric reaches the market.",
+            story_id,
+            _turn_id(),
         )
 
         entry = sbs.get_character(story_id, cast_id)
         assert entry is not None
         assert entry.current_location == "The Market Square"
 
-
-# ---------------------------------------------------------------------------
-# Classification routing — unresolved threads
-# ---------------------------------------------------------------------------
-
-
-class TestUnresolvedThreadRouting:
-    def test_unresolved_thread_auto_ratified(  # type: ignore[no-untyped-def]
+    def test_transient_state_has_ratified_staging_row(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """An unresolved-thread proposal is RATIFIED."""
+        """A RATIFIED audit staging row exists for each transient-state update."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "unresolved_threads": [
-                        {"description": "Who left the hooded figure at the inn?"}
-                    ]
-                }
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "A hooded figure watches."
-        )
-
-        assert len(result.auto_committed) == 1
-        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
-        assert result.auto_committed[0].proposal_type == ProposalType.UNRESOLVED_THREAD
-
-    def test_unresolved_thread_creates_thread_row(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """Ratifying an unresolved-thread proposal creates a thread row."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {
-                    "unresolved_threads": [
-                        {"description": "Where is the missing artefact hidden?"}
+                    "proposals": [
+                        {
+                            "kind": "transient_state",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_location",
+                            "proposed_value": "The Vault",
+                        }
                     ]
                 }
             )
@@ -550,7 +559,83 @@ class TestUnresolvedThreadRouting:
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The artefact is gone."
+            _make_assembled(story_id, cast_id),
+            "Aldric enters the vault.",
+            story_id,
+            _turn_id(),
+        )
+
+        rows = (
+            session.query(SBProvisionalStagingORM)
+            .filter_by(
+                proposal_type=ProposalType.TRANSIENT_STATE.value,
+                status=ProposalStatus.RATIFIED.value,
+            )
+            .all()
+        )
+        assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Classification routing — unresolved threads
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvedThreadRouting:
+    def test_unresolved_thread_staged_id_returned(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """An unresolved-thread proposal returns a staged_id."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "unresolved_thread",
+                            "description": "Who left the hooded figure at the inn?",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id),
+            "A hooded figure watches.",
+            story_id,
+            _turn_id(),
+        )
+
+        assert len(result.routed.unresolved_thread_staged_ids) == 1
+
+    def test_unresolved_thread_creates_thread_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """An unresolved-thread proposal creates a row in sb_unresolved_threads."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "unresolved_thread",
+                            "description": "Where is the missing artefact hidden?",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            "The artefact is gone.",
+            story_id,
+            _turn_id(),
         )
 
         rows = (
@@ -559,6 +644,43 @@ class TestUnresolvedThreadRouting:
         assert len(rows) == 1
         assert "artefact" in rows[0].description.lower()
 
+    def test_unresolved_thread_has_ratified_staging_row(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """A RATIFIED audit staging row exists for each unresolved-thread proposal."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "unresolved_thread",
+                            "description": "Who opened the gate?",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            "The gate is open.",
+            story_id,
+            _turn_id(),
+        )
+
+        rows = (
+            session.query(SBProvisionalStagingORM)
+            .filter_by(
+                proposal_type=ProposalType.UNRESOLVED_THREAD.value,
+                status=ProposalStatus.RATIFIED.value,
+            )
+            .all()
+        )
+        assert len(rows) == 1
+
 
 # ---------------------------------------------------------------------------
 # Classification routing — events
@@ -566,16 +688,18 @@ class TestUnresolvedThreadRouting:
 
 
 class TestEventRouting:
-    def test_event_auto_ratified(  # type: ignore[no-untyped-def]
+    def test_event_id_returned(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """An event proposal is RATIFIED."""
+        """An event proposal returns an event_id in routed.event_ids."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "events": [
+                    "proposals": [
                         {
+                            "kind": "event",
+                            "event_kind": "scene_transition",
                             "description": "Aldric crossed the Thornbridge.",
                             "significance": "routine",
                         }
@@ -588,24 +712,25 @@ class TestEventRouting:
 
         result = service.extract(
             _make_assembled(story_id, cast_id),
-            story_id,
             "Aldric crosses the bridge.",
+            story_id,
+            _turn_id(),
         )
 
-        assert len(result.auto_committed) == 1
-        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
-        assert result.auto_committed[0].proposal_type == ProposalType.EVENT
+        assert len(result.routed.event_ids) == 1
 
-    def test_event_creates_event_row(  # type: ignore[no-untyped-def]
+    def test_event_creates_event_row_with_event_kind(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """Ratifying an event proposal creates a row in sb_events."""
+        """An event proposal creates a row in sb_events with the correct event_kind."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "events": [
+                    "proposals": [
                         {
+                            "kind": "event",
+                            "event_kind": "death",
                             "description": "Aldric slew the Night Warden.",
                             "significance": "major_plot_turn",
                         }
@@ -618,27 +743,31 @@ class TestEventRouting:
 
         service.extract(
             _make_assembled(story_id, cast_id),
-            story_id,
             "The Night Warden falls.",
+            story_id,
+            _turn_id(),
         )
 
         rows = session.query(SBEventORM).filter_by(story_id=str(story_id)).all()
         assert len(rows) == 1
         assert "night warden" in rows[0].description.lower()
         assert rows[0].significance == "major_plot_turn"
+        assert rows[0].event_kind == "death"
 
-    def test_event_with_character_death_significance(  # type: ignore[no-untyped-def]
+    def test_event_bypasses_staging_table(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """character_death significance is stored correctly."""
+        """Events go directly to sb_events — no staging row is created."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "events": [
+                    "proposals": [
                         {
-                            "description": "Aldric is slain.",
-                            "significance": "character_death",
+                            "kind": "event",
+                            "event_kind": "plot_reveal",
+                            "description": "The prophecy is revealed.",
+                            "significance": "locked_fact_established",
                         }
                     ]
                 }
@@ -647,46 +776,32 @@ class TestEventRouting:
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        service.extract(_make_assembled(story_id, cast_id), story_id, "Aldric falls.")
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            "The prophecy becomes clear.",
+            story_id,
+            _turn_id(),
+        )
 
-        rows = session.query(SBEventORM).filter_by(story_id=str(story_id)).all()
-        assert len(rows) == 1
-        assert rows[0].significance == "character_death"
+        staging_rows = session.query(SBProvisionalStagingORM).all()
+        assert staging_rows == [], "Event created a staging row — should bypass staging"
 
-
-# ---------------------------------------------------------------------------
-# Direct-write prevention — architectural invariant
-# ---------------------------------------------------------------------------
-
-
-class TestDirectWritePrevention:
-    def test_all_auto_committed_proposals_have_staging_row(  # type: ignore[no-untyped-def]
+    def test_event_id_matches_db_row(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """Every auto-committed update has a corresponding RATIFIED staging row.
-
-        This is the architectural invariant: the Extractor CANNOT write to canon
-        without first staging a proposal.  We verify it by confirming that for
-        each auto-committed proposal returned in ExtractorResult, a matching row
-        exists in the provisional staging table with RATIFIED status.
-        """
+        """routed.event_ids[0] matches the event_id column in sb_events."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "transient_states": [
+                    "proposals": [
                         {
-                            "character_name": "Aldric",
-                            "field_name": "current_location",
-                            "new_value": "The Vault",
-                        }
-                    ],
-                    "events": [
-                        {
-                            "description": "Aldric found the vault.",
+                            "kind": "event",
+                            "event_kind": "npc_introduction",
+                            "description": "A stranger arrived.",
                             "significance": "routine",
                         }
-                    ],
+                    ]
                 }
             )
         )
@@ -694,63 +809,39 @@ class TestDirectWritePrevention:
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "Aldric enters the vault."
+            _make_assembled(story_id, cast_id),
+            "A stranger appears.",
+            story_id,
+            _turn_id(),
         )
 
-        # For every auto-committed proposal, a RATIFIED staging row must exist.
-        ratified_ids = {
-            str(row.proposal_id)
-            for row in session.query(SBProvisionalStagingORM)
-            .filter_by(status=ProposalStatus.RATIFIED.value)
-            .all()
-        }
-        for p in result.auto_committed:
-            assert str(p.proposal_id) in ratified_ids, (
-                f"Proposal {p.proposal_id} ({p.proposal_type.value}) was "
-                "auto-committed without a staging row — direct-write invariant violated"
-            )
-
-    def test_no_auto_committed_proposals_without_staging_for_locked_facts(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """Locked facts are NOT in auto_committed — they require confirmation."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {"locked_facts": [{"fact_text": "The throne is vacant forever."}]}
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The throne stands empty."
-        )
-
-        # Locked facts must be PENDING, not auto-committed.
-        assert all(p.status == ProposalStatus.PENDING for p in result.pending_proposals)
-        assert len(result.auto_committed) == 0
+        event_id = result.routed.event_ids[0]
+        row = session.get(SBEventORM, str(event_id))
+        assert row is not None
+        assert "stranger" in row.description.lower()
 
 
 # ---------------------------------------------------------------------------
-# Unresolvable character name
+# Fail-loud unresolvable character name
 # ---------------------------------------------------------------------------
 
 
 class TestUnresolvableCharacter:
-    def test_unresolvable_name_still_ratifies_proposal(  # type: ignore[no-untyped-def]
+    def test_unresolvable_character_name_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """Soft-fact for unknown character name is RATIFIED without error."""
+        """Soft-fact for unknown character name raises ExtractorPassError."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "soft_facts": [
+                    "proposals": [
                         {
-                            "character_name": "UnknownHero",
-                            "field_name": "current_location",
-                            "new_value": "Somewhere",
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "UnknownHero",
+                            "target_field": "current_location",
+                            "proposed_value": "Somewhere",
                         }
                     ]
                 }
@@ -759,17 +850,82 @@ class TestUnresolvableCharacter:
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The unknown hero walks."
+        with pytest.raises(ExtractorPassError) as exc_info:
+            service.extract(
+                _make_assembled(story_id, cast_id),
+                "The unknown hero walks.",
+                story_id,
+                _turn_id(),
+            )
+
+        assert (
+            "UnknownHero" in str(exc_info.value)
+            or "routing failed" in str(exc_info.value).lower()
         )
 
-        # Proposal is staged and ratified even without a resolvable cast entry.
-        assert len(result.auto_committed) == 1
-        assert result.auto_committed[0].status == ProposalStatus.RATIFIED
-        # The real cast entry is unchanged.
-        entry = sbs.get_character(story_id, cast_id)
-        assert entry is not None
-        assert entry.current_location == "The Crossroads Inn"
+    def test_unresolvable_name_leaves_no_db_state(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """When routing fails, no staging rows or event rows are committed."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "transient_state",
+                            "target_domain": "character",
+                            "target_natural_key": "GhostCharacter",
+                            "target_field": "current_location",
+                            "proposed_value": "Nowhere",
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id),
+                "The ghost walks.",
+                story_id,
+                _turn_id(),
+            )
+
+        # Session is dirty (not committed) — re-open to see committed state.
+        session.rollback()
+        staging_rows = session.query(SBProvisionalStagingORM).all()
+        assert staging_rows == []
+
+
+# ---------------------------------------------------------------------------
+# Story-id guard
+# ---------------------------------------------------------------------------
+
+
+class TestStoryIdGuard:
+    def test_story_id_mismatch_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """built_context.story_id != story_id raises ExtractorPassError immediately."""
+        story_id, cast_id = story_and_cast
+        wrong_story_id = uuid4()
+        fake = _make_fake_caller(_fake_tool_response())
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        # _make_assembled uses story_id, but we pass wrong_story_id as story_id arg
+        with pytest.raises(ExtractorPassError) as exc_info:
+            service.extract(
+                _make_assembled(story_id, cast_id),
+                "prose.",
+                wrong_story_id,
+                _turn_id(),
+            )
+
+        assert "story_id" in str(exc_info.value).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -778,76 +934,87 @@ class TestUnresolvableCharacter:
 
 
 class TestEmptyToolResponse:
-    def test_empty_tool_response_produces_empty_result(  # type: ignore[no-untyped-def]
+    def test_empty_proposals_produces_empty_routed(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """When the model proposes nothing, all lists are empty."""
+        """When the model proposes nothing, all routed ID lists are empty."""
         story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(_fake_tool_response({}))
+        fake = _make_fake_caller(_fake_tool_response({"proposals": []}))
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "Nothing changed."
+            _make_assembled(story_id, cast_id), "Nothing changed.", story_id, _turn_id()
         )
 
-        assert result.proposals == []
-        assert result.pending_proposals == []
-        assert result.auto_committed == []
+        assert result.routed.locked_fact_staged_ids == []
+        assert result.routed.soft_fact_staged_ids == []
+        assert result.routed.transient_state_staged_ids == []
+        assert result.routed.unresolved_thread_staged_ids == []
+        assert result.routed.event_ids == []
 
-    def test_empty_result_pass_forward_says_no_updates(  # type: ignore[no-untyped-def]
+    def test_empty_proposal_set_is_valid(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """Pass-forward content says no updates when the model finds nothing."""
+        """An empty proposals array is valid and produces a non-None proposal_set."""
         story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(_fake_tool_response({}))
+        fake = _make_fake_caller(_fake_tool_response({"proposals": []}))
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "Nothing changed."
+            _make_assembled(story_id, cast_id), "Nothing changed.", story_id, _turn_id()
         )
 
-        assert "no narrative updates" in result.pass_forward_content.lower()
+        assert result.proposal_set is not None
+        assert result.proposal_set.proposals == []
 
 
 # ---------------------------------------------------------------------------
-# Pass-forward content
+# list_pending_locked_fact_proposals
 # ---------------------------------------------------------------------------
 
 
-class TestPassForwardContent:
-    def test_pass_forward_mentions_pending_locked_fact(  # type: ignore[no-untyped-def]
+class TestListPendingLockedFactProposals:
+    def test_list_pending_locked_fact_proposals_returns_locked_facts(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """Pass-forward content references pending locked-fact proposals."""
+        """list_pending_locked_fact_proposals returns PENDING LOCKED_FACT rows."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
-                {"locked_facts": [{"fact_text": "The emperor is dead."}]}
+                {
+                    "proposals": [
+                        {"kind": "locked_fact", "fact_text": "The wall has fallen."}
+                    ]
+                }
             )
         )
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "The emperor falls."
+        service.extract(
+            _make_assembled(story_id, cast_id), "The wall falls.", story_id, _turn_id()
         )
 
-        assert "emperor" in result.pass_forward_content.lower()
-        assert "pending" in result.pass_forward_content.lower()
+        pending = sbs.list_pending_locked_fact_proposals(story_id)
+        assert len(pending) == 1
+        assert pending[0].proposal_type == ProposalType.LOCKED_FACT
+        assert pending[0].status == ProposalStatus.PENDING
 
-    def test_pass_forward_mentions_auto_committed_event(  # type: ignore[no-untyped-def]
+    def test_list_pending_excludes_auto_committed_proposals(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """Pass-forward content references auto-committed events."""
+        """list_pending_locked_fact_proposals excludes RATIFIED proposals."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
                 {
-                    "events": [
+                    "proposals": [
                         {
-                            "description": "Aldric found the hidden door.",
+                            "kind": "event",
+                            "event_kind": "routine",
+                            "description": "A small skirmish occurred.",
                             "significance": "routine",
                         }
                     ]
@@ -857,11 +1024,15 @@ class TestPassForwardContent:
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        result = service.extract(
-            _make_assembled(story_id, cast_id), story_id, "A door appears."
+        service.extract(
+            _make_assembled(story_id, cast_id),
+            "A fight breaks out.",
+            story_id,
+            _turn_id(),
         )
 
-        assert "event" in result.pass_forward_content.lower()
+        pending = sbs.list_pending_locked_fact_proposals(story_id)
+        assert pending == []
 
 
 # ---------------------------------------------------------------------------
@@ -877,7 +1048,7 @@ class TestTokenMetrics:
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
-                {},
+                {"proposals": []},
                 input_tokens=200,
                 output_tokens=80,
                 cache_read_input_tokens=150,
@@ -887,7 +1058,9 @@ class TestTokenMetrics:
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+        result = service.extract(
+            _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+        )
 
         assert result.input_token_count == 200
         assert result.output_token_count == 80
@@ -901,7 +1074,7 @@ class TestTokenMetrics:
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(
             _fake_tool_response(
-                {},
+                {"proposals": []},
                 input_tokens=100,
                 output_tokens=40,
                 cache_read_input_tokens=None,
@@ -911,24 +1084,12 @@ class TestTokenMetrics:
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+        result = service.extract(
+            _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+        )
 
         assert result.cache_read_token_count is None
         assert result.cache_creation_token_count is None
-
-    def test_model_identifier_format(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """model_identifier is formatted as 'anthropic:<model_string>'."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(_fake_tool_response())
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
-
-        assert result.model_identifier.startswith("anthropic:")
-        assert "haiku" in result.model_identifier
 
 
 # ---------------------------------------------------------------------------
@@ -948,7 +1109,9 @@ class TestErrorHandling:
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         with pytest.raises(ExtractorPassError) as exc_info:
-            service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+            service.extract(
+                _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+            )
 
         assert exc_info.value.__cause__ is original_exc
 
@@ -973,18 +1136,22 @@ class TestErrorHandling:
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         with pytest.raises(ExtractorPassError):
-            service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+            service.extract(
+                _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+            )
 
-    def test_fake_caller_receives_tool_spec(  # type: ignore[no-untyped-def]
+    def test_fake_caller_receives_tool_spec_with_new_name(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """The injected caller receives a payload with the extraction tool spec."""
+        """The injected caller receives a payload with 'propose_canon_updates' tool."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(_fake_tool_response())
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+        service.extract(
+            _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+        )
 
         assert len(fake.captured) == 1  # type: ignore[attr-defined]
         payload = fake.captured[0]  # type: ignore[attr-defined]
@@ -992,70 +1159,20 @@ class TestErrorHandling:
         tools = payload["tools"]
         assert isinstance(tools, list)
         assert len(tools) == 1
+        assert tools[0]["name"] == "propose_canon_updates"
         assert tools[0]["name"] == EXTRACT_TOOL_NAME
 
     def test_result_is_typed_extractor_result(  # type: ignore[no-untyped-def]
         self, session, story_and_cast
     ) -> None:
-        """extract() returns a typed ExtractorResult, not a raw dict."""
+        """extract() returns a typed ExtractorResult."""
         story_id, cast_id = story_and_cast
         fake = _make_fake_caller(_fake_tool_response())
         sbs = StoryBibleService(session)
         service = ExtractorService(session, sbs, _make_config(), fake)
 
-        result = service.extract(_make_assembled(story_id, cast_id), story_id, "prose.")
+        result = service.extract(
+            _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+        )
 
         assert isinstance(result, ExtractorResult)
-
-
-# ---------------------------------------------------------------------------
-# StoryBibleService.get_pending_proposals
-# ---------------------------------------------------------------------------
-
-
-class TestGetPendingProposals:
-    def test_get_pending_proposals_returns_locked_facts(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """get_pending_proposals() returns the staged locked-fact proposals."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {"locked_facts": [{"fact_text": "The wall has fallen."}]}
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        service.extract(_make_assembled(story_id, cast_id), story_id, "The wall falls.")
-
-        pending = sbs.get_pending_proposals(story_id)
-        assert len(pending) == 1
-        assert pending[0].proposal_type == ProposalType.LOCKED_FACT
-
-    def test_get_pending_proposals_empty_after_all_auto_committed(  # type: ignore[no-untyped-def]
-        self, session, story_and_cast
-    ) -> None:
-        """get_pending_proposals() is empty when only auto-committed proposals exist."""
-        story_id, cast_id = story_and_cast
-        fake = _make_fake_caller(
-            _fake_tool_response(
-                {
-                    "events": [
-                        {
-                            "description": "A small skirmish occurred.",
-                            "significance": "routine",
-                        }
-                    ]
-                }
-            )
-        )
-        sbs = StoryBibleService(session)
-        service = ExtractorService(session, sbs, _make_config(), fake)
-
-        service.extract(
-            _make_assembled(story_id, cast_id), story_id, "A fight breaks out."
-        )
-
-        pending = sbs.get_pending_proposals(story_id)
-        assert pending == []

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -1199,6 +1199,114 @@ class TestErrorHandling:
 
         assert isinstance(result, ExtractorResult)
 
+    def test_missing_proposals_key_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Missing 'proposals' key in tool response raises ExtractorPassError."""
+        story_id, cast_id = story_and_cast
+        empty_obj_response = Message(
+            id="msg_missing_proposals",
+            type="message",
+            role="assistant",
+            content=[
+                ToolUseBlock(
+                    type="tool_use",
+                    id="toolu_missing",
+                    name=EXTRACT_TOOL_NAME,
+                    input={},  # missing 'proposals' key entirely
+                )
+            ],
+            model="claude-haiku-4-5-20251001",
+            stop_reason="tool_use",
+            stop_sequence=None,
+            usage=Usage(input_tokens=10, output_tokens=5),
+        )
+        fake = _make_fake_caller(empty_obj_response)
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id), "prose.", story_id, _turn_id()
+            )
+
+
+# ---------------------------------------------------------------------------
+# Boolean proposed_value (is_alive)
+# ---------------------------------------------------------------------------
+
+
+class TestBooleanProposedValue:
+    def test_is_alive_false_routes_as_boolean(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """soft_fact with is_alive=False (JSON boolean) writes False to cast row."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "is_alive",
+                            "proposed_value": False,
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id),
+            "Aldric falls dead.",
+            story_id,
+            _turn_id(),
+        )
+
+        assert len(result.routed.soft_fact_staged_ids) == 1
+        entry = sbs.get_character(story_id, cast_id)
+        assert entry is not None
+        assert entry.is_alive is False
+
+    def test_is_alive_true_routes_as_boolean(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """transient_state with is_alive=True (JSON boolean) writes True to cast row."""
+        story_id, cast_id = story_and_cast
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "transient_state",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "is_alive",
+                            "proposed_value": True,
+                        }
+                    ]
+                }
+            )
+        )
+        sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        result = service.extract(
+            _make_assembled(story_id, cast_id),
+            "Aldric lives.",
+            story_id,
+            _turn_id(),
+        )
+
+        assert len(result.routed.transient_state_staged_ids) == 1
+        entry = sbs.get_character(story_id, cast_id)
+        assert entry is not None
+        assert entry.is_alive is True
+
 
 # ---------------------------------------------------------------------------
 # Shared fixture — relationship seeding

--- a/tests/pipeline/extractor/test_service.py
+++ b/tests/pipeline/extractor/test_service.py
@@ -876,6 +876,51 @@ class TestUnresolvableCharacter:
         staging_rows = session.query(SBProvisionalStagingORM).all()
         assert staging_rows == []
 
+    def test_ambiguous_character_name_raises_extractor_pass_error(  # type: ignore[no-untyped-def]
+        self, session, story_and_cast
+    ) -> None:
+        """Ambiguous case-insensitive name match raises ExtractorPassError."""
+        story_id, cast_id = story_and_cast
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        sbs = StoryBibleService(session)
+        # Seed a second "Aldric" entry (schema has no uniqueness constraint).
+        duplicate = CastEntry(
+            story_id=story_id,
+            name="aldric",  # same name, different casing — still matches
+            role=CastRole.MINOR,
+            created_at=now,
+        )
+        sbs.add_cast_entry(story_id, duplicate)
+        session.commit()
+
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "character",
+                            "target_natural_key": "Aldric",
+                            "target_field": "current_location",
+                            "proposed_value": "Somewhere",
+                        }
+                    ]
+                }
+            )
+        )
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
 
 # ---------------------------------------------------------------------------
 # Story-id guard
@@ -1368,6 +1413,54 @@ class TestRelationshipDomain:
             )
         )
         sbs = StoryBibleService(session)
+        service = ExtractorService(session, sbs, _make_config(), fake)
+
+        with pytest.raises(ExtractorPassError):
+            service.extract(
+                _make_assembled(story_id, aldric_cast_id),
+                "prose.",
+                story_id,
+                _turn_id(),
+            )
+
+        session.rollback()
+        assert session.query(SBProvisionalStagingORM).all() == []
+
+    def test_duplicate_active_relationship_rows_raises(  # type: ignore[no-untyped-def]
+        self, session, story_with_relationship
+    ) -> None:
+        """Two active relationship rows for the same pair raises ExtractorPassError."""
+        story_id, aldric_cast_id, mira_cast_id = story_with_relationship
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        sbs = StoryBibleService(session)
+        # Seed a second active row for the same (subject, object) pair.
+        duplicate_rel = RelationshipLedger(
+            story_id=story_id,
+            subject_cast_id=aldric_cast_id,
+            object_cast_id=mira_cast_id,
+            relationship_type=RelationshipType.ENEMY,
+            current_status_description="Duplicate row",
+            created_at=now,
+            updated_at=now,
+        )
+        sbs.add_relationship(story_id, duplicate_rel)
+        session.commit()
+
+        fake = _make_fake_caller(
+            _fake_tool_response(
+                {
+                    "proposals": [
+                        {
+                            "kind": "soft_fact",
+                            "target_domain": "relationship",
+                            "target_natural_key": "Aldric -> Mira",
+                            "target_field": "current_status_description",
+                            "proposed_value": "enemies now",
+                        }
+                    ]
+                }
+            )
+        )
         service = ExtractorService(session, sbs, _make_config(), fake)
 
         with pytest.raises(ExtractorPassError):

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -15,7 +15,7 @@ import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401
 import afterworlds.persistence.orm.story  # noqa: F401
 import afterworlds.persistence.orm.story_bible  # noqa: F401
-from afterworlds.models.enums import CastRole, EventSignificance, StoryMode
+from afterworlds.models.enums import CastRole, EventKind, EventSignificance, StoryMode
 from afterworlds.models.story import Story
 from afterworlds.models.story_bible import (
     CastEntry,
@@ -118,11 +118,13 @@ def make_event(
     story_id: UUID,
     desc: str = "The king was slain.",
     significance: EventSignificance = EventSignificance.CHARACTER_DEATH,
+    event_kind: EventKind = EventKind.DEATH,
 ) -> Event:
     return Event(
         story_id=story_id,
         description=desc,
         significance=significance,
+        event_kind=event_kind,
         created_at=datetime(2026, 1, 1, tzinfo=UTC),
     )
 

--- a/tests/services/test_context_builder.py
+++ b/tests/services/test_context_builder.py
@@ -40,6 +40,7 @@ from afterworlds.models.context import (
 )
 from afterworlds.models.enums import (
     CastRole,
+    EventKind,
     EventSignificance,
     IntentType,
     RelationshipType,
@@ -193,6 +194,7 @@ def _moderate_bible() -> StoryBibleContext:
         story_id=_STORY_ID,
         description="The king was slain by an unknown assassin.",
         significance=EventSignificance.CHARACTER_DEATH,
+        event_kind=EventKind.DEATH,
         created_at=_NOW,
     )
     return StoryBibleContext(
@@ -271,12 +273,14 @@ def _complex_bible() -> StoryBibleContext:
         story_id=_STORY_ID,
         description="Emperor Aldus assassinated.",
         significance=EventSignificance.CHARACTER_DEATH,
+        event_kind=EventKind.DEATH,
         created_at=_NOW,
     )
     event2 = Event(
         story_id=_STORY_ID,
         description="Rebel cell at the docks compromised.",
         significance=EventSignificance.MAJOR_PLOT_TURN,
+        event_kind=EventKind.PLOT_REVEAL,
         created_at=_NOW,
     )
     return StoryBibleContext(


### PR DESCRIPTION
## Summary

Full architecture realignment to CRD Issue 10 as posted. The prior iteration diverged from the spec in multiple load-bearing ways; this commit replaces it entirely.

- **Discriminated-union proposal schema**: tool renamed to `propose_canon_updates`; flat parallel arrays replaced with a single `proposals: [{oneOf discriminated by kind}]` array
- **EventProposal bypasses staging**: events go directly to `add_event()` — no `SBProvisionalStagingORM` row; `ProposalType.EVENT` removed from the enum
- **Fail-loud natural-key resolution**: unresolvable character name or malformed relationship key fails the entire routing transaction with no DB state committed (`EntityNotFoundError` → `ExtractorPassError`)
- **Transaction ownership in `StoryBibleService`**: `route_extractor_proposals()` owns the commit; `ExtractorService.extract()` never touches the session
- **EventKind taxonomy**: 11-value enum added; `event_kind` is a required field on `Event` and a non-nullable column on `sb_events` (migration 0008)
- **`extract()` signature change**: `(built_context, writer_output, story_id, turn_id)` — story_id guard added at entry; `turn_id: UUID` replaces `source_turn_id: str | None`
- **`ExtractorResult` simplified**: carries `proposal_set: ExtractorProposalSet` + `routed: ExtractorRoutingSummary` + token counts — drops `proposals`, `pending_proposals`, `auto_committed`, `pass_forward_content`, `model_identifier`, `latency_ms`
- **New `list_pending_locked_fact_proposals()`**: returns only PENDING LOCKED_FACT proposals; `get_pending_proposals()` removed (no callers)

## New files

| File | Purpose |
|---|---|
| `src/afterworlds/models/extractor.py` | Typed proposal models + `ExtractorProposalSet` + `ExtractorRoutingSummary` |
| `alembic/versions/0008_event_kind.py` | Adds `event_kind` column to `sb_events` (server_default="routine") |

## Modified files

| File | Key change |
|---|---|
| `src/afterworlds/models/enums.py` | Add `EventKind`, `TargetDomain`; remove `ProposalType.EVENT` |
| `src/afterworlds/models/story_bible.py` | `event_kind: EventKind` required field on `Event` |
| `src/afterworlds/persistence/orm/story_bible.py` | `event_kind` column on `SBEventORM` |
| `src/afterworlds/services/story_bible.py` | `route_extractor_proposals`, `find_character_by_name`, `get_writable_fields`, `list_pending_locked_fact_proposals`, `_find_relationship_row`, `_update_relationship_field`; remove EVENT branch from `ratify_update`; remove dead `get_pending_proposals` |
| `src/afterworlds/pipeline/extractor/caller.py` | Tool rename + discriminated union schema |
| `src/afterworlds/pipeline/extractor/models.py` | New `ExtractorResult` |
| `src/afterworlds/pipeline/extractor/service.py` | New `extract()` signature; delegates routing to `route_extractor_proposals` |
| `tests/pipeline/extractor/test_service.py` | Full rewrite + RELATIONSHIP, WORLD, and transaction-boundary test classes |
| `tests/services/conftest.py` | `make_event` updated to include `event_kind` |
| `tests/services/test_context_builder.py` | `Event` constructors updated with `event_kind` |
| `docs/prompts/extractor.md` | Updated for new tool name, discriminated union, EventKind, allowlists |
| `docs/decisions/ADR-0011-extractor-design-decisions.md` | Rewritten: 8 decisions covering all spec-level choices |

## Gate results

```
black    — all files pass
ruff     — all checks passed
mypy     — success: no issues found in 55 source files
pytest   — 677 passed, 1 skipped; total coverage 95.27% (≥80% required)
pip-audit — CVE-2026-3219 (pip 26.0.1, no fix available) — pre-existing residual
            finding carried from prior PRs; affects pip tool only, not application
            dependencies. No new vulnerabilities introduced by this PR.
```

## Architecture Notes

1. **Transaction ownership.** `route_extractor_proposals()` commits on success; `ExtractorService.extract()` does not touch the session. The caller is responsible for rollback on `ExtractorPassError`. Issue 12 must decide whether per-pass sessions or a single pipeline session is correct.

2. **Fail-loud natural-key resolution.** `find_character_by_name()` raises `EntityNotFoundError` on any unresolvable name; `_parse_relationship_natural_key()` raises `ValueError` on bad format. Both abort the entire turn with no DB state committed. If this proves operationally undesirable in production, relaxing the contract is a future owner decision — not resolved silently here.

3. **EventKind is required on Event.** Pre-Issue-10 rows in `sb_events` receive `server_default="routine"` via migration 0008. Any caller that constructs `Event` outside the Extractor (e.g., direct story-setup flows) must supply `event_kind`. All test fixtures updated.

4. **`ProposalType.EVENT` removed.** Rows from Issues 1–9 do not carry this value. The column has no CHECK constraint, so existing rows are unaffected.

5. **Cross-pass cache sharing deferred to Issue 12.** Extractor renders stable-prefix blocks in identical order to the Writer's `PromptRenderer`, but uses a different system prompt. Cross-pass cache sharing is a Known Unknown flagged in ADR-0011 Decision 8 for Issue 12.

6. **WORLD domain not writable in v1.** `get_writable_fields(TargetDomain.WORLD)` returns `frozenset()`, so any proposal targeting WORLD immediately fails field validation and aborts the turn. No WORLD-domain writes were possible before this PR either; this is a hardening, not a regression.

7. **`session` parameter retained on `ExtractorService.__init__`.** Kept for API continuity with the Writer pattern; session management responsibility has moved to `StoryBibleService`. Issue 12 may remove it if pipeline orchestration centralises session ownership.

8. **`get_pending_proposals` removed.** Method had no callers in `src/` or tests. `list_pending_locked_fact_proposals` is the intended replacement per the CRD Issue 10 spec.

## Test plan

- [x] `TestLockedFactRouting` — locked-fact proposals staged PENDING with `requires_confirmation=True`; ID matches DB row
- [x] `TestSoftFactRouting` — staged_id returned; live cast field updated; RATIFIED audit row exists (direct-write invariant)
- [x] `TestTransientStateRouting` — staged_id returned; live cast field updated; RATIFIED audit row exists
- [x] `TestUnresolvedThreadRouting` — staged_id returned; thread row created; RATIFIED audit row exists
- [x] `TestEventRouting` — event_id returned; `sb_events` row created with correct `event_kind`; no staging row (bypass test)
- [x] `TestUnresolvableCharacter` — `ExtractorPassError` raised; `session.rollback()` confirms no DB state committed
- [x] `TestStoryIdGuard` — mismatched story_id raises `ExtractorPassError` before any LLM call
- [x] `TestEmptyToolResponse` — empty proposals array produces zero routed IDs
- [x] `TestListPendingLockedFactProposals` — returns only PENDING LOCKED_FACT rows; excludes auto-committed proposals
- [x] `TestTokenMetrics` — all four token counts propagate; None when provider omits
- [x] `TestErrorHandling` — provider exception, text-only response, new tool name, typed result
- [x] `TestRelationshipDomain` — success path (field updated + RATIFIED audit row); malformed key (zero delimiters); malformed key (two delimiters); unresolvable subject; unresolvable object — all fail-loud, no DB state on failure
- [x] `TestWorldDomain` — `frozenset()` allowlist path raises `ExtractorPassError`; no DB state committed
- [x] `TestTransactionBoundary` — locked_fact flush + soft_fact name-resolution failure → zero staging rows after rollback; proves all-or-nothing commit boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)