### PR TITLE
feat(safety): Safety Service — CRD Issue 12b

### DIFF
--- a/docs/architecture/known_unknowns.md
+++ b/docs/architecture/known_unknowns.md
@@ -43,6 +43,26 @@ These are genuinely open. Each has a designated resolution window. Do not resolv
 
 ---
 
+### Provider refusal reason opacity (Issue 12c surface)
+
+**Resolve during:** Issue 12c (orchestration) and Issue 14 (provider routing).
+
+Provider refusal reasons are often opaque or too coarse to map reliably onto Afterworlds policy categories. The orchestrator must treat provider refusal as a typed pass failure with advisory provider metadata, not as a Safety BLOCK verdict. When no reliable provider reason is available, user-facing messaging must be transparent that the provider refused without exposing a guessed cause. Issue 14 may improve routing based on observed refusal patterns, but routing must not depend on granular refusal reasons being available.
+
+**What resolution requires:** Issue 12c must define how provider refusal metadata is captured, represented, and surfaced to the orchestration layer without treating it as authoritative policy signal. Issue 14 must specify what refusal pattern data is logged, how it informs routing heuristics, and what guarantees are forbidden (e.g., routing decisions that assume a specific refusal reason is correct). Document decisions in ADRs before implementation begins.
+
+---
+
+### Provider refusal handling in the pipeline (Issue 12b surface)
+
+**Resolve during:** Issue 12c (orchestration) and Issue 14 (provider routing).
+
+Provider refusal handling is not resolved in Issue 12b. `SafetyPassError` and other pass-level provider refusals are typed failures, not Safety BLOCK verdicts. Issue 12c must define orchestration behavior for provider refusals, including whether Writer refusal produces a controlled user-facing response, a bounded retry, or a provider-routing handoff. Issue 14 must account for provider capability/refusal profiles during routing.
+
+**What resolution requires:** Issue 12c must specify the orchestration contract for each pass-level refusal path: does it propagate as an error, trigger a retry, produce a fallback user-facing message, or route to an alternate provider? Issue 14 must record which providers have distinct refusal profiles and how routing logic accounts for them. Document decisions in ADRs before implementation of the affected issues begins.
+
+---
+
 ### React or Svelte for the initial frontend
 
 **Resolve before:** Issue 19

--- a/docs/decisions/ADR-0013-safety-service-design-decisions.md
+++ b/docs/decisions/ADR-0013-safety-service-design-decisions.md
@@ -1,0 +1,69 @@
+# ADR-0013: Safety Service Design Decisions
+
+**Issue:** CRD Issue 12b — Safety Service: Input Preflight and Conditional Output Audit
+**Date:** 2026-05-13
+**Status:** Accepted
+
+---
+
+## Context
+
+CRD Issue 12b scopes the Safety pass to a single callable service (`SafetyService.check()`) and typed results. Orchestration (when to call INPUT vs OUTPUT, gating pipeline flow) belongs to Issue 12c. This document records design decisions made during implementation that are not fully specified by the issue spec.
+
+---
+
+## Decision 1: SafetyResult omits `latency_ms` and `model_identifier`
+
+**Decision:** `SafetyResult` contains `report`, `target`, and `usage` only. It does not include `latency_ms` or `model_identifier`.
+
+**Rationale:** The Issue 12b spec defines the SafetyResult fields. `latency_ms` and `model_identifier` are absent from the spec. Following CLAUDE.md scope discipline ("don't add features beyond what the task requires"), these fields were omitted. The `usage` field (TokenUsage) carries input/output/cache token counts, which are sufficient for billing and observability at this scope boundary.
+
+If Issue 12c or a future issue requires latency tracking, it should be added as a separate change with an explicit spec.
+
+---
+
+## Decision 2: TokenUsage is a Safety-specific model, not a shared type
+
+**Decision:** `TokenUsage` is defined in `pipeline/safety/models.py` rather than as a shared cross-pass type.
+
+**Rationale:** The issue spec says "do not introduce shared provider-failure types." The spirit of this constraint is pass isolation — each pass owns its own data contracts. Defining a shared `TokenUsage` across Planner, Safety, and future passes would create coupling. When a future consolidation is warranted (e.g. Issue 14 provider routing), it can introduce a shared type explicitly.
+
+---
+
+## Decision 3: PassForwardLedger is not rendered into the Safety payload
+
+**Decision:** The Safety pass does not call `built_context.pass_forward_ledger.render()` or append to the ledger.
+
+**Rationale:** The spec states "No PassForwardLedger mutation." The corollary is that the Safety payload should not include ledger content. For INPUT target, the ledger is empty at Safety's call site (Safety runs before Planner). For OUTPUT target, the Writer's prose is explicitly placed in the volatile suffix with a `[WRITER OUTPUT FOR SAFETY EVALUATION]` label — rendering the ledger would duplicate that content with different framing. The spec's volatile suffix description is exhaustive and does not mention the ledger.
+
+---
+
+## Decision 4: SafetyPassError.cause vs Python `__cause__`
+
+**Decision:** `SafetyPassError` carries an explicit `self.cause: Exception | None` attribute rather than relying on Python's implicit `__cause__` chaining via `raise ... from exc`.
+
+**Rationale:** The spec requires `SafetyPassError` as the single public exception type. Code that catches `SafetyPassError` and needs to inspect the underlying provider or validation error must be able to do so without introspecting `__cause__`. The explicit `self.cause` attribute makes the contract visible in the type signature and accessible without relying on exception chaining conventions.
+
+Note: the service still uses `raise ... from exc` in addition to setting `self.cause`, so both mechanisms are available to callers.
+
+---
+
+## Decision 5: Mode contract in system parameter (Planner pattern, not Contradiction pattern)
+
+**Decision:** The active mode contract (`built_context.stable_prefix.system_prompt`) is placed as the second block in the Anthropic `system` parameter. It is NOT included in the user-message blocks.
+
+**Rationale:** Two patterns exist in the codebase. The Contradiction pass places `system_prompt` as the first user block. The Planner pass places it as the second system block. For the Safety pass, the mode contract tells the evaluator what behavioural constraints are active for the current story mode — it is a configuration input to the evaluator, not narrative content. This aligns with the `system` parameter's intended role. Following the Planner pattern also means the mode contract is outside the user-message stable-prefix region, which avoids confusing it with story content.
+
+---
+
+## Decision 6: Verdict is a computed property, never model-supplied
+
+**Decision:** `SafetyResult.verdict` is a `@computed_field` derived from `report.concerns`. The model is never asked to supply a verdict field.
+
+**Rationale:** The spec requires this explicitly: "Computed verdict from concerns list — no model-supplied verdict field." This is an architectural safety property: a model that could supply `verdict=ALLOW` with non-empty concerns would create an exploitable ambiguity. Computing the verdict locally from the concerns list closes that gap.
+
+---
+
+## Architecture Notes
+
+No drift from design principles. The Safety pass is implemented as a guardrail envelope per CRD v7 / Design doc v9. It does not participate in narrative generation, does not persist, does not mutate caller state, and fails closed on any error.

--- a/docs/prompts/safety.md
+++ b/docs/prompts/safety.md
@@ -1,0 +1,135 @@
+# Safety Pass — Evaluation Contract
+
+You are the Sojourn Safety Evaluator. Your job is to identify content that crosses hard safety thresholds — not to police mature storytelling.
+
+Sojourn is an adult interactive fiction platform. Dark themes, violence, moral ambiguity, explicit sexuality between adults, horror, grief, trauma, and disturbing subject matter are normal and expected. **The presence of uncomfortable content is not, by itself, a safety concern.** Your role is narrowly scoped: identify content that would cause real-world harm regardless of fictional framing, or that falls into the hard-prohibited categories below.
+
+---
+
+## Evaluation Modes
+
+You operate in two modes, indicated by a label in the text:
+
+- **`[SOJOURNER INPUT FOR SAFETY EVALUATION]`** — INPUT preflight. You are evaluating a player's raw input before it reaches the narrative pipeline. Block requests that would direct the story toward hard-prohibited content.
+- **`[WRITER OUTPUT FOR SAFETY EVALUATION]`** — OUTPUT audit. You are evaluating the Writer pass's generated narrative prose. Block output that has produced hard-prohibited content even when the input was borderline.
+
+Apply the same category thresholds in both modes. The label tells you what was sent, not how strictly to judge it.
+
+---
+
+## Hard-Prohibited Categories
+
+### SEXUAL_MINOR
+Sexual content involving a character who is, or is clearly written as, a minor.
+
+**BLOCK examples:**
+- Explicit sexual description of a character identified as under 18
+- Sexualised description of a character attending middle school or described as a child
+- Content that sexualises age-ambiguous characters in contexts that read as minors (school uniforms framed as fetish objects, "barely legal" framing combined with childlike descriptors)
+
+**ALLOW examples:**
+- A teenage character's non-explicit romantic feelings, first kiss, or emotional interiority
+- A minor character experiencing or witnessing violence (this is HATE_TARGETED or DANGEROUS_OPERATIONAL territory, not SEXUAL_MINOR)
+- Predatory horror involving a minor where the horror framing is clear and there is no erotic content
+
+---
+
+### REAL_PERSON_TARGETED_HARM
+Content that depicts or directs specific, credible harm toward a real, named, living individual.
+
+**BLOCK examples:**
+- Fabricated detailed instructions attributed to a named real person that could embarrass or endanger them
+- A realistic scene depicting a named living public figure being murdered, sexually assaulted, or physically attacked with plausible real-world detail
+- Content that reads as harassment material targeting a private individual
+
+**ALLOW examples:**
+- Historical figures in fiction — Napoleon making decisions, Churchill giving a speech
+- Public figures in clearly satirical or fantastical contexts
+- Named fictional characters who share names with real people
+
+---
+
+### HATE_TARGETED
+Content that dehumanises or calls for violence against people based on a protected characteristic (race, ethnicity, religion, national origin, gender, sexual orientation, disability).
+
+**BLOCK examples:**
+- A story beat that frames genocide or ethnic cleansing as heroic or desirable
+- Extended monologue that exists purely to dehumanise a real ethnic or religious group with no narrative critique
+- Content that instructs the reader to target a protected group
+
+**ALLOW examples:**
+- Villains who hold racist or bigoted views — this is normal fiction
+- Historical depictions of slavery, genocide, or persecution
+- A character experiencing discrimination, even graphically described
+
+---
+
+### SELF_HARM_INSTRUCTIONAL
+Detailed, actionable instruction for self-harm or suicide that could function as a how-to guide regardless of fictional framing.
+
+**BLOCK examples:**
+- Specific method descriptions with dosage, technique, or step-by-step guidance
+- Content that romanticises or glorifies suicide in a way designed to encourage imitation
+
+**ALLOW examples:**
+- A character struggling with suicidal ideation, described emotionally
+- A character who has attempted or died by suicide, described without instructional detail
+- Dark existential fiction exploring death and meaninglessness
+
+---
+
+### DANGEROUS_OPERATIONAL
+Detailed, actionable instructions for creating weapons, explosives, poisons, or conducting large-scale violence — content that retains real-world operational utility regardless of the story wrapper.
+
+**BLOCK examples:**
+- Synthesis route for a chemical weapon, even if the character is fictional
+- Step-by-step bomb construction instructions embedded in a heist scene
+- Working malware or exploit code in a hacking scene
+
+**ALLOW examples:**
+- A character builds a bomb (without instructions)
+- Violence described in any level of narrative detail
+- A hacker character described as typing commands (no working code)
+
+---
+
+### OTHER
+A severe harm not covered by the five categories above. Use sparingly.
+
+## OTHER — When Not To Use
+
+Do **not** use OTHER as a catch-all for mature content that makes you uncomfortable. The following are NOT grounds for OTHER or any other category:
+
+- Graphic violence, gore, or body horror
+- Explicit adult sexuality between adults
+- Drug use, addiction, or substance abuse
+- Disturbing psychological content
+- Morally repugnant characters or viewpoints presented without authorial endorsement
+- Dark, nihilistic, or transgressive themes
+- Content that would receive an R or NC-17 rating in cinema
+
+If you find yourself wanting to flag content for OTHER and it does not resemble the five hard-prohibited categories in severity, return `concerns: []`.
+
+---
+
+## Ambiguity Rule
+
+When content is ambiguous — where a threshold might be crossed but you are not certain — **err toward ALLOW**. Return `concerns: []`.
+
+The cost of a false positive is a broken story experience for a legitimate user. The cost of a false negative for borderline content is low because the OUTPUT audit provides a second check after the INPUT preflight.
+
+Only flag content when you can clearly identify which category threshold is crossed and why. If you cannot articulate a specific, concrete reason, do not flag it.
+
+---
+
+## Tool Call Contract
+
+Call `report_safety_assessment` exactly once with:
+- `concerns`: array of concern objects, **empty array `[]` when the text is safe**
+
+Each concern object requires:
+- `category`: one of the enum values above
+- `description`: brief explanation of why this concern was flagged
+- `evidence_summary`: direct quote or precise paraphrase of the offending content, **≤ 300 characters**
+
+Do **not** return prose analysis. Do **not** call the tool more than once. If you return text without calling the tool, the pipeline will treat it as a parse failure.

--- a/src/afterworlds/pipeline/safety/__init__.py
+++ b/src/afterworlds/pipeline/safety/__init__.py
@@ -1,0 +1,1 @@
+"""Safety pass — CRD Issue 12b."""

--- a/src/afterworlds/pipeline/safety/caller.py
+++ b/src/afterworlds/pipeline/safety/caller.py
@@ -1,0 +1,179 @@
+"""Safety pass model caller protocol and default Anthropic implementation.
+
+CRD Issue 12b.  The Safety pass uses Anthropic tool use to obtain a structured
+``SafetyReport``.  ``tool_choice={"type": "tool", "name": REPORT_SAFETY_TOOL_NAME}``
+forces the model to always call the assessment tool, eliminating prose-parsing
+ambiguity.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol
+
+import anthropic
+from anthropic.types import (
+    Message,
+    MessageParam,
+    TextBlockParam,
+)
+
+from afterworlds.pipeline._tool_use import parse_tool_use_block
+from afterworlds.pipeline.safety.config import SafetyConfig
+
+# ---------------------------------------------------------------------------
+# Tool specification
+# ---------------------------------------------------------------------------
+
+REPORT_SAFETY_TOOL_NAME: str = "report_safety_assessment"
+
+REPORT_SAFETY_TOOL_SPEC: dict[str, Any] = {
+    "name": REPORT_SAFETY_TOOL_NAME,
+    "description": (
+        "Report the safety assessment for the evaluated text. "
+        "Call this tool exactly once. "
+        "Pass an empty concerns array when no threshold is clearly crossed."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "concerns": {
+                "type": "array",
+                "description": (
+                    "List of safety concerns identified in the text. "
+                    "Empty array when the text is safe."
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "category": {
+                            "type": "string",
+                            "enum": [
+                                "SEXUAL_MINOR",
+                                "REAL_PERSON_TARGETED_HARM",
+                                "HATE_TARGETED",
+                                "SELF_HARM_INSTRUCTIONAL",
+                                "DANGEROUS_OPERATIONAL",
+                                "OTHER",
+                            ],
+                            "description": (
+                                "The safety category this concern falls under."
+                            ),
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": (
+                                "Brief explanation of why this is a concern."
+                            ),
+                        },
+                        "evidence_summary": {
+                            "type": "string",
+                            "description": (
+                                "Direct quote or precise paraphrase of the offending "
+                                "content. Must be ≤ 300 characters."
+                            ),
+                        },
+                    },
+                    "required": ["category", "description", "evidence_summary"],
+                },
+            },
+        },
+        "required": ["concerns"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Payload type alias
+# ---------------------------------------------------------------------------
+
+SafetyPayload = dict[str, object]
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class SafetyModelCaller(Protocol):
+    """Protocol for the Safety pass model invocation seam."""
+
+    def __call__(self, payload: SafetyPayload) -> Message:
+        """Invoke the model with the safety payload and return the response."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Default Anthropic implementation
+# ---------------------------------------------------------------------------
+
+
+class AnthropicSafetyCaller:
+    """Default SafetyModelCaller wired to the Anthropic Python SDK."""
+
+    def __init__(self, config: SafetyConfig) -> None:
+        self._config = config
+
+    def __call__(self, payload: SafetyPayload) -> Message:
+        api_key = self._config.get_api_key()
+        client = anthropic.Anthropic(api_key=api_key)
+
+        system_blocks: list[TextBlockParam] = payload["system"]  # type: ignore[assignment]
+        messages: list[MessageParam] = payload["messages"]  # type: ignore[assignment]
+        model: str = payload["model"]  # type: ignore[assignment]
+        max_tokens: int = payload["max_tokens"]  # type: ignore[assignment]
+        tools: list[Any] = payload["tools"]  # type: ignore[assignment]
+        tool_choice: dict[str, Any] = payload["tool_choice"]  # type: ignore[assignment]
+
+        return client.messages.create(  # type: ignore[call-overload, no-any-return]
+            model=model,
+            max_tokens=max_tokens,
+            system=system_blocks,
+            messages=messages,
+            tools=tools,
+            tool_choice=tool_choice,
+            stream=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timing wrapper and response parsing
+# ---------------------------------------------------------------------------
+
+
+def timed_call(
+    caller: SafetyModelCaller,
+    payload: SafetyPayload,
+) -> tuple[Message, int]:
+    """Call the model caller and return (response, latency_ms)."""
+    start = time.monotonic()
+    response = caller(payload)
+    latency_ms = int((time.monotonic() - start) * 1000)
+    return response, latency_ms
+
+
+def parse_tool_input(response: Message) -> dict[str, Any]:
+    """Extract the tool-use input dict from an Anthropic Message.
+
+    Raises:
+        SafetyPassError: if no matching tool-use block is found or the
+            response envelope is malformed.
+    """
+    from afterworlds.pipeline.safety.models import SafetyPassError
+
+    try:
+        return parse_tool_use_block(response, REPORT_SAFETY_TOOL_NAME)
+    except ValueError as exc:
+        raise SafetyPassError(str(exc), cause=exc) from exc
+
+
+__all__ = [
+    "REPORT_SAFETY_TOOL_NAME",
+    "REPORT_SAFETY_TOOL_SPEC",
+    "SafetyPayload",
+    "SafetyModelCaller",
+    "AnthropicSafetyCaller",
+    "timed_call",
+    "parse_tool_input",
+    "TextBlockParam",
+    "MessageParam",
+]

--- a/src/afterworlds/pipeline/safety/config.py
+++ b/src/afterworlds/pipeline/safety/config.py
@@ -1,0 +1,43 @@
+"""Safety pass configuration — CRD Issue 12b."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+_DEFAULT_SAFETY_MODEL: str = "claude-haiku-4-5-20251001"
+SAFETY_MAX_TOKENS: int = 1024
+
+
+@dataclass
+class SafetyConfig:
+    """Configuration for the Safety pass.
+
+    Attributes:
+        model: Anthropic model identifier.
+        api_key_env: Environment variable name holding the Anthropic API key.
+        extended_ttl: Enable extended (1 h) cache TTL.  Must default True per
+            CRD Item 14 invariant #9 (economic requirement, not preference).
+    """
+
+    model: str = field(default=_DEFAULT_SAFETY_MODEL)
+    api_key_env: str = field(default="ANTHROPIC_API_KEY")
+    extended_ttl: bool = field(default=True)
+
+    @classmethod
+    def from_env(cls) -> SafetyConfig:
+        """Build a SafetyConfig from environment variables."""
+        model = os.environ.get("SAFETY_MODEL", _DEFAULT_SAFETY_MODEL)
+        api_key_env = os.environ.get("SAFETY_API_KEY_ENV", "ANTHROPIC_API_KEY")
+        extended_ttl_raw = os.environ.get("SAFETY_EXTENDED_TTL", "true")
+        extended_ttl = extended_ttl_raw.lower() not in {"false", "0", "no"}
+        return cls(model=model, api_key_env=api_key_env, extended_ttl=extended_ttl)
+
+    def get_api_key(self) -> str:
+        """Read the API key from the configured environment variable."""
+        value = os.environ.get(self.api_key_env)
+        if not value:
+            raise RuntimeError(
+                f"Environment variable '{self.api_key_env}' is not set or empty"
+            )
+        return value

--- a/src/afterworlds/pipeline/safety/models.py
+++ b/src/afterworlds/pipeline/safety/models.py
@@ -1,0 +1,92 @@
+"""Safety pass data models — CRD Issue 12b."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, computed_field, field_validator
+
+
+class SafetyTarget(StrEnum):
+    """Which text the safety pass is evaluating."""
+
+    INPUT = "input"
+    OUTPUT = "output"
+
+
+class SafetyVerdict(StrEnum):
+    """Computed safety decision derived from the concerns list."""
+
+    ALLOW = "allow"
+    BLOCK = "block"
+
+
+class SafetyCategory(StrEnum):
+    """Categories of safety concern the model can flag."""
+
+    SEXUAL_MINOR = "SEXUAL_MINOR"
+    REAL_PERSON_TARGETED_HARM = "REAL_PERSON_TARGETED_HARM"
+    HATE_TARGETED = "HATE_TARGETED"
+    SELF_HARM_INSTRUCTIONAL = "SELF_HARM_INSTRUCTIONAL"
+    DANGEROUS_OPERATIONAL = "DANGEROUS_OPERATIONAL"
+    OTHER = "OTHER"
+
+
+class SafetyConcern(BaseModel):
+    """A single flagged safety concern."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    category: SafetyCategory
+    description: str
+    evidence_summary: str
+
+    @field_validator("evidence_summary")
+    @classmethod
+    def _evidence_summary_max_300(cls, v: str) -> str:
+        if len(v) > 300:
+            raise ValueError(f"evidence_summary must be ≤ 300 characters; got {len(v)}")
+        return v
+
+
+class SafetyReport(BaseModel):
+    """Parsed output from the safety model call."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    concerns: list[SafetyConcern]
+
+
+class TokenUsage(BaseModel):
+    """Token usage metrics from the safety provider call."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+
+
+class SafetyResult(BaseModel):
+    """Typed result returned by SafetyService.check()."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    report: SafetyReport
+    target: SafetyTarget
+    usage: TokenUsage | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def verdict(self) -> SafetyVerdict:
+        """Derived verdict: BLOCK if any concerns, ALLOW if none."""
+        return SafetyVerdict.BLOCK if self.report.concerns else SafetyVerdict.ALLOW
+
+
+class SafetyPassError(Exception):
+    """Raised on any safety pass failure — fail-closed, never silent ALLOW."""
+
+    def __init__(self, message: str, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.cause = cause

--- a/src/afterworlds/pipeline/safety/service.py
+++ b/src/afterworlds/pipeline/safety/service.py
@@ -1,0 +1,313 @@
+"""Safety pass service — CRD Issue 12b.
+
+Safety envelope: receives AssembledContext + text + SafetyTarget, renders an
+Anthropic Messages payload, calls the LLM using Anthropic tool use, validates
+the SafetyReport, and returns a typed SafetyResult.
+
+Architectural invariants enforced here:
+  - The Safety pass is a guardrail envelope, NOT a narrative pass.  It does
+    NOT call the Writer, does NOT persist, and does NOT mutate the caller's
+    AssembledContext or PassForwardLedger.
+  - Every pass receives both a pass contract and an active mode contract.  The
+    Safety ``system`` parameter contains two blocks in order:
+      1. Safety pass contract (loaded from docs/prompts/safety.md) — defines
+         evaluation posture, categories, and ambiguity rules.
+      2. Active mode contract (built_context.stable_prefix.system_prompt) —
+         behavioural constraints that determine what is acceptable for the
+         current story mode.
+  - The mode contract is placed in the ``system`` parameter (not user blocks),
+    following the Planner pattern (not the Contradiction pattern).
+  - Stable-prefix user blocks follow canonical Writer order:
+    Story Bible → Rolling Summary → Rules Package slice → Retrieval Memory.
+    The mode contract (system_prompt) is NOT repeated in the user blocks.
+  - Cache breakpoint is placed on the last stable-prefix block.
+  - Extended TTL caching is enabled by default (CRD Item 14 invariant #9).
+  - The evaluated text is placed in the volatile suffix, labelled by target.
+  - PassForwardLedger is NOT rendered into the Safety payload and is NOT
+    mutated by the Safety pass.
+  - Verdict is computed from the concerns list — the model never supplies it.
+  - Fail-closed: SafetyPassError on any provider, parsing, or validation
+    failure.  No silent ALLOW.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from anthropic.types import (
+    CacheControlEphemeralParam,
+    MessageParam,
+    TextBlockParam,
+)
+
+from afterworlds.models.context import (
+    AssembledContext,
+    _render_retrieval_memory,
+    _render_rule_slice,
+    _render_story_bible_context,
+)
+from afterworlds.pipeline.safety.caller import (
+    REPORT_SAFETY_TOOL_NAME,
+    REPORT_SAFETY_TOOL_SPEC,
+    AnthropicSafetyCaller,
+    SafetyModelCaller,
+    SafetyPayload,
+    parse_tool_input,
+    timed_call,
+)
+from afterworlds.pipeline.safety.config import (
+    SAFETY_MAX_TOKENS,
+    SafetyConfig,
+)
+from afterworlds.pipeline.safety.models import (
+    SafetyPassError,
+    SafetyReport,
+    SafetyResult,
+    SafetyTarget,
+    TokenUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Prompt loading
+# ---------------------------------------------------------------------------
+
+_PROMPT_DIR: Path = Path(__file__).parents[4] / "docs" / "prompts"
+
+
+class UnknownPromptError(ValueError):
+    """Raised when the safety prompt file is missing."""
+
+
+def load_safety_prompt() -> str:
+    """Load the Safety pass system prompt from docs/prompts/safety.md."""
+    prompt_path = _PROMPT_DIR / "safety.md"
+    try:
+        return prompt_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise UnknownPromptError(
+            f"Safety prompt file not found at {prompt_path}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Target labels
+# ---------------------------------------------------------------------------
+
+_LABEL_INPUT: str = "[SOJOURNER INPUT FOR SAFETY EVALUATION]"
+_LABEL_OUTPUT: str = "[WRITER OUTPUT FOR SAFETY EVALUATION]"
+
+# ---------------------------------------------------------------------------
+# TTL constants
+# ---------------------------------------------------------------------------
+
+_TTL_EXTENDED: Literal["1h"] = "1h"
+_TTL_DEFAULT: Literal["5m"] = "5m"
+
+
+# ---------------------------------------------------------------------------
+# SafetyService
+# ---------------------------------------------------------------------------
+
+
+class SafetyService:
+    """Safety pass service.
+
+    Responsibilities:
+      1. Render the AssembledContext + evaluated text into an Anthropic
+         Messages payload.
+         System parameter: two blocks — Safety pass contract and active mode
+         contract.  User-message stable-prefix blocks start with Story Bible.
+      2. Invoke the provider via the injected caller (forced tool use).
+      3. Parse the ToolUseBlock response.
+      4. Validate the tool input against SafetyReport.
+      5. Return a typed SafetyResult with a computed verdict.
+
+    The caller's AssembledContext and PassForwardLedger are NEVER mutated.
+
+    Args:
+        config: Safety configuration.  Defaults to SafetyConfig.from_env().
+        caller: Injectable model caller.  Defaults to AnthropicSafetyCaller.
+    """
+
+    def __init__(
+        self,
+        config: SafetyConfig | None = None,
+        caller: SafetyModelCaller | None = None,
+    ) -> None:
+        self._config = config or SafetyConfig.from_env()
+        self._caller: SafetyModelCaller = caller or AnthropicSafetyCaller(self._config)
+        self._system_prompt: str = load_safety_prompt()
+
+    def check(
+        self,
+        built_context: AssembledContext,
+        text: str,
+        target: SafetyTarget,
+    ) -> SafetyResult:
+        """Execute one Safety pass and return a typed result.
+
+        Args:
+            built_context: AssembledContext produced by the Context Builder.
+                Never mutated by this call.
+            text: The text to evaluate — either the Sojourner's raw input
+                (INPUT target) or the Writer's output prose (OUTPUT target).
+            target: Which target is being evaluated; determines the label
+                placed around the text in the volatile suffix.
+
+        Returns:
+            SafetyResult with report (concerns list), target, usage, and
+            computed verdict (ALLOW when concerns is empty, BLOCK otherwise).
+
+        Raises:
+            SafetyPassError: if the provider call fails, the response contains
+                no tool-use block, or the tool input fails schema validation.
+                Never returns ALLOW on failure — always raises.
+        """
+        payload = self._render(built_context, text, target)
+
+        try:
+            response, _latency_ms = timed_call(self._caller, payload)
+        except SafetyPassError:
+            raise
+        except Exception as exc:
+            raise SafetyPassError(
+                f"Safety provider call failed: {exc}", cause=exc
+            ) from exc
+
+        try:
+            tool_input = parse_tool_input(response)
+        except SafetyPassError:
+            raise
+        except Exception as exc:
+            raise SafetyPassError(
+                f"Safety response parsing failed: {exc}", cause=exc
+            ) from exc
+
+        try:
+            report = SafetyReport.model_validate(tool_input)
+        except Exception as exc:
+            raise SafetyPassError(
+                f"Safety tool input failed schema validation: {exc}", cause=exc
+            ) from exc
+
+        raw_usage = response.usage
+        usage = TokenUsage(
+            input_tokens=raw_usage.input_tokens,
+            output_tokens=raw_usage.output_tokens,
+            cache_read_input_tokens=raw_usage.cache_read_input_tokens,
+            cache_creation_input_tokens=raw_usage.cache_creation_input_tokens,
+        )
+
+        return SafetyResult(report=report, target=target, usage=usage)
+
+    # -----------------------------------------------------------------------
+    # Private: prompt rendering
+    # -----------------------------------------------------------------------
+
+    def _render(
+        self,
+        built_context: AssembledContext,
+        text: str,
+        target: SafetyTarget,
+    ) -> SafetyPayload:
+        """Render the AssembledContext + text into a Safety payload."""
+        cache_control = CacheControlEphemeralParam(
+            type="ephemeral",
+            ttl=_TTL_EXTENDED if self._config.extended_ttl else _TTL_DEFAULT,
+        )
+
+        stable_texts = _collect_stable_texts(built_context)
+        user_blocks: list[TextBlockParam] = []
+
+        if stable_texts:
+            for t in stable_texts[:-1]:
+                user_blocks.append(TextBlockParam(type="text", text=t))
+            user_blocks.append(
+                TextBlockParam(
+                    type="text",
+                    text=stable_texts[-1],
+                    cache_control=cache_control,
+                )
+            )
+
+        # Volatile suffix: recent turns + evaluated text with target label.
+        vs = built_context.volatile_suffix
+        for turn in vs.recent_turns:
+            user_blocks.append(
+                TextBlockParam(
+                    type="text",
+                    text=(
+                        f"Player: {turn.user_input}\n"
+                        f"Narrator: {turn.assistant_output}"
+                    ),
+                )
+            )
+
+        label = _LABEL_INPUT if target == SafetyTarget.INPUT else _LABEL_OUTPUT
+        user_blocks.append(
+            TextBlockParam(
+                type="text",
+                text=(
+                    f"{label}\n{text}\n\n"
+                    f"[Intent: {vs.classified_intent.intent_type.value}]"
+                ),
+            )
+        )
+
+        return {
+            "model": self._config.model,
+            "max_tokens": SAFETY_MAX_TOKENS,
+            "system": [
+                TextBlockParam(type="text", text=self._system_prompt),
+                TextBlockParam(
+                    type="text",
+                    text=built_context.stable_prefix.system_prompt,
+                ),
+            ],
+            "messages": [MessageParam(role="user", content=user_blocks)],
+            "tools": [REPORT_SAFETY_TOOL_SPEC],
+            "tool_choice": {
+                "type": "tool",
+                "name": REPORT_SAFETY_TOOL_NAME,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_stable_texts(built_context: AssembledContext) -> list[str]:
+    """Return stable-prefix section texts in canonical Writer order.
+
+    Mirrors the Writer renderer so the Safety pass stable-prefix blocks are
+    byte-for-byte identical to the Writer's, enabling cache reuse across
+    passes (CRD Item 14 invariant #10).
+
+    The mode contract (system_prompt) is placed in the ``system`` parameter
+    as the second block; it is NOT included here.
+
+    Order:
+      1. Story Bible active context
+      2. Rolling Summary (omitted if None)
+      3. Rules Package slice (omitted if None)
+      4. Retrieval Memory (omitted when empty)
+    """
+    texts: list[str] = []
+    sp = built_context.stable_prefix
+
+    texts.append(_render_story_bible_context(sp.story_bible_context))
+
+    if sp.rolling_summary_text is not None:
+        texts.append(sp.rolling_summary_text)
+
+    if sp.rules_package_slice is not None:
+        texts.append(_render_rule_slice(sp.rules_package_slice))
+
+    retrieval_text = _render_retrieval_memory(sp.retrieval_memory)
+    if retrieval_text:
+        texts.append(retrieval_text)
+
+    return texts

--- a/tests/pipeline/safety/test_config.py
+++ b/tests/pipeline/safety/test_config.py
@@ -1,0 +1,83 @@
+"""Unit tests for SafetyConfig — CRD Issue 12b."""
+
+from __future__ import annotations
+
+import pytest
+
+from afterworlds.pipeline.safety.config import _DEFAULT_SAFETY_MODEL, SafetyConfig
+
+
+class TestSafetyConfigDefaults:
+    def test_default_model(self) -> None:
+        config = SafetyConfig()
+        assert config.model == _DEFAULT_SAFETY_MODEL
+
+    def test_default_api_key_env(self) -> None:
+        config = SafetyConfig()
+        assert config.api_key_env == "ANTHROPIC_API_KEY"
+
+    def test_extended_ttl_true_by_default(self) -> None:
+        config = SafetyConfig()
+        assert config.extended_ttl is True
+
+
+class TestSafetyConfigFromEnv:
+    def test_from_env_uses_defaults_when_vars_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SAFETY_MODEL", raising=False)
+        monkeypatch.delenv("SAFETY_API_KEY_ENV", raising=False)
+        monkeypatch.delenv("SAFETY_EXTENDED_TTL", raising=False)
+        config = SafetyConfig.from_env()
+        assert config.model == _DEFAULT_SAFETY_MODEL
+        assert config.api_key_env == "ANTHROPIC_API_KEY"
+        assert config.extended_ttl is True
+
+    def test_from_env_reads_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SAFETY_MODEL", "claude-opus-test")
+        config = SafetyConfig.from_env()
+        assert config.model == "claude-opus-test"
+
+    def test_from_env_reads_api_key_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SAFETY_API_KEY_ENV", "MY_SAFETY_KEY")
+        config = SafetyConfig.from_env()
+        assert config.api_key_env == "MY_SAFETY_KEY"
+
+    def test_from_env_extended_ttl_false_when_set_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SAFETY_EXTENDED_TTL", "false")
+        config = SafetyConfig.from_env()
+        assert config.extended_ttl is False
+
+    def test_from_env_extended_ttl_false_when_set_0(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SAFETY_EXTENDED_TTL", "0")
+        config = SafetyConfig.from_env()
+        assert config.extended_ttl is False
+
+
+class TestSafetyConfigGetApiKey:
+    def test_get_api_key_returns_env_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key-123")
+        config = SafetyConfig()
+        assert config.get_api_key() == "sk-test-key-123"
+
+    def test_get_api_key_raises_when_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        config = SafetyConfig()
+        with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+            config.get_api_key()
+
+    def test_get_api_key_raises_when_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        config = SafetyConfig()
+        with pytest.raises(RuntimeError):
+            config.get_api_key()

--- a/tests/pipeline/safety/test_integration.py
+++ b/tests/pipeline/safety/test_integration.py
@@ -1,0 +1,281 @@
+"""Default-CI integration tests for SafetyService — CRD Issue 12b.
+
+Uses a high-fidelity fake caller with four scripted scenarios:
+  - Scenario 1: INPUT × ALLOW (benign player input)
+  - Scenario 2: INPUT × BLOCK (hard-prohibited player input)
+  - Scenario 3: OUTPUT × ALLOW (clean writer prose)
+  - Scenario 4: OUTPUT × BLOCK (writer prose that crossed a threshold)
+
+These tests run in default CI (no special env flags required).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from anthropic.types import Message, ToolUseBlock, Usage
+
+from afterworlds.models.context import (
+    AssembledContext,
+    PassForwardLedger,
+    RetrievalMemoryPayload,
+    StablePrefix,
+    VolatileSuffix,
+)
+from afterworlds.models.enums import CastRole, IntentType
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.story_bible import CastEntry, StoryBibleContext
+from afterworlds.pipeline.safety.caller import REPORT_SAFETY_TOOL_NAME
+from afterworlds.pipeline.safety.config import SafetyConfig
+from afterworlds.pipeline.safety.models import (
+    SafetyTarget,
+    SafetyVerdict,
+)
+from afterworlds.pipeline.safety.service import SafetyService
+
+# ---------------------------------------------------------------------------
+# Shared context factory
+# ---------------------------------------------------------------------------
+
+
+def _make_context(current_input: str = "I look around.") -> AssembledContext:
+    story_id = uuid4()
+    ctx = StoryBibleContext(
+        story_id=story_id,
+        setting=None,
+        cast=(
+            CastEntry(
+                story_id=story_id,
+                name="Aldric Crane",
+                role=CastRole.PROTAGONIST,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ),
+        locked_facts=(),
+        forbidden_facts=(),
+        relationship_ledger=(),
+        active_plot_threads=(),
+        events=(),
+    )
+    sp = StablePrefix(
+        system_prompt="You are the Sojourn safety evaluator.",
+        story_bible_context=ctx,
+        rolling_summary_text=None,
+        rules_package_slice=None,
+        retrieval_memory=RetrievalMemoryPayload(),
+    )
+    icr = IntentClassificationResult(
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        confidence=0.95,
+        raw_input=current_input,
+        ambiguous=False,
+    )
+    vs = VolatileSuffix(
+        recent_turns=[],
+        current_input=current_input,
+        classified_intent=icr,
+    )
+    return AssembledContext(
+        stable_prefix=sp,
+        volatile_suffix=vs,
+        pass_forward_ledger=PassForwardLedger(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# High-fidelity fake
+# ---------------------------------------------------------------------------
+
+
+def _scripted_caller(tool_inputs: list[dict]) -> object:  # type: ignore[type-arg]
+    """Return a caller that plays back scripted tool inputs in order."""
+    responses = [
+        Message(
+            id=f"msg_fake_{i}",
+            type="message",
+            role="assistant",
+            content=[
+                ToolUseBlock(
+                    type="tool_use",
+                    id=f"toolu_fake_{i}",
+                    name=REPORT_SAFETY_TOOL_NAME,
+                    input=ti,
+                )
+            ],
+            model="claude-haiku-4-5-20251001",
+            stop_reason="tool_use",
+            stop_sequence=None,
+            usage=Usage(
+                input_tokens=100,
+                output_tokens=40,
+                cache_read_input_tokens=75,
+                cache_creation_input_tokens=None,
+            ),
+        )
+        for i, ti in enumerate(tool_inputs)
+    ]
+    idx = [0]
+
+    def caller(payload: object) -> Message:  # type: ignore[type-arg]
+        response = responses[idx[0]]
+        idx[0] += 1
+        return response
+
+    return caller
+
+
+def _make_svc(tool_inputs: list[dict]) -> SafetyService:  # type: ignore[type-arg]
+    config = SafetyConfig(
+        model="claude-haiku-test",
+        api_key_env="ANTHROPIC_API_KEY",
+        extended_ttl=True,
+    )
+    svc = SafetyService(
+        config=config,
+        caller=_scripted_caller(tool_inputs),  # type: ignore[arg-type]
+    )
+    svc._system_prompt = "SAFETY PROMPT"
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — INPUT × ALLOW
+# ---------------------------------------------------------------------------
+
+
+class TestScenario1InputAllow:
+    SCRIPTED = {"concerns": []}
+
+    def test_verdict_allow(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context("I open the door."), "I open the door.", SafetyTarget.INPUT
+        )
+        assert result.verdict == SafetyVerdict.ALLOW
+
+    def test_target_input(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context("I open the door."), "I open the door.", SafetyTarget.INPUT
+        )
+        assert result.target == SafetyTarget.INPUT
+
+    def test_no_concerns(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context("I open the door."), "I open the door.", SafetyTarget.INPUT
+        )
+        assert result.report.concerns == []
+
+    def test_built_context_unchanged(self) -> None:
+        ctx = _make_context("I open the door.")
+        original_ledger_len = len(ctx.pass_forward_ledger.entries)
+        _make_svc([self.SCRIPTED]).check(ctx, "I open the door.", SafetyTarget.INPUT)
+        assert len(ctx.pass_forward_ledger.entries) == original_ledger_len
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — INPUT × BLOCK
+# ---------------------------------------------------------------------------
+
+
+class TestScenario2InputBlock:
+    SCRIPTED = {
+        "concerns": [
+            {
+                "category": "SEXUAL_MINOR",
+                "description": "Request explicitly involving a minor sexually.",
+                "evidence_summary": "Character stated to be 13 in explicit context.",
+            }
+        ]
+    }
+
+    def test_verdict_block(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context("bad input"), "bad input", SafetyTarget.INPUT
+        )
+        assert result.verdict == SafetyVerdict.BLOCK
+
+    def test_one_concern(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context("bad input"), "bad input", SafetyTarget.INPUT
+        )
+        assert len(result.report.concerns) == 1
+
+    def test_concern_category(self) -> None:
+        from afterworlds.pipeline.safety.models import SafetyCategory
+
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context("bad input"), "bad input", SafetyTarget.INPUT
+        )
+        assert result.report.concerns[0].category == SafetyCategory.SEXUAL_MINOR
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — OUTPUT × ALLOW
+# ---------------------------------------------------------------------------
+
+
+class TestScenario3OutputAllow:
+    SCRIPTED = {"concerns": []}
+
+    def test_verdict_allow(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context(),
+            "Aldric Crane stepped into the corridor.",
+            SafetyTarget.OUTPUT,
+        )
+        assert result.verdict == SafetyVerdict.ALLOW
+
+    def test_target_output(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context(),
+            "Aldric Crane stepped into the corridor.",
+            SafetyTarget.OUTPUT,
+        )
+        assert result.target == SafetyTarget.OUTPUT
+
+    def test_built_context_unchanged(self) -> None:
+        ctx = _make_context()
+        original_ledger_len = len(ctx.pass_forward_ledger.entries)
+        _make_svc([self.SCRIPTED]).check(
+            ctx, "Aldric Crane stepped into the corridor.", SafetyTarget.OUTPUT
+        )
+        assert len(ctx.pass_forward_ledger.entries) == original_ledger_len
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — OUTPUT × BLOCK
+# ---------------------------------------------------------------------------
+
+
+class TestScenario4OutputBlock:
+    SCRIPTED = {
+        "concerns": [
+            {
+                "category": "DANGEROUS_OPERATIONAL",
+                "description": "Working synthesis instructions in narrative text.",
+                "evidence_summary": (
+                    "Step-by-step chemical synthesis route with reagents."
+                ),
+            }
+        ]
+    }
+
+    def test_verdict_block(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context(),
+            "Writer produced dangerous content.",
+            SafetyTarget.OUTPUT,
+        )
+        assert result.verdict == SafetyVerdict.BLOCK
+
+    def test_usage_surfaced(self) -> None:
+        result = _make_svc([self.SCRIPTED]).check(
+            _make_context(),
+            "Writer produced dangerous content.",
+            SafetyTarget.OUTPUT,
+        )
+        assert result.usage is not None
+        assert result.usage.input_tokens == 100
+        assert result.usage.output_tokens == 40
+        assert result.usage.cache_read_input_tokens == 75
+        assert result.usage.cache_creation_input_tokens is None

--- a/tests/pipeline/safety/test_integration_live.py
+++ b/tests/pipeline/safety/test_integration_live.py
@@ -1,0 +1,136 @@
+"""Live-provider integration tests for SafetyService — CRD Issue 12b.
+
+These tests make real Anthropic API calls and are gated behind a CI flag.
+They do NOT run in default CI.
+
+To run locally:
+    AFTERWORLDS_LIVE_TESTS=1 pytest tests/pipeline/safety/test_integration_live.py -v
+
+Tests:
+  - INPUT benign → ALLOW
+  - OUTPUT benign → ALLOW
+  - INPUT hard-prohibited (clearly synthetic/labelled) → BLOCK
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.models.context import (
+    AssembledContext,
+    PassForwardLedger,
+    RetrievalMemoryPayload,
+    StablePrefix,
+    VolatileSuffix,
+)
+from afterworlds.models.enums import CastRole, IntentType
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.story_bible import CastEntry, StoryBibleContext
+from afterworlds.pipeline.safety.config import SafetyConfig
+from afterworlds.pipeline.safety.models import SafetyTarget, SafetyVerdict
+from afterworlds.pipeline.safety.service import SafetyService
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("AFTERWORLDS_LIVE_TESTS") != "1",
+    reason="Live provider tests require AFTERWORLDS_LIVE_TESTS=1",
+)
+
+
+def _make_context(current_input: str = "I look around.") -> AssembledContext:
+    story_id = uuid4()
+    ctx = StoryBibleContext(
+        story_id=story_id,
+        setting=None,
+        cast=(
+            CastEntry(
+                story_id=story_id,
+                name="Mira Sol",
+                role=CastRole.PROTAGONIST,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ),
+        locked_facts=(),
+        forbidden_facts=(),
+        relationship_ledger=(),
+        active_plot_threads=(),
+        events=(),
+    )
+    sp = StablePrefix(
+        system_prompt="You are the Sojourn safety evaluator operating in RPG mode.",
+        story_bible_context=ctx,
+        rolling_summary_text=None,
+        rules_package_slice=None,
+        retrieval_memory=RetrievalMemoryPayload(),
+    )
+    icr = IntentClassificationResult(
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        confidence=0.9,
+        raw_input=current_input,
+        ambiguous=False,
+    )
+    vs = VolatileSuffix(
+        recent_turns=[],
+        current_input=current_input,
+        classified_intent=icr,
+    )
+    return AssembledContext(
+        stable_prefix=sp,
+        volatile_suffix=vs,
+        pass_forward_ledger=PassForwardLedger(),
+    )
+
+
+@pytest.fixture()
+def svc() -> SafetyService:
+    return SafetyService(config=SafetyConfig.from_env())
+
+
+class TestLiveInputAllow:
+    def test_benign_input_returns_allow(self, svc: SafetyService) -> None:
+        ctx = _make_context("I try to pick the lock.")
+        result = svc.check(ctx, "I try to pick the lock.", SafetyTarget.INPUT)
+        assert result.verdict == SafetyVerdict.ALLOW
+
+    def test_usage_populated(self, svc: SafetyService) -> None:
+        ctx = _make_context("I examine the room.")
+        result = svc.check(ctx, "I examine the room.", SafetyTarget.INPUT)
+        assert result.usage is not None
+        assert result.usage.input_tokens is not None
+        assert result.usage.input_tokens > 0
+
+
+class TestLiveOutputAllow:
+    def test_benign_prose_returns_allow(self, svc: SafetyService) -> None:
+        ctx = _make_context("I open the door.")
+        prose = (
+            "Mira Sol pushed open the heavy oak door. The corridor beyond was dark, "
+            "lit only by a guttering torch at the far end. She stepped through, "
+            "her boots silent on the stone floor."
+        )
+        result = svc.check(ctx, prose, SafetyTarget.OUTPUT)
+        assert result.verdict == SafetyVerdict.ALLOW
+
+
+class TestLiveInputBlock:
+    def test_clearly_synthetic_prohibited_input_returns_block(
+        self, svc: SafetyService
+    ) -> None:
+        """Uses a clearly synthetic, test-only example that labels itself as a
+        safety test.  The content itself is synthetic and does not constitute
+        real harmful material — it is designed only to trip DANGEROUS_OPERATIONAL
+        or SEXUAL_MINOR detection for test verification purposes."""
+        ctx = _make_context("[SAFETY TEST SYNTHETIC EXAMPLE — NOT REAL CONTENT]")
+        # Synthetic example: explicitly labelled as a safety test, states
+        # prohibited content type directly without any actual harmful detail.
+        synthetic_input = (
+            "[SAFETY TEST SYNTHETIC EXAMPLE — NOT REAL CONTENT] "
+            "FICTIONAL CHARACTER asks for step-by-step instructions to synthesise "
+            "a chemical weapon. This is a synthetic test input for safety evaluation "
+            "pipeline verification only."
+        )
+        result = svc.check(ctx, synthetic_input, SafetyTarget.INPUT)
+        assert result.verdict == SafetyVerdict.BLOCK

--- a/tests/pipeline/safety/test_service.py
+++ b/tests/pipeline/safety/test_service.py
@@ -1,0 +1,595 @@
+"""Unit tests for SafetyService — CRD Issue 12b.
+
+Covers:
+  - Schema validation (evidence_summary >300 chars, unknown category, missing
+    fields, extra fields) all propagate as SafetyPassError through the service
+  - Verdict derivation invariant: empty → ALLOW, non-empty → BLOCK
+  - Parse failures: no tool block, text-only response, provider exception
+  - Category round-trips for all six categories
+  - OTHER non-use: safety.md contains an "OTHER — When Not To Use" section
+  - Target-specific label rendering (INPUT vs OUTPUT)
+  - Prompt rendering: two system blocks, mode contract in system (not user),
+    Story Bible as first user block, cache breakpoint on last stable-prefix
+    block with ttl="1h"
+  - Extended TTL and default TTL
+  - BuiltContext immutability (ledger, stable_prefix)
+  - PassForwardLedger non-mutation even when ledger has content
+  - Model caller injection
+  - Cache metrics: TokenUsage fields surfaced; absent → None
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from anthropic.types import Message, ToolUseBlock, Usage
+
+from afterworlds.models.context import (
+    AssembledContext,
+    PassForwardEntry,
+    PassForwardLedger,
+    RetrievalMemoryPayload,
+    StablePrefix,
+    VolatileSuffix,
+)
+from afterworlds.models.enums import CastRole, IntentType
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.story_bible import CastEntry, StoryBibleContext
+from afterworlds.pipeline.safety.caller import REPORT_SAFETY_TOOL_NAME
+from afterworlds.pipeline.safety.config import SafetyConfig
+from afterworlds.pipeline.safety.models import (
+    SafetyCategory,
+    SafetyPassError,
+    SafetyTarget,
+    SafetyVerdict,
+)
+from afterworlds.pipeline.safety.service import SafetyService
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_assembled(
+    current_input: str = "I look around.",
+    system_prompt: str = "You are a story planner.",
+    ledger_entries: list[PassForwardEntry] | None = None,
+) -> AssembledContext:
+    story_id = uuid4()
+    ctx = StoryBibleContext(
+        story_id=story_id,
+        setting=None,
+        cast=(
+            CastEntry(
+                story_id=story_id,
+                name="Mira Sol",
+                role=CastRole.PROTAGONIST,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            ),
+        ),
+        locked_facts=(),
+        forbidden_facts=(),
+        relationship_ledger=(),
+        active_plot_threads=(),
+        events=(),
+    )
+    sp = StablePrefix(
+        system_prompt=system_prompt,
+        story_bible_context=ctx,
+        rolling_summary_text=None,
+        rules_package_slice=None,
+        retrieval_memory=RetrievalMemoryPayload(),
+    )
+    icr = IntentClassificationResult(
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        confidence=0.9,
+        raw_input=current_input,
+        ambiguous=False,
+    )
+    vs = VolatileSuffix(
+        recent_turns=[],
+        current_input=current_input,
+        classified_intent=icr,
+    )
+    ledger = PassForwardLedger(entries=ledger_entries or [])
+    return AssembledContext(
+        stable_prefix=sp, volatile_suffix=vs, pass_forward_ledger=ledger
+    )
+
+
+def _fake_tool_response(
+    tool_input: dict,  # type: ignore[type-arg]
+    cache_read: int | None = 80,
+    cache_creation: int | None = None,
+) -> Message:
+    return Message(
+        id="msg_fake_safety",
+        type="message",
+        role="assistant",
+        content=[
+            ToolUseBlock(
+                type="tool_use",
+                id="toolu_fake_safety",
+                name=REPORT_SAFETY_TOOL_NAME,
+                input=tool_input,
+            )
+        ],
+        model="claude-haiku-test",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        usage=Usage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        ),
+    )
+
+
+def _text_only_response() -> Message:
+    from anthropic.types import TextBlock
+
+    return Message(
+        id="msg_fake_text",
+        type="message",
+        role="assistant",
+        content=[TextBlock(type="text", text="I cannot help with that.")],
+        model="claude-haiku-test",
+        stop_reason="end_turn",
+        stop_sequence=None,
+        usage=Usage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_input_tokens=None,
+            cache_creation_input_tokens=None,
+        ),
+    )
+
+
+def _make_svc(caller: object) -> SafetyService:  # type: ignore[type-arg]
+    config = SafetyConfig(
+        model="claude-haiku-test",
+        api_key_env="ANTHROPIC_API_KEY",
+        extended_ttl=True,
+    )
+    svc = SafetyService(config=config, caller=caller)  # type: ignore[arg-type]
+    svc._system_prompt = "SAFETY PROMPT"
+    return svc
+
+
+def _make_svc_default_ttl(caller: object) -> SafetyService:  # type: ignore[type-arg]
+    config = SafetyConfig(
+        model="claude-haiku-test",
+        api_key_env="ANTHROPIC_API_KEY",
+        extended_ttl=False,
+    )
+    svc = SafetyService(config=config, caller=caller)  # type: ignore[arg-type]
+    svc._system_prompt = "SAFETY PROMPT"
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Verdict derivation
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictDerivation:
+    def test_empty_concerns_yields_allow(self) -> None:
+        caller = lambda _: _fake_tool_response({"concerns": []})  # noqa: E731
+        result = _make_svc(caller).check(
+            _make_assembled(), "Hello world", SafetyTarget.INPUT
+        )
+        assert result.verdict == SafetyVerdict.ALLOW
+
+    def test_non_empty_concerns_yields_block(self) -> None:
+        concern = {
+            "category": "SEXUAL_MINOR",
+            "description": "Explicit content involving a minor.",
+            "evidence_summary": "Character described as 14 in explicit scene.",
+        }
+        caller = lambda _: _fake_tool_response({"concerns": [concern]})  # noqa: E731
+        result = _make_svc(caller).check(
+            _make_assembled(), "some text", SafetyTarget.INPUT
+        )
+        assert result.verdict == SafetyVerdict.BLOCK
+
+    def test_verdict_is_computed_not_model_supplied(self) -> None:
+        caller = lambda _: _fake_tool_response({"concerns": []})  # noqa: E731
+        result = _make_svc(caller).check(
+            _make_assembled(), "safe text", SafetyTarget.INPUT
+        )
+        assert not hasattr(result.report, "verdict")
+        assert result.verdict == SafetyVerdict.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# Schema validation → SafetyPassError
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidation:
+    def _check(self, tool_input: dict) -> None:  # type: ignore[type-arg]
+        caller = lambda _: _fake_tool_response(tool_input)  # noqa: E731
+        with pytest.raises(SafetyPassError):
+            _make_svc(caller).check(_make_assembled(), "text", SafetyTarget.INPUT)
+
+    def test_missing_category_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [
+                    {
+                        "description": "desc",
+                        "evidence_summary": "summary",
+                    }
+                ]
+            }
+        )
+
+    def test_missing_description_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [
+                    {
+                        "category": "OTHER",
+                        "evidence_summary": "summary",
+                    }
+                ]
+            }
+        )
+
+    def test_missing_evidence_summary_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [
+                    {
+                        "category": "OTHER",
+                        "description": "desc",
+                    }
+                ]
+            }
+        )
+
+    def test_evidence_summary_over_300_chars_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [
+                    {
+                        "category": "OTHER",
+                        "description": "desc",
+                        "evidence_summary": "x" * 301,
+                    }
+                ]
+            }
+        )
+
+    def test_unknown_category_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [
+                    {
+                        "category": "MADE_UP_CATEGORY",
+                        "description": "desc",
+                        "evidence_summary": "summary",
+                    }
+                ]
+            }
+        )
+
+    def test_extra_fields_on_concern_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [
+                    {
+                        "category": "OTHER",
+                        "description": "desc",
+                        "evidence_summary": "summary",
+                        "severity": "high",  # extra field
+                    }
+                ]
+            }
+        )
+
+    def test_extra_fields_on_report_raises(self) -> None:
+        self._check(
+            {
+                "concerns": [],
+                "verdict": "allow",  # extra field
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Category round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryRoundTrips:
+    @pytest.mark.parametrize(
+        "category",
+        [
+            "SEXUAL_MINOR",
+            "REAL_PERSON_TARGETED_HARM",
+            "HATE_TARGETED",
+            "SELF_HARM_INSTRUCTIONAL",
+            "DANGEROUS_OPERATIONAL",
+            "OTHER",
+        ],
+    )
+    def test_category_deserializes(self, category: str) -> None:
+        concern = {
+            "category": category,
+            "description": f"Concern in {category}",
+            "evidence_summary": "Evidence here.",
+        }
+        caller = lambda _: _fake_tool_response({"concerns": [concern]})  # noqa: E731
+        result = _make_svc(caller).check(_make_assembled(), "text", SafetyTarget.INPUT)
+        assert result.report.concerns[0].category == SafetyCategory(category)
+
+
+# ---------------------------------------------------------------------------
+# Parse failures
+# ---------------------------------------------------------------------------
+
+
+class TestParseFailures:
+    def test_no_tool_block_raises_safety_pass_error(self) -> None:
+        caller = lambda _: _text_only_response()  # noqa: E731
+        with pytest.raises(SafetyPassError):
+            _make_svc(caller).check(_make_assembled(), "text", SafetyTarget.INPUT)
+
+    def test_provider_exception_raises_safety_pass_error(self) -> None:
+        def failing_caller(_: object) -> Message:
+            raise RuntimeError("Network error")
+
+        with pytest.raises(SafetyPassError):
+            _make_svc(failing_caller).check(
+                _make_assembled(), "text", SafetyTarget.INPUT
+            )
+
+    def test_provider_exception_never_returns_allow(self) -> None:
+        def failing_caller(_: object) -> Message:
+            raise RuntimeError("Connection refused")
+
+        with pytest.raises(SafetyPassError) as exc_info:
+            _make_svc(failing_caller).check(
+                _make_assembled(), "text", SafetyTarget.INPUT
+            )
+        assert exc_info.value is not None
+
+
+# ---------------------------------------------------------------------------
+# Target label rendering
+# ---------------------------------------------------------------------------
+
+
+class TestTargetLabelRendering:
+    def _capture_payload(self) -> tuple[dict, SafetyService]:  # type: ignore[type-arg]
+        captured: list[dict] = []  # type: ignore[type-arg]
+
+        def capturing_caller(payload: dict) -> Message:  # type: ignore[type-arg]
+            captured.append(payload)
+            return _fake_tool_response({"concerns": []})
+
+        svc = _make_svc(capturing_caller)
+        return captured, svc  # type: ignore[return-value]
+
+    def test_input_label_in_user_block(self) -> None:
+        captured, svc = self._capture_payload()
+        ctx = _make_assembled()
+        svc.check(ctx, "Player typed this.", SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        last_block = user_content[-1]
+        assert "[SOJOURNER INPUT FOR SAFETY EVALUATION]" in last_block["text"]
+        assert "Player typed this." in last_block["text"]
+
+    def test_output_label_in_user_block(self) -> None:
+        captured, svc = self._capture_payload()
+        ctx = _make_assembled()
+        svc.check(ctx, "Writer wrote this.", SafetyTarget.OUTPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        last_block = user_content[-1]
+        assert "[WRITER OUTPUT FOR SAFETY EVALUATION]" in last_block["text"]
+        assert "Writer wrote this." in last_block["text"]
+
+    def test_evaluated_text_not_in_stable_prefix_blocks(self) -> None:
+        """Evaluated text must only appear in the volatile suffix, not in
+        stable-prefix blocks that would pollute the cache."""
+        captured, svc = self._capture_payload()
+        ctx = _make_assembled()
+        evaluated_text = "UNIQUE_EVAL_TEXT_12345"
+        svc.check(ctx, evaluated_text, SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        # last block is the volatile/label block — all preceding blocks are stable
+        for block in user_content[:-1]:
+            assert evaluated_text not in block["text"]
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+class TestPromptRendering:
+    def _capture_payload(self) -> tuple[list[dict], SafetyService]:  # type: ignore[type-arg]
+        captured: list[dict] = []  # type: ignore[type-arg]
+
+        def capturing_caller(payload: dict) -> Message:  # type: ignore[type-arg]
+            captured.append(payload)
+            return _fake_tool_response({"concerns": []})
+
+        svc = _make_svc(capturing_caller)
+        return captured, svc  # type: ignore[return-value]
+
+    def test_two_system_blocks(self) -> None:
+        captured, svc = self._capture_payload()
+        svc.check(_make_assembled(), "text", SafetyTarget.INPUT)
+        assert len(captured[0]["system"]) == 2
+
+    def test_first_system_block_is_safety_prompt(self) -> None:
+        captured, svc = self._capture_payload()
+        svc.check(_make_assembled(), "text", SafetyTarget.INPUT)
+        assert captured[0]["system"][0]["text"] == "SAFETY PROMPT"
+
+    def test_second_system_block_is_mode_contract(self) -> None:
+        captured, svc = self._capture_payload()
+        mode_prompt = "You are the RPG narrator."
+        ctx = _make_assembled(system_prompt=mode_prompt)
+        svc.check(ctx, "text", SafetyTarget.INPUT)
+        assert captured[0]["system"][1]["text"] == mode_prompt
+
+    def test_mode_contract_not_in_user_blocks(self) -> None:
+        captured, svc = self._capture_payload()
+        mode_prompt = "UNIQUE_MODE_CONTRACT_XYZ"
+        ctx = _make_assembled(system_prompt=mode_prompt)
+        svc.check(ctx, "text", SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        for block in user_content:
+            assert mode_prompt not in block["text"]
+
+    def test_story_bible_is_first_user_block(self) -> None:
+        captured, svc = self._capture_payload()
+        svc.check(_make_assembled(), "text", SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        first_block = user_content[0]
+        assert "Mira Sol" in first_block["text"]
+
+    def test_cache_breakpoint_on_last_stable_prefix_block(self) -> None:
+        captured, svc = self._capture_payload()
+        ctx = _make_assembled()
+        svc.check(ctx, "text", SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        # The volatile block (last) has no cache_control; the last stable block does
+        # We have one stable block (Story Bible only, no rolling summary etc.)
+        stable_blocks = user_content[:-1] if len(user_content) > 1 else []
+        if stable_blocks:
+            last_stable = stable_blocks[-1]
+            assert "cache_control" in last_stable
+        volatile_block = user_content[-1]
+        assert (
+            "cache_control" not in volatile_block
+            or volatile_block.get("cache_control") is None
+        )
+
+    def test_extended_ttl_on_cache_block(self) -> None:
+        captured, svc = self._capture_payload()
+        svc.check(_make_assembled(), "text", SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        for block in user_content:
+            if block.get("cache_control"):
+                assert block["cache_control"]["ttl"] == "1h"
+                break
+
+    def test_default_ttl_when_extended_disabled(self) -> None:
+        captured: list[dict] = []  # type: ignore[type-arg]
+
+        def capturing_caller(payload: dict) -> Message:  # type: ignore[type-arg]
+            captured.append(payload)
+            return _fake_tool_response({"concerns": []})
+
+        svc = _make_svc_default_ttl(capturing_caller)
+        svc.check(_make_assembled(), "text", SafetyTarget.INPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        for block in user_content:
+            if block.get("cache_control"):
+                assert block["cache_control"]["ttl"] == "5m"
+                break
+
+
+# ---------------------------------------------------------------------------
+# PassForwardLedger non-mutation
+# ---------------------------------------------------------------------------
+
+
+class TestPassForwardLedgerNonMutation:
+    def test_empty_ledger_unchanged(self) -> None:
+        caller = lambda _: _fake_tool_response({"concerns": []})  # noqa: E731
+        ctx = _make_assembled()
+        original_len = len(ctx.pass_forward_ledger.entries)
+        _make_svc(caller).check(ctx, "text", SafetyTarget.INPUT)
+        assert len(ctx.pass_forward_ledger.entries) == original_len
+
+    def test_ledger_with_writer_content_unchanged(self) -> None:
+        """Even when the ledger has Writer content, it must not be mutated."""
+        entry = PassForwardEntry(pass_name="writer", content="Writer prose here.")
+        caller = lambda _: _fake_tool_response({"concerns": []})  # noqa: E731
+        ctx = _make_assembled(ledger_entries=[entry])
+        original_len = len(ctx.pass_forward_ledger.entries)
+        _make_svc(caller).check(ctx, "text", SafetyTarget.OUTPUT)
+        assert len(ctx.pass_forward_ledger.entries) == original_len
+
+    def test_writer_ledger_not_in_safety_user_blocks(self) -> None:
+        """Writer prose in the ledger must not appear in Safety user blocks."""
+        captured: list[dict] = []  # type: ignore[type-arg]
+
+        def capturing_caller(payload: dict) -> Message:  # type: ignore[type-arg]
+            captured.append(payload)
+            return _fake_tool_response({"concerns": []})
+
+        writer_prose = "WRITER_PROSE_CONTENT_UNIQUE_99"
+        entry = PassForwardEntry(pass_name="writer", content=writer_prose)
+        ctx = _make_assembled(ledger_entries=[entry])
+        _make_svc(capturing_caller).check(ctx, "eval text", SafetyTarget.OUTPUT)
+        user_content = captured[0]["messages"][0]["content"]
+        for block in user_content:
+            assert writer_prose not in block["text"]
+
+
+# ---------------------------------------------------------------------------
+# BuiltContext immutability
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltContextImmutability:
+    def test_stable_prefix_unchanged(self) -> None:
+        caller = lambda _: _fake_tool_response({"concerns": []})  # noqa: E731
+        ctx = _make_assembled(system_prompt="Original mode contract.")
+        _make_svc(caller).check(ctx, "text", SafetyTarget.INPUT)
+        assert ctx.stable_prefix.system_prompt == "Original mode contract."
+
+    def test_volatile_suffix_unchanged(self) -> None:
+        caller = lambda _: _fake_tool_response({"concerns": []})  # noqa: E731
+        ctx = _make_assembled(current_input="original input")
+        _make_svc(caller).check(ctx, "text", SafetyTarget.INPUT)
+        assert ctx.volatile_suffix.current_input == "original input"
+
+
+# ---------------------------------------------------------------------------
+# Token usage / cache metrics
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUsage:
+    def test_usage_fields_populated(self) -> None:
+        caller = lambda _: _fake_tool_response(  # noqa: E731
+            {"concerns": []}, cache_read=80, cache_creation=None
+        )
+        result = _make_svc(caller).check(_make_assembled(), "text", SafetyTarget.INPUT)
+        assert result.usage is not None
+        assert result.usage.input_tokens == 100
+        assert result.usage.output_tokens == 50
+        assert result.usage.cache_read_input_tokens == 80
+        assert result.usage.cache_creation_input_tokens is None
+
+    def test_absent_cache_creation_is_none_not_zero(self) -> None:
+        caller = lambda _: _fake_tool_response(  # noqa: E731
+            {"concerns": []}, cache_read=None, cache_creation=None
+        )
+        result = _make_svc(caller).check(_make_assembled(), "text", SafetyTarget.INPUT)
+        assert result.usage is not None
+        assert result.usage.cache_read_input_tokens is None
+        assert result.usage.cache_creation_input_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# Safety prompt — OTHER non-use section
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyPromptOtherNonUse:
+    def test_other_non_use_section_present(self) -> None:
+        prompt_path = Path(__file__).parents[3] / "docs" / "prompts" / "safety.md"
+        content = prompt_path.read_text(encoding="utf-8")
+        assert "## OTHER — When Not To Use" in content


### PR DESCRIPTION
## Summary

- Implements `SafetyService.check(built_context, text, target)` — the complete Safety pass callable per CRD Issue 12b scope
- `SafetyTarget` INPUT/OUTPUT; computed `SafetyVerdict` derived from `SafetyReport.concerns` list (model never supplies the verdict)
- Fail-closed: `SafetyPassError` only — no silent ALLOW on any provider, parse, or validation failure
- `docs/prompts/safety.md` prompt contract: fiction-first posture, six hard-prohibited categories, OTHER non-use section, ambiguity-errs-toward-ALLOW rule
- ADR-0013 documents six implementation decisions (result fields, TokenUsage isolation, ledger non-mutation, SafetyPassError.cause, system block pattern, computed verdict)
- Two Known Unknowns added to `known_unknowns.md`: provider refusal handling and refusal reason opacity, both deferred to Issues 12c/14

## Scope Boundaries (Issue 12b)

This PR delivers the callable service and typed results only. It does NOT implement:
- Pipeline gating or orchestration (Issue 12c)
- Provider routing or capability profiles (Issue 14)

## Architecture Notes

No drift from design principles.

The Safety pass is implemented as a guardrail envelope per CRD v7 / Design doc v9, not as a fifth narrative pass. Key invariants enforced:

- **Two system blocks**: Safety pass contract + active mode contract. Mode contract is in the `system` parameter (Planner pattern), NOT in user-message blocks (Contradiction pattern). Rationale in ADR-0013 Decision 5.
- **Stable-prefix user blocks**: Story Bible → Rolling Summary → Rules Package → Retrieval Memory — identical order to Writer for cache reuse (CRD Item 14 invariant #10).
- **PassForwardLedger**: Not rendered into the Safety payload; not mutated. For INPUT target the ledger is empty; for OUTPUT target the Writer prose is placed in the volatile suffix with a `[WRITER OUTPUT FOR SAFETY EVALUATION]` label — rendering the ledger would duplicate it. See ADR-0013 Decision 3.
- **Extended TTL default**: `extended_ttl=True` on `SafetyConfig` per CRD Item 14 invariant #9 (economic requirement).
- **TokenUsage**: Safety-specific type in `pipeline/safety/models.py` — not shared with Planner or Contradiction. Per "no shared provider-failure types" spirit. See ADR-0013 Decision 2.
- **SafetyResult fields**: `report`, `target`, `usage` only — no `latency_ms` or `model_identifier`. Spec-literal. See ADR-0013 Decision 1.
- **`SafetyPassError.cause`**: Explicit attribute, not only Python `__cause__` chaining. See ADR-0013 Decision 4.

### Known Unknowns surfaced during implementation

Two new entries added to `docs/architecture/known_unknowns.md`:

1. **Provider refusal handling in the pipeline (Issue 12b surface)** — `SafetyPassError` and other pass-level provider refusals are typed failures, not Safety BLOCK verdicts. Issue 12c must define orchestration behavior; Issue 14 must account for provider capability/refusal profiles during routing.

2. **Provider refusal reason opacity (Issue 12c surface)** — Provider refusal reasons are opaque and must not be treated as authoritative policy signal. Issue 12c and Issue 14 must define how refusal metadata is captured and surfaced without guessing causes.

## Test plan

- [ ] `pytest tests/pipeline/safety/test_service.py` — 38 unit tests: verdict derivation, schema validation (all 6 error paths), category round-trips (all 6 categories), parse failures (no tool block, text-only response, provider exception), target label rendering, prompt rendering (2 system blocks, mode contract placement, Story Bible first, cache breakpoint, TTL), ledger non-mutation (including when ledger has writer content), context immutability, token usage/cache metrics
- [ ] `pytest tests/pipeline/safety/test_integration.py` — 12 integration tests: 4 scenarios (INPUT×ALLOW, INPUT×BLOCK, OUTPUT×ALLOW, OUTPUT×BLOCK) with high-fidelity fake provider
- [ ] `pytest tests/pipeline/safety/test_config.py` — 9 config tests: defaults, `from_env()`, `get_api_key()`
- [ ] `AFTERWORLDS_LIVE_TESTS=1 pytest tests/pipeline/safety/test_integration_live.py` — 4 live tests (gated): INPUT benign → ALLOW, OUTPUT benign → ALLOW, synthetic prohibited INPUT → BLOCK
- [ ] Black, Ruff, mypy all pass on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)