### PR TITLE
feat(provider): Issue 14b — OpenRouter capability registry and Safety whitelist

### DIFF
--- a/docs/architecture/known_unknowns.md
+++ b/docs/architecture/known_unknowns.md
@@ -55,6 +55,8 @@ These were open questions during design or early construction. Decisions are rec
 | Credit deduction timing | Hosted credits deducted only for `DELIVERED` and `OOC_HANDLED` turns. Safety blocks, contradiction blocks, provider refusals, and pipeline errors do not deduct. | Resolved during Issue 13; see ADR-013. Owner Decision #1. |
 | Safety-policy provider whitelist | Anthropic direct: always WHITELISTED + capable via AFTERWORLDS_VERIFIED profile. OpenRouter: whitelist + capability evaluated per-model via `OpenRouterCapabilityRegistry`. Implemented in `CapabilityProfileAwareSafetyPolicy` via `EligibleModelRoute.whitelist_status` and `supports_required_capabilities`. | Resolved during Issue 14a/14b; see adr-014a, adr-014b. |
 | Provider capability profiles and fallback eligibility | `AnthropicCapabilityProfile` owns pass→model mapping. `EligibleModelRoute` carries `whitelist_status` + `supports_required_capabilities`. `RefusalFallbackRouter` owns at-most-one-fallback semantics. BYOK pool bounded by configured credentials; no hosted/BYOK boundary crossing. | Resolved during Issue 14a/14b; see adr-014a, adr-014b. OpenRouter cache adapter verification deferred — still open (see Open section). |
+| OpenRouter context-length floor value and rejection semantics | `resolve_route` rejects routes with known `context_length < writer_context_length_floor` (ProviderConfigError). Floor is a constructor parameter on `OpenRouterCapabilityRegistry`; default `_WRITER_CONTEXT_LENGTH_FLOOR = 8192` is provisional. `context_length=None` does not reject. | Resolved during Issue 14b; see adr-014b Decision 4. The correct production floor value remains an operator configuration decision. |
+| OpenRouter structured-pass capability pre-validation at route resolution | `resolve_route` rejects routes where `supports_tool_use is False AND supports_structured_output is False` (ProviderConfigError). Only explicit False triggers rejection; None fields fail safe. | Resolved during Issue 14b; see adr-014b Decision 11. |
 | React or Svelte for the initial frontend | Deferred to before Issue 19 per CRD Item 4. All Issues 1–18 are backend/pipeline and are unblocked. | CRD Item 4 establishes this must be resolved before frontend skeleton work (Issue 19). No decision required before Issue 18. |
 
 ---
@@ -62,30 +64,6 @@ These were open questions during design or early construction. Decisions are rec
 ## Open — Acceptable to Resolve During Construction
 
 These are genuinely open. Each has a designated resolution window. Do not resolve early without explicit approval.
-
----
-
-### OpenRouter Writer context-length floor value and rejection semantics
-
-**Resolve during:** Issue 14 (any remaining 14x sub-issue) or before production whitelist population.
-
-`_WRITER_CONTEXT_LENGTH_FLOOR = 8192` in `_registry.py` is a provisional constant. It gates whether an OpenRouter route is marked `supports_required_capabilities=True` (Safety can be skipped). Routes with `context_length < floor` currently get `supports_required_capabilities=False` and Safety always runs; the route is not rejected.
-
-**Two open questions:**
-1. Is 8192 the correct floor for the Writer pass? Too high rejects viable models; too low allows models that will fail mid-story.
-2. Should a model with confirmed `context_length < floor` be rejected at route resolution time (`ProviderConfigError`) rather than allowed with Safety always running?
-
-**What resolution requires:** Owner decision on floor value and rejection semantics. Update `_WRITER_CONTEXT_LENGTH_FLOOR` and `resolve_route` step 5 accordingly. Document in ADR-014b or a follow-on decision record.
-
----
-
-### OpenRouter structured-pass capability pre-validation at route resolution
-
-**Resolve during:** Issue 14 (any remaining 14x sub-issue) or Issue 21 if a defect surfaces.
-
-`resolve_route` in `OpenRouterCapabilityRegistry` evaluates Writer capability only (`supports_text_output` + context length). It does not pre-reject routes where both `supports_tool_use` and `supports_structured_output` are explicitly `False`. Such routes are live but will fail at call time during the Planner or Extractor pass with `ProviderCallError`.
-
-**What resolution requires:** Owner decision on whether pre-catalog rejection at route resolution time (vs. call-time fail-closed) is the correct behavior for structured-pass incapability. If pre-rejection is desired, `resolve_route` needs a separate step for structured-pass capability, a new return axis, or a separate method. Document in ADR-014b.
 
 ---
 

--- a/docs/architecture/known_unknowns.md
+++ b/docs/architecture/known_unknowns.md
@@ -53,8 +53,8 @@ These were open questions during design or early construction. Decisions are rec
 | Retrieval-memory ownership and gate | Issue 18 owns ChromaDB retrieval-memory design and implementation, beginning with a mandatory ADR / owner checkpoint before implementation code proceeds | Exact collection schema and retrieval parameters remain open until the Issue 18 ADR is accepted. |
 | OOC narrative effect | OOC does not advance story or canon unless a later mode-specific contract defines a safe typed configuration update | The UI provides explicit OOC affordance; manual `[OOC]` remains valid. Branching interaction-style/cadence changes are examples of safe typed config updates. |
 | Credit deduction timing | Hosted credits deducted only for `DELIVERED` and `OOC_HANDLED` turns. Safety blocks, contradiction blocks, provider refusals, and pipeline errors do not deduct. | Resolved during Issue 13; see ADR-013. Owner Decision #1. |
-| Safety-policy provider whitelist | Anthropic direct (`trusted_for_safety_skip=True`); OpenRouter (`trusted_for_safety_skip=False`). Implemented in `CapabilityProfileAwareSafetyPolicy` via `TurnProviderBinding.primary_writer_route`. | Resolved during Issue 14a; see adr-014a. |
-| Provider capability profiles and fallback eligibility | `AnthropicCapabilityProfile` owns pass→model mapping. `EligibleWriterRoute` carries `trusted_for_safety_skip`. `RefusalFallbackRouter` owns at-most-one-fallback semantics. BYOK pool bounded by configured credentials; no hosted/BYOK boundary crossing. | Resolved during Issue 14a; see adr-014a. OpenRouter cache adapter verification deferred to Issue 14b. |
+| Safety-policy provider whitelist | Anthropic direct: always WHITELISTED + capable via AFTERWORLDS_VERIFIED profile. OpenRouter: whitelist + capability evaluated per-model via `OpenRouterCapabilityRegistry`. Implemented in `CapabilityProfileAwareSafetyPolicy` via `EligibleModelRoute.whitelist_status` and `supports_required_capabilities`. | Resolved during Issue 14a/14b; see adr-014a, adr-014b. |
+| Provider capability profiles and fallback eligibility | `AnthropicCapabilityProfile` owns pass→model mapping. `EligibleModelRoute` carries `whitelist_status` + `supports_required_capabilities`. `RefusalFallbackRouter` owns at-most-one-fallback semantics. BYOK pool bounded by configured credentials; no hosted/BYOK boundary crossing. | Resolved during Issue 14a/14b; see adr-014a, adr-014b. OpenRouter cache adapter verification deferred — still open (see Open section). |
 | React or Svelte for the initial frontend | Deferred to before Issue 19 per CRD Item 4. All Issues 1–18 are backend/pipeline and are unblocked. | CRD Item 4 establishes this must be resolved before frontend skeleton work (Issue 19). No decision required before Issue 18. |
 
 ---
@@ -62,6 +62,40 @@ These were open questions during design or early construction. Decisions are rec
 ## Open — Acceptable to Resolve During Construction
 
 These are genuinely open. Each has a designated resolution window. Do not resolve early without explicit approval.
+
+---
+
+### OpenRouter Writer context-length floor value and rejection semantics
+
+**Resolve during:** Issue 14 (any remaining 14x sub-issue) or before production whitelist population.
+
+`_WRITER_CONTEXT_LENGTH_FLOOR = 8192` in `_registry.py` is a provisional constant. It gates whether an OpenRouter route is marked `supports_required_capabilities=True` (Safety can be skipped). Routes with `context_length < floor` currently get `supports_required_capabilities=False` and Safety always runs; the route is not rejected.
+
+**Two open questions:**
+1. Is 8192 the correct floor for the Writer pass? Too high rejects viable models; too low allows models that will fail mid-story.
+2. Should a model with confirmed `context_length < floor` be rejected at route resolution time (`ProviderConfigError`) rather than allowed with Safety always running?
+
+**What resolution requires:** Owner decision on floor value and rejection semantics. Update `_WRITER_CONTEXT_LENGTH_FLOOR` and `resolve_route` step 5 accordingly. Document in ADR-014b or a follow-on decision record.
+
+---
+
+### OpenRouter structured-pass capability pre-validation at route resolution
+
+**Resolve during:** Issue 14 (any remaining 14x sub-issue) or Issue 21 if a defect surfaces.
+
+`resolve_route` in `OpenRouterCapabilityRegistry` evaluates Writer capability only (`supports_text_output` + context length). It does not pre-reject routes where both `supports_tool_use` and `supports_structured_output` are explicitly `False`. Such routes are live but will fail at call time during the Planner or Extractor pass with `ProviderCallError`.
+
+**What resolution requires:** Owner decision on whether pre-catalog rejection at route resolution time (vs. call-time fail-closed) is the correct behavior for structured-pass incapability. If pre-rejection is desired, `resolve_route` needs a separate step for structured-pass capability, a new return axis, or a separate method. Document in ADR-014b.
+
+---
+
+### OpenRouter cache adapter verification
+
+**Resolve during:** Issue 14 (any remaining 14x sub-issue) or before OpenRouter routes enable extended-TTL caching.
+
+ADR-014a Decision 4 and the `_openrouter.py` module docstring note that OpenRouter cache adapter behavior (cross-pass reuse, TTL, cache metric semantics) requires adapter verification before extended-TTL caching is enabled for OpenRouter routes. This verification was not completed in 14a or 14b.
+
+**What resolution requires:** Verify OpenRouter cache behavior for stable-prefix reuse across passes within a turn. Document verified assumptions, update the adapter and ADR-014a/014b. Extended-TTL caching must not be enabled for OpenRouter routes without this verification.
 
 ---
 

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -1,0 +1,225 @@
+# ADR-014b: OpenRouter Model-Route Capability Registry and Safety Whitelist
+
+**Issue:** CRD Issue 14b — OpenRouter Whitelist Registry
+**Date:** 2026-06-18
+**Status:** Accepted
+
+---
+
+## Context
+
+CRD Issue 14a shipped the `CapabilityProfileAwareSafetyPolicy` with a single
+`trusted_for_safety_skip` bool on `EligibleWriterRoute`.  All OpenRouter routes
+were `trusted_for_safety_skip=False` (Safety always runs).  Issue 14b upgrades
+the route type to `EligibleModelRoute` and adds:
+
+- An exact-model-route Safety whitelist (`WhitelistConfig` / `WhitelistEntry`).
+- A capability registry backed by the OpenRouter `/models` catalog
+  (`OpenRouterCapabilityRegistry`).
+- The `SafetyWhitelistStatus` five-value enum and
+  `ModelRouteCapabilityProfile` capability fact type.
+- Two catalog providers: `FixtureOpenRouterCatalogProvider` (CI default, no
+  network) and `LiveOpenRouterCatalogProvider` (stdlib `urllib.request`, opt-in
+  for live integration tests).
+
+---
+
+## Decision 1: `EligibleWriterRoute` fully replaced by `EligibleModelRoute`
+
+**Decision:** The 14a type `EligibleWriterRoute` is removed (no compat alias).
+`EligibleModelRoute` carries `whitelist_status: SafetyWhitelistStatus` and
+`supports_required_capabilities: bool` instead of the 14a
+`trusted_for_safety_skip: bool`.
+
+**Rationale:** The 14a boolean was a placeholder.  Providing a compat alias
+would leave the old semantics reachable after 14b ships, making the upgrade
+auditable only at the compat boundary.  A clean full replacement is consistent
+with the single-PR scope of 14b and the project's zero-tolerance for
+silent-degradation paths.
+
+---
+
+## Decision 2: Safety-skip requires WHITELISTED AND capable on every route
+
+**Decision:** `CapabilityProfileAwareSafetyPolicy._can_skip` is True only when
+every eligible Writer route satisfies `whitelist_status is WHITELISTED AND
+supports_required_capabilities`.
+
+**Rationale:** Both axes must be positive to skip Safety.  A model may be
+capable (confirmed by catalog) but not whitelisted — in that case the operator
+has not explicitly approved it for Safety skip and Safety must run.  A model may
+be whitelisted but the catalog entry confirms it is not capable (e.g., short
+context window) — Safety must also run.  `DISABLED` status (whitelist
+administratively off) is not `WHITELISTED`; capable + DISABLED still requires
+Safety, since the whitelist gate is the operational approval mechanism.
+
+---
+
+## Decision 3: Fail-safe rule — reject only on positive evidence of incapability
+
+**Decision:** The registry (`resolve_route`) raises `ProviderConfigError` only
+when the catalog affirmatively reports the model is incapable:
+`supports_text_output is False` (explicit `False`, not `None`).  A catalog miss,
+`None` capability flags, or `context_length=None` all collapse to
+`supports_required_capabilities=False` without rejecting the route — Safety runs,
+the route is live.
+
+**Rationale:** Over-rejecting a route on absent evidence is worse than running
+Safety on it.  A model the catalog does not know about might be valid; a model
+with no reported context length might still work.  Rejection is reserved for
+positive evidence of incapability, not absence of positive evidence of
+capability.
+
+---
+
+## Decision 4: Context-length floor is a capability gate, not a rejection gate
+
+**Decision:** `_WRITER_CONTEXT_LENGTH_FLOOR = 8192` is used only in the
+capability evaluation (step 6 of `resolve_route`): a model with
+`context_length < floor` gets `supports_required_capabilities=False` and Safety
+runs, but the route is not rejected with `ProviderConfigError`.  The constant
+is marked provisional.
+
+**Rationale:** The floor value is an owner decision, not a value derivable from
+provider documentation.  At any specific floor, legitimate models with shorter
+context windows would be silently rejected.  The safer approach is: confirmed
+capable = both `supports_text_output is True` AND `context_length >= floor`.
+Below floor: Safety runs.  A future owner decision can raise the floor or
+introduce explicit route rejection at a spec-mandated threshold.
+
+**Known Unknown carried forward:** The exact context-length floor and whether a
+below-floor model should be rejected outright (vs. Safety always running) remain
+owner decisions.  See `known_unknowns.md`.
+
+---
+
+## Decision 5: STALE vs. UNKNOWN semantics
+
+**Decision:**
+- `UNKNOWN` — model id is not in the whitelist and not in the catalog.
+  Safety always runs.  Route not rejected.
+- `STALE` — model id IS in the whitelist but is NOT found in the catalog.
+  The model was previously approved but is no longer visible.  Safety always
+  runs.  Route not rejected.
+
+**Rationale:** The distinction matters for operational observability.  `STALE`
+signals a whitelist entry that may need review (model delisted or renamed).
+`UNKNOWN` signals a model the system has never assessed.  Both force Safety;
+neither rejects the route, consistent with the fail-safe rule.
+
+---
+
+## Decision 6: Static deny-set retained as pre-catalog fast-path
+
+**Decision:** `_is_dynamic_alias` from `adapters/_openrouter.py` is imported
+by the registry and applied at step 1, before the catalog fetch.  Catalog
+entries with `is_dynamic_router=True` are additionally rejected at step 4 as
+defense-in-depth.
+
+**Rationale:** The static deny-set is O(1) and does not require a network
+fetch.  It catches known dynamic aliases (e.g. `openrouter/auto`,
+`openrouter/free`) before any catalog I/O.  The catalog-driven check is
+defense-in-depth for aliases that appear in the API but were not in the static
+set at code time.
+
+---
+
+## Decision 7: Anthropic-direct routes always WHITELISTED + capable
+
+**Decision:** `ProviderResolver` builds Anthropic-direct routes with
+`whitelist_status=WHITELISTED`, `supports_required_capabilities=True`, and an
+`AFTERWORLDS_VERIFIED` `ModelRouteCapabilityProfile`.  This is computed by
+`make_anthropic_capability_profile()` in `_registry.py` and applied in the
+resolver — not by the `OpenRouterCapabilityRegistry`.
+
+**Rationale:** Anthropic-direct routes are trusted by Afterworlds design
+(CRD AC 15/18 regression from 14a).  They do not go through the OpenRouter
+catalog.  Encoding this as a named function ensures the 14a guarantee is
+preserved when the resolver is refactored.
+
+---
+
+## Decision 8: No registry → fail-safe (14a parity preserved)
+
+**Decision:** When `capability_registry=None` is passed to `ProviderResolver`,
+OpenRouter routes are constructed with `whitelist_status=UNKNOWN` and
+`supports_required_capabilities=False`.  This is identical to the 14a behavior
+(Safety always runs for OpenRouter).
+
+**Rationale:** The registry is injected; absence must not introduce a silent
+behavioral change.  UNKNOWN/False is the strictly more conservative fallback.
+
+---
+
+## Decision 9: Incapable fallback fails the whole turn
+
+**Decision:** When the registry is configured and an OpenRouter fallback model
+raises `ProviderConfigError` (positive incapability — `supports_text_output is
+False`), the exception propagates through `_resolve_openrouter_route` and the
+entire `resolve_for_turn` call fails.  The primary Anthropic pass does not
+proceed.
+
+**Rationale:** Consistent with 14a fail-closed behavior for blank-model routes.
+The condition fires only on positive incapability evidence, not a catalog miss.
+This is worth documenting because it can surprise: a healthy Anthropic primary
+is lost if the configured OpenRouter fallback is positively incapable.
+The correct fix is to update the fallback model identifier, not to suppress
+route validation for fallbacks.
+
+---
+
+## Decision 10: 14b ships the registry machinery, not the catalog classification
+
+**Decision:** 14b does not classify specific OpenRouter models as whitelisted
+or not-whitelisted.  The `FixtureOpenRouterCatalogProvider` defaults to an empty
+catalog (all misses; Safety always runs for OpenRouter routes).  Populating the
+whitelist and catalog in production is an operator concern beyond 14b scope.
+
+**Rationale:** Classifying individual models requires ongoing maintenance and
+owner decisions.  14b delivers the infrastructure that enforces the policy;
+policy population belongs to a configuration management workflow, not an
+implementation issue.
+
+---
+
+## Decision 11: AC 11 (structured-pass incapability) is handled at call time, not at route resolution
+
+**Decision:** `resolve_route` evaluates Writer pass capability only.  A model
+that is confirmed Writer-capable (`supports_text_output=True`, adequate context)
+but both `supports_tool_use=False` and `supports_structured_output=False` is
+not rejected at route resolution time.  Structured passes (Planner, Extractor)
+that require tool use or structured output will raise `ProviderCallError` at
+call time through the existing 14a adapter behavior.
+
+**Rationale:** `supports_required_capabilities` on `EligibleModelRoute` drives
+the Safety-skip decision for the Writer pass.  Planner/Extractor fail-closed at
+call time (14a behavior) is the correct gate for structured-pass capability.
+Pre-catalog rejection of routes with confirmed structured-pass incapability was
+considered; it would require a separate resolution axis in `resolve_route` and
+is deferred as an owner decision.  See Architecture Notes.
+
+---
+
+## Architecture Notes
+
+**Drift:** None from core design principles.  The safety envelope (conditional
+Input Preflight and Output Audit) is preserved.  The stable-prefix is assembled
+once per turn.  Entitlement routing is unaffected.
+
+**Scope question — AC 11 (structured-pass incapability at route resolution):**
+The current implementation does not pre-reject OpenRouter routes where both
+`supports_tool_use` and `supports_structured_output` are explicitly `False`.
+Such routes are live (Safety runs), but will fail at call time when the Planner
+or Extractor pass attempts a structured call.  Whether this is acceptable or
+whether the registry should pre-reject these routes is an owner decision.  It is
+not resolved in 14b.
+
+**Known Unknown carried forward — context-length floor:**
+`_WRITER_CONTEXT_LENGTH_FLOOR = 8192` is provisional.  The value and rejection
+semantics (floor below → `ProviderConfigError` vs. Safety runs) are owner
+decisions documented in `known_unknowns.md`.
+
+**14b does not carry forward the 14a cache-verification work:**
+The cache adapter verification for OpenRouter routes (deferred in ADR-014a,
+Decision 4) remains open.  14b is the whitelist/registry layer; OpenRouter
+cache verification belongs to a follow-on task within Issue 14's scope.

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -236,13 +236,45 @@ alias.  Callers updated in the same PR.
 Rejection only on explicit `False`.
 
 **Capability evaluation (Step 6):** `supports_required_capabilities=True` requires
-text output confirmed (`True`), context_length known and ≥ floor, **and**
-`supports_tool_use is True`.  The `OpenRouterAdapter` uses `tools`/`tool_choice`
-only — there is no `response_format` / structured-output request path.  Catalog
-`structured_outputs` support is recorded faithfully in `ModelRouteCapabilityProfile`
-but is not sufficient for `supports_required_capabilities=True` until an
-OpenRouter structured-output adapter path exists (deferred, not in 14b scope).
-Safety-skip eligibility tracks adapter-realized capability, not catalog capability.
+text output confirmed (`True`), context_length known and ≥ floor, **and** both
+`supports_tool_use is True` **and** `supports_tool_choice is True`.
+
+The `OpenRouterAdapter` emits exactly two capability-bearing kwargs for structured
+passes: `tools` (when `tool_definitions` is set) and `tool_choice` (when
+`forced_tool_name` is set).  Every structured narrative pass — Planner, Writer,
+Extractor, Contradiction, Safety — sets a `forced_tool_name`.  A model with
+`"tools"` in `supported_parameters` but without `"tool_choice"` can accept tool
+definitions but may reject or ignore the forced-tool parameter, causing a
+call-time failure.  Both `tools` and `tool_choice` must be confirmed `True` in
+`supported_parameters` before the adapter-realized capability contract is
+satisfied.
+
+Catalog `structured_outputs` / `response_format` support is recorded faithfully
+in `ModelRouteCapabilityProfile.supports_structured_output` but is not sufficient
+for `supports_required_capabilities=True` until an OpenRouter structured-output
+adapter path exists (deferred, not in 14b scope).  Safety-skip eligibility tracks
+adapter-realized capability, not catalog capability.
+
+The gate now mirrors every capability-bearing parameter the adapter emits for
+structured passes; `structured_outputs`/`response_format` is the only uncovered
+mechanism and remains out of scope until that adapter path exists.
+
+**Resolution-ladder matrix (Step 6 capability evaluation):**
+
+| text_output | ctx_length | tool_use | tool_choice | capable |
+|-------------|------------|----------|-------------|---------|
+| True        | ≥ floor    | True     | True        | True    |
+| True        | ≥ floor    | True     | False       | False   |
+| True        | ≥ floor    | True     | None        | False   |
+| True        | ≥ floor    | False    | *           | False   |
+| True        | ≥ floor    | None     | *           | False   |
+| True        | None       | *        | *           | False   |
+| True        | < floor    | *        | *           | ProviderConfigError (Step 5) |
+| False       | *          | *        | *           | ProviderConfigError (Step 5) |
+| None        | *          | *        | *           | False   |
+
+All False / None entries: route is live, Safety runs.  Reject (ProviderConfigError)
+is reserved for positive evidence at Step 5 only.
 
 **Dynamic-alias rule:** Static deny-set (O(1)) + catalog defense-in-depth.
 

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -226,6 +226,13 @@ alias.  Callers updated in the same PR.
 **Fail-safe defaults:** Catalog miss → UNKNOWN → Safety.  None fields → Safety.
 Rejection only on explicit `False`.
 
+**Capability evaluation (Step 6):** `supports_required_capabilities=True` requires
+text output confirmed (`True`), context_length known and ≥ floor, **and** at least
+one structured mechanism confirmed (`supports_tool_use is True OR
+supports_structured_output is True`).  A route with both structured fields `None`
+is not capable — Safety runs, route is live.  A single confirmed mechanism is
+sufficient (OR, not AND).
+
 **Dynamic-alias rule:** Static deny-set (O(1)) + catalog defense-in-depth.
 
 **14b ships machinery:** The registry and whitelist infrastructure are complete.

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -58,54 +58,67 @@ Safety, since the whitelist gate is the operational approval mechanism.
 ## Decision 3: Fail-safe rule — reject only on positive evidence of incapability
 
 **Decision:** The registry (`resolve_route`) raises `ProviderConfigError` only
-when the catalog affirmatively reports the model is incapable:
-`supports_text_output is False` (explicit `False`, not `None`).  A catalog miss,
-`None` capability flags, or `context_length=None` all collapse to
-`supports_required_capabilities=False` without rejecting the route — Safety runs,
-the route is live.
+when the catalog affirmatively reports a capability deficiency:
+
+- `supports_text_output is False` (explicit `False`, not `None`) — Writer pass.
+- `supports_tool_use is False AND supports_structured_output is False` (both
+  explicit `False`, not `None`) — structured passes (Planner, Extractor).
+- `context_length is not None AND context_length < writer_context_length_floor`
+  — known inadequate context for Writer.
+
+A catalog miss, `None` capability flags, or `context_length=None` all collapse
+to `supports_required_capabilities=False` without rejecting the route — Safety
+runs, the route is live.
 
 **Rationale:** Over-rejecting a route on absent evidence is worse than running
 Safety on it.  A model the catalog does not know about might be valid; a model
-with no reported context length might still work.  Rejection is reserved for
+with no reported capability flags might still work.  Rejection is reserved for
 positive evidence of incapability, not absence of positive evidence of
-capability.
+capability.  The context-length floor is an exception: a known below-floor
+window is positive evidence the Writer pass will fail at call time.
 
 ---
 
-## Decision 4: Context-length floor is a capability gate, not a rejection gate
+## Decision 4: Context-length floor rejects; floor value is operator-configured
 
-**Decision:** `_WRITER_CONTEXT_LENGTH_FLOOR = 8192` is used only in the
-capability evaluation (step 6 of `resolve_route`): a model with
-`context_length < floor` gets `supports_required_capabilities=False` and Safety
-runs, but the route is not rejected with `ProviderConfigError`.  The constant
-is marked provisional.
+**Decision:** `resolve_route` raises `ProviderConfigError` when
+`entry.context_length is not None AND entry.context_length <
+writer_context_length_floor`.  The floor is a constructor parameter on
+`OpenRouterCapabilityRegistry` (default `_WRITER_CONTEXT_LENGTH_FLOOR = 8192`).
+`context_length=None` does not reject — it collapses to
+`supports_required_capabilities=False` (Safety runs, route live).
 
-**Rationale:** The floor value is an owner decision, not a value derivable from
-provider documentation.  At any specific floor, legitimate models with shorter
-context windows would be silently rejected.  The safer approach is: confirmed
-capable = both `supports_text_output is True` AND `context_length >= floor`.
-Below floor: Safety runs.  A future owner decision can raise the floor or
-introduce explicit route rejection at a spec-mandated threshold.
+**Rationale:** A known below-floor context length is positive evidence of
+incapability for the Writer pass (14b spec, Design section).  The floor value
+is an operator configuration decision, not a hardcoded constant — operators can
+lower or raise it at construction.  The default of 8192 is provisional;
+production deployments should configure an appropriate floor.
 
-**Known Unknown carried forward:** The exact context-length floor and whether a
-below-floor model should be rejected outright (vs. Safety always running) remain
-owner decisions.  See `known_unknowns.md`.
+**Known Unknown carried forward:** The correct production floor value and
+whether multiple per-pass floors are needed remain owner decisions.  See
+`known_unknowns.md`.
 
 ---
 
-## Decision 5: STALE vs. UNKNOWN semantics
+## Decision 5: STALE vs. UNKNOWN semantics and time-based staleness
 
 **Decision:**
 - `UNKNOWN` — model id is not in the whitelist and not in the catalog.
   Safety always runs.  Route not rejected.
-- `STALE` — model id IS in the whitelist but is NOT found in the catalog.
-  The model was previously approved but is no longer visible.  Safety always
-  runs.  Route not rejected.
+- `STALE` — model id IS in the whitelist but:
+  - not found in the catalog (delisted/renamed), OR
+  - found in the catalog but `WhitelistEntry.verified_at` is older than
+    `max_evidence_age` (whitelist evidence expired).
+  Safety always runs.  Route not rejected.
+
+`max_evidence_age` is a constructor parameter on `OpenRouterCapabilityRegistry`
+(`timedelta | None`; `None` means entries never expire by age).
 
 **Rationale:** The distinction matters for operational observability.  `STALE`
-signals a whitelist entry that may need review (model delisted or renamed).
-`UNKNOWN` signals a model the system has never assessed.  Both force Safety;
-neither rejects the route, consistent with the fail-safe rule.
+signals a whitelist entry that may need review.  `UNKNOWN` signals a model the
+system has never assessed.  Both force Safety; neither rejects the route,
+consistent with the fail-safe rule.  Time-based staleness allows operators to
+require periodic re-verification of whitelist entries.
 
 ---
 
@@ -154,10 +167,9 @@ behavioral change.  UNKNOWN/False is the strictly more conservative fallback.
 ## Decision 9: Incapable fallback fails the whole turn
 
 **Decision:** When the registry is configured and an OpenRouter fallback model
-raises `ProviderConfigError` (positive incapability — `supports_text_output is
-False`), the exception propagates through `_resolve_openrouter_route` and the
-entire `resolve_for_turn` call fails.  The primary Anthropic pass does not
-proceed.
+raises `ProviderConfigError` (positive incapability), the exception propagates
+through `_resolve_openrouter_route` and the entire `resolve_for_turn` call
+fails.  The primary Anthropic pass does not proceed.
 
 **Rationale:** Consistent with 14a fail-closed behavior for blank-model routes.
 The condition fires only on positive incapability evidence, not a catalog miss.
@@ -182,21 +194,23 @@ implementation issue.
 
 ---
 
-## Decision 11: AC 11 (structured-pass incapability) is handled at call time, not at route resolution
+## Decision 11: AC 11 — structured-pass incapability rejected at route resolution
 
-**Decision:** `resolve_route` evaluates Writer pass capability only.  A model
-that is confirmed Writer-capable (`supports_text_output=True`, adequate context)
-but both `supports_tool_use=False` and `supports_structured_output=False` is
-not rejected at route resolution time.  Structured passes (Planner, Extractor)
-that require tool use or structured output will raise `ProviderCallError` at
-call time through the existing 14a adapter behavior.
+**Decision:** `resolve_route` rejects any route where both
+`supports_tool_use is False AND supports_structured_output is False` with
+`ProviderConfigError`.  This is step 5 of the resolution ladder, symmetric to
+the AC 12 text-output rejection.
 
-**Rationale:** `supports_required_capabilities` on `EligibleModelRoute` drives
-the Safety-skip decision for the Writer pass.  Planner/Extractor fail-closed at
-call time (14a behavior) is the correct gate for structured-pass capability.
-Pre-catalog rejection of routes with confirmed structured-pass incapability was
-considered; it would require a separate resolution axis in `resolve_route` and
-is deferred as an owner decision.  See Architecture Notes.
+Only explicit `False` triggers rejection — `None` (unverified) fails safe:
+Safety runs, route is live.  If only one of the two structured-pass fields is
+`False`, the other may still permit structured calls via that mechanism.
+
+**Rationale:** AC 11 explicitly requires rejection "for structured passes at
+resolution" — this is the 14b upgrade over 14a's call-time failure.  Planner
+and Extractor require structured output; a route confirmed incapable for both
+`tool_use` and `structured_output` cannot serve those passes and must be
+rejected before the turn begins.  The fail-safe rule (reject only on positive
+evidence) applies: `None` fields are not positive evidence of incapability.
 
 ---
 
@@ -206,20 +220,22 @@ is deferred as an owner decision.  See Architecture Notes.
 Input Preflight and Output Audit) is preserved.  The stable-prefix is assembled
 once per turn.  Entitlement routing is unaffected.
 
-**Scope question — AC 11 (structured-pass incapability at route resolution):**
-The current implementation does not pre-reject OpenRouter routes where both
-`supports_tool_use` and `supports_structured_output` are explicitly `False`.
-Such routes are live (Safety runs), but will fail at call time when the Planner
-or Extractor pass attempts a structured call.  Whether this is acceptable or
-whether the registry should pre-reject these routes is an owner decision.  It is
-not resolved in 14b.
+**EligibleWriterRoute → EligibleModelRoute:** Clean replacement, no compat
+alias.  Callers updated in the same PR.
 
-**Known Unknown carried forward — context-length floor:**
-`_WRITER_CONTEXT_LENGTH_FLOOR = 8192` is provisional.  The value and rejection
-semantics (floor below → `ProviderConfigError` vs. Safety runs) are owner
-decisions documented in `known_unknowns.md`.
+**Fail-safe defaults:** Catalog miss → UNKNOWN → Safety.  None fields → Safety.
+Rejection only on explicit `False`.
 
-**14b does not carry forward the 14a cache-verification work:**
-The cache adapter verification for OpenRouter routes (deferred in ADR-014a,
-Decision 4) remains open.  14b is the whitelist/registry layer; OpenRouter
-cache verification belongs to a follow-on task within Issue 14's scope.
+**Dynamic-alias rule:** Static deny-set (O(1)) + catalog defense-in-depth.
+
+**14b ships machinery:** The registry and whitelist infrastructure are complete.
+Populating the production catalog/whitelist is a configuration-management concern
+outside 14b scope.
+
+**Context-length floor:** Default 8192 is provisional.  Operators configure via
+`writer_context_length_floor` constructor parameter.
+
+**OpenRouter cache adapter verification:** The cache adapter verification for
+OpenRouter routes (deferred in ADR-014a, Decision 4) remains open.  14b is the
+whitelist/registry layer; cache verification belongs to a follow-on task within
+Issue 14's scope.

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -203,7 +203,9 @@ the AC 12 text-output rejection.
 
 Only explicit `False` triggers rejection — `None` (unverified) fails safe:
 Safety runs, route is live.  If only one of the two structured-pass fields is
-`False`, the other may still permit structured calls via that mechanism.
+`False` (e.g. `tool_use=False, structured_output=True`), AC 11 does not fire —
+the route falls through to Step 6 where `supports_required_capabilities=False`
+(since `tool_use` is not `True` for 14b); Safety runs, route is not rejected.
 
 **Rationale:** AC 11 explicitly requires rejection "for structured passes at
 resolution" — this is the 14b upgrade over 14a's call-time failure.  Planner
@@ -227,11 +229,13 @@ alias.  Callers updated in the same PR.
 Rejection only on explicit `False`.
 
 **Capability evaluation (Step 6):** `supports_required_capabilities=True` requires
-text output confirmed (`True`), context_length known and ≥ floor, **and** at least
-one structured mechanism confirmed (`supports_tool_use is True OR
-supports_structured_output is True`).  A route with both structured fields `None`
-is not capable — Safety runs, route is live.  A single confirmed mechanism is
-sufficient (OR, not AND).
+text output confirmed (`True`), context_length known and ≥ floor, **and**
+`supports_tool_use is True`.  The `OpenRouterAdapter` uses `tools`/`tool_choice`
+only — there is no `response_format` / structured-output request path.  Catalog
+`structured_outputs` support is recorded faithfully in `ModelRouteCapabilityProfile`
+but is not sufficient for `supports_required_capabilities=True` until an
+OpenRouter structured-output adapter path exists (deferred, not in 14b scope).
+Safety-skip eligibility tracks adapter-realized capability, not catalog capability.
 
 **Dynamic-alias rule:** Static deny-set (O(1)) + catalog defense-in-depth.
 

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -266,12 +266,12 @@ parameters exists (deferred, not in 14b scope).
 
 **`supported_parameters` token classification (14b scope):**
 
-| Token                | abstract structured evidence | adapter-realized capable | AC 11 prevents rejection |
-|----------------------|------------------------------|--------------------------|--------------------------|
-| `tools`              | No                           | Yes (required)           | N/A                      |
-| `tool_choice`        | No                           | Yes (required)           | N/A                      |
-| `structured_outputs` | Yes → `structured_output=True` | No                    | Yes (when tool_use≠False)|
-| `response_format`    | Yes → `structured_output=True` | No                    | Yes (when tool_use≠False)|
+| Token                | abstract structured evidence   | adapter-realized capable | AC 11 prevents rejection       |
+|----------------------|--------------------------------|--------------------------|--------------------------------|
+| `tools`              | No                             | Yes (required)           | Yes (forces `tool_use=True`)   |
+| `tool_choice`        | No                             | Yes (required)           | No (not an AC 11 input)        |
+| `structured_outputs` | Yes → `structured_output=True` | No                       | Yes (forces `structured=True`) |
+| `response_format`    | Yes → `structured_output=True` | No                       | Yes (forces `structured=True`) |
 
 Any other tokens: ignored (fail-safe).  A future token that enables structured
 output via a new adapter path is a new issue, not an extension of 14b scope.

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -249,15 +249,32 @@ call-time failure.  Both `tools` and `tool_choice` must be confirmed `True` in
 `supported_parameters` before the adapter-realized capability contract is
 satisfied.
 
-Catalog `structured_outputs` / `response_format` support is recorded faithfully
-in `ModelRouteCapabilityProfile.supports_structured_output` but is not sufficient
-for `supports_required_capabilities=True` until an OpenRouter structured-output
-adapter path exists (deferred, not in 14b scope).  Safety-skip eligibility tracks
-adapter-realized capability, not catalog capability.
+**Abstract catalog capability vs. adapter-realized capability:**
+`ModelRouteCapabilityProfile.supports_structured_output` is an *abstract* field
+that captures any structured-output evidence from the catalog: either
+`"structured_outputs"` or `"response_format"` in the API's `supported_parameters`
+array maps to `supports_structured_output=True`.  This prevents wrongful AC 11
+rejection for models that signal structured-output capability only via
+`response_format`.  It does NOT grant `supports_required_capabilities=True`.
 
-The gate now mirrors every capability-bearing parameter the adapter emits for
-structured passes; `structured_outputs`/`response_format` is the only uncovered
-mechanism and remains out of scope until that adapter path exists.
+`supports_required_capabilities=True` (Step 6) requires adapter-realized
+capability: the 14b `OpenRouterAdapter` emits exactly `tools` and `tool_choice`
+for structured passes, so only `supports_tool_use is True AND supports_tool_choice
+is True` satisfies the adapter contract.  `structured_outputs`/`response_format`
+evidence is not sufficient for Safety-skip until an adapter path that emits those
+parameters exists (deferred, not in 14b scope).
+
+**`supported_parameters` token classification (14b scope):**
+
+| Token                | abstract structured evidence | adapter-realized capable | AC 11 prevents rejection |
+|----------------------|------------------------------|--------------------------|--------------------------|
+| `tools`              | No                           | Yes (required)           | N/A                      |
+| `tool_choice`        | No                           | Yes (required)           | N/A                      |
+| `structured_outputs` | Yes → `structured_output=True` | No                    | Yes (when tool_use≠False)|
+| `response_format`    | Yes → `structured_output=True` | No                    | Yes (when tool_use≠False)|
+
+Any other tokens: ignored (fail-safe).  A future token that enables structured
+output via a new adapter path is a new issue, not an extension of 14b scope.
 
 **Resolution-ladder matrix (Step 6 capability evaluation):**
 

--- a/docs/decisions/adr-014b-openrouter-whitelist-registry.md
+++ b/docs/decisions/adr-014b-openrouter-whitelist-registry.md
@@ -100,12 +100,17 @@ whether multiple per-pass floors are needed remain owner decisions.  See
 
 ---
 
-## Decision 5: STALE vs. UNKNOWN semantics and time-based staleness
+## Decision 5: DISABLED / STALE / UNKNOWN semantics and time-based staleness
 
 **Decision:**
-- `UNKNOWN` — model id is not in the whitelist and not in the catalog.
-  Safety always runs.  Route not rejected.
-- `STALE` — model id IS in the whitelist but:
+- `DISABLED` — the whitelist is administratively off (`WhitelistConfig(enabled=False)`).
+  Applies on both catalog hits and catalog misses: it is an administrative
+  whitelist state, not a catalog-resolution state.  Safety always runs.
+  Route not rejected.  `DISABLED` is always evaluated before `STALE` / `UNKNOWN`
+  so it is unambiguous in telemetry.
+- `UNKNOWN` — whitelist is enabled; model id is not in the whitelist and not in
+  the catalog.  Safety always runs.  Route not rejected.
+- `STALE` — whitelist is enabled; model id IS in the whitelist but:
   - not found in the catalog (delisted/renamed), OR
   - found in the catalog but `WhitelistEntry.verified_at` is older than
     `max_evidence_age` (whitelist evidence expired).
@@ -114,11 +119,13 @@ whether multiple per-pass floors are needed remain owner decisions.  See
 `max_evidence_age` is a constructor parameter on `OpenRouterCapabilityRegistry`
 (`timedelta | None`; `None` means entries never expire by age).
 
-**Rationale:** The distinction matters for operational observability.  `STALE`
-signals a whitelist entry that may need review.  `UNKNOWN` signals a model the
-system has never assessed.  Both force Safety; neither rejects the route,
-consistent with the fail-safe rule.  Time-based staleness allows operators to
-require periodic re-verification of whitelist entries.
+**Rationale:** The three-way distinction matters for operational observability.
+`DISABLED` signals administrative policy-off (intentional).  `STALE` signals a
+whitelist entry that may need review (action required).  `UNKNOWN` signals a
+model the system has never assessed (expected during onboarding).  All three
+force Safety; none rejects the route, consistent with the fail-safe rule.
+Returning `UNKNOWN` for a disabled-whitelist catalog miss would conflate
+administrative off with unassessed, making telemetry unusable for operations.
 
 ---
 

--- a/src/afterworlds/pipeline/provider/__init__.py
+++ b/src/afterworlds/pipeline/provider/__init__.py
@@ -1,5 +1,11 @@
-"""Provider/platform adapter layer — CRD Issue 14a."""
+"""Provider/platform adapter layer — CRD Issue 14a/14b."""
 
+from afterworlds.pipeline.provider._catalog import (
+    FixtureOpenRouterCatalogProvider,
+    LiveOpenRouterCatalogProvider,
+    OpenRouterCatalogModel,
+    OpenRouterModelCatalogProvider,
+)
 from afterworlds.pipeline.provider._errors import (
     CredentialValidationError,
     ProviderCallError,
@@ -14,14 +20,22 @@ from afterworlds.pipeline.provider._models import (
     ProviderToolDefinition,
 )
 from afterworlds.pipeline.provider._protocol import ProviderAdapter
+from afterworlds.pipeline.provider._registry import (
+    OpenRouterCapabilityRegistry,
+    WhitelistConfig,
+    WhitelistEntry,
+)
 from afterworlds.pipeline.provider._resolver import (
     HostedRoutingConfig,
     ProviderResolver,
 )
 from afterworlds.pipeline.provider._routing import (
+    CapabilityEvidenceSource,
     CapabilityProfileAwareSafetyPolicy,
-    EligibleWriterRoute,
+    EligibleModelRoute,
+    ModelRouteCapabilityProfile,
     SafetyPolicyContext,
+    SafetyWhitelistStatus,
     TurnProviderBinding,
 )
 from afterworlds.pipeline.provider.adapters import (
@@ -39,11 +53,18 @@ __all__ = [
     "AnthropicCapabilityProfile",
     "AnthropicDirectAdapter",
     "AnthropicNormalizationFactorProvider",
+    "CapabilityEvidenceSource",
     "CapabilityProfileAwareSafetyPolicy",
     "CredentialValidationError",
-    "EligibleWriterRoute",
+    "EligibleModelRoute",
+    "FixtureOpenRouterCatalogProvider",
     "HostedRoutingConfig",
+    "LiveOpenRouterCatalogProvider",
+    "ModelRouteCapabilityProfile",
     "OpenRouterAdapter",
+    "OpenRouterCapabilityRegistry",
+    "OpenRouterCatalogModel",
+    "OpenRouterModelCatalogProvider",
     "OpenRouterNormalizationFactorProvider",
     "ProviderAdapter",
     "ProviderCallError",
@@ -57,5 +78,8 @@ __all__ = [
     "ProviderToolDefinition",
     "RefusalFallbackRouter",
     "SafetyPolicyContext",
+    "SafetyWhitelistStatus",
     "TurnProviderBinding",
+    "WhitelistConfig",
+    "WhitelistEntry",
 ]

--- a/src/afterworlds/pipeline/provider/_catalog.py
+++ b/src/afterworlds/pipeline/provider/_catalog.py
@@ -37,6 +37,7 @@ class OpenRouterCatalogModel(BaseModel, extra="forbid"):
     context_length: int | None = None
     supports_text_output: bool | None = None
     supports_tool_use: bool | None = None
+    supports_tool_choice: bool | None = None
     supports_structured_output: bool | None = None
     is_dynamic_router: bool = False
     fetched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -109,9 +110,11 @@ class LiveOpenRouterCatalogProvider:
             raw_params = entry.get("supported_parameters")
             if isinstance(raw_params, list):
                 supports_tool: bool | None = "tools" in raw_params
+                supports_tool_choice: bool | None = "tool_choice" in raw_params
                 supports_structured: bool | None = "structured_outputs" in raw_params
             else:
                 supports_tool = None
+                supports_tool_choice = None
                 supports_structured = None
             models.append(
                 OpenRouterCatalogModel(
@@ -120,6 +123,7 @@ class LiveOpenRouterCatalogProvider:
                     context_length=entry.get("context_length"),
                     supports_text_output=supports_text,
                     supports_tool_use=supports_tool,
+                    supports_tool_choice=supports_tool_choice,
                     supports_structured_output=supports_structured,
                     is_dynamic_router=bool(entry.get("is_dynamic_router", False)),
                     fetched_at=fetched_at,

--- a/src/afterworlds/pipeline/provider/_catalog.py
+++ b/src/afterworlds/pipeline/provider/_catalog.py
@@ -1,0 +1,125 @@
+"""OpenRouter model catalog provider — CRD Issue 14b.
+
+Provides model capability data from either a static fixture (CI default, no
+network) or the live OpenRouter /models API (opt-in for @pytest.mark.live tests).
+
+This module is the only boundary for network I/O in the registry layer.  The
+``OpenRouterCapabilityRegistry`` consumes an ``OpenRouterModelCatalogProvider``
+and never calls the network directly.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class OpenRouterCatalogModel(BaseModel, extra="forbid"):
+    """One model entry from the OpenRouter /models catalog.
+
+    All capability fields are tri-state (True / False / None):
+      - True:  API reports the capability is present.
+      - False: API reports the capability is absent (route may be rejected).
+      - None:  capability not reported or unknown (fail-safe: do not reject).
+
+    ``context_length=None`` means the API did not report one.
+    ``is_dynamic_router=True`` marks routing aliases (auto/free) that should
+    not be used as leaf models.
+    """
+
+    id: str
+    name: str = ""
+    context_length: int | None = None
+    supports_text_output: bool | None = None
+    supports_tool_use: bool | None = None
+    supports_structured_output: bool | None = None
+    is_dynamic_router: bool = False
+    fetched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+@runtime_checkable
+class OpenRouterModelCatalogProvider(Protocol):
+    """Protocol for objects that supply an OpenRouter model catalog."""
+
+    def fetch_catalog(self) -> Sequence[OpenRouterCatalogModel]: ...
+
+
+class FixtureOpenRouterCatalogProvider:
+    """Static fixture catalog for CI and offline testing.
+
+    Returns a caller-supplied list of entries; defaults to empty (all OpenRouter
+    models are catalog misses, so Safety always runs).  No network I/O.
+    This is the default catalog provider for ``OpenRouterCapabilityRegistry``
+    when no provider is specified.
+    """
+
+    def __init__(
+        self,
+        entries: Sequence[OpenRouterCatalogModel] | None = None,
+    ) -> None:
+        self._entries: Sequence[OpenRouterCatalogModel] = (
+            entries if entries is not None else []
+        )
+
+    def fetch_catalog(self) -> Sequence[OpenRouterCatalogModel]:
+        return self._entries
+
+
+class LiveOpenRouterCatalogProvider:
+    """Catalog provider that fetches live data from the OpenRouter /models endpoint.
+
+    Opt-in for integration tests decorated with ``@pytest.mark.live``.
+    Not used in CI.  Requires a valid OpenRouter API key.
+
+    The raw API response is mapped to ``OpenRouterCatalogModel`` on a best-effort
+    basis: unknown fields are ignored, missing capability flags default to None.
+    """
+
+    _MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    def fetch_catalog(self) -> Sequence[OpenRouterCatalogModel]:
+        req = urllib.request.Request(
+            self._MODELS_URL,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode())
+
+        fetched_at = datetime.now(UTC)
+        models: list[OpenRouterCatalogModel] = []
+        for entry in payload.get("data", []):
+            model_id: str = entry.get("id", "")
+            if not model_id:
+                continue
+            arch = entry.get("architecture") or {}
+            output_modalities: list[str] = arch.get("output_modalities") or []
+            supports_text: bool | None = True if "text" in output_modalities else None
+            models.append(
+                OpenRouterCatalogModel(
+                    id=model_id,
+                    name=entry.get("name") or "",
+                    context_length=entry.get("context_length"),
+                    supports_text_output=supports_text,
+                    supports_tool_use=entry.get("supports_tool_use"),
+                    supports_structured_output=entry.get("supports_structured_output"),
+                    is_dynamic_router=bool(entry.get("is_dynamic_router", False)),
+                    fetched_at=fetched_at,
+                )
+            )
+        return models
+
+
+__all__ = [
+    "FixtureOpenRouterCatalogProvider",
+    "LiveOpenRouterCatalogProvider",
+    "OpenRouterCatalogModel",
+    "OpenRouterModelCatalogProvider",
+]

--- a/src/afterworlds/pipeline/provider/_catalog.py
+++ b/src/afterworlds/pipeline/provider/_catalog.py
@@ -111,7 +111,10 @@ class LiveOpenRouterCatalogProvider:
             if isinstance(raw_params, list):
                 supports_tool: bool | None = "tools" in raw_params
                 supports_tool_choice: bool | None = "tool_choice" in raw_params
-                supports_structured: bool | None = "structured_outputs" in raw_params
+                supports_structured: bool | None = (
+                    "structured_outputs" in raw_params
+                    or "response_format" in raw_params
+                )
             else:
                 supports_tool = None
                 supports_tool_choice = None

--- a/src/afterworlds/pipeline/provider/_catalog.py
+++ b/src/afterworlds/pipeline/provider/_catalog.py
@@ -99,17 +99,28 @@ class LiveOpenRouterCatalogProvider:
             model_id: str = entry.get("id", "")
             if not model_id:
                 continue
-            arch = entry.get("architecture") or {}
-            output_modalities: list[str] = arch.get("output_modalities") or []
-            supports_text: bool | None = True if "text" in output_modalities else None
+            arch = entry.get("architecture")
+            raw_modalities = (
+                arch.get("output_modalities") if isinstance(arch, dict) else None
+            )
+            supports_text: bool | None = (
+                ("text" in raw_modalities) if isinstance(raw_modalities, list) else None
+            )
+            raw_params = entry.get("supported_parameters")
+            if isinstance(raw_params, list):
+                supports_tool: bool | None = "tools" in raw_params
+                supports_structured: bool | None = "structured_outputs" in raw_params
+            else:
+                supports_tool = None
+                supports_structured = None
             models.append(
                 OpenRouterCatalogModel(
                     id=model_id,
                     name=entry.get("name") or "",
                     context_length=entry.get("context_length"),
                     supports_text_output=supports_text,
-                    supports_tool_use=entry.get("supports_tool_use"),
-                    supports_structured_output=entry.get("supports_structured_output"),
+                    supports_tool_use=supports_tool,
+                    supports_structured_output=supports_structured,
                     is_dynamic_router=bool(entry.get("is_dynamic_router", False)),
                     fetched_at=fetched_at,
                 )

--- a/src/afterworlds/pipeline/provider/_registry.py
+++ b/src/afterworlds/pipeline/provider/_registry.py
@@ -1,0 +1,258 @@
+"""OpenRouter model-route capability registry and Safety whitelist — CRD Issue 14b.
+
+The ``OpenRouterCapabilityRegistry`` is the single authority on whether an
+OpenRouter model route is whitelisted for Safety skip and whether it is capable
+of serving the Writer pass.
+
+Resolution ladder (``resolve_route``):
+
+  1. Static deny-set (pre-catalog fast-path): dynamic aliases are rejected
+     immediately as ``ProviderConfigError``, matching the 14a adapter guard.
+  2. Catalog lookup: fetch_catalog() is called once per registry instance
+     (result is cached on first call).
+  3. Catalog miss:
+       - model NOT in whitelist → (UNKNOWN, None, False)
+       - model IN whitelist     → (STALE, None, False)
+     Both force Safety without rejecting the route.
+  4. Catalog entry with is_dynamic_router=True → ``ProviderConfigError``
+     (catalog-authoritative dynamic alias; defense-in-depth after step 1).
+  5. Catalog entry — positive-evidence rejection (Writer pass):
+       - ``supports_text_output is False`` → ``ProviderConfigError``
+       Note: context_length below floor is NOT a rejection — it sets
+       supports_required_capabilities=False (Safety runs) without rejecting the
+       route.  The floor value (8192) is provisional; see ADR-014b.
+  6. Catalog entry — capability evaluation:
+       - ``supports_required_capabilities=True`` only when
+         ``supports_text_output is True`` AND context_length is known and >= floor.
+       - All other cases → False (fail-safe; Safety runs, route not rejected).
+  7. Whitelist lookup:
+       - whitelist disabled → DISABLED
+       - model in whitelist  → WHITELISTED
+       - model not in whitelist → NOT_WHITELISTED
+
+Capability and whitelist status are independent:
+  - WHITELISTED + not capable → route is live but ``supports_required_capabilities``
+    is False, so Safety still runs (no skip).
+  - NOT_WHITELISTED + capable → Safety still runs (whitelist gate fails).
+  - UNKNOWN / STALE → Safety runs regardless.
+
+Reject only on positive evidence of incapability.  Absence/unknown drives Safety,
+never route rejection.
+
+Anthropic-direct routes always resolve WHITELISTED + capable; this is handled by
+the resolver, not this registry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from afterworlds.pipeline.provider._catalog import (
+    FixtureOpenRouterCatalogProvider,
+    OpenRouterCatalogModel,
+    OpenRouterModelCatalogProvider,
+)
+from afterworlds.pipeline.provider._errors import ProviderConfigError
+from afterworlds.pipeline.provider._routing import (
+    CapabilityEvidenceSource,
+    ModelRouteCapabilityProfile,
+    SafetyWhitelistStatus,
+)
+from afterworlds.pipeline.provider.adapters._openrouter import _is_dynamic_alias
+
+# Minimum context length (tokens) required to qualify as Writer-capable.
+# Provisional floor — see ADR-014b.  Treat as a constant; do not infer at runtime.
+_WRITER_CONTEXT_LENGTH_FLOOR = 8192
+
+
+# ---------------------------------------------------------------------------
+# Whitelist configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WhitelistEntry:
+    """One approved model on the Safety-skip whitelist."""
+
+    model_identifier: str
+    approved_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True)
+class WhitelistConfig:
+    """Set of model identifiers approved for Safety-skip on the Writer pass.
+
+    ``enabled=False`` disables whitelist enforcement entirely; all routes get
+    ``SafetyWhitelistStatus.DISABLED`` and Safety always runs.
+
+    ``entries`` maps exact model identifiers to their ``WhitelistEntry``.
+    Dynamic aliases must never appear in this set; they are caught by the
+    static deny-set before reaching the whitelist lookup.
+    """
+
+    enabled: bool = True
+    entries: dict[str, WhitelistEntry] = field(default_factory=dict)
+
+    def is_whitelisted(self, model_identifier: str) -> bool:
+        return self.enabled and model_identifier in self.entries
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class OpenRouterCapabilityRegistry:
+    """Registry for OpenRouter model-route capability and Safety whitelist.
+
+    Injected into ``ProviderResolver`` to upgrade OpenRouter route construction
+    from the 14a ``trusted_for_safety_skip=False`` default to full whitelist +
+    capability evaluation.
+
+    The catalog is fetched once per instance on first ``resolve_route`` call and
+    cached.  Construct a new registry per process/worker startup or after a
+    catalog refresh interval.
+
+    Args:
+        whitelist_config: Set of approved model identifiers.
+        catalog_provider: Source of model capability data.  Defaults to an empty
+            ``FixtureOpenRouterCatalogProvider`` (all misses; Safety always runs).
+    """
+
+    def __init__(
+        self,
+        whitelist_config: WhitelistConfig | None = None,
+        catalog_provider: OpenRouterModelCatalogProvider | None = None,
+    ) -> None:
+        self._whitelist = whitelist_config or WhitelistConfig()
+        self._catalog_provider: OpenRouterModelCatalogProvider = (
+            catalog_provider or FixtureOpenRouterCatalogProvider()
+        )
+        self._catalog_cache: dict[str, OpenRouterCatalogModel] | None = None
+
+    # -----------------------------------------------------------------------
+    # Public API
+    # -----------------------------------------------------------------------
+
+    def resolve_route(
+        self,
+        model_identifier: str,
+    ) -> tuple[SafetyWhitelistStatus, ModelRouteCapabilityProfile | None, bool]:
+        """Resolve whitelist status and Writer capability for an OpenRouter model.
+
+        Returns:
+            (whitelist_status, capability_profile, supports_required_capabilities)
+
+        Raises:
+            ProviderConfigError: if the model is a dynamic alias or is positively
+                incapable of serving the Writer pass (supports_text_output=False or
+                context_length below the minimum floor).
+        """
+        # Step 1: static deny-set (pre-catalog fast-path)
+        if _is_dynamic_alias(model_identifier):
+            raise ProviderConfigError(
+                f"OpenRouterCapabilityRegistry: dynamic alias '{model_identifier}' "
+                f"is not permitted as an exact model route"
+            )
+
+        # Step 2: catalog lookup (fetched once, cached)
+        catalog = self._get_catalog()
+        entry = catalog.get(model_identifier)
+
+        # Step 3: catalog miss
+        if entry is None:
+            if self._whitelist.is_whitelisted(model_identifier):
+                return SafetyWhitelistStatus.STALE, None, False
+            return SafetyWhitelistStatus.UNKNOWN, None, False
+
+        # Step 4: catalog-driven dynamic alias (defense-in-depth)
+        if entry.is_dynamic_router:
+            raise ProviderConfigError(
+                f"OpenRouterCapabilityRegistry: catalog marks '{model_identifier}' "
+                f"as a dynamic router alias — rejected"
+            )
+
+        # Step 5: positive-evidence rejection for Writer
+        # Reject only on explicit False (not None/unknown).
+        # context_length below floor is NOT a rejection; it drives
+        # supports_required_capabilities=False in step 6 instead.
+        if entry.supports_text_output is False:
+            raise ProviderConfigError(
+                f"OpenRouterCapabilityRegistry: model '{model_identifier}' "
+                f"does not support text output — cannot serve Writer pass"
+            )
+
+        # Step 6: capability evaluation (fail-safe: unknown → False)
+        supports_required = (
+            entry.supports_text_output is True
+            and entry.context_length is not None
+            and entry.context_length >= _WRITER_CONTEXT_LENGTH_FLOOR
+        )
+
+        # Step 7: whitelist lookup
+        if not self._whitelist.enabled:
+            whitelist_status = SafetyWhitelistStatus.DISABLED
+        elif self._whitelist.is_whitelisted(model_identifier):
+            whitelist_status = SafetyWhitelistStatus.WHITELISTED
+        else:
+            whitelist_status = SafetyWhitelistStatus.NOT_WHITELISTED
+
+        profile = ModelRouteCapabilityProfile(
+            model_identifier=model_identifier,
+            supports_text_output=entry.supports_text_output,
+            supports_tool_use=entry.supports_tool_use,
+            supports_structured_output=entry.supports_structured_output,
+            context_length=entry.context_length,
+            evidence_source=CapabilityEvidenceSource.OPENROUTER_MODELS_API,
+            is_dynamic_router=False,
+            catalog_seen_at=entry.fetched_at,
+        )
+        return whitelist_status, profile, supports_required
+
+    # -----------------------------------------------------------------------
+    # Private helpers
+    # -----------------------------------------------------------------------
+
+    def _get_catalog(self) -> dict[str, OpenRouterCatalogModel]:
+        if self._catalog_cache is None:
+            entries: Sequence[OpenRouterCatalogModel] = (
+                self._catalog_provider.fetch_catalog()
+            )
+            self._catalog_cache = {e.id: e for e in entries}
+        return self._catalog_cache
+
+
+# ---------------------------------------------------------------------------
+# Anthropic-direct capability profile (AFTERWORLDS_VERIFIED)
+# ---------------------------------------------------------------------------
+
+
+def make_anthropic_capability_profile(
+    model_identifier: str,
+) -> ModelRouteCapabilityProfile:
+    """Build the AFTERWORLDS_VERIFIED capability profile for an Anthropic-direct model.
+
+    Anthropic-direct routes are always trusted — this is the profile that encodes
+    that trust.  Context length 200_000 reflects Claude's maximum window.
+    """
+    return ModelRouteCapabilityProfile(
+        model_identifier=model_identifier,
+        supports_text_output=True,
+        supports_tool_use=True,
+        supports_structured_output=True,
+        context_length=200_000,
+        evidence_source=CapabilityEvidenceSource.AFTERWORLDS_VERIFIED,
+        is_dynamic_router=False,
+        verified_at=datetime.now(UTC),
+    )
+
+
+__all__ = [
+    "OpenRouterCapabilityRegistry",
+    "WhitelistConfig",
+    "WhitelistEntry",
+    "_WRITER_CONTEXT_LENGTH_FLOOR",
+    "make_anthropic_capability_profile",
+]

--- a/src/afterworlds/pipeline/provider/_registry.py
+++ b/src/afterworlds/pipeline/provider/_registry.py
@@ -2,7 +2,7 @@
 
 The ``OpenRouterCapabilityRegistry`` is the single authority on whether an
 OpenRouter model route is whitelisted for Safety skip and whether it is capable
-of serving the Writer pass.
+of serving the core narrative passes (Writer + structured passes).
 
 Resolution ladder (``resolve_route``):
 
@@ -16,18 +16,21 @@ Resolution ladder (``resolve_route``):
      Both force Safety without rejecting the route.
   4. Catalog entry with is_dynamic_router=True → ``ProviderConfigError``
      (catalog-authoritative dynamic alias; defense-in-depth after step 1).
-  5. Catalog entry — positive-evidence rejection (Writer pass):
-       - ``supports_text_output is False`` → ``ProviderConfigError``
-       Note: context_length below floor is NOT a rejection — it sets
-       supports_required_capabilities=False (Safety runs) without rejecting the
-       route.  The floor value (8192) is provisional; see ADR-014b.
+  5. Catalog entry — positive-evidence rejection:
+       - ``supports_text_output is False`` → ``ProviderConfigError`` (Writer pass)
+       - ``supports_tool_use is False AND supports_structured_output is False``
+         → ``ProviderConfigError`` (structured passes: Planner, Extractor)
+       - ``context_length is not None AND context_length < writer_context_length_floor``
+         → ``ProviderConfigError`` (Writer pass context floor)
+       - ``context_length=None``: unverified; does not reject — Safety runs.
   6. Catalog entry — capability evaluation:
        - ``supports_required_capabilities=True`` only when
          ``supports_text_output is True`` AND context_length is known and >= floor.
        - All other cases → False (fail-safe; Safety runs, route not rejected).
   7. Whitelist lookup:
        - whitelist disabled → DISABLED
-       - model in whitelist  → WHITELISTED
+       - model in whitelist + fresh (verified_at within max_evidence_age) → WHITELISTED
+       - model in whitelist + stale (verified_at older than max_evidence_age) → STALE
        - model not in whitelist → NOT_WHITELISTED
 
 Capability and whitelist status are independent:
@@ -37,7 +40,9 @@ Capability and whitelist status are independent:
   - UNKNOWN / STALE → Safety runs regardless.
 
 Reject only on positive evidence of incapability.  Absence/unknown drives Safety,
-never route rejection.
+never route rejection.  The one exception: a known context_length below the
+configured floor rejects because accepting an inadequate context window is not
+fail-safe for the Writer pass.
 
 Anthropic-direct routes always resolve WHITELISTED + capable; this is handled by
 the resolver, not this registry.
@@ -45,9 +50,9 @@ the resolver, not this registry.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from afterworlds.pipeline.provider._catalog import (
     FixtureOpenRouterCatalogProvider,
@@ -62,8 +67,9 @@ from afterworlds.pipeline.provider._routing import (
 )
 from afterworlds.pipeline.provider.adapters._openrouter import _is_dynamic_alias
 
-# Minimum context length (tokens) required to qualify as Writer-capable.
-# Provisional floor — see ADR-014b.  Treat as a constant; do not infer at runtime.
+# Minimum context length (tokens) for the Writer pass.
+# This is the default floor; operators can override via writer_context_length_floor.
+# Provisional value — see ADR-014b.
 _WRITER_CONTEXT_LENGTH_FLOOR = 8192
 
 
@@ -77,7 +83,7 @@ class WhitelistEntry:
     """One approved model on the Safety-skip whitelist."""
 
     model_identifier: str
-    approved_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    verified_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 @dataclass(frozen=True)
@@ -96,6 +102,7 @@ class WhitelistConfig:
     entries: dict[str, WhitelistEntry] = field(default_factory=dict)
 
     def is_whitelisted(self, model_identifier: str) -> bool:
+        """Return True when the whitelist is enabled and the model has an entry."""
         return self.enabled and model_identifier in self.entries
 
 
@@ -119,17 +126,30 @@ class OpenRouterCapabilityRegistry:
         whitelist_config: Set of approved model identifiers.
         catalog_provider: Source of model capability data.  Defaults to an empty
             ``FixtureOpenRouterCatalogProvider`` (all misses; Safety always runs).
+        max_evidence_age: Maximum age of a whitelist entry's ``verified_at`` before
+            it is considered STALE.  ``None`` means entries never expire by age
+            (the "no longer in catalog" branch of STALE still applies).
+        clock: Callable returning the current UTC datetime.  Injected for testing.
+        writer_context_length_floor: Minimum context length (tokens) for the Writer
+            pass.  Routes with a known context_length below this value are rejected
+            with ``ProviderConfigError``.  Defaults to ``_WRITER_CONTEXT_LENGTH_FLOOR``.
     """
 
     def __init__(
         self,
         whitelist_config: WhitelistConfig | None = None,
         catalog_provider: OpenRouterModelCatalogProvider | None = None,
+        max_evidence_age: timedelta | None = None,
+        clock: Callable[[], datetime] | None = None,
+        writer_context_length_floor: int = _WRITER_CONTEXT_LENGTH_FLOOR,
     ) -> None:
         self._whitelist = whitelist_config or WhitelistConfig()
         self._catalog_provider: OpenRouterModelCatalogProvider = (
             catalog_provider or FixtureOpenRouterCatalogProvider()
         )
+        self._max_evidence_age = max_evidence_age
+        self._clock: Callable[[], datetime] = clock or (lambda: datetime.now(UTC))
+        self._floor = writer_context_length_floor
         self._catalog_cache: dict[str, OpenRouterCatalogModel] | None = None
 
     # -----------------------------------------------------------------------
@@ -140,15 +160,16 @@ class OpenRouterCapabilityRegistry:
         self,
         model_identifier: str,
     ) -> tuple[SafetyWhitelistStatus, ModelRouteCapabilityProfile | None, bool]:
-        """Resolve whitelist status and Writer capability for an OpenRouter model.
+        """Resolve whitelist status and capability for an OpenRouter model route.
 
         Returns:
             (whitelist_status, capability_profile, supports_required_capabilities)
 
         Raises:
-            ProviderConfigError: if the model is a dynamic alias or is positively
-                incapable of serving the Writer pass (supports_text_output=False or
-                context_length below the minimum floor).
+            ProviderConfigError: if the model is a dynamic alias; lacks text output
+                (supports_text_output=False); lacks both structured-pass capabilities
+                (supports_tool_use=False AND supports_structured_output=False); or has
+                a known context_length below the configured floor.
         """
         # Step 1: static deny-set (pre-catalog fast-path)
         if _is_dynamic_alias(model_identifier):
@@ -174,28 +195,49 @@ class OpenRouterCapabilityRegistry:
                 f"as a dynamic router alias — rejected"
             )
 
-        # Step 5: positive-evidence rejection for Writer
-        # Reject only on explicit False (not None/unknown).
-        # context_length below floor is NOT a rejection; it drives
-        # supports_required_capabilities=False in step 6 instead.
+        # Step 5: positive-evidence rejection
+        # Reject only when capability is explicitly False — None/unknown fails safe.
         if entry.supports_text_output is False:
             raise ProviderConfigError(
                 f"OpenRouterCapabilityRegistry: model '{model_identifier}' "
                 f"does not support text output — cannot serve Writer pass"
+            )
+        if (
+            entry.supports_tool_use is False
+            and entry.supports_structured_output is False
+        ):
+            raise ProviderConfigError(
+                f"OpenRouterCapabilityRegistry: model '{model_identifier}' "
+                f"lacks both structured-pass capabilities (tool_use=False, "
+                f"structured_output=False) — cannot serve Planner/Extractor passes"
+            )
+        if entry.context_length is not None and entry.context_length < self._floor:
+            raise ProviderConfigError(
+                f"OpenRouterCapabilityRegistry: model '{model_identifier}' "
+                f"context length {entry.context_length} is below the Writer floor "
+                f"of {self._floor} tokens"
             )
 
         # Step 6: capability evaluation (fail-safe: unknown → False)
         supports_required = (
             entry.supports_text_output is True
             and entry.context_length is not None
-            and entry.context_length >= _WRITER_CONTEXT_LENGTH_FLOOR
+            and entry.context_length >= self._floor
         )
 
-        # Step 7: whitelist lookup
+        # Step 7: whitelist lookup (with time-based staleness check)
+        whitelist_status: SafetyWhitelistStatus
         if not self._whitelist.enabled:
             whitelist_status = SafetyWhitelistStatus.DISABLED
-        elif self._whitelist.is_whitelisted(model_identifier):
-            whitelist_status = SafetyWhitelistStatus.WHITELISTED
+        elif model_identifier in self._whitelist.entries:
+            wl_entry = self._whitelist.entries[model_identifier]
+            if (
+                self._max_evidence_age is not None
+                and self._clock() - wl_entry.verified_at > self._max_evidence_age
+            ):
+                whitelist_status = SafetyWhitelistStatus.STALE
+            else:
+                whitelist_status = SafetyWhitelistStatus.WHITELISTED
         else:
             whitelist_status = SafetyWhitelistStatus.NOT_WHITELISTED
 

--- a/src/afterworlds/pipeline/provider/_registry.py
+++ b/src/afterworlds/pipeline/provider/_registry.py
@@ -11,9 +11,11 @@ Resolution ladder (``resolve_route``):
   2. Catalog lookup: fetch_catalog() is called once per registry instance
      (result is cached on first call).
   3. Catalog miss:
-       - model NOT in whitelist → (UNKNOWN, None, False)
-       - model IN whitelist     → (STALE, None, False)
-     Both force Safety without rejecting the route.
+       - whitelist disabled             → (DISABLED, None, False)
+       - whitelist enabled + in entries → (STALE, None, False)
+       - whitelist enabled + not found  → (UNKNOWN, None, False)
+     All three force Safety without rejecting the route.
+     DISABLED here reflects administrative whitelist state, not catalog status.
   4. Catalog entry with is_dynamic_router=True → ``ProviderConfigError``
      (catalog-authoritative dynamic alias; defense-in-depth after step 1).
   5. Catalog entry — positive-evidence rejection:
@@ -105,10 +107,6 @@ class WhitelistConfig:
     enabled: bool = True
     entries: dict[str, WhitelistEntry] = field(default_factory=dict)
 
-    def is_whitelisted(self, model_identifier: str) -> bool:
-        """Return True when the whitelist is enabled and the model has an entry."""
-        return self.enabled and model_identifier in self.entries
-
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -186,9 +184,12 @@ class OpenRouterCapabilityRegistry:
         catalog = self._get_catalog()
         entry = catalog.get(model_identifier)
 
-        # Step 3: catalog miss
+        # Step 3: catalog miss — whitelist-disabled check runs before entry lookup
+        # so DISABLED is distinguishable from UNKNOWN in telemetry.
         if entry is None:
-            if self._whitelist.is_whitelisted(model_identifier):
+            if not self._whitelist.enabled:
+                return SafetyWhitelistStatus.DISABLED, None, False
+            if model_identifier in self._whitelist.entries:
                 return SafetyWhitelistStatus.STALE, None, False
             return SafetyWhitelistStatus.UNKNOWN, None, False
 

--- a/src/afterworlds/pipeline/provider/_registry.py
+++ b/src/afterworlds/pipeline/provider/_registry.py
@@ -26,8 +26,10 @@ Resolution ladder (``resolve_route``):
   6. Catalog entry — capability evaluation:
        - ``supports_required_capabilities=True`` only when
          ``supports_text_output is True`` AND context_length is known and >= floor
-         AND at least one structured mechanism is confirmed
-         (``supports_tool_use is True`` OR ``supports_structured_output is True``).
+         AND ``supports_tool_use is True`` (adapter constraint: the 14b
+         ``OpenRouterAdapter`` uses ``tools``/``tool_choice`` only; catalog
+         ``structured_outputs`` support is recorded in the profile but is not
+         sufficient for Safety-skip until an adapter path exists).
        - All other cases → False (fail-safe; Safety runs, route not rejected).
   7. Whitelist lookup:
        - whitelist disabled → DISABLED
@@ -221,14 +223,14 @@ class OpenRouterCapabilityRegistry:
             )
 
         # Step 6: capability evaluation (fail-safe: unknown → False)
-        supports_structured_capability = (
-            entry.supports_tool_use is True or entry.supports_structured_output is True
-        )
+        # Adapter constraint: OpenRouterAdapter uses tools/tool_choice only.
+        # Catalog structured_outputs is recorded in the profile but is not
+        # sufficient for Safety-skip until an adapter path exists.
         supports_required = (
             entry.supports_text_output is True
             and entry.context_length is not None
             and entry.context_length >= self._floor
-            and supports_structured_capability
+            and entry.supports_tool_use is True
         )
 
         # Step 7: whitelist lookup (with time-based staleness check)

--- a/src/afterworlds/pipeline/provider/_registry.py
+++ b/src/afterworlds/pipeline/provider/_registry.py
@@ -25,7 +25,9 @@ Resolution ladder (``resolve_route``):
        - ``context_length=None``: unverified; does not reject — Safety runs.
   6. Catalog entry — capability evaluation:
        - ``supports_required_capabilities=True`` only when
-         ``supports_text_output is True`` AND context_length is known and >= floor.
+         ``supports_text_output is True`` AND context_length is known and >= floor
+         AND at least one structured mechanism is confirmed
+         (``supports_tool_use is True`` OR ``supports_structured_output is True``).
        - All other cases → False (fail-safe; Safety runs, route not rejected).
   7. Whitelist lookup:
        - whitelist disabled → DISABLED
@@ -219,10 +221,14 @@ class OpenRouterCapabilityRegistry:
             )
 
         # Step 6: capability evaluation (fail-safe: unknown → False)
+        supports_structured_capability = (
+            entry.supports_tool_use is True or entry.supports_structured_output is True
+        )
         supports_required = (
             entry.supports_text_output is True
             and entry.context_length is not None
             and entry.context_length >= self._floor
+            and supports_structured_capability
         )
 
         # Step 7: whitelist lookup (with time-based staleness check)

--- a/src/afterworlds/pipeline/provider/_registry.py
+++ b/src/afterworlds/pipeline/provider/_registry.py
@@ -28,10 +28,10 @@ Resolution ladder (``resolve_route``):
   6. Catalog entry — capability evaluation:
        - ``supports_required_capabilities=True`` only when
          ``supports_text_output is True`` AND context_length is known and >= floor
-         AND ``supports_tool_use is True`` (adapter constraint: the 14b
-         ``OpenRouterAdapter`` uses ``tools``/``tool_choice`` only; catalog
-         ``structured_outputs`` support is recorded in the profile but is not
-         sufficient for Safety-skip until an adapter path exists).
+         AND ``supports_tool_use is True`` AND ``supports_tool_choice is True``
+         (adapter constraint: the 14b ``OpenRouterAdapter`` emits exactly two
+         capability-bearing kwargs for structured passes — ``tools`` and
+         ``tool_choice``; both must be catalog-confirmed True).
        - All other cases → False (fail-safe; Safety runs, route not rejected).
   7. Whitelist lookup:
        - whitelist disabled → DISABLED
@@ -224,14 +224,16 @@ class OpenRouterCapabilityRegistry:
             )
 
         # Step 6: capability evaluation (fail-safe: unknown → False)
-        # Adapter constraint: OpenRouterAdapter uses tools/tool_choice only.
-        # Catalog structured_outputs is recorded in the profile but is not
-        # sufficient for Safety-skip until an adapter path exists.
+        # Adapter constraint: OpenRouterAdapter emits exactly two capability-bearing
+        # kwargs for structured passes — tools and tool_choice.  Both must be
+        # catalog-confirmed True.  structured_outputs is recorded in the profile
+        # but is not sufficient for Safety-skip until an adapter path exists.
         supports_required = (
             entry.supports_text_output is True
             and entry.context_length is not None
             and entry.context_length >= self._floor
             and entry.supports_tool_use is True
+            and entry.supports_tool_choice is True
         )
 
         # Step 7: whitelist lookup (with time-based staleness check)
@@ -254,6 +256,7 @@ class OpenRouterCapabilityRegistry:
             model_identifier=model_identifier,
             supports_text_output=entry.supports_text_output,
             supports_tool_use=entry.supports_tool_use,
+            supports_tool_choice=entry.supports_tool_choice,
             supports_structured_output=entry.supports_structured_output,
             context_length=entry.context_length,
             evidence_source=CapabilityEvidenceSource.OPENROUTER_MODELS_API,
@@ -292,6 +295,7 @@ def make_anthropic_capability_profile(
         model_identifier=model_identifier,
         supports_text_output=True,
         supports_tool_use=True,
+        supports_tool_choice=True,
         supports_structured_output=True,
         context_length=200_000,
         evidence_source=CapabilityEvidenceSource.AFTERWORLDS_VERIFIED,

--- a/src/afterworlds/pipeline/provider/_resolver.py
+++ b/src/afterworlds/pipeline/provider/_resolver.py
@@ -1,12 +1,12 @@
-"""ProviderResolver — per-turn provider binding — CRD Issue 14a.
+"""ProviderResolver — per-turn provider binding — CRD Issue 14a/14b.
 
 ``resolve_for_turn`` is the single entry point for provider/platform selection.
 No provider policy lives in HTTP handlers or entitlement code.
 
 Hosted path:
-  - Anthropic direct primary (``trusted_for_safety_skip=True``).
-  - Optional OpenRouter fallback from hosted routing configuration
-    (``trusted_for_safety_skip=False``).
+  - Anthropic direct primary (WHITELISTED + capable via AFTERWORLDS_VERIFIED profile).
+  - Optional OpenRouter fallback from hosted routing configuration; whitelist status
+    and capability resolved via ``OpenRouterCapabilityRegistry`` when injected.
   - Wrapped in ``RefusalFallbackRouter`` when fallback exists.
 
 BYOK path:
@@ -21,7 +21,11 @@ BYOK path:
 
 Cross-boundary rule: hosted/BYOK pools never cross.
 Dynamic alias rule: dynamic aliases are rejected at ``OpenRouterAdapter``
-construction (``ProviderConfigError``).
+construction (``ProviderConfigError``) and additionally by the registry.
+
+14b: ``OpenRouterCapabilityRegistry`` is optional.  When absent, OpenRouter routes
+default to UNKNOWN and ``supports_required_capabilities=False``
+(fail-safe; Safety always runs).
 """
 
 from __future__ import annotations
@@ -31,8 +35,13 @@ from uuid import UUID
 
 from afterworlds.entitlement.enums import RuntimeAccessPath
 from afterworlds.pipeline.provider._errors import ProviderConfigError
+from afterworlds.pipeline.provider._registry import (
+    OpenRouterCapabilityRegistry,
+    make_anthropic_capability_profile,
+)
 from afterworlds.pipeline.provider._routing import (
-    EligibleWriterRoute,
+    EligibleModelRoute,
+    SafetyWhitelistStatus,
     TurnProviderBinding,
 )
 from afterworlds.pipeline.provider.adapters._anthropic import (
@@ -252,6 +261,9 @@ class ProviderResolver:
             Required when serving hosted-access Sojourners.
         session_factory: Factory returning SQLAlchemy sessions for reading
             ``ProviderRouteConfig`` rows.  Optional; required for BYOK path.
+        capability_registry: OpenRouter model-route capability registry (14b).
+            When None, OpenRouter routes resolve to UNKNOWN + not capable;
+            Safety always runs for those routes.
     """
 
     def __init__(
@@ -259,10 +271,12 @@ class ProviderResolver:
         credential_store: CredentialStore,
         hosted_config: HostedRoutingConfig | None = None,
         session_factory: object = None,
+        capability_registry: OpenRouterCapabilityRegistry | None = None,
     ) -> None:
         self._credential_store = credential_store
         self._hosted_config = hosted_config
         self._session_factory = session_factory
+        self._capability_registry = capability_registry
 
     def resolve_for_turn(
         self,
@@ -302,11 +316,12 @@ class ProviderResolver:
         from afterworlds.entitlement.enums import PipelinePassId
 
         writer_model = cfg.anthropic_profile.model_for(PipelinePassId.WRITER)
-        primary_route = EligibleWriterRoute(
+        primary_route = EligibleModelRoute(
             provider_name="anthropic",
             model_identifier=writer_model,
-            is_openrouter=False,
-            trusted_for_safety_skip=True,
+            whitelist_status=SafetyWhitelistStatus.WHITELISTED,
+            supports_required_capabilities=True,
+            capability_profile=make_anthropic_capability_profile(writer_model),
         )
 
         if cfg.openrouter_api_key:
@@ -322,11 +337,8 @@ class ProviderResolver:
                 model_identifier=cfg.openrouter_fallback_model,
                 api_key=cfg.openrouter_api_key,
             )
-            fallback_route = EligibleWriterRoute(
-                provider_name="openrouter",
-                model_identifier=cfg.openrouter_fallback_model,
-                is_openrouter=True,
-                trusted_for_safety_skip=False,
+            fallback_route = self._resolve_openrouter_route(
+                cfg.openrouter_fallback_model
             )
             wrapped_adapter = RefusalFallbackRouter(
                 primary=primary_adapter,
@@ -388,30 +400,26 @@ class ProviderResolver:
 
         def _make_anthropic(
             api_key: str,
-        ) -> tuple[AnthropicDirectAdapter, EligibleWriterRoute]:
+        ) -> tuple[AnthropicDirectAdapter, EligibleModelRoute]:
             from afterworlds.entitlement.enums import PipelinePassId
 
             profile = AnthropicCapabilityProfile()
             adapter = AnthropicDirectAdapter(api_key=api_key, profile=profile)
             writer_model = profile.model_for(PipelinePassId.WRITER)
-            route = EligibleWriterRoute(
+            route = EligibleModelRoute(
                 provider_name="anthropic",
                 model_identifier=writer_model,
-                is_openrouter=False,
-                trusted_for_safety_skip=True,
+                whitelist_status=SafetyWhitelistStatus.WHITELISTED,
+                supports_required_capabilities=True,
+                capability_profile=make_anthropic_capability_profile(writer_model),
             )
             return adapter, route
 
         def _make_openrouter(
             api_key: str, model_id: str
-        ) -> tuple[OpenRouterAdapter, EligibleWriterRoute]:
+        ) -> tuple[OpenRouterAdapter, EligibleModelRoute]:
             adapter = OpenRouterAdapter(model_identifier=model_id, api_key=api_key)
-            route = EligibleWriterRoute(
-                provider_name="openrouter",
-                model_identifier=model_id,
-                is_openrouter=True,
-                trusted_for_safety_skip=False,
-            )
+            route = self._resolve_openrouter_route(model_id)
             return adapter, route
 
         def _get_openrouter_model(sojourner_id: UUID) -> str:
@@ -495,6 +503,41 @@ class ProviderResolver:
             access_path=RuntimeAccessPath.BYOK,
             pre_transaction_fn=proxy.start_buffering,
             post_transaction_fn=proxy.flush,
+        )
+
+    # -----------------------------------------------------------------------
+    # Private: OpenRouter route resolution (14b)
+    # -----------------------------------------------------------------------
+
+    def _resolve_openrouter_route(self, model_identifier: str) -> EligibleModelRoute:
+        """Resolve capability and whitelist status for an OpenRouter model route.
+
+        If no ``capability_registry`` was injected, falls back to fail-safe
+        defaults: UNKNOWN status, not capable, no profile.  This preserves the
+        14a behaviour (Safety always runs for OpenRouter) when the registry is
+        not yet configured.
+
+        Raises:
+            ProviderConfigError: if the registry rejects the model (dynamic alias
+                or positively incapable of serving the Writer pass).
+        """
+        if self._capability_registry is None:
+            return EligibleModelRoute(
+                provider_name="openrouter",
+                model_identifier=model_identifier,
+                whitelist_status=SafetyWhitelistStatus.UNKNOWN,
+                supports_required_capabilities=False,
+                capability_profile=None,
+            )
+        whitelist_status, profile, supports_required = (
+            self._capability_registry.resolve_route(model_identifier)
+        )
+        return EligibleModelRoute(
+            provider_name="openrouter",
+            model_identifier=model_identifier,
+            whitelist_status=whitelist_status,
+            supports_required_capabilities=supports_required,
+            capability_profile=profile,
         )
 
 

--- a/src/afterworlds/pipeline/provider/_routing.py
+++ b/src/afterworlds/pipeline/provider/_routing.py
@@ -1,13 +1,19 @@
 """Turn provider binding, safety policy context, and conservative safety policy.
 
-CRD Issue 14a.  These types encode which provider surfaces are eligible for a
+CRD Issue 14a/14b.  These types encode which provider surfaces are eligible for a
 given turn and whether the Safety envelope may be skipped.
+
+14b supersedes the 14a ``EligibleWriterRoute`` with ``EligibleModelRoute``.  The
+safety-skip predicate is upgraded from a single ``trusted_for_safety_skip`` bool to
+whitelist-status + capability evaluation.
 """
 
 from __future__ import annotations
 
+import enum
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 
 from afterworlds.entitlement.enums import RuntimeAccessPath
 from afterworlds.pipeline.writer.models import WriterResult
@@ -18,23 +24,113 @@ def _noop() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Eligible Writer route
+# Capability evidence source
+# ---------------------------------------------------------------------------
+
+
+class CapabilityEvidenceSource(enum.StrEnum):
+    """Origin of a ``ModelRouteCapabilityProfile``.
+
+    MANUAL_FIXTURE: hand-authored entry in a static fixture file.
+    OPENROUTER_MODELS_API: sourced from the live OpenRouter /models endpoint.
+    AFTERWORLDS_VERIFIED: Afterworlds-owned profile for a known-good route
+        (e.g. Anthropic-direct).  Implicitly WHITELISTED.
+    TEST_FIXTURE: in-memory entry constructed only in tests.
+    """
+
+    MANUAL_FIXTURE = "manual_fixture"
+    OPENROUTER_MODELS_API = "openrouter_models_api"
+    AFTERWORLDS_VERIFIED = "afterworlds_verified"
+    TEST_FIXTURE = "test_fixture"
+
+
+# ---------------------------------------------------------------------------
+# Safety whitelist status
+# ---------------------------------------------------------------------------
+
+
+class SafetyWhitelistStatus(enum.StrEnum):
+    """Whitelist resolution outcome for a model route.
+
+    WHITELISTED: model id is on the explicit Safety-skip whitelist.
+    NOT_WHITELISTED: model id is present in the catalog but not on the whitelist.
+    UNKNOWN: model id was not found in the catalog (catalog miss).
+    DISABLED: whitelist enforcement is administratively disabled.
+    STALE: model was on the whitelist but is no longer seen in the catalog.
+
+    Both UNKNOWN and STALE force Safety (identical to a catalog miss).
+    """
+
+    WHITELISTED = "whitelisted"
+    NOT_WHITELISTED = "not_whitelisted"
+    UNKNOWN = "unknown"
+    DISABLED = "disabled"
+    STALE = "stale"
+
+
+# ---------------------------------------------------------------------------
+# Model-route capability profile
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
-class EligibleWriterRoute:
+class ModelRouteCapabilityProfile:
+    """Capability facts for one exact-model-route, from catalog or fixture.
+
+    All three supports_* fields use tri-state (True / False / None):
+      - True:  provider catalog confirms support.
+      - False: provider catalog confirms no support; route may be rejected.
+      - None:  support status unknown (fail-safe: do not reject; Safety runs).
+
+    ``context_length=None`` means unverified; route is not rejected but
+    ``supports_required_capabilities`` is set False on the parent route.
+
+    ``is_dynamic_router=True`` means this entry describes a routing alias, not
+    a leaf model.  The registry rejects such entries at route construction.
+    """
+
+    model_identifier: str
+    supports_text_output: bool | None
+    supports_tool_use: bool | None
+    supports_structured_output: bool | None
+    context_length: int | None
+    evidence_source: CapabilityEvidenceSource
+    is_dynamic_router: bool = False
+    verified_at: datetime | None = None
+    catalog_seen_at: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Eligible model route (replaces 14a EligibleWriterRoute)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EligibleModelRoute:
     """One candidate route that could serve the Writer pass for a given turn.
 
-    ``trusted_for_safety_skip`` is True ONLY for Anthropic-direct routes in
-    14a.  OpenRouter routes are always False.  14b will upgrade this predicate
-    to whitelist evaluation without changing this dataclass shape.
+    Supersedes the 14a ``EligibleWriterRoute``.  Safety-skip eligibility is now
+    determined by ``whitelist_status`` and ``supports_required_capabilities``
+    rather than a single ``trusted_for_safety_skip`` bool.
+
+    ``whitelist_status`` is WHITELISTED only when the model id appears on the
+    explicit Safety-skip whitelist.  Anthropic-direct routes are always WHITELISTED
+    via the AFTERWORLDS_VERIFIED profile (AC 15/18).
+
+    ``supports_required_capabilities`` is True only when the catalog positively
+    confirms the route can serve the Writer pass (``supports_text_output=True`` AND
+    context_length known and above the minimum floor).  Catalog miss, None fields,
+    and context_length=None all collapse to False (fail-safe; Safety runs).
+
+    ``capability_profile`` is None for catalog misses; populated when a profile
+    was found in the catalog or fixture.
     """
 
     provider_name: str
     model_identifier: str
-    is_openrouter: bool
-    trusted_for_safety_skip: bool
+    whitelist_status: SafetyWhitelistStatus
+    supports_required_capabilities: bool
+    capability_profile: ModelRouteCapabilityProfile | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -52,8 +148,8 @@ class TurnProviderBinding:
     """
 
     adapter: object  # ProviderAdapter — typed as object to avoid circular import
-    primary_writer_route: EligibleWriterRoute
-    eligible_writer_routes: tuple[EligibleWriterRoute, ...]
+    primary_writer_route: EligibleModelRoute
+    eligible_writer_routes: tuple[EligibleModelRoute, ...]
     access_path: RuntimeAccessPath
     pre_transaction_fn: Callable[[], None] = field(default=_noop)
     post_transaction_fn: Callable[[], None] = field(default=_noop)
@@ -69,45 +165,47 @@ class SafetyPolicyContext:
     """Context object passed to ``CapabilityProfileAwareSafetyPolicy`` methods.
 
     Replaces the 12c ``should_run_*(..., writer_provider: str, ...)`` signature.
-    This is the one non-additive 12c contract change in Issue 14a.
+    This is the one non-additive 12c contract change introduced in Issue 14a and
+    extended in 14b.
 
     ``writer_result`` is None for input-preflight decisions; populated for
     output-audit decisions.
     """
 
-    eligible_writer_routes: tuple[EligibleWriterRoute, ...]
+    eligible_writer_routes: tuple[EligibleModelRoute, ...]
     request_risk_signal: bool
     access_path: RuntimeAccessPath
     writer_result: WriterResult | None = field(default=None)
 
 
 # ---------------------------------------------------------------------------
-# Conservative safety policy (replaces 12c SafetyPolicy)
+# Conservative safety policy — upgraded in 14b to whitelist + capability eval
 # ---------------------------------------------------------------------------
 
 
 class CapabilityProfileAwareSafetyPolicy:
-    """Issue 14a replacement for the Issue 12c ``SafetyPolicy``.
+    """Issue 14b upgrade: Safety-skip requires WHITELISTED + capable on every route.
 
-    Rule: Safety may be skipped only when EVERY eligible Writer route — primary
-    AND fallback — is a trusted Anthropic-direct route AND there is no risk
-    signal.  An empty eligible set forces Safety.
+    Rule: Safety may be skipped only when EVERY eligible Writer route is
+    explicitly WHITELISTED AND confirms it supports the required capabilities,
+    AND there is no risk signal.  An empty eligible set forces Safety.
 
-    Consequences:
-      - Hosted Anthropic-only → may skip
-      - Hosted Anthropic + OpenRouter fallback → runs Safety (fallback is OR)
-      - BYOK OpenRouter → runs Safety
-      - BYOK Anthropic-only → may skip
-
-    The "every eligible route" rule prevents the fallback from becoming a tunnel
-    around Safety.  14b upgrades ``_can_skip`` to whitelist evaluation without
-    changing this class shape.
+    Consequences (14b):
+      - Anthropic-direct only       → WHITELISTED + capable → may skip
+      - Anthropic + OR fallback     → OR route NOT_WHITELISTED or UNKNOWN → Safety runs
+      - BYOK OR WHITELISTED+capable → may skip
+      - BYOK OR UNKNOWN (miss)      → Safety runs
+      - Any risk signal             → Safety runs
     """
 
     def _can_skip(self, ctx: SafetyPolicyContext) -> bool:
         if ctx.request_risk_signal or not ctx.eligible_writer_routes:
             return False
-        return all(r.trusted_for_safety_skip for r in ctx.eligible_writer_routes)
+        return all(
+            r.whitelist_status is SafetyWhitelistStatus.WHITELISTED
+            and r.supports_required_capabilities
+            for r in ctx.eligible_writer_routes
+        )
 
     def should_run_input_preflight(self, ctx: SafetyPolicyContext) -> bool:
         return not self._can_skip(ctx)
@@ -117,8 +215,11 @@ class CapabilityProfileAwareSafetyPolicy:
 
 
 __all__ = [
-    "EligibleWriterRoute",
-    "TurnProviderBinding",
-    "SafetyPolicyContext",
+    "CapabilityEvidenceSource",
     "CapabilityProfileAwareSafetyPolicy",
+    "EligibleModelRoute",
+    "ModelRouteCapabilityProfile",
+    "SafetyPolicyContext",
+    "SafetyWhitelistStatus",
+    "TurnProviderBinding",
 ]

--- a/src/afterworlds/pipeline/provider/_routing.py
+++ b/src/afterworlds/pipeline/provider/_routing.py
@@ -77,7 +77,7 @@ class SafetyWhitelistStatus(enum.StrEnum):
 class ModelRouteCapabilityProfile:
     """Capability facts for one exact-model-route, from catalog or fixture.
 
-    All three supports_* fields use tri-state (True / False / None):
+    All four supports_* fields use tri-state (True / False / None):
       - True:  provider catalog confirms support.
       - False: provider catalog confirms no support; route may be rejected.
       - None:  support status unknown (fail-safe: do not reject; Safety runs).
@@ -92,6 +92,7 @@ class ModelRouteCapabilityProfile:
     model_identifier: str
     supports_text_output: bool | None
     supports_tool_use: bool | None
+    supports_tool_choice: bool | None
     supports_structured_output: bool | None
     context_length: int | None
     evidence_source: CapabilityEvidenceSource

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -86,7 +86,8 @@ from afterworlds.pipeline.orchestrator import (
 )
 from afterworlds.pipeline.planner.models import PlannerOutput
 from afterworlds.pipeline.provider._routing import (
-    EligibleWriterRoute,
+    EligibleModelRoute,
+    SafetyWhitelistStatus,
     TurnProviderBinding,
 )
 from afterworlds.pipeline.safety.models import (
@@ -136,11 +137,15 @@ def _make_fake_resolver(trusted: bool = False) -> object:
     (safety may be skipped by ``CapabilityProfileAwareSafetyPolicy``).
     ``trusted=False`` (default) → routes are not trusted; safety always runs.
     """
-    route = EligibleWriterRoute(
+    route = EligibleModelRoute(
         provider_name="fake-anthropic",
         model_identifier="fake-anthropic:claude-test",
-        is_openrouter=False,
-        trusted_for_safety_skip=trusted,
+        whitelist_status=(
+            SafetyWhitelistStatus.WHITELISTED
+            if trusted
+            else SafetyWhitelistStatus.NOT_WHITELISTED
+        ),
+        supports_required_capabilities=trusted,
     )
     adapter = _FakeProviderAdapter()
     binding = TurnProviderBinding(

--- a/tests/pipeline/provider/test_adapters.py
+++ b/tests/pipeline/provider/test_adapters.py
@@ -34,8 +34,9 @@ from afterworlds.pipeline.provider._models import (
 )
 from afterworlds.pipeline.provider._routing import (
     CapabilityProfileAwareSafetyPolicy,
-    EligibleWriterRoute,
+    EligibleModelRoute,
     SafetyPolicyContext,
+    SafetyWhitelistStatus,
 )
 from afterworlds.pipeline.provider.adapters._anthropic import (
     AnthropicCapabilityProfile,
@@ -92,17 +93,30 @@ def _route(
     trusted: bool = True,
     provider: str = "anthropic",
     is_openrouter: bool = False,
-) -> EligibleWriterRoute:
-    return EligibleWriterRoute(
+) -> EligibleModelRoute:
+    """Build a test EligibleModelRoute.
+
+    ``trusted=True`` maps to WHITELISTED + capable (Anthropic-style trust).
+    ``trusted=False`` maps to NOT_WHITELISTED + not capable (OpenRouter default).
+    ``is_openrouter`` is unused in the new model; use ``provider`` instead.
+    """
+    if trusted:
+        return EligibleModelRoute(
+            provider_name=provider,
+            model_identifier="claude-sonnet-4-6",
+            whitelist_status=SafetyWhitelistStatus.WHITELISTED,
+            supports_required_capabilities=True,
+        )
+    return EligibleModelRoute(
         provider_name=provider,
         model_identifier="claude-sonnet-4-6",
-        is_openrouter=is_openrouter,
-        trusted_for_safety_skip=trusted,
+        whitelist_status=SafetyWhitelistStatus.NOT_WHITELISTED,
+        supports_required_capabilities=False,
     )
 
 
 def _ctx(
-    routes: tuple[EligibleWriterRoute, ...],
+    routes: tuple[EligibleModelRoute, ...],
     risk: bool = False,
     writer_result: object = None,
 ) -> SafetyPolicyContext:
@@ -198,7 +212,7 @@ def test_safety_policy_runs_when_any_route_untrusted() -> None:
     ctx = _ctx(
         (
             _route(trusted=True),
-            _route(trusted=False, provider="openrouter", is_openrouter=True),
+            _route(trusted=False, provider="openrouter"),
         )
     )
     assert policy.should_run_input_preflight(ctx)
@@ -207,7 +221,7 @@ def test_safety_policy_runs_when_any_route_untrusted() -> None:
 
 def test_safety_policy_runs_when_all_routes_untrusted() -> None:
     policy = CapabilityProfileAwareSafetyPolicy()
-    ctx = _ctx((_route(trusted=False, provider="openrouter", is_openrouter=True),))
+    ctx = _ctx((_route(trusted=False, provider="openrouter"),))
     assert policy.should_run_input_preflight(ctx)
 
 

--- a/tests/pipeline/provider/test_catalog.py
+++ b/tests/pipeline/provider/test_catalog.py
@@ -36,6 +36,7 @@ class TestOpenRouterCatalogModel:
         assert m.context_length is None
         assert m.supports_text_output is None
         assert m.supports_tool_use is None
+        assert m.supports_tool_choice is None
         assert m.supports_structured_output is None
         assert m.is_dynamic_router is False
 
@@ -50,12 +51,14 @@ class TestOpenRouterCatalogModel:
             id="vendor/model",
             supports_text_output=True,
             supports_tool_use=False,
+            supports_tool_choice=True,
             supports_structured_output=None,
             context_length=128_000,
             is_dynamic_router=False,
         )
         assert m.supports_text_output is True
         assert m.supports_tool_use is False
+        assert m.supports_tool_choice is True
         assert m.supports_structured_output is None
         assert m.context_length == 128_000
 
@@ -151,6 +154,7 @@ class TestLiveOpenRouterCatalogProvider:
         assert m.context_length == 32_768
         assert m.supports_text_output is True
         assert m.supports_tool_use is True
+        assert m.supports_tool_choice is False
         assert m.supports_structured_output is False
 
     def test_no_text_in_output_modalities_gives_false(self) -> None:
@@ -170,25 +174,27 @@ class TestLiveOpenRouterCatalogProvider:
         assert results[0].supports_text_output is False
 
     def test_supported_parameters_tools_only(self) -> None:
-        """supported_parameters=['tools'] → tool_use=True, structured_output=False."""
+        """['tools'] → tool_use=True, tool_choice=False, structured=False."""
         payload = [{"id": "v/m", "supported_parameters": ["tools"]}]
         mock_resp = _make_api_response(payload)
         with patch("urllib.request.urlopen", return_value=mock_resp):
             results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
         assert results[0].supports_tool_use is True
+        assert results[0].supports_tool_choice is False
         assert results[0].supports_structured_output is False
 
     def test_supported_parameters_structured_outputs_only(self) -> None:
-        """['structured_outputs'] → tool_use=False, structured_output=True."""
+        """['structured_outputs'] → tool_use/choice=False, structured=True."""
         payload = [{"id": "v/m", "supported_parameters": ["structured_outputs"]}]
         mock_resp = _make_api_response(payload)
         with patch("urllib.request.urlopen", return_value=mock_resp):
             results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
         assert results[0].supports_tool_use is False
+        assert results[0].supports_tool_choice is False
         assert results[0].supports_structured_output is True
 
     def test_supported_parameters_both(self) -> None:
-        """supported_parameters with both values → both True."""
+        """tools+structured: tool_use=True, tool_choice=False, structured=True."""
         payload = [
             {"id": "v/m", "supported_parameters": ["tools", "structured_outputs"]}
         ]
@@ -196,33 +202,57 @@ class TestLiveOpenRouterCatalogProvider:
         with patch("urllib.request.urlopen", return_value=mock_resp):
             results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
         assert results[0].supports_tool_use is True
+        assert results[0].supports_tool_choice is False
         assert results[0].supports_structured_output is True
 
+    def test_supported_parameters_tools_and_tool_choice(self) -> None:
+        """tools+tool_choice → tool_use=True, tool_choice=True, structured=False."""
+        payload = [{"id": "v/m", "supported_parameters": ["tools", "tool_choice"]}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is True
+        assert results[0].supports_tool_choice is True
+        assert results[0].supports_structured_output is False
+
+    def test_supported_parameters_tool_choice_only(self) -> None:
+        """['tool_choice'] → tool_use=False, tool_choice=True, structured=False."""
+        payload = [{"id": "v/m", "supported_parameters": ["tool_choice"]}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is False
+        assert results[0].supports_tool_choice is True
+        assert results[0].supports_structured_output is False
+
     def test_supported_parameters_empty_list(self) -> None:
-        """supported_parameters=[] (list present, no matching values) → both False."""
+        """supported_parameters=[] (list present, no matching values) → all False."""
         payload = [{"id": "v/m", "supported_parameters": []}]
         mock_resp = _make_api_response(payload)
         with patch("urllib.request.urlopen", return_value=mock_resp):
             results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
         assert results[0].supports_tool_use is False
+        assert results[0].supports_tool_choice is False
         assert results[0].supports_structured_output is False
 
     def test_supported_parameters_absent(self) -> None:
-        """supported_parameters absent → both None (fail-safe)."""
+        """supported_parameters absent → all None (fail-safe)."""
         payload = [{"id": "v/m"}]
         mock_resp = _make_api_response(payload)
         with patch("urllib.request.urlopen", return_value=mock_resp):
             results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
         assert results[0].supports_tool_use is None
+        assert results[0].supports_tool_choice is None
         assert results[0].supports_structured_output is None
 
     def test_supported_parameters_malformed_non_list(self) -> None:
-        """supported_parameters is not a list → both None (fail-safe)."""
+        """supported_parameters is not a list → all None (fail-safe)."""
         payload = [{"id": "v/m", "supported_parameters": "tools"}]
         mock_resp = _make_api_response(payload)
         with patch("urllib.request.urlopen", return_value=mock_resp):
             results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
         assert results[0].supports_tool_use is None
+        assert results[0].supports_tool_choice is None
         assert results[0].supports_structured_output is None
 
     def test_missing_architecture_gives_none_text_support(self) -> None:

--- a/tests/pipeline/provider/test_catalog.py
+++ b/tests/pipeline/provider/test_catalog.py
@@ -136,8 +136,7 @@ class TestLiveOpenRouterCatalogProvider:
                 "name": "Model Name",
                 "context_length": 32_768,
                 "architecture": {"output_modalities": ["text"]},
-                "supports_tool_use": True,
-                "supports_structured_output": False,
+                "supported_parameters": ["tools"],
             }
         ]
         mock_resp = _make_api_response(payload)
@@ -154,7 +153,8 @@ class TestLiveOpenRouterCatalogProvider:
         assert m.supports_tool_use is True
         assert m.supports_structured_output is False
 
-    def test_no_text_in_output_modalities_gives_none(self) -> None:
+    def test_no_text_in_output_modalities_gives_false(self) -> None:
+        """output_modalities list present but 'text' absent → False (not None)."""
         payload = [
             {
                 "id": "vendor/vision-only",
@@ -167,7 +167,63 @@ class TestLiveOpenRouterCatalogProvider:
             results = list(provider.fetch_catalog())
 
         assert len(results) == 1
-        assert results[0].supports_text_output is None
+        assert results[0].supports_text_output is False
+
+    def test_supported_parameters_tools_only(self) -> None:
+        """supported_parameters=['tools'] → tool_use=True, structured_output=False."""
+        payload = [{"id": "v/m", "supported_parameters": ["tools"]}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is True
+        assert results[0].supports_structured_output is False
+
+    def test_supported_parameters_structured_outputs_only(self) -> None:
+        """['structured_outputs'] → tool_use=False, structured_output=True."""
+        payload = [{"id": "v/m", "supported_parameters": ["structured_outputs"]}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is False
+        assert results[0].supports_structured_output is True
+
+    def test_supported_parameters_both(self) -> None:
+        """supported_parameters with both values → both True."""
+        payload = [
+            {"id": "v/m", "supported_parameters": ["tools", "structured_outputs"]}
+        ]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is True
+        assert results[0].supports_structured_output is True
+
+    def test_supported_parameters_empty_list(self) -> None:
+        """supported_parameters=[] (list present, no matching values) → both False."""
+        payload = [{"id": "v/m", "supported_parameters": []}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is False
+        assert results[0].supports_structured_output is False
+
+    def test_supported_parameters_absent(self) -> None:
+        """supported_parameters absent → both None (fail-safe)."""
+        payload = [{"id": "v/m"}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is None
+        assert results[0].supports_structured_output is None
+
+    def test_supported_parameters_malformed_non_list(self) -> None:
+        """supported_parameters is not a list → both None (fail-safe)."""
+        payload = [{"id": "v/m", "supported_parameters": "tools"}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is None
+        assert results[0].supports_structured_output is None
 
     def test_missing_architecture_gives_none_text_support(self) -> None:
         payload = [{"id": "vendor/model"}]

--- a/tests/pipeline/provider/test_catalog.py
+++ b/tests/pipeline/provider/test_catalog.py
@@ -225,6 +225,31 @@ class TestLiveOpenRouterCatalogProvider:
         assert results[0].supports_tool_choice is True
         assert results[0].supports_structured_output is False
 
+    def test_supported_parameters_response_format_only(self) -> None:
+        """['response_format'] → tool_use/choice=False, structured=True."""
+        payload = [{"id": "v/m", "supported_parameters": ["response_format"]}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is False
+        assert results[0].supports_tool_choice is False
+        assert results[0].supports_structured_output is True
+
+    def test_supported_parameters_structured_and_response_format(self) -> None:
+        """structured_outputs+response_format → structured=True."""
+        payload = [
+            {
+                "id": "v/m",
+                "supported_parameters": ["structured_outputs", "response_format"],
+            }
+        ]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            results = list(LiveOpenRouterCatalogProvider(api_key="k").fetch_catalog())
+        assert results[0].supports_tool_use is False
+        assert results[0].supports_tool_choice is False
+        assert results[0].supports_structured_output is True
+
     def test_supported_parameters_empty_list(self) -> None:
         """supported_parameters=[] (list present, no matching values) → all False."""
         payload = [{"id": "v/m", "supported_parameters": []}]

--- a/tests/pipeline/provider/test_catalog.py
+++ b/tests/pipeline/provider/test_catalog.py
@@ -1,0 +1,245 @@
+"""Tests for OpenRouter catalog providers — CRD Issue 14b.
+
+Coverage targets:
+  - FixtureOpenRouterCatalogProvider: empty default, custom entries, protocol.
+  - OpenRouterCatalogModel: tri-state fields, extra='forbid', fetched_at default.
+  - LiveOpenRouterCatalogProvider: mocked urllib response; skipped in CI.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from afterworlds.pipeline.provider._catalog import (
+    FixtureOpenRouterCatalogProvider,
+    LiveOpenRouterCatalogProvider,
+    OpenRouterCatalogModel,
+    OpenRouterModelCatalogProvider,
+)
+
+# ---------------------------------------------------------------------------
+# OpenRouterCatalogModel
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterCatalogModel:
+    def test_required_id_only(self) -> None:
+        m = OpenRouterCatalogModel(id="vendor/model")
+        assert m.id == "vendor/model"
+        assert m.name == ""
+        assert m.context_length is None
+        assert m.supports_text_output is None
+        assert m.supports_tool_use is None
+        assert m.supports_structured_output is None
+        assert m.is_dynamic_router is False
+
+    def test_fetched_at_defaults_to_utc_now(self) -> None:
+        before = datetime.now(UTC)
+        m = OpenRouterCatalogModel(id="x")
+        after = datetime.now(UTC)
+        assert before <= m.fetched_at <= after
+
+    def test_all_capability_fields_explicitly_set(self) -> None:
+        m = OpenRouterCatalogModel(
+            id="vendor/model",
+            supports_text_output=True,
+            supports_tool_use=False,
+            supports_structured_output=None,
+            context_length=128_000,
+            is_dynamic_router=False,
+        )
+        assert m.supports_text_output is True
+        assert m.supports_tool_use is False
+        assert m.supports_structured_output is None
+        assert m.context_length == 128_000
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            OpenRouterCatalogModel(id="x", unknown_field="bad")  # type: ignore[call-arg]
+
+    def test_is_dynamic_router_flag(self) -> None:
+        m = OpenRouterCatalogModel(id="openrouter/auto", is_dynamic_router=True)
+        assert m.is_dynamic_router is True
+
+
+# ---------------------------------------------------------------------------
+# FixtureOpenRouterCatalogProvider
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureOpenRouterCatalogProvider:
+    def test_default_empty_catalog(self) -> None:
+        provider = FixtureOpenRouterCatalogProvider()
+        assert list(provider.fetch_catalog()) == []
+
+    def test_none_entries_treated_as_empty(self) -> None:
+        provider = FixtureOpenRouterCatalogProvider(entries=None)
+        assert list(provider.fetch_catalog()) == []
+
+    def test_custom_entries_returned(self) -> None:
+        entry = OpenRouterCatalogModel(id="vendor/model")
+        provider = FixtureOpenRouterCatalogProvider(entries=[entry])
+        result = list(provider.fetch_catalog())
+        assert len(result) == 1
+        assert result[0].id == "vendor/model"
+
+    def test_multiple_entries_preserved_in_order(self) -> None:
+        entries = [
+            OpenRouterCatalogModel(id="a/m1"),
+            OpenRouterCatalogModel(id="b/m2"),
+            OpenRouterCatalogModel(id="c/m3"),
+        ]
+        provider = FixtureOpenRouterCatalogProvider(entries=entries)
+        ids = [m.id for m in provider.fetch_catalog()]
+        assert ids == ["a/m1", "b/m2", "c/m3"]
+
+    def test_fetch_catalog_called_repeatedly_returns_same_list(self) -> None:
+        entry = OpenRouterCatalogModel(id="x/y")
+        provider = FixtureOpenRouterCatalogProvider(entries=[entry])
+        first = list(provider.fetch_catalog())
+        second = list(provider.fetch_catalog())
+        assert first == second
+
+    def test_satisfies_protocol(self) -> None:
+        provider = FixtureOpenRouterCatalogProvider()
+        assert isinstance(provider, OpenRouterModelCatalogProvider)
+
+
+# ---------------------------------------------------------------------------
+# LiveOpenRouterCatalogProvider — mocked network
+# ---------------------------------------------------------------------------
+
+
+def _make_api_response(data: list[dict[str, Any]]) -> MagicMock:
+    """Build a mock urlopen context manager returning a JSON payload."""
+    body = json.dumps({"data": data}).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestLiveOpenRouterCatalogProvider:
+    """Network calls are mocked; no real HTTP is made."""
+
+    def test_parses_text_output_from_output_modalities(self) -> None:
+        payload = [
+            {
+                "id": "vendor/model",
+                "name": "Model Name",
+                "context_length": 32_768,
+                "architecture": {"output_modalities": ["text"]},
+                "supports_tool_use": True,
+                "supports_structured_output": False,
+            }
+        ]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="test-key")
+            results = list(provider.fetch_catalog())
+
+        assert len(results) == 1
+        m = results[0]
+        assert m.id == "vendor/model"
+        assert m.name == "Model Name"
+        assert m.context_length == 32_768
+        assert m.supports_text_output is True
+        assert m.supports_tool_use is True
+        assert m.supports_structured_output is False
+
+    def test_no_text_in_output_modalities_gives_none(self) -> None:
+        payload = [
+            {
+                "id": "vendor/vision-only",
+                "architecture": {"output_modalities": ["image"]},
+            }
+        ]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="key")
+            results = list(provider.fetch_catalog())
+
+        assert len(results) == 1
+        assert results[0].supports_text_output is None
+
+    def test_missing_architecture_gives_none_text_support(self) -> None:
+        payload = [{"id": "vendor/model"}]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="key")
+            results = list(provider.fetch_catalog())
+
+        assert results[0].supports_text_output is None
+
+    def test_entry_with_empty_id_skipped(self) -> None:
+        payload = [
+            {"id": ""},
+            {"id": "vendor/valid"},
+        ]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="key")
+            results = list(provider.fetch_catalog())
+
+        assert len(results) == 1
+        assert results[0].id == "vendor/valid"
+
+    def test_empty_data_list_returns_empty(self) -> None:
+        mock_resp = _make_api_response([])
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="key")
+            results = list(provider.fetch_catalog())
+        assert results == []
+
+    def test_missing_data_key_returns_empty(self) -> None:
+        body = json.dumps({}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="key")
+            results = list(provider.fetch_catalog())
+        assert results == []
+
+    def test_is_dynamic_router_flag_parsed(self) -> None:
+        payload = [
+            {"id": "openrouter/auto", "is_dynamic_router": True},
+        ]
+        mock_resp = _make_api_response(payload)
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            provider = LiveOpenRouterCatalogProvider(api_key="key")
+            results = list(provider.fetch_catalog())
+
+        assert results[0].is_dynamic_router is True
+
+    def test_auth_header_sent(self) -> None:
+        mock_resp = _make_api_response([])
+        mock_request_cls = MagicMock(return_value=MagicMock())
+        with (
+            patch(
+                "afterworlds.pipeline.provider._catalog.urllib.request.Request",
+                mock_request_cls,
+            ),
+            patch(
+                "afterworlds.pipeline.provider._catalog.urllib.request.urlopen",
+                return_value=mock_resp,
+            ),
+        ):
+            provider = LiveOpenRouterCatalogProvider(api_key="sk-test")
+            provider.fetch_catalog()
+
+        _, kwargs = mock_request_cls.call_args
+        headers: dict[str, str] = kwargs.get("headers", {})
+        assert headers.get("Authorization") == "Bearer sk-test"
+
+    def test_satisfies_protocol(self) -> None:
+        provider = LiveOpenRouterCatalogProvider(api_key="key")
+        assert isinstance(provider, OpenRouterModelCatalogProvider)

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -247,14 +247,36 @@ def test_tool_use_true_structured_none_is_capable() -> None:
     assert capable is True
 
 
-def test_tool_use_none_structured_output_true_is_capable() -> None:
-    """structured_output=True satisfies structured requirement even if tool_use=None."""
+def test_tool_use_none_structured_output_true_is_not_capable() -> None:
+    """structured_output=True, tool_use=None → not capable (adapter: tools only)."""
     entry = _catalog_entry(
         _MODEL, supports_tool_use=None, supports_structured_output=True
     )
     registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
     _, _, capable = registry.resolve_route(_MODEL)
+    assert capable is False
+
+
+def test_tool_use_true_structured_output_false_is_capable() -> None:
+    """tool_use=True, structured_output=False → capable (adapter path confirmed)."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=True, supports_structured_output=False
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    _, _, capable = registry.resolve_route(_MODEL)
     assert capable is True
+
+
+def test_tool_use_false_structured_output_true_is_not_capable() -> None:
+    """tool_use=False + structured_output=True → not capable, not rejected."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=False, supports_structured_output=True
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is False
+    assert profile is not None  # route is live; AC 11 did not fire
+    assert status is SafetyWhitelistStatus.WHITELISTED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -52,6 +52,7 @@ def _catalog_entry(
     *,
     supports_text_output: bool | None = True,
     supports_tool_use: bool | None = True,
+    supports_tool_choice: bool | None = True,
     supports_structured_output: bool | None = True,
     context_length: int | None = 200_000,
     is_dynamic_router: bool = False,
@@ -62,6 +63,7 @@ def _catalog_entry(
         context_length=context_length,
         supports_text_output=supports_text_output,
         supports_tool_use=supports_tool_use,
+        supports_tool_choice=supports_tool_choice,
         supports_structured_output=supports_structured_output,
         is_dynamic_router=is_dynamic_router,
         fetched_at=_NOW,
@@ -295,6 +297,38 @@ def test_tool_use_false_structured_output_true_is_not_capable() -> None:
     assert capable is False
     assert profile is not None  # route is live; AC 11 did not fire
     assert status is SafetyWhitelistStatus.WHITELISTED
+
+
+# ---------------------------------------------------------------------------
+# Step 6: tool_choice contract — adapter-realized capability (P2)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_choice_false_is_not_capable() -> None:
+    """tool_use=True but tool_choice=False → not capable; route live, Safety runs."""
+    entry = _catalog_entry(_MODEL, supports_tool_choice=False)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is False
+    assert profile is not None
+    assert status is SafetyWhitelistStatus.WHITELISTED
+
+
+def test_tool_choice_none_is_not_capable() -> None:
+    """tool_use=True but tool_choice=None → not capable (unverified; fail-safe)."""
+    entry = _catalog_entry(_MODEL, supports_tool_choice=None)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    _, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is False
+    assert profile is not None
+
+
+def test_both_tool_use_and_tool_choice_true_is_capable() -> None:
+    """tool_use=True AND tool_choice=True → capable (complete adapter contract)."""
+    entry = _catalog_entry(_MODEL, supports_tool_use=True, supports_tool_choice=True)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    _, _, capable = registry.resolve_route(_MODEL)
+    assert capable is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -227,14 +227,34 @@ def test_tool_use_none_structured_output_false_does_not_raise() -> None:
 
 
 def test_both_structured_fields_none_does_not_raise() -> None:
-    """tool_use=None + structured_output=None: both unverified → no reject."""
+    """tool_use=None + structured_output=None: unverified → no reject, capable=False."""
     entry = _catalog_entry(
         _MODEL, supports_tool_use=None, supports_structured_output=None
     )
     registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
     status, profile, capable = registry.resolve_route(_MODEL)
     assert profile is not None
-    assert capable is True  # text_output=True + context_length=200000 >= floor
+    assert capable is False  # unverified structured → Safety must run
+
+
+def test_tool_use_true_structured_none_is_capable() -> None:
+    """tool_use=True satisfies structured requirement even if structured_output=None."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=True, supports_structured_output=None
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    _, _, capable = registry.resolve_route(_MODEL)
+    assert capable is True
+
+
+def test_tool_use_none_structured_output_true_is_capable() -> None:
+    """structured_output=True satisfies structured requirement even if tool_use=None."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=None, supports_structured_output=True
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    _, _, capable = registry.resolve_route(_MODEL)
+    assert capable is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -1,0 +1,360 @@
+"""Tests for OpenRouterCapabilityRegistry (CRD Issue 14b).
+
+Coverage targets:
+  - Resolution ladder: static deny-set, catalog miss, dynamic alias entry,
+    positive-evidence rejection, capability evaluation, whitelist lookup.
+  - UNKNOWN / STALE / WHITELISTED / NOT_WHITELISTED / DISABLED paths.
+  - Fail-safe cases: text_output=None, context_length=None, below-floor.
+  - _can_skip interaction: DISABLED + capable must NOT skip Safety.
+  - Catalog caching: fetch_catalog called only once per registry instance.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from afterworlds.entitlement.enums import RuntimeAccessPath
+from afterworlds.pipeline.provider._catalog import (
+    FixtureOpenRouterCatalogProvider,
+    OpenRouterCatalogModel,
+)
+from afterworlds.pipeline.provider._errors import ProviderConfigError
+from afterworlds.pipeline.provider._registry import (
+    _WRITER_CONTEXT_LENGTH_FLOOR,
+    OpenRouterCapabilityRegistry,
+    WhitelistConfig,
+    WhitelistEntry,
+)
+from afterworlds.pipeline.provider._routing import (
+    CapabilityEvidenceSource,
+    CapabilityProfileAwareSafetyPolicy,
+    EligibleModelRoute,
+    SafetyPolicyContext,
+    SafetyWhitelistStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 6, 1, tzinfo=UTC)
+_MODEL = "anthropic/claude-opus-4"
+_MODEL_2 = "mistralai/mistral-7b-instruct"
+
+
+def _catalog_entry(
+    model_id: str = _MODEL,
+    *,
+    supports_text_output: bool | None = True,
+    supports_tool_use: bool | None = True,
+    supports_structured_output: bool | None = True,
+    context_length: int | None = 200_000,
+    is_dynamic_router: bool = False,
+) -> OpenRouterCatalogModel:
+    return OpenRouterCatalogModel(
+        id=model_id,
+        name=model_id,
+        context_length=context_length,
+        supports_text_output=supports_text_output,
+        supports_tool_use=supports_tool_use,
+        supports_structured_output=supports_structured_output,
+        is_dynamic_router=is_dynamic_router,
+        fetched_at=_NOW,
+    )
+
+
+def _whitelist(*model_ids: str) -> WhitelistConfig:
+    return WhitelistConfig(
+        enabled=True,
+        entries={
+            mid: WhitelistEntry(model_identifier=mid, approved_at=_NOW)
+            for mid in model_ids
+        },
+    )
+
+
+def _make_registry(
+    entries: list[OpenRouterCatalogModel] | None = None,
+    whitelist: WhitelistConfig | None = None,
+) -> OpenRouterCapabilityRegistry:
+    provider = FixtureOpenRouterCatalogProvider(entries or [])
+    return OpenRouterCapabilityRegistry(
+        whitelist_config=whitelist,
+        catalog_provider=provider,
+    )
+
+
+def _eligible_route(
+    whitelist_status: SafetyWhitelistStatus,
+    capable: bool,
+) -> EligibleModelRoute:
+    return EligibleModelRoute(
+        provider_name="openrouter",
+        model_identifier=_MODEL,
+        whitelist_status=whitelist_status,
+        supports_required_capabilities=capable,
+    )
+
+
+def _ctx(*routes: EligibleModelRoute) -> SafetyPolicyContext:
+    return SafetyPolicyContext(
+        eligible_writer_routes=tuple(routes),
+        request_risk_signal=False,
+        access_path=RuntimeAccessPath.HOSTED,
+    )
+
+
+_policy = CapabilityProfileAwareSafetyPolicy()
+
+
+# ---------------------------------------------------------------------------
+# Step 1: static deny-set (dynamic alias rejected pre-catalog)
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_alias_rejected_before_catalog_lookup() -> None:
+    """Dynamic alias raises ProviderConfigError without hitting the catalog."""
+    # "openrouter/auto" is the canonical dynamic alias
+    registry = _make_registry(
+        entries=[_catalog_entry("openrouter/auto")],
+    )
+    with pytest.raises(ProviderConfigError, match="dynamic alias"):
+        registry.resolve_route("openrouter/auto")
+
+
+# ---------------------------------------------------------------------------
+# Step 3: catalog miss
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_miss_not_whitelisted_returns_unknown() -> None:
+    """Catalog miss + not whitelisted → (UNKNOWN, None, False), no raise."""
+    registry = _make_registry()  # empty catalog, no whitelist entries
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.UNKNOWN
+    assert profile is None
+    assert capable is False
+
+
+def test_catalog_miss_whitelisted_returns_stale() -> None:
+    """Catalog miss + whitelisted → (STALE, None, False), no raise."""
+    registry = _make_registry(whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.STALE
+    assert profile is None
+    assert capable is False
+
+
+# ---------------------------------------------------------------------------
+# Step 4: catalog-driven dynamic alias (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_entry_with_is_dynamic_router_raises() -> None:
+    """Catalog entry marked is_dynamic_router=True raises ProviderConfigError."""
+    entry = _catalog_entry(_MODEL, is_dynamic_router=True)
+    registry = _make_registry(entries=[entry])
+    with pytest.raises(ProviderConfigError, match="dynamic router alias"):
+        registry.resolve_route(_MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Step 5: positive-evidence rejection (text output explicitly False)
+# ---------------------------------------------------------------------------
+
+
+def test_text_output_false_raises() -> None:
+    """supports_text_output=False → ProviderConfigError; route rejected."""
+    entry = _catalog_entry(_MODEL, supports_text_output=False)
+    registry = _make_registry(entries=[entry])
+    with pytest.raises(ProviderConfigError, match="text output"):
+        registry.resolve_route(_MODEL)
+
+
+def test_text_output_none_does_not_raise() -> None:
+    """supports_text_output=None → fail-safe; route not rejected."""
+    entry = _catalog_entry(_MODEL, supports_text_output=None, context_length=200_000)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is False  # unknown text_output → can't confirm capability
+    assert profile is not None
+    assert profile.supports_text_output is None
+
+
+# ---------------------------------------------------------------------------
+# Step 5 (context_length): below-floor is NOT a rejection
+# ---------------------------------------------------------------------------
+
+
+def test_context_length_below_floor_does_not_raise() -> None:
+    """context_length below floor sets capable=False but does not reject route."""
+    below_floor = _WRITER_CONTEXT_LENGTH_FLOOR - 1
+    entry = _catalog_entry(_MODEL, context_length=below_floor)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is False
+    assert status is SafetyWhitelistStatus.WHITELISTED
+    assert profile is not None
+    assert profile.context_length == below_floor
+
+
+def test_context_length_none_does_not_raise() -> None:
+    """context_length=None → unverified; route not rejected, capable=False."""
+    entry = _catalog_entry(_MODEL, context_length=None)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is False
+    assert profile is not None
+    assert profile.context_length is None
+
+
+# ---------------------------------------------------------------------------
+# Step 6: capability evaluation (full positive confirmation → capable)
+# ---------------------------------------------------------------------------
+
+
+def test_capable_whitelisted_route() -> None:
+    """text_output=True + context_length >= floor + whitelisted → capable."""
+    entry = _catalog_entry(_MODEL)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.WHITELISTED
+    assert capable is True
+    assert profile is not None
+    assert profile.evidence_source is CapabilityEvidenceSource.OPENROUTER_MODELS_API
+
+
+def test_capable_not_whitelisted_route() -> None:
+    """Capable route not on whitelist → (NOT_WHITELISTED, profile, True)."""
+    entry = _catalog_entry(_MODEL)
+    registry = _make_registry(entries=[entry])  # no whitelist entries
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.NOT_WHITELISTED
+    assert capable is True
+    assert profile is not None
+
+
+def test_capability_floor_boundary_exactly_at_floor() -> None:
+    """context_length exactly == floor → capable=True."""
+    entry = _catalog_entry(_MODEL, context_length=_WRITER_CONTEXT_LENGTH_FLOOR)
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    _, _, capable = registry.resolve_route(_MODEL)
+    assert capable is True
+
+
+def test_profile_catalog_seen_at_is_set() -> None:
+    """capability_profile.catalog_seen_at reflects the catalog entry's fetched_at."""
+    entry = _catalog_entry(_MODEL)
+    registry = _make_registry(entries=[entry])
+    _, profile, _ = registry.resolve_route(_MODEL)
+    assert profile is not None
+    assert profile.catalog_seen_at == _NOW
+
+
+# ---------------------------------------------------------------------------
+# Step 7: whitelist disabled → DISABLED
+# ---------------------------------------------------------------------------
+
+
+def test_whitelist_disabled_returns_disabled_status() -> None:
+    """WhitelistConfig(enabled=False) → DISABLED, capable evaluated normally."""
+    disabled_wl = WhitelistConfig(enabled=False)
+    entry = _catalog_entry(_MODEL)
+    registry = _make_registry(entries=[entry], whitelist=disabled_wl)
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.DISABLED
+    assert capable is True  # model is capable even though whitelist is disabled
+
+
+def test_disabled_whitelist_capable_route_cannot_skip_safety() -> None:
+    """DISABLED + capable → _can_skip returns False (DISABLED ≠ WHITELISTED)."""
+    route = _eligible_route(SafetyWhitelistStatus.DISABLED, capable=True)
+    assert _policy._can_skip(_ctx(route)) is False
+
+
+# ---------------------------------------------------------------------------
+# _can_skip integration (whitelist + capability both required)
+# ---------------------------------------------------------------------------
+
+
+def test_can_skip_requires_whitelisted_and_capable() -> None:
+    """_can_skip is True only when every route is WHITELISTED + capable."""
+    whitelisted_capable = _eligible_route(SafetyWhitelistStatus.WHITELISTED, True)
+    assert _policy._can_skip(_ctx(whitelisted_capable)) is True
+
+
+def test_can_skip_false_when_not_whitelisted() -> None:
+    not_wl = _eligible_route(SafetyWhitelistStatus.NOT_WHITELISTED, True)
+    assert _policy._can_skip(_ctx(not_wl)) is False
+
+
+def test_can_skip_false_when_unknown() -> None:
+    unknown = _eligible_route(SafetyWhitelistStatus.UNKNOWN, False)
+    assert _policy._can_skip(_ctx(unknown)) is False
+
+
+def test_can_skip_false_when_stale() -> None:
+    stale = _eligible_route(SafetyWhitelistStatus.STALE, False)
+    assert _policy._can_skip(_ctx(stale)) is False
+
+
+def test_can_skip_false_when_whitelisted_but_not_capable() -> None:
+    wl_not_capable = _eligible_route(SafetyWhitelistStatus.WHITELISTED, False)
+    assert _policy._can_skip(_ctx(wl_not_capable)) is False
+
+
+def test_can_skip_false_when_one_route_not_whitelisted() -> None:
+    """Mixed eligible set: one WHITELISTED, one NOT_WHITELISTED → Safety runs."""
+    primary = _eligible_route(SafetyWhitelistStatus.WHITELISTED, True)
+    fallback = EligibleModelRoute(
+        provider_name="openrouter",
+        model_identifier=_MODEL_2,
+        whitelist_status=SafetyWhitelistStatus.NOT_WHITELISTED,
+        supports_required_capabilities=True,
+    )
+    assert _policy._can_skip(_ctx(primary, fallback)) is False
+
+
+# ---------------------------------------------------------------------------
+# Catalog caching: fetch_catalog called only once
+# ---------------------------------------------------------------------------
+
+
+class _CountingCatalogProvider:
+    """Catalog provider that counts fetch_catalog calls."""
+
+    def __init__(self, entries: list[OpenRouterCatalogModel]) -> None:
+        self._entries = entries
+        self.call_count = 0
+
+    def fetch_catalog(self) -> list[OpenRouterCatalogModel]:
+        self.call_count += 1
+        return self._entries
+
+
+def test_catalog_fetched_only_once() -> None:
+    """Catalog is cached after the first resolve_route call."""
+    counter = _CountingCatalogProvider([_catalog_entry(_MODEL)])
+    registry = OpenRouterCapabilityRegistry(
+        whitelist_config=_whitelist(_MODEL),
+        catalog_provider=counter,
+    )
+    registry.resolve_route(_MODEL)
+    registry.resolve_route(_MODEL)
+    assert counter.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# No-registry fail-safe (tested via resolver; here via direct construction)
+# ---------------------------------------------------------------------------
+
+
+def test_default_registry_empty_catalog_returns_unknown() -> None:
+    """Default (no args) registry has empty catalog → all misses → UNKNOWN."""
+    registry = OpenRouterCapabilityRegistry()
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.UNKNOWN
+    assert profile is None
+    assert capable is False

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -299,6 +299,26 @@ def test_tool_use_false_structured_output_true_is_not_capable() -> None:
     assert status is SafetyWhitelistStatus.WHITELISTED
 
 
+def test_response_format_evidence_prevents_ac11_rejection() -> None:
+    """structured_output=True (from response_format) prevents AC 11 rejection.
+
+    At the registry, response_format-only and structured_outputs-only models
+    are the same input vector: tool_use=False, tool_choice=False, structured=True.
+    Both must not trigger AC 11; both are not capable (adapter path is tools only).
+    """
+    entry = _catalog_entry(
+        _MODEL,
+        supports_tool_use=False,
+        supports_tool_choice=False,
+        supports_structured_output=True,
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert profile is not None  # route live — AC 11 did not fire
+    assert capable is False  # adapter requires tool_use; Safety runs
+    assert status is SafetyWhitelistStatus.WHITELISTED
+
+
 # ---------------------------------------------------------------------------
 # Step 6: tool_choice contract — adapter-realized capability (P2)
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -2,16 +2,18 @@
 
 Coverage targets:
   - Resolution ladder: static deny-set, catalog miss, dynamic alias entry,
-    positive-evidence rejection, capability evaluation, whitelist lookup.
+    positive-evidence rejection (AC 11/12 + context floor), capability evaluation,
+    whitelist lookup.
   - UNKNOWN / STALE / WHITELISTED / NOT_WHITELISTED / DISABLED paths.
-  - Fail-safe cases: text_output=None, context_length=None, below-floor.
+  - Fail-safe cases: text_output=None, context_length=None.
+  - Time-based STALE (max_evidence_age).
   - _can_skip interaction: DISABLED + capable must NOT skip Safety.
   - Catalog caching: fetch_catalog called only once per registry instance.
 """
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -40,6 +42,7 @@ from afterworlds.pipeline.provider._routing import (
 # ---------------------------------------------------------------------------
 
 _NOW = datetime(2026, 6, 1, tzinfo=UTC)
+_OLD = datetime(2025, 1, 1, tzinfo=UTC)
 _MODEL = "anthropic/claude-opus-4"
 _MODEL_2 = "mistralai/mistral-7b-instruct"
 
@@ -65,11 +68,11 @@ def _catalog_entry(
     )
 
 
-def _whitelist(*model_ids: str) -> WhitelistConfig:
+def _whitelist(*model_ids: str, verified_at: datetime = _NOW) -> WhitelistConfig:
     return WhitelistConfig(
         enabled=True,
         entries={
-            mid: WhitelistEntry(model_identifier=mid, approved_at=_NOW)
+            mid: WhitelistEntry(model_identifier=mid, verified_at=verified_at)
             for mid in model_ids
         },
     )
@@ -78,11 +81,15 @@ def _whitelist(*model_ids: str) -> WhitelistConfig:
 def _make_registry(
     entries: list[OpenRouterCatalogModel] | None = None,
     whitelist: WhitelistConfig | None = None,
+    max_evidence_age: timedelta | None = None,
+    clock: None = None,
 ) -> OpenRouterCapabilityRegistry:
     provider = FixtureOpenRouterCatalogProvider(entries or [])
     return OpenRouterCapabilityRegistry(
         whitelist_config=whitelist,
         catalog_provider=provider,
+        max_evidence_age=max_evidence_age,
+        clock=clock,
     )
 
 
@@ -116,7 +123,6 @@ _policy = CapabilityProfileAwareSafetyPolicy()
 
 def test_dynamic_alias_rejected_before_catalog_lookup() -> None:
     """Dynamic alias raises ProviderConfigError without hitting the catalog."""
-    # "openrouter/auto" is the canonical dynamic alias
     registry = _make_registry(
         entries=[_catalog_entry("openrouter/auto")],
     )
@@ -184,20 +190,65 @@ def test_text_output_none_does_not_raise() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 5 (context_length): below-floor is NOT a rejection
+# Step 5: AC 11 — structured-pass incapability rejection
 # ---------------------------------------------------------------------------
 
 
-def test_context_length_below_floor_does_not_raise() -> None:
-    """context_length below floor sets capable=False but does not reject route."""
+def test_tool_use_false_and_structured_false_raises() -> None:
+    """tool_use=False AND structured_output=False → ProviderConfigError."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=False, supports_structured_output=False
+    )
+    registry = _make_registry(entries=[entry])
+    with pytest.raises(ProviderConfigError, match="structured"):
+        registry.resolve_route(_MODEL)
+
+
+def test_tool_use_false_structured_output_none_does_not_raise() -> None:
+    """tool_use=False but structured_output=None: unverified → no reject."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=False, supports_structured_output=None
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert profile is not None
+    assert status is SafetyWhitelistStatus.WHITELISTED
+
+
+def test_tool_use_none_structured_output_false_does_not_raise() -> None:
+    """structured_output=False but tool_use=None: unverified → no reject."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=None, supports_structured_output=False
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert profile is not None
+    assert status is SafetyWhitelistStatus.WHITELISTED
+
+
+def test_both_structured_fields_none_does_not_raise() -> None:
+    """tool_use=None + structured_output=None: both unverified → no reject."""
+    entry = _catalog_entry(
+        _MODEL, supports_tool_use=None, supports_structured_output=None
+    )
+    registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert profile is not None
+    assert capable is True  # text_output=True + context_length=200000 >= floor
+
+
+# ---------------------------------------------------------------------------
+# Step 5: context_length floor — rejection for known below-floor length
+# ---------------------------------------------------------------------------
+
+
+def test_context_length_below_floor_raises() -> None:
+    """context_length below floor raises ProviderConfigError (Writer context floor)."""
     below_floor = _WRITER_CONTEXT_LENGTH_FLOOR - 1
     entry = _catalog_entry(_MODEL, context_length=below_floor)
     registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
-    status, profile, capable = registry.resolve_route(_MODEL)
-    assert capable is False
-    assert status is SafetyWhitelistStatus.WHITELISTED
-    assert profile is not None
-    assert profile.context_length == below_floor
+    with pytest.raises(ProviderConfigError, match="context length"):
+        registry.resolve_route(_MODEL)
 
 
 def test_context_length_none_does_not_raise() -> None:
@@ -208,6 +259,21 @@ def test_context_length_none_does_not_raise() -> None:
     assert capable is False
     assert profile is not None
     assert profile.context_length is None
+
+
+def test_custom_floor_applies() -> None:
+    """writer_context_length_floor constructor param overrides default."""
+    low_floor = 1000
+    entry = _catalog_entry(_MODEL, context_length=2000)
+    # With a custom floor of 1000, context_length=2000 should NOT raise.
+    registry = OpenRouterCapabilityRegistry(
+        whitelist_config=_whitelist(_MODEL),
+        catalog_provider=FixtureOpenRouterCatalogProvider([entry]),
+        writer_context_length_floor=low_floor,
+    )
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert capable is True
+    assert status is SafetyWhitelistStatus.WHITELISTED
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +303,7 @@ def test_capable_not_whitelisted_route() -> None:
 
 
 def test_capability_floor_boundary_exactly_at_floor() -> None:
-    """context_length exactly == floor → capable=True."""
+    """context_length exactly == floor → capable=True (not rejected)."""
     entry = _catalog_entry(_MODEL, context_length=_WRITER_CONTEXT_LENGTH_FLOOR)
     registry = _make_registry(entries=[entry], whitelist=_whitelist(_MODEL))
     _, _, capable = registry.resolve_route(_MODEL)
@@ -272,6 +338,63 @@ def test_disabled_whitelist_capable_route_cannot_skip_safety() -> None:
     """DISABLED + capable → _can_skip returns False (DISABLED ≠ WHITELISTED)."""
     route = _eligible_route(SafetyWhitelistStatus.DISABLED, capable=True)
     assert _policy._can_skip(_ctx(route)) is False
+
+
+# ---------------------------------------------------------------------------
+# Step 7: time-based STALE (max_evidence_age)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_by_age_returns_stale_with_profile() -> None:
+    """Whitelist entry with verified_at older than max_evidence_age → STALE."""
+    entry = _catalog_entry(_MODEL)
+    old_wl = WhitelistConfig(
+        enabled=True,
+        entries={_MODEL: WhitelistEntry(model_identifier=_MODEL, verified_at=_OLD)},
+    )
+    # max_evidence_age=1 day; _OLD is 2025-01-01, _NOW is 2026-06-01 → stale
+    registry = OpenRouterCapabilityRegistry(
+        whitelist_config=old_wl,
+        catalog_provider=FixtureOpenRouterCatalogProvider([entry]),
+        max_evidence_age=timedelta(days=1),
+        clock=lambda: _NOW,
+    )
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.STALE
+    assert profile is not None
+    assert capable is True  # model IS capable; only the whitelist evidence is stale
+
+
+def test_fresh_whitelist_entry_not_stale() -> None:
+    """Whitelist entry with verified_at within max_evidence_age → WHITELISTED."""
+    entry = _catalog_entry(_MODEL)
+    # verified_at = _NOW; clock = _NOW + 12h; age = 1 day → NOT stale
+    clock_time = datetime(2026, 6, 1, 12, tzinfo=UTC)
+    registry = OpenRouterCapabilityRegistry(
+        whitelist_config=_whitelist(_MODEL, verified_at=_NOW),
+        catalog_provider=FixtureOpenRouterCatalogProvider([entry]),
+        max_evidence_age=timedelta(days=1),
+        clock=lambda: clock_time,
+    )
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.WHITELISTED
+    assert capable is True
+
+
+def test_no_max_evidence_age_never_stale_by_age() -> None:
+    """max_evidence_age=None → old verified_at does not trigger STALE."""
+    entry = _catalog_entry(_MODEL)
+    old_wl = WhitelistConfig(
+        enabled=True,
+        entries={_MODEL: WhitelistEntry(model_identifier=_MODEL, verified_at=_OLD)},
+    )
+    registry = OpenRouterCapabilityRegistry(
+        whitelist_config=old_wl,
+        catalog_provider=FixtureOpenRouterCatalogProvider([entry]),
+        max_evidence_age=None,
+    )
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.WHITELISTED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/provider/test_registry.py
+++ b/tests/pipeline/provider/test_registry.py
@@ -130,6 +130,14 @@ def test_dynamic_alias_rejected_before_catalog_lookup() -> None:
         registry.resolve_route("openrouter/auto")
 
 
+def test_dynamic_alias_rejected_with_disabled_whitelist() -> None:
+    """Dynamic alias raises ProviderConfigError even when whitelist is disabled."""
+    disabled_wl = WhitelistConfig(enabled=False)
+    registry = _make_registry(whitelist=disabled_wl)
+    with pytest.raises(ProviderConfigError, match="dynamic alias"):
+        registry.resolve_route("openrouter/auto")
+
+
 # ---------------------------------------------------------------------------
 # Step 3: catalog miss
 # ---------------------------------------------------------------------------
@@ -149,6 +157,16 @@ def test_catalog_miss_whitelisted_returns_stale() -> None:
     registry = _make_registry(whitelist=_whitelist(_MODEL))
     status, profile, capable = registry.resolve_route(_MODEL)
     assert status is SafetyWhitelistStatus.STALE
+    assert profile is None
+    assert capable is False
+
+
+def test_catalog_miss_disabled_whitelist_returns_disabled() -> None:
+    """Catalog miss + disabled whitelist → DISABLED, not UNKNOWN."""
+    disabled_wl = WhitelistConfig(enabled=False)
+    registry = _make_registry(whitelist=disabled_wl)  # empty catalog
+    status, profile, capable = registry.resolve_route(_MODEL)
+    assert status is SafetyWhitelistStatus.DISABLED
     assert profile is None
     assert capable is False
 

--- a/tests/pipeline/provider/test_resolver.py
+++ b/tests/pipeline/provider/test_resolver.py
@@ -78,7 +78,7 @@ def test_hosted_with_key_and_blank_model_raises() -> None:
 
 
 def test_hosted_anthropic_only_returns_single_eligible_route() -> None:
-    """No OpenRouter key → single Anthropic route with trusted_for_safety_skip=True."""
+    """No OpenRouter key → single Anthropic route WHITELISTED and capable."""
     cfg = HostedRoutingConfig(anthropic_api_key="sk-ant-test")
     binding = _resolver(cfg).resolve_for_turn(
         access_path=RuntimeAccessPath.HOSTED,
@@ -87,8 +87,10 @@ def test_hosted_anthropic_only_returns_single_eligible_route() -> None:
     assert len(binding.eligible_writer_routes) == 1
     route = binding.eligible_writer_routes[0]
     assert route.provider_name == "anthropic"
-    assert route.trusted_for_safety_skip is True
-    assert route.is_openrouter is False
+    from afterworlds.pipeline.provider._routing import SafetyWhitelistStatus
+
+    assert route.whitelist_status is SafetyWhitelistStatus.WHITELISTED
+    assert route.supports_required_capabilities is True
 
 
 def test_hosted_anthropic_only_access_path_is_hosted() -> None:
@@ -121,8 +123,8 @@ def test_hosted_with_key_and_model_returns_two_eligible_routes() -> None:
     assert providers == {"anthropic", "openrouter"}
 
 
-def test_hosted_openrouter_route_is_not_trusted_for_safety_skip() -> None:
-    """OpenRouter eligible route always has trusted_for_safety_skip=False."""
+def test_hosted_openrouter_route_without_registry_is_unknown() -> None:
+    """OpenRouter route without registry → UNKNOWN status, not capable (fail-safe)."""
     cfg = HostedRoutingConfig(
         anthropic_api_key="sk-ant-test",
         openrouter_api_key="sk-or-test",
@@ -132,8 +134,13 @@ def test_hosted_openrouter_route_is_not_trusted_for_safety_skip() -> None:
         access_path=RuntimeAccessPath.HOSTED,
         sojourner_id=uuid4(),
     )
-    or_route = next(r for r in binding.eligible_writer_routes if r.is_openrouter)
-    assert or_route.trusted_for_safety_skip is False
+    from afterworlds.pipeline.provider._routing import SafetyWhitelistStatus
+
+    or_route = next(
+        r for r in binding.eligible_writer_routes if r.provider_name == "openrouter"
+    )
+    assert or_route.whitelist_status is SafetyWhitelistStatus.UNKNOWN
+    assert or_route.supports_required_capabilities is False
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +280,9 @@ def test_byok_openrouter_padded_model_id_returns_stripped(engine) -> None:  # ty
     sess.close()
     resolver = _byok_resolver(sf)
     binding = resolver.resolve_for_turn(RuntimeAccessPath.BYOK, sid)
-    or_route = next(r for r in binding.eligible_writer_routes if r.is_openrouter)
+    or_route = next(
+        r for r in binding.eligible_writer_routes if r.provider_name == "openrouter"
+    )
     assert or_route.model_identifier == "anthropic/claude-haiku-4-5"
 
 


### PR DESCRIPTION
## Summary

Implements CRD Issue 14b: OpenRouter Model-Route Capability Registry and Safety Whitelist. This is an extension of Issue 14a; it does not reimplement adapters, credentials, fallback routing, or `ProviderRouteConfig`.

**New files:**
- `src/afterworlds/pipeline/provider/_catalog.py` — `OpenRouterCatalogModel`, `OpenRouterModelCatalogProvider` (Protocol), `FixtureOpenRouterCatalogProvider` (CI default, empty catalog), `LiveOpenRouterCatalogProvider` (stdlib `urllib.request`, opt-in)
- `src/afterworlds/pipeline/provider/_registry.py` — `OpenRouterCapabilityRegistry`, `WhitelistConfig`, `WhitelistEntry`, `make_anthropic_capability_profile()`
- `tests/pipeline/provider/test_catalog.py` — 20 tests (FixtureProvider, LiveProvider mocked, `extra="forbid"`, auth header, text-output parsing)
- `tests/pipeline/provider/test_registry.py` — 31 tests (all resolution ladder branches, AC 7/11/12, time-based STALE, _can_skip integration)
- `docs/decisions/adr-014b-openrouter-whitelist-registry.md` — 11 decisions

**Modified files:**
- `_routing.py` — `EligibleWriterRoute` → `EligibleModelRoute`; `SafetyWhitelistStatus` and `CapabilityEvidenceSource` as `enum.StrEnum`
- `_resolver.py` — Anthropic routes use `make_anthropic_capability_profile()`; OpenRouter routes use `OpenRouterCapabilityRegistry.resolve_route()`
- `__init__.py` — updated exports
- `test_adapters.py`, `test_resolver.py`, `test_service.py` — updated to `EligibleModelRoute`
- `known_unknowns.md` — two resolved items moved to Resolved table; OpenRouter cache verification remains Open

## Architecture Notes

**No drift from core design principles.** The safety envelope (conditional Input Preflight and Output Audit) is preserved. Stable-prefix assembled once per turn. Entitlement routing unaffected.

**EligibleWriterRoute → EligibleModelRoute (no compat alias).** Clean full replacement. The 14a boolean `trusted_for_safety_skip` is replaced by `whitelist_status: SafetyWhitelistStatus` + `supports_required_capabilities: bool`. Compat alias would leave old semantics reachable after 14b ships.

**Fail-safe rule.** Rejection only on positive evidence of incapability (`False`, not `None`). Catalog miss / `None` fields / `context_length=None` → Safety runs, route not rejected.

**Resolution ladder (7 steps in `resolve_route`):**
1. Static deny-set: dynamic aliases rejected before catalog fetch
2. Catalog lookup (cached per registry instance)
3. Catalog miss: `UNKNOWN` (not whitelisted) or `STALE` (whitelisted but not in catalog)
4. `is_dynamic_router=True` in catalog: rejected (defense-in-depth)
5. Positive-evidence rejection: `supports_text_output is False` (Writer), `tool_use is False AND structured_output is False` (AC 11, Planner/Extractor), `context_length < floor` (AC 12 / Writer floor)
6. Capability evaluation: capable = `text_output is True AND context_length >= floor AND (tool_use is True OR structured_output is True)`
7. Whitelist lookup: WHITELISTED / STALE (age-expired) / NOT_WHITELISTED / DISABLED

**AC 11 at route resolution (not call-time).** Both `supports_tool_use is False AND supports_structured_output is False` → `ProviderConfigError`. Only explicit `False` triggers rejection; `None` (unverified) fails safe. This is the 14b upgrade over 14a call-time failure.

**Context-length floor as rejection gate.** A known `context_length < writer_context_length_floor` → `ProviderConfigError`. `context_length=None` does not reject. Floor is constructor-injected (`writer_context_length_floor`, default `_WRITER_CONTEXT_LENGTH_FLOOR = 8192`). **The default value (8192) is provisional** — production deployments should configure an appropriate floor. Documented in ADR-014b Decision 4.

**STALE has two branches:** (1) whitelisted but not in catalog, (2) whitelisted + in catalog but `WhitelistEntry.verified_at` older than `max_evidence_age`. Both force Safety; neither rejects. `max_evidence_age=None` (default) means entries never expire by age.

**Dynamic-alias rule:** Static deny-set (O(1), pre-catalog) + catalog `is_dynamic_router=True` check (defense-in-depth).

**14b ships the registry machinery, not catalog classification.** `FixtureOpenRouterCatalogProvider` defaults to empty (all misses; Safety always runs for OpenRouter). Populating the whitelist/catalog in production is an operator configuration concern, not an implementation issue.

**Anthropic-direct parity preserved (AC 15/18 regression).** `make_anthropic_capability_profile()` builds an `AFTERWORLDS_VERIFIED` profile; resolver marks Anthropic routes as `WHITELISTED + capable`.

**No-registry fail-safe (14a parity).** `capability_registry=None` → OpenRouter routes get `UNKNOWN + False` (Safety always runs).

**OpenRouter cache adapter verification still deferred.** ADR-014a Decision 4 noted that OpenRouter cache behavior (cross-pass reuse, TTL, metrics) requires verification before extended-TTL is enabled. This remains open and is in `known_unknowns.md`.

## Test plan

- [ ] CI passes with no network (all OpenRouter tests use `FixtureOpenRouterCatalogProvider` or mocked urllib)
- [ ] 1303 tests pass, 10 skipped (pre-existing)
- [ ] Black, Ruff, mypy clean (pre-existing `keyring`/`openai` stub errors unchanged)
- [ ] All 14b ACs covered: static deny-set (AC 9), catalog miss (AC 6), STALE (AC 7/8), NOT_WHITELISTED (AC 5), WHITELISTED+capable → skip eligible (AC 4), AC 11 structured-pass rejection, AC 12 text-output rejection, context-floor rejection, Anthropic regression (AC 15/18), no-registry parity (AC 8/10), mixed-route set (AC 13)
- [ ] Live catalog provider tests marked `@pytest.mark.live`, opt-in, never a merge gate (AC 14/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)