### PR TITLE
feat(branching): implement CRD Issue 16 — Branching Mode integration

### DIFF
--- a/alembic/versions/0012_branching_mode.py
+++ b/alembic/versions/0012_branching_mode.py
@@ -1,0 +1,106 @@
+"""Branching mode interaction configuration — CRD Issue 16.
+
+Extends the existing ``branching_session_states`` table with interaction-
+configuration and setup-context columns required by the typed output contract
+and code-owned affordances introduced in Issue 16.
+
+All new columns except ``play_status`` are nullable so existing rows are never
+silently backfilled to a default interaction style.  ``play_status`` has a safe
+server-default of ``setup`` (matching the Pydantic model's BranchingPlayStatus
+default) so existing rows stay in the setup phase.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-06-24
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012"
+down_revision: Union[str, None] = "0011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # Extend branching_session_states with interaction-configuration columns.
+    # interaction_style / branching_cadence / length_preference /
+    # branch_count_range are nullable — conservative backfill rule: never
+    # silently assign freeform_only to rows that predate Issue 16.
+    # play_status is NOT NULL with server_default "setup" (safe for all rows).
+    # ------------------------------------------------------------------
+    op.add_column(
+        "branching_session_states",
+        sa.Column("interaction_style", sa.String(32), nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("branching_cadence", sa.String(32), nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("length_preference", sa.String(32), nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("branch_count_range", sa.String(8), nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column(
+            "play_status",
+            sa.String(16),
+            nullable=False,
+            server_default="setup",
+        ),
+    )
+    # Setup-context text fields — all nullable, narrative scaffolding only.
+    op.add_column(
+        "branching_session_states",
+        sa.Column("world_summary", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("story_seeds", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("character_concept", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("supporting_cast", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("world_constraints", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("pacing_notes", sa.Text, nullable=True),
+    )
+    op.add_column(
+        "branching_session_states",
+        sa.Column("acceptable_content", sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("branching_session_states", "acceptable_content")
+    op.drop_column("branching_session_states", "pacing_notes")
+    op.drop_column("branching_session_states", "world_constraints")
+    op.drop_column("branching_session_states", "supporting_cast")
+    op.drop_column("branching_session_states", "character_concept")
+    op.drop_column("branching_session_states", "story_seeds")
+    op.drop_column("branching_session_states", "world_summary")
+    op.drop_column("branching_session_states", "play_status")
+    op.drop_column("branching_session_states", "branch_count_range")
+    op.drop_column("branching_session_states", "length_preference")
+    op.drop_column("branching_session_states", "branching_cadence")
+    op.drop_column("branching_session_states", "interaction_style")

--- a/docs/architecture/known_unknowns.md
+++ b/docs/architecture/known_unknowns.md
@@ -79,13 +79,15 @@ ADR-014a Decision 4 and the `_openrouter.py` module docstring note that OpenRout
 
 ### Mode-specific OOC handler selection and final protocol implementation
 
-**Resolve during:** Issues 16 (Branching), 17 (Writing). **RPG mode resolved during Issue 15.**
+**Resolve during:** Issue 17 (Writing). **RPG mode resolved during Issue 15. Branching mode resolved during Issue 16.**
 
 Issue 12c short-circuits OOC turns away from the ordinary narrative passes and routes them through `WriterService` with the thin v1 placeholder at `/docs/prompts/ooc_handler.md`. The v2 mode prompt contracts now contain OOC sections, but the implementation question remains: how the orchestrator selects or injects the final mode-specific OOC instruction, and whether the placeholder is replaced outright or retained as a generic fallback.
 
 **RPG resolution (Issue 15):** Implemented as a distinct mode-specific handler for RPG mode via `docs/prompts/rpg_ooc_handler.md`. Replaces the 12c placeholder when `StoryMode.RPG` is active. Answers rules, configuration, setup, and clarification questions; advances no story; mutates no canon; routes configuration changes through typed paths. The orchestrator `_run_ooc()` now accepts `story_mode` and selects between `rpg_ooc_handler.md` (RPG mode) and `ooc_handler.md` (other modes). See ADR-015 Decision 11 and `/docs/prompts/rpg_ooc_handler.md`.
 
-**What remaining resolution requires:** Issues 16–17 must finalize the Branching and Writing mode OOC protocol sections via `/docs/prompts/branching_ooc_handler.md` and `/docs/prompts/writing_ooc_handler.md` respectively, and implement mode-aware handler file selection if the orchestrator’s OOC-routing logic needs revision. Document any changes in an ADR if the orchestrator’s handler-selection path changes shape.
+**Branching resolution (Issue 16):** Implemented as a distinct mode-specific handler for Branching mode via `docs/prompts/branching_ooc_handler.md`. When `StoryMode.BRANCHING` is active, the orchestrator `_run_ooc()` now selects `branching_ooc_handler.md`. Handles interaction-style/cadence/length configuration updates (transaction-scoped to `OOC_HANDLED`), Branching Mode platform questions, and True CYOA rejection guidance. See ADR-016 Decisions 4 and the OOC handler Known Unknown section.
+
+**What remaining resolution requires:** Issue 17 must finalize the Writing mode OOC protocol via `/docs/prompts/writing_ooc_handler.md` and implement mode-aware handler selection in `_run_ooc()`. Document any changes in an ADR if the handler-selection path changes shape.
 
 ---
 
@@ -171,6 +173,20 @@ The question is whether Mentors and Peers should be constrained to match or appr
 2. **Scope — Peers only or all personas:** Parity makes clean sense for Peers, who are co-writers. It is murkier for Mentors, whose output is often feedback and craft instruction rather than prose.
 
 **What resolution requires:** Decide on the parity model, the scope, and how Mentor feedback is measured differently from generated prose. If implemented, store the required counters in Writing session state and document how they are updated.
+
+---
+
+### True CYOA intent-classifier precision (ClassificationHints not wired)
+
+**Resolve during:** A future issue after Issue 16 (target: Issue 20 or whichever issue next touches the classifier).
+
+**Surfaced during:** Issue 16.
+
+Issue 16 ships the `INTERACTION_REJECTED` disposition for True CYOA invalid freeform input. The v1 rejection predicate is: reject if `intent_type not in {branch_choice, ooc}`. However, the classifier (CRD Issue 7) does not receive `ClassificationHints` about the current interaction style or presented branch options.
+
+**V1 limitation:** A Sojourner in True CYOA mode who writes "Cross the bridge" — even when "cross the bridge" paraphrases a presented option — will be rejected because the classifier returns `in_character_action`, not `branch_choice`. `branch_choice` is only emitted for explicit selection language ("I choose option 2", "Take the second option", "Option 1"). This is a precision gap, not a correctness gap: the safest behavior in True CYOA is explicit rejection of ambiguous input.
+
+**What resolution requires:** Wire `ClassificationHints` (containing the presented branch-option texts and `interaction_style=TRUE_CYOA`) into the classifier call when `story_mode is BRANCHING`. The classifier uses the hints to detect when freeform input clearly matches an offered option by paraphrase and emits `branch_choice` in that case. Requires owner decision on whether the classifier should do fuzzy matching or only exact/near-exact option-text matching. Document in an ADR or Architecture Notes for the owning issue.
 
 ---
 

--- a/docs/decisions/adr-016-branching-mode.md
+++ b/docs/decisions/adr-016-branching-mode.md
@@ -219,6 +219,30 @@ to) is deferred to a future issue.
 }
 ```
 
+**⚠ Boundary: `Node.branching_logic` type mismatch with labeled-edge requirement**
+
+The CRD Issue 16 spec describes the realized selection edge as a labeled entry in
+`Node.branching_logic`. The current field type is `list[UUID]`, which **cannot
+express the labeled-edge shape** `{"option_id": "opt_1", "target_node_id": "<UUID>"}`
+without a schema change. Two problems compound this:
+
+1. **Type incompatibility:** `list[UUID]` cannot carry `option_id` labels.
+   Changing to `list[dict]` or a `LabeledEdge` model requires a migration.
+2. **Missing target:** `target_node_id` does not exist until the next node is
+   created via graph traversal — which is itself deferred.
+
+**What Issue 16 implements instead:** Phase G writes `selected_option_id` and
+`selection_annotation` to `Node.mode_metadata.branching` (the JSON sub-document
+field on the same Node). This preserves the selection record for observability and
+future navigation without the schema change required to write labeled edges to
+`branching_logic`.
+
+**What remains open:** Full compliance with the `branching_logic` labeled-edge
+requirement needs: (a) a migration to change the field type, (b) graph traversal
+to resolve `target_node_id`, and (c) Phase G to write both fields atomically. This
+is explicitly out of scope for Issue 16. Owner acceptance is required before merge
+if the `branching_logic` field-type change is considered a blocking requirement.
+
 **Rationale:** Recording what was selected on a beat (`selected_option_id`) is
 needed for observability and future navigation even before the graph traversal
 layer exists. Activating `BranchTree`/`BranchNode` requires resolving the

--- a/docs/decisions/adr-016-branching-mode.md
+++ b/docs/decisions/adr-016-branching-mode.md
@@ -1,0 +1,307 @@
+# ADR-016: Branching Mode Integration — Typed Output Contract, Code-Owned Affordances, and Persisted Interaction Configuration
+
+**Issue:** CRD Issue 16 — Branching Mode Integration  
+**Date:** 2026-06-24  
+**Status:** Accepted
+
+---
+
+## Context
+
+CRD Issue 16 ships the Branching Mode typed output contract, code-owned affordance
+enforcement, persisted interaction configuration (interaction style, cadence,
+length preference, branch count range), the general Branching-mode rejection
+disposition, branch-choice resolution, and the Branching Mode OOC configuration
+path.
+
+The central invariant:
+> The model may author narrative prose and *propose* branch options; it may never
+> author the interaction affordances. Interaction style, freeform availability,
+> branch-count range, cadence, branch identity, and selection state are
+> code-owned from persisted configuration and validated structured output —
+> never inferred from, nor made authoritative by, loose Writer prose.
+
+Seven decisions were made during Issue 16. They are recorded here.
+
+---
+
+## Decision 1: Branch-card output = `BranchingWriterService`, not `WriterService` widening
+
+**Decision:** Structured branch-card output for HYBRID and TRUE_CYOA interaction
+styles is produced by a new `BranchingWriterService` (forced tool use) modeled on
+`RpgAdjudicationPassService`. `WriterService.write()` and `WriterResult` are not
+widened. FREEFORM_ONLY interaction style continues to use the prose `WriterService`
+unchanged.
+
+**Rationale:** The branch-card output contract is structurally different from the
+prose writer contract. Forced tool use enforces the schema-level invariant that
+`option_id`, `interaction_style`, `branching_cadence`, `freeform_available`, and
+`branch_count_range` are absent from the tool schema — making it impossible for
+the model to propose these code-owned fields. Widening `WriterService` or
+`WriterResult` would contaminate the freeform prose path with Branching-specific
+structure and break the mode-agnostic writer contract.
+
+**Consequence:** The orchestrator routes BRANCHING + HYBRID/TRUE_CYOA narrative
+turns through `BranchingWriterService`. The resulting `BranchingPassResult` carries
+both the narrative text and the validated branch-option list; it is stored in
+`OrchestrationResult.branching_pass_result` so downstream callers (frontend,
+entitlement, observability) can inspect the full typed output without re-parsing
+prose. A thin `WriterResult` wrapping only the narrative text is derived from
+`BranchingPassResult` for downstream Extractor and Contradiction passes.
+`PipelinePassId.BRANCHING_WRITER` and `PassIdentifier.BRANCHING_WRITER` are added
+to their respective enums.
+
+---
+
+## Decision 2: `INTERACTION_REJECTED` — general Branching-mode non-narrative rejection disposition
+
+**Decision:** `PipelineDisposition.INTERACTION_REJECTED` is the typed disposition
+for all deterministic Branching-mode rejections: cases where the orchestrator can
+evaluate the input without a narrative LLM call and determine it is definitively
+invalid for the current session configuration or branch-card state.
+
+Four typed reasons (`InteractionRejectionReason`):
+
+| Reason | Trigger |
+|---|---|
+| `INVALID_FOR_INTERACTION_STYLE` | Non-OOC freeform prose in TRUE_CYOA mode |
+| `INVALID_BRANCH_SELECTION` | BRANCH_CHOICE references an option_id absent from the current card set, or no card set was presented |
+| `MATERIAL_BRANCH_REWRITE` | Trailing annotation materially rewrites the selected branch label's canonical meaning |
+| `CANON_OR_GENRE_CONTRADICTION` | Selected action violates Story Bible canon or established genre/world constraints |
+
+**Branch-selection validation is v1 in-scope.** `BranchSelectionValidationService`
+runs after BRANCH_CHOICE intent classification and before the Writer (or
+`BranchingWriterService`). Validation sequence:
+
+1. **Option-existence check (deterministic):** resolve explicit `opt_N` token,
+   positional-numeric phrase, or ordinal word against the presented option set
+   from `Node.mode_metadata.branching.branch_options`. No match →
+   `INVALID_BRANCH_SELECTION`.
+2. **Annotation extraction (deterministic):** trailing text after the selection
+   token is captured as `SelectedBranchContext.annotation`.
+3. **On ACCEPT:** `SelectedBranchContext` (option_id, action_text, annotation) is
+   threaded to the Writer so the narrative can reference the chosen branch.
+
+`MATERIAL_BRANCH_REWRITE` and `CANON_OR_GENRE_CONTRADICTION` are defined in the
+typed enum and available for use without changing the rejection surface. Narrow
+forced-tool validation for non-trivial annotations is reserved for future
+expansion within this issue scope; v1 deterministic validation covers option
+existence and annotation extraction.
+
+**Invariants:** INTERACTION_REJECTED is non-billable — no Turn is created, no
+Node is created, no canon is mutated, and no full narrative Writer call is made.
+OOC intent bypasses the rejection check entirely (OOC is always valid regardless
+of interaction style).
+
+**Typed fields:** `OrchestrationResult.interaction_rejection_reason` is typed as
+`InteractionRejectionReason` (not a free string). `interaction_rejection_message`
+(non-empty human-readable string) is required alongside it. Both are None on all
+other dispositions.
+
+**V1 classifier limitation:** The Issue 7 classifier does not receive
+`ClassificationHints` about the current interaction style. `branch_choice` is
+only emitted for inputs with explicit selection language. A Sojourner who writes
+"Cross the bridge" in TRUE_CYOA mode will be rejected as
+`INVALID_FOR_INTERACTION_STYLE` because the classifier returns
+`in_character_action`. Wiring `ClassificationHints` is a future issue.
+
+**Consequence:** `PipelineDisposition.INTERACTION_REJECTED` added to
+`orchestrator/models.py`. `OrchestrationResult.interaction_rejection_reason:
+InteractionRejectionReason | None` and `interaction_rejection_message: str | None`
+added. `InteractionRejectionReason` enum with four values added to
+`models/enums.py`. `BranchSelectionValidationService` added to
+`pipeline/branching/selection.py`. `BranchSelectionValidationResult` and
+`SelectedBranchContext` models added to `pipeline/branching/models.py`.
+
+---
+
+## Decision 3: Branching setup confirmation = `DELIVERED` turn (full pipeline, creates Node)
+
+**Decision:** Turns during the Branching setup phase (interaction style/cadence
+not yet configured; `play_status = "setup"`) route through the standard narrative
+pipeline using the prose `WriterService`. No setup-specific disposition is introduced.
+Setup turns are ordinary `DELIVERED` turns.
+
+**Rationale:** The setup phase is narrative — the story architect responds to the
+Sojourner's world-building inputs. This narrative should be canon-tracked by the
+Extractor and contradiction-checked, just like in-play narrative. No special
+dispatch is required.
+
+**Consequence:** When `interaction_style is None` (setup not complete or pre-Issue-16
+row), the orchestrator uses the prose `WriterService` path. This is the safe default
+and satisfies the conservative-backfill rule (never silently freeform_only).
+
+---
+
+## Decision 4: OOC Branching-config updates use forced-tool extraction, transaction-scoped to `OOC_HANDLED`
+
+**Decision:** When a Sojourner uses OOC to change interaction style, cadence, or
+other session configuration, the configuration change is extracted via a narrow
+forced-tool LLM call (`BranchingOocConfigExtractorService`) and persisted inside
+the existing OOC outer transaction that produces `OOC_HANDLED`. The configuration
+write commits atomically with the OOC Turn row.
+
+**Rationale:** Forced-tool extraction produces a machine-readable `BranchingConfigUpdate`
+that code can validate against `ALLOWED_RANGES_BY_STYLE` before persisting. Prose
+confirmation alone would require fragile text-parsing for a structured config change.
+Transaction-scoping is the correct architectural boundary per the Issue 12c
+outer-transaction contract — decoupling the configuration write from the OOC Turn
+persistence would create a two-phase-commit problem.
+
+**Best-effort:** The extraction pass is best-effort. Extractor failure (provider
+error, schema mismatch, invalid range) silently skips config persistence without
+blocking `OOC_HANDLED` delivery — the Sojourner still receives the OOC prose
+response. The next OOC turn may succeed.
+
+**Consequence:** `BranchingOocConfigExtractorService` added to
+`pipeline/branching/ooc_config_extractor.py`. `BranchingConfigUpdate` model added
+to `pipeline/branching/models.py`. `PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR`
+added to `entitlement/enums.py`. `apply_branching_config_update` CRUD helper added
+to `persistence/crud/session_state.py`. `OrchestratorService._run_ooc()` wired
+with `branching_ooc_config_extractor` constructor param (optional; best-effort).
+
+---
+
+## Decision 5: Persistence = extend `branching_session_states` (no new config table)
+
+**Decision:** The five new configuration fields (`interaction_style`,
+`branching_cadence`, `length_preference`, `branch_count_range`, `play_status`)
+and seven optional setup-context fields are added to the existing
+`branching_session_states` table via Alembic migration 0012. No new
+`branching_config` or `branching_interaction_config` table is created.
+
+**Conservative backfill rule:** All new interaction-configuration columns are
+nullable with a NULL server default. `play_status` has a `server_default="setup"`
+(safe for all existing rows). Existing rows receive `NULL` for `interaction_style`,
+`branching_cadence`, `length_preference`, and `branch_count_range` — never
+`"freeform_only"`. This preserves the invariant that pre-Issue-16 rows do not
+silently gain an interaction contract they were not configured for.
+
+**Rationale:** One persisted session state per story per mode is the correct
+granularity. A separate config table adds a join and a new transaction boundary
+without adding semantic value. The existing table is the natural home for this
+configuration.
+
+**Consequence:** Migration 0012 adds 12 columns to `branching_session_states`.
+`BranchingSessionStateORM` is extended. `BranchingSessionState` Pydantic model
+gains nullable configuration fields.
+
+---
+
+## Decision 6: `BranchTree`/`BranchNode` graph-traversal activation deferred; v1 ships `SelectedBranchContext` resolution
+
+**Decision:** v1 ships branch-choice resolution via `SelectedBranchContext`
+pass-forward and records the selected option on the current Node. `BranchTree`
+and `BranchNode` graph-traversal activation (looking up the next node to navigate
+to) is deferred to a future issue.
+
+**What IS v1 in-scope:**
+- `BranchSelectionValidationService` resolves a BRANCH_CHOICE input to a
+  `SelectedBranchContext` (option_id, action_text, annotation).
+- `SelectedBranchContext` is threaded from the validation service to the Writer
+  so the narrative can reference the chosen branch.
+- **Phase G (selection edge):** after the Writer and persistence complete,
+  `selected_option_id` and `selection_annotation` are written to
+  `Node.mode_metadata.branching` — recording which option was chosen on this
+  beat for future graph-traversal lookup.
+
+**What is DEFERRED:**
+- `BranchTree` / `BranchNode` activation: they are left structurally present but
+  not written to or read by the Issue 16 pipeline.
+- `Node.branching_logic` (a `list[UUID]`) is NOT written by Issue 16. Full
+  graph-edge realization — building typed labeled-edge entries — is a future
+  migration. The intended labeled-edge shape for future implementors is:
+
+```json
+{
+  "option_id": "opt_1",
+  "target_node_id": "<UUID of the next narrative node>"
+}
+```
+
+**Rationale:** Recording what was selected on a beat (`selected_option_id`) is
+needed for observability and future navigation even before the graph traversal
+layer exists. Activating `BranchTree`/`BranchNode` requires resolving the
+next-node lookup, which is a larger scope than Issue 16's output-contract and
+selection-validation mandate.
+
+---
+
+## Decision 7: `BranchingCadence` is a distinct axis from `PacingStage`
+
+**Decision:** `BranchingCadence` (INTERACTIVE / BALANCED / IMMERSIVE) is a new
+enum in `models/enums.py`, distinct from the existing `PacingStage` enum
+(SETUP / ESCALATION / REVERSAL / CLIMAX / AFTERMATH). They are not merged,
+aliased, or conflated.
+
+**Rationale:** `PacingStage` is an internal narrative arc tracker (the five-stage
+dramatic arc) — it is structural and the model tracks it invisibly. `BranchingCadence`
+is a Sojourner-configured response-density setting. They are orthogonal axes:
+a Climax beat can be any cadence; an Interactive cadence can be at any pacing stage.
+Collapsing them into a single enum would force a one-to-one mapping that doesn't
+exist in the design.
+
+**Consequence:** `BranchingCadence` added to `models/enums.py`. `PacingStage`
+unchanged. `BranchingSessionState` carries both independently. The OOC handler
+can update `branching_cadence` without affecting `pacing_stage`.
+
+---
+
+## Mode-Specific OOC Handler — Known Unknown Resolution
+
+ADR-015 Decision 11 established the mode-aware OOC handler selection pattern and
+noted: "Issues 16 and 17 should follow the same pattern for Branching and Writing
+modes."
+
+Issue 16 resolves the Branching OOC handler Known Unknown:
+- `docs/prompts/branching_ooc_handler.md` created (Branching-specific OOC instructions).
+- `OrchestratorService._run_ooc()` extended: when `story_mode is StoryMode.BRANCHING`,
+  uses `self._branching_ooc_handler_prompt` instead of the generic handler.
+- `load_branching_ooc_handler_prompt()` loader added.
+- `known_unknowns.md` updated to RESOLVED for Branching mode OOC handler.
+
+Writing mode OOC handler (Issue 17) remains OPEN.
+
+---
+
+## Consequences
+
+- `PipelineDisposition.INTERACTION_REJECTED` added to `orchestrator/models.py`
+- `PassIdentifier.BRANCHING_WRITER` added to `pipeline/_refusal.py`
+- `PipelinePassId.BRANCHING_WRITER` and `PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR`
+  added to `entitlement/enums.py`
+- `OrchestrationResult.interaction_rejection_reason: InteractionRejectionReason | None`
+  and `OrchestrationResult.interaction_rejection_message: str | None` added
+- `OrchestrationResult.branching_pass_result: Any | None` added (typed as
+  `BranchingPassResult` by callers; `Any` to avoid import cycle with
+  `pipeline/branching/models.py`)
+- `OrchestrationResult.branching_visible_state: Any | None` added
+- `InteractionStyle`, `BranchingCadence`, `LengthPreference`, `BranchCountRange`,
+  `BranchingPlayStatus`, `InteractionRejectionReason`, `BranchPresentationState`
+  enums added to `models/enums.py`
+- `BranchingSessionState` extended with interaction-configuration fields
+- `BranchingSessionStateORM` extended with 12 new columns
+- Alembic migration 0012 added
+- `BranchingNodeMetadata` enriched with typed output-contract fields
+  (`interaction_style`, `branching_cadence`, `freeform_available`,
+  `branch_count_range`, `branch_options`, `branch_presentation_state`,
+  `selected_option_id`, `selection_annotation`)
+- `PersistedBranchOption` model added to `models/node.py`
+- `pipeline/branching/` package created:
+  `__init__.py`, `caller.py`, `config.py`, `models.py`, `service.py`,
+  `selection.py`, `ooc_config_extractor.py`, `visible_state.py`
+- `BranchSelectionValidationService`, `BranchSelectionValidationResult`,
+  `SelectedBranchContext` added to `pipeline/branching/`
+- `BranchingConfigUpdate` and `BranchingOocConfigExtractorService` added to
+  `pipeline/branching/`
+- `BranchingVisibleState` and `BranchingVisibleStateService` added to
+  `pipeline/branching/`
+- `apply_branching_config_update` CRUD helper added to
+  `persistence/crud/session_state.py`
+- `docs/prompts/branching_ooc_handler.md` created
+- `known_unknowns.md` updated: Branching OOC handler RESOLVED; v1 CYOA
+  classifier limitation documented as new Known Unknown (future issue)
+- `OrchestratorService` wired with `branching_writer_service`,
+  `branching_session_resolver`, `branching_visible_state_service`,
+  `branching_selection_service`, and `branching_ooc_config_extractor`
+  constructor params

--- a/docs/decisions/adr-016-branching-mode.md
+++ b/docs/decisions/adr-016-branching-mode.md
@@ -201,9 +201,12 @@ to) is deferred to a future issue.
 - `SelectedBranchContext` is threaded from the validation service to the Writer
   so the narrative can reference the chosen branch.
 - **Phase G (selection edge):** after the Writer and persistence complete,
-  `selected_option_id` and `selection_annotation` are written to
-  `Node.mode_metadata.branching` — recording which option was chosen on this
-  beat for future graph-traversal lookup.
+  stable selected branch context — `selected_option_id`, `selected_action_text`,
+  and `selection_annotation` — is written to `Node.mode_metadata.branching`,
+  recording which option was chosen on this beat for future graph-traversal
+  lookup. `selected_action_text` keeps the selection reconstructable after the
+  next beat overwrites `branch_options`, since option IDs (`opt_1`, …) are
+  reused every beat.
 
 **What is DEFERRED:**
 - `BranchTree` / `BranchNode` activation: they are left structurally present but
@@ -231,11 +234,11 @@ without a schema change. Two problems compound this:
 2. **Missing target:** `target_node_id` does not exist until the next node is
    created via graph traversal — which is itself deferred.
 
-**What Issue 16 implements instead:** Phase G writes `selected_option_id` and
-`selection_annotation` to `Node.mode_metadata.branching` (the JSON sub-document
-field on the same Node). This preserves the selection record for observability and
-future navigation without the schema change required to write labeled edges to
-`branching_logic`.
+**What Issue 16 implements instead:** Phase G writes `selected_option_id`,
+`selected_action_text`, and `selection_annotation` to
+`Node.mode_metadata.branching` (the JSON sub-document field on the same Node).
+This preserves a stable selection record for observability and future navigation
+without the schema change required to write labeled edges to `branching_logic`.
 
 **What remains open:** Full compliance with the `branching_logic` labeled-edge
 requirement needs: (a) a migration to change the field type, (b) graph traversal

--- a/docs/prompts/branching_ooc_handler.md
+++ b/docs/prompts/branching_ooc_handler.md
@@ -1,0 +1,75 @@
+# Branching Mode OOC Handler — Afterworlds
+
+You are the out-of-character assistant for **Afterworlds Branching Mode**.
+
+## Role
+
+You handle out-of-character (OOC) questions and configuration requests from
+Sojourners who are playing in Branching Mode. OOC turns do not advance the
+story. They do not create narrative canon. The story pauses while you answer.
+
+## What You May Help With
+
+**Platform and mode questions:**
+- Explain how Branching Mode works (interaction styles, cadences, branch options).
+- Explain the difference between Freeform Only, Hybrid, and True CYOA.
+- Explain how branch options work and how to select them.
+- Answer questions about pacing stages, cadence, and length preferences.
+- Answer general platform questions (saving, export, commands, mechanics).
+
+**Interaction configuration updates:**
+- Interaction style changes (freeform_only → hybrid → true_cyoa and back).
+- Cadence changes (interactive ↔ balanced ↔ immersive).
+- Length preference changes (short_story ↔ novella ↔ novel).
+
+When the Sojourner requests a configuration change, confirm the change clearly
+in your response. The configuration update is applied by code from this OOC
+transaction; you do not need to track it in narrative memory.
+
+## Interaction Style Reference
+
+| Style | Freeform Input | Branch Cards | When to Suggest |
+|-------|---------------|--------------|-----------------|
+| Freeform Only | Yes (only) | No | Sojourner wants full narrative freedom |
+| Hybrid | Yes | Yes (equal prominence) | Default; best of both worlds |
+| True CYOA | No | Yes (required) | Sojourner wants structured choice-only play |
+
+**Branch Count Ranges:**
+- Hybrid: 1–2, 2–3, or 3–4 options per beat.
+- True CYOA: 2–3, 2–4, or 2–5 options per beat.
+
+## Cadence Reference
+
+| Cadence | Beat Length | Decision Frequency | Good For |
+|---------|------------|-------------------|----------|
+| Interactive | Short | High | Fast-paced action |
+| Balanced | Moderate | Moderate | Most stories (default) |
+| Immersive | Long literary | Lower | Rich world-building prose |
+
+## What You Must Not Do
+
+- Do not narrate story content or advance the story.
+- Do not propose canon changes, world facts, or character development.
+- Do not tell the Sojourner what their character "does" or "thinks."
+- Do not make up game rules that do not exist.
+- Do not confirm a configuration change if the request was ambiguous — ask
+  for clarification first.
+
+## True CYOA Rejection Guidance
+
+If the Sojourner asks why their freeform input was rejected in True CYOA mode:
+- Explain that True CYOA requires explicit branch selection (e.g., "I choose
+  option 2" or "Take the second option").
+- Mention that typing a paraphrase of an option's action text is not sufficient
+  — the system requires explicit selection language.
+- Offer to switch to Hybrid mode if they prefer freeform input.
+- Remind them that `[OOC]` prefix is always valid in any mode.
+
+## Tone
+
+Helpful, clear, and brief. You are a platform assistant, not a narrator.
+Match the Sojourner's register. Do not over-explain. Do not lecture.
+
+---
+
+*Branching Mode OOC Handler v1 — CRD Issue 16*

--- a/src/afterworlds/entitlement/enums.py
+++ b/src/afterworlds/entitlement/enums.py
@@ -60,6 +60,8 @@ class PipelinePassId(StrEnum):
     INPUT_SAFETY = "input_safety"
     PLANNER = "planner"
     RPG_ADJUDICATION = "rpg_adjudication"
+    BRANCHING_WRITER = "branching_writer"
+    BRANCHING_OOC_CONFIG_EXTRACTOR = "branching_ooc_config_extractor"
     WRITER = "writer"
     OUTPUT_SAFETY = "output_safety"
     EXTRACTOR = "extractor"

--- a/src/afterworlds/entitlement/policy.py
+++ b/src/afterworlds/entitlement/policy.py
@@ -31,6 +31,8 @@ PASS_TIER_DEFAULTS: dict[PipelinePassId, ModelTier] = {
     PipelinePassId.CONTRADICTION: ModelTier.HAIKU,
     PipelinePassId.INPUT_SAFETY: ModelTier.HAIKU,
     PipelinePassId.OUTPUT_SAFETY: ModelTier.HAIKU,
+    PipelinePassId.BRANCHING_WRITER: ModelTier.SONNET,
+    PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR: ModelTier.HAIKU,
 }
 
 _CREDIT_QUANTIZE = Decimal("0.0001")
@@ -308,6 +310,48 @@ class TurnCostPolicy:
                     cr_result.model_identifier,
                     provider=cr_result.provider,
                     model_tier_str=cr_result.model_tier,
+                )
+            )
+
+        if result.branching_pass_result is not None:
+            from afterworlds.pipeline.branching.models import (  # noqa: PLC0415
+                BranchingPassResult,
+            )
+
+            assert isinstance(result.branching_pass_result, BranchingPassResult)
+            bpr = result.branching_pass_result
+            snapshots.append(
+                _require_tokens(
+                    PipelinePassId.BRANCHING_WRITER,
+                    bpr.input_token_count,
+                    bpr.output_token_count,
+                    bpr.cache_read_token_count,
+                    bpr.cache_creation_token_count,
+                    bpr.model_identifier,
+                    provider=bpr.provider,
+                    model_tier_str=bpr.model_tier,
+                )
+            )
+
+        if result.branching_ooc_config_result is not None:
+            from afterworlds.pipeline.branching.models import (  # noqa: PLC0415
+                BranchingOocConfigExtractorResult,
+            )
+
+            assert isinstance(
+                result.branching_ooc_config_result, BranchingOocConfigExtractorResult
+            )
+            bocr = result.branching_ooc_config_result
+            snapshots.append(
+                _require_tokens(
+                    PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR,
+                    bocr.input_token_count,
+                    bocr.output_token_count,
+                    bocr.cache_read_token_count,
+                    bocr.cache_creation_token_count,
+                    bocr.model_identifier,
+                    provider=bocr.provider,
+                    model_tier_str=bocr.model_tier,
                 )
             )
 

--- a/src/afterworlds/entitlement/policy.py
+++ b/src/afterworlds/entitlement/policy.py
@@ -260,7 +260,7 @@ class TurnCostPolicy:
                     )
                 )
 
-        if result.writer_result is not None:
+        if result.writer_result is not None and result.branching_pass_result is None:
             wr = result.writer_result
             snapshots.append(
                 _require_tokens(

--- a/src/afterworlds/models/enums.py
+++ b/src/afterworlds/models/enums.py
@@ -67,6 +67,88 @@ class PacingStage(StrEnum):
     AFTERMATH = "aftermath"
 
 
+class InteractionStyle(StrEnum):
+    """Branching-mode interaction contract: how the Sojourner interacts."""
+
+    FREEFORM_ONLY = "freeform_only"
+    HYBRID = "hybrid"
+    TRUE_CYOA = "true_cyoa"
+
+
+class BranchingCadence(StrEnum):
+    """Branching-mode pacing density — distinct axis from PacingStage."""
+
+    INTERACTIVE = "interactive"
+    BALANCED = "balanced"
+    IMMERSIVE = "immersive"
+
+
+class LengthPreference(StrEnum):
+    """Preferred response length for Branching-mode narrative beats."""
+
+    SHORT_STORY = "short_story"
+    NOVELLA = "novella"
+    NOVEL = "novel"
+
+
+class BranchCountRange(StrEnum):
+    """Validated branch-count ranges by interaction style.
+
+    Hybrid allows: 1-2, 2-3, 3-4.
+    True CYOA allows: 2-3, 2-4, 2-5.
+    """
+
+    ONE_TO_TWO = "1-2"
+    TWO_TO_THREE = "2-3"
+    THREE_TO_FOUR = "3-4"
+    TWO_TO_FOUR = "2-4"
+    TWO_TO_FIVE = "2-5"
+
+
+class BranchingPlayStatus(StrEnum):
+    """Play-status for a Branching story: setup phase or active play."""
+
+    SETUP = "setup"
+    IN_PLAY = "in_play"
+
+
+class InteractionRejectionReason(StrEnum):
+    """Typed reason an Interaction was rejected (CRD Issue 16).
+
+    Used in ``OrchestrationResult.interaction_rejection_reason`` when
+    ``disposition`` is ``INTERACTION_REJECTED``.  A human-readable message
+    is always emitted alongside this typed reason via
+    ``interaction_rejection_message``.
+
+    INVALID_FOR_INTERACTION_STYLE: input style is incompatible with the
+        current ``InteractionStyle`` (e.g. freeform prose in TRUE_CYOA).
+    MATERIAL_BRANCH_REWRITE: a branch annotation materially rewrites the
+        label in a way that changes the canonical meaning.
+    CANON_OR_GENRE_CONTRADICTION: the selected action violates Story Bible
+        canon or established genre constraints.
+    INVALID_BRANCH_SELECTION: BRANCH_CHOICE intent references an option_id
+        that does not appear in the most-recently-presented branch card set.
+    """
+
+    INVALID_FOR_INTERACTION_STYLE = "invalid_for_interaction_style"
+    MATERIAL_BRANCH_REWRITE = "material_branch_rewrite"
+    CANON_OR_GENRE_CONTRADICTION = "canon_or_genre_contradiction"
+    INVALID_BRANCH_SELECTION = "invalid_branch_selection"
+
+
+class BranchPresentationState(StrEnum):
+    """Whether branch-choice cards are shown, held, or omitted for a beat.
+
+    SHOWN: branch cards are rendered for the Sojourner this beat.
+    HELD: branch cards exist but are withheld (e.g. mid-scene tension).
+    OMITTED: no branch cards for this beat (freeform or narrative-only).
+    """
+
+    SHOWN = "shown"
+    HELD = "held"
+    OMITTED = "omitted"
+
+
 class DiceHandling(StrEnum):
     """Dice-roll mode configured by the player in RPG mode."""
 

--- a/src/afterworlds/models/node.py
+++ b/src/afterworlds/models/node.py
@@ -85,7 +85,15 @@ class BranchingNodeMetadata(BaseModel):
     branch_options: list[PersistedBranchOption] = Field(default_factory=list)
     branch_presentation_state: str | None = None
     # Set when the Sojourner resolves their branch selection (Phase G).
+    #
+    # ``selected_option_id`` alone is NOT a stable selection record: option IDs
+    # (``opt_1``, …) are reused every beat, so once this beat's branch_options
+    # are overwritten with the next beat's cards the same ID points at a
+    # different option.  ``selected_action_text`` captures the chosen option's
+    # label independently of ``branch_options`` so the selection stays
+    # reconstructable after the next beat's cards are persisted.
     selected_option_id: str | None = None
+    selected_action_text: str | None = None
     selection_annotation: str | None = None
 
 

--- a/src/afterworlds/models/node.py
+++ b/src/afterworlds/models/node.py
@@ -14,7 +14,12 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, field_validator
 
-from afterworlds.models.enums import IntentType, normalize_legacy_intent_type
+from afterworlds.models.enums import (
+    BranchingCadence,
+    IntentType,
+    InteractionStyle,
+    normalize_legacy_intent_type,
+)
 
 
 class StateDelta(BaseModel):
@@ -44,17 +49,44 @@ class RpgNodeMetadata(BaseModel):
     dice_results: list[int] = Field(default_factory=list)
 
 
-class BranchingNodeMetadata(BaseModel):
-    """Branching-mode beat metadata.
+class PersistedBranchOption(BaseModel):
+    """Branch option as persisted on a Node after delivery.
 
-    ``extra_branch_options`` holds additional Branching-mode detail for this
-    beat.  It does *not* replace ``Node.branching_logic``, which remains the
-    canonical location of next-node pointers.
+    ``option_id`` is the code-assigned sequential identifier (``opt_1``, …).
+    ``action_text`` is the model-proposed label.
+    """
+
+    option_id: str
+    action_text: str
+
+
+class BranchingNodeMetadata(BaseModel):
+    """Branching-mode beat metadata — presentation/config/selection only.
+
+    This model stores what was presented and selected for this beat.  It must
+    never hold canonical graph pointers — those live in ``Node.branching_logic``
+    (a list of next-node UUIDs, populated when edges are realized).
+
+    Issue 16 adds typed output-contract fields so the frontend can render the
+    delivered branch card without re-deriving config from session state.
+
+    ``extra_branch_options`` is retained for backward compatibility but new
+    code should use ``branch_options`` (typed ``PersistedBranchOption`` list).
     """
 
     mode: Literal["branching"] = "branching"
     pacing_stage_at_beat: str | None = None
     extra_branch_options: list[str] = Field(default_factory=list)
+    # Issue 16: typed output-contract fields (None on legacy/setup nodes)
+    interaction_style: InteractionStyle | None = None
+    branching_cadence: BranchingCadence | None = None
+    freeform_available: bool | None = None
+    branch_count_range: str | None = None
+    branch_options: list[PersistedBranchOption] = Field(default_factory=list)
+    branch_presentation_state: str | None = None
+    # Set when the Sojourner resolves their branch selection (Phase G).
+    selected_option_id: str | None = None
+    selection_annotation: str | None = None
 
 
 class WritingNodeMetadata(BaseModel):

--- a/src/afterworlds/models/session.py
+++ b/src/afterworlds/models/session.py
@@ -16,7 +16,12 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field, model_validator
 
 from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    BranchingPlayStatus,
     DiceHandling,
+    InteractionStyle,
+    LengthPreference,
     PacingStage,
     RpgPlayStatus,
     RpgSessionType,
@@ -127,8 +132,11 @@ class BranchingSessionState(BaseModel):
 
     Distinct structured fields — not fields on Node:
     - ``pacing_stage`` — current position in the five-stage narrative arc
-    - ``branch_tree`` — full branch graph (distinct structured model)
+    - ``branch_tree`` — full branch graph (distinct structured model, dormant)
     - ``plot_thread_tracker`` — unresolved threads queued by the Extractor
+    - ``interaction_style`` — None when setup is not yet complete (never silently
+      freeform_only for backfilled rows per CRD Issue 16 conservative backfill rule)
+    - ``play_status`` — SETUP → IN_PLAY once configuration is finalized
     """
 
     session_id: UUID = Field(default_factory=uuid4)
@@ -137,6 +145,21 @@ class BranchingSessionState(BaseModel):
     branch_tree: BranchTree = Field(default_factory=BranchTree)
     plot_thread_tracker: list[PlotThread] = Field(default_factory=list)
     current_node_id: UUID | None = None
+    # Issue 16: interaction configuration — nullable so existing rows are
+    # never silently backfilled to freeform_only.  None = setup not complete.
+    interaction_style: InteractionStyle | None = None
+    branching_cadence: BranchingCadence | None = None
+    length_preference: LengthPreference | None = None
+    branch_count_range: BranchCountRange | None = None
+    play_status: BranchingPlayStatus = BranchingPlayStatus.SETUP
+    # Optional setup context fields (narrative scaffolding, not mechanical state)
+    world_summary: str | None = None
+    story_seeds: str | None = None
+    character_concept: str | None = None
+    supporting_cast: str | None = None
+    world_constraints: str | None = None
+    pacing_notes: str | None = None
+    acceptable_content: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/afterworlds/persistence/crud/node.py
+++ b/src/afterworlds/persistence/crud/node.py
@@ -167,6 +167,29 @@ def get_turn(session: Session, turn_id: UUID) -> Turn | None:
     return _turn_orm_to_model(row)
 
 
+def update_turn_assistant_output(
+    session: Session, turn_id: UUID, assistant_output: str
+) -> bool:
+    """Overwrite a Turn's persisted assistant_output.  Returns True if updated.
+
+    Used to keep the persisted OOC Turn truthful when a corrective no-op note
+    is appended to the delivered output: the stored prose must carry the same
+    correction so future recent-turn context cannot reintroduce a false
+    confirmation of a change that did not happen.
+
+    Deliberately does NOT flush: the row is part of the caller's open unit of
+    work, so the dirty attribute is emitted by the surrounding transaction's
+    commit.  Flushing here would add a mid-pipeline raise surface that could
+    escape the orchestrator's typed-terminal contract; deferring keeps the
+    only failure point the commit, which already preserves usage on rebuild.
+    """
+    row = session.get(TurnORM, str(turn_id))
+    if row is None:
+        return False
+    row.assistant_output = assistant_output
+    return True
+
+
 def delete_turn(session: Session, turn_id: UUID) -> bool:
     """Delete a Turn.  Returns True if deleted."""
     row = session.get(TurnORM, str(turn_id))

--- a/src/afterworlds/persistence/crud/session_state.py
+++ b/src/afterworlds/persistence/crud/session_state.py
@@ -308,11 +308,18 @@ def apply_branching_config_update(
     branching_cadence: BranchingCadence | None = None,
     branch_count_range: BranchCountRange | None = None,
     length_preference: LengthPreference | None = None,
+    *,
+    clear_branch_count_range: bool = False,
 ) -> bool:
     """Apply non-None config fields to the BranchingSessionState ORM row for a story.
 
     Only updates the fields that are non-None.  Returns True when the row was
     found and flushed; False when no row exists for the given story_id.
+
+    ``clear_branch_count_range=True`` explicitly sets ``branch_count_range`` to
+    NULL regardless of the ``branch_count_range`` argument (use when switching to
+    FREEFORM_ONLY, which has no valid range).  When ``False``, the usual
+    "non-None means set, None means leave unchanged" semantics apply.
     """
     row = session.scalars(
         select(BranchingSessionStateORM).where(
@@ -325,7 +332,9 @@ def apply_branching_config_update(
         row.interaction_style = interaction_style.value
     if branching_cadence is not None:
         row.branching_cadence = branching_cadence.value
-    if branch_count_range is not None:
+    if clear_branch_count_range:
+        row.branch_count_range = None
+    elif branch_count_range is not None:
         row.branch_count_range = branch_count_range.value
     if length_preference is not None:
         row.length_preference = length_preference.value

--- a/src/afterworlds/persistence/crud/session_state.py
+++ b/src/afterworlds/persistence/crud/session_state.py
@@ -9,7 +9,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    BranchingPlayStatus,
     DiceHandling,
+    InteractionStyle,
+    LengthPreference,
     RpgPlayStatus,
     RpgSessionType,
     RpgSetupPhase,
@@ -148,6 +153,35 @@ def _branching_orm_to_model(row: BranchingSessionStateORM) -> BranchingSessionSt
         current_node_id=(
             UUID(row.current_node_id) if row.current_node_id is not None else None
         ),
+        # Issue 16: interaction configuration fields — nullable, read as enum or None.
+        interaction_style=(
+            InteractionStyle(row.interaction_style)
+            if row.interaction_style is not None
+            else None
+        ),
+        branching_cadence=(
+            BranchingCadence(row.branching_cadence)
+            if row.branching_cadence is not None
+            else None
+        ),
+        length_preference=(
+            LengthPreference(row.length_preference)
+            if row.length_preference is not None
+            else None
+        ),
+        branch_count_range=(
+            BranchCountRange(row.branch_count_range)
+            if row.branch_count_range is not None
+            else None
+        ),
+        play_status=BranchingPlayStatus(row.play_status),
+        world_summary=row.world_summary,
+        story_seeds=row.story_seeds,
+        character_concept=row.character_concept,
+        supporting_cast=row.supporting_cast,
+        world_constraints=row.world_constraints,
+        pacing_notes=row.pacing_notes,
+        acceptable_content=row.acceptable_content,
     )
 
 
@@ -170,6 +204,34 @@ def create_branching_session_state(
         current_node_id=(
             str(state.current_node_id) if state.current_node_id is not None else None
         ),
+        interaction_style=(
+            state.interaction_style.value
+            if state.interaction_style is not None
+            else None
+        ),
+        branching_cadence=(
+            state.branching_cadence.value
+            if state.branching_cadence is not None
+            else None
+        ),
+        length_preference=(
+            state.length_preference.value
+            if state.length_preference is not None
+            else None
+        ),
+        branch_count_range=(
+            state.branch_count_range.value
+            if state.branch_count_range is not None
+            else None
+        ),
+        play_status=state.play_status.value,
+        world_summary=state.world_summary,
+        story_seeds=state.story_seeds,
+        character_concept=state.character_concept,
+        supporting_cast=state.supporting_cast,
+        world_constraints=state.world_constraints,
+        pacing_notes=state.pacing_notes,
+        acceptable_content=state.acceptable_content,
     )
     session.add(row)
     session.flush()
@@ -215,8 +277,60 @@ def update_branching_session_state(
     row.current_node_id = (
         str(state.current_node_id) if state.current_node_id is not None else None
     )
+    row.interaction_style = (
+        state.interaction_style.value if state.interaction_style is not None else None
+    )
+    row.branching_cadence = (
+        state.branching_cadence.value if state.branching_cadence is not None else None
+    )
+    row.length_preference = (
+        state.length_preference.value if state.length_preference is not None else None
+    )
+    row.branch_count_range = (
+        state.branch_count_range.value if state.branch_count_range is not None else None
+    )
+    row.play_status = state.play_status.value
+    row.world_summary = state.world_summary
+    row.story_seeds = state.story_seeds
+    row.character_concept = state.character_concept
+    row.supporting_cast = state.supporting_cast
+    row.world_constraints = state.world_constraints
+    row.pacing_notes = state.pacing_notes
+    row.acceptable_content = state.acceptable_content
     session.flush()
     return _branching_orm_to_model(row)
+
+
+def apply_branching_config_update(
+    session: Session,
+    story_id: UUID,
+    interaction_style: InteractionStyle | None = None,
+    branching_cadence: BranchingCadence | None = None,
+    branch_count_range: BranchCountRange | None = None,
+    length_preference: LengthPreference | None = None,
+) -> bool:
+    """Apply non-None config fields to the BranchingSessionState ORM row for a story.
+
+    Only updates the fields that are non-None.  Returns True when the row was
+    found and flushed; False when no row exists for the given story_id.
+    """
+    row = session.scalars(
+        select(BranchingSessionStateORM).where(
+            BranchingSessionStateORM.story_id == str(story_id)
+        )
+    ).first()
+    if row is None:
+        return False
+    if interaction_style is not None:
+        row.interaction_style = interaction_style.value
+    if branching_cadence is not None:
+        row.branching_cadence = branching_cadence.value
+    if branch_count_range is not None:
+        row.branch_count_range = branch_count_range.value
+    if length_preference is not None:
+        row.length_preference = length_preference.value
+    session.flush()
+    return True
 
 
 def delete_branching_session_state(session: Session, session_id: UUID) -> bool:

--- a/src/afterworlds/persistence/orm/session_state.py
+++ b/src/afterworlds/persistence/orm/session_state.py
@@ -74,6 +74,22 @@ class BranchingSessionStateORM(Base):
         sa.ForeignKey("nodes.node_id", ondelete="SET NULL"),
         nullable=True,
     )
+    # Issue 16: interaction configuration columns.  All nullable so existing rows
+    # are never silently backfilled to freeform_only (conservative backfill rule).
+    interaction_style: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    branching_cadence: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    length_preference: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    branch_count_range: Mapped[str | None] = mapped_column(sa.String(8), nullable=True)
+    play_status: Mapped[str] = mapped_column(
+        sa.String(16), nullable=False, server_default="setup"
+    )
+    world_summary: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    story_seeds: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    character_concept: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    supporting_cast: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    world_constraints: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    pacing_notes: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+    acceptable_content: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
 
 
 class WritingSessionStateORM(Base):

--- a/src/afterworlds/pipeline/_refusal.py
+++ b/src/afterworlds/pipeline/_refusal.py
@@ -26,6 +26,7 @@ class PassIdentifier(StrEnum):
     PLANNER = "planner"
     RPG_ADJUDICATION = "rpg_adjudication"
     BRANCHING_WRITER = "branching_writer"
+    BRANCHING_OOC_CONFIG_EXTRACTOR = "branching_ooc_config_extractor"
     WRITER = "writer"
     EXTRACTOR = "extractor"
     CONTRADICTION = "contradiction"

--- a/src/afterworlds/pipeline/_refusal.py
+++ b/src/afterworlds/pipeline/_refusal.py
@@ -25,6 +25,7 @@ class PassIdentifier(StrEnum):
 
     PLANNER = "planner"
     RPG_ADJUDICATION = "rpg_adjudication"
+    BRANCHING_WRITER = "branching_writer"
     WRITER = "writer"
     EXTRACTOR = "extractor"
     CONTRADICTION = "contradiction"

--- a/src/afterworlds/pipeline/branching/__init__.py
+++ b/src/afterworlds/pipeline/branching/__init__.py
@@ -1,0 +1,1 @@
+"""Branching-mode writer pass package — CRD Issue 16."""

--- a/src/afterworlds/pipeline/branching/caller.py
+++ b/src/afterworlds/pipeline/branching/caller.py
@@ -1,0 +1,100 @@
+"""Branching Writer pass tool specification — CRD Issue 16.
+
+The Branching Writer pass uses forced tool use to obtain a structured
+``BranchingWriterProposal``.  The tool schema enforces the code-owns-affordances
+invariant at the schema level:
+
+- ``option_id`` is absent from the schema — code assigns sequential IDs.
+- ``interaction_style``, ``branching_cadence``, ``freeform_available``, and
+  ``branch_count_range`` are absent — all stamped from session state by code.
+- Branch option count is NOT specified in the schema — code validates the count
+  against the session's ``branch_count_range``; the model must propose within
+  the configured range but the schema cannot enforce the exact numeric bounds
+  without knowing the session configuration at schema-build time.
+
+The model proposes:
+- narrative prose (``narrative_text``)
+- branch option labels only (``branch_options_text``, list of strings)
+- presentation state for this beat (``branch_presentation_state``)
+- an optional advisory pacing hint (``pacing_stage_hint``)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+PRODUCE_BRANCH_OUTPUT_TOOL_NAME: str = "produce_branch_output"
+
+PRODUCE_BRANCH_OUTPUT_TOOL_SPEC: dict[str, Any] = {
+    "name": PRODUCE_BRANCH_OUTPUT_TOOL_NAME,
+    "description": (
+        "Produce the narrative text and branch option labels for this beat."
+        " Call this tool exactly once."
+        " You propose narrative prose and action-text labels only."
+        " Do NOT propose option IDs, branch counts, interaction style,"
+        " freeform availability, or cadence — those are code-owned from the"
+        " session configuration and are stamped by the system after validation."
+        " The number of branch options you propose must match the configured"
+        " branch_count_range for this session."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "narrative_text": {
+                "type": "string",
+                "description": (
+                    "The prose narrative for this beat."
+                    " Respond as the story architect — third-person present"
+                    " or the mode-appropriate voice."
+                    " Non-empty."
+                ),
+            },
+            "branch_options_text": {
+                "type": "array",
+                "description": (
+                    "Ordered list of branch option labels for this beat."
+                    " Each entry is a short action phrase that the Sojourner"
+                    " could select (e.g. 'Cross the rope bridge')."
+                    " The count must match the configured branch_count_range."
+                    " Omit this array entirely (or set to []) only when"
+                    " branch_presentation_state is 'held' or 'omitted'."
+                ),
+                "items": {
+                    "type": "string",
+                    "description": "Short action phrase for one branch option.",
+                },
+            },
+            "branch_presentation_state": {
+                "type": "string",
+                "enum": ["shown", "held", "omitted"],
+                "description": (
+                    "'shown' — present branch options to the Sojourner now."
+                    " 'held' — narrative tension warrants withholding options"
+                    " until this beat resolves; options come in the next beat."
+                    " 'omitted' — no branch options this beat (pacing decision)."
+                    " Use 'shown' for the majority of beats."
+                ),
+            },
+            "pacing_stage_hint": {
+                "oneOf": [{"type": "string"}, {"type": "null"}],
+                "description": (
+                    "Optional advisory hint about the current arc stage"
+                    " (e.g. 'escalation', 'climax')."
+                    " Non-authoritative — code does not use this for routing."
+                    " Null when absent."
+                ),
+            },
+        },
+        "required": [
+            "narrative_text",
+            "branch_options_text",
+            "branch_presentation_state",
+        ],
+    },
+}
+
+
+__all__ = [
+    "PRODUCE_BRANCH_OUTPUT_TOOL_NAME",
+    "PRODUCE_BRANCH_OUTPUT_TOOL_SPEC",
+]

--- a/src/afterworlds/pipeline/branching/config.py
+++ b/src/afterworlds/pipeline/branching/config.py
@@ -1,0 +1,72 @@
+"""Branching Writer pass configuration — CRD Issue 16."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from afterworlds.models.enums import BranchCountRange, InteractionStyle
+
+_DEFAULT_BRANCHING_WRITER_MODEL: str = "claude-sonnet-4-6"
+
+BRANCHING_WRITER_MAX_TOKENS: int = 1024
+
+#: Maps branch_count_range string to (min_options, max_options) tuple.
+#: Code uses this to validate proposal count — never clamp, pad, or truncate.
+BRANCH_COUNT_RANGE_BOUNDS: dict[str, tuple[int, int]] = {
+    "1-2": (1, 2),
+    "2-3": (2, 3),
+    "3-4": (3, 4),
+    "2-4": (2, 4),
+    "2-5": (2, 5),
+}
+
+#: Code-owned frozen mapping of which branch-count ranges are valid per
+#: InteractionStyle.  FREEFORM_ONLY maps to None (no branch cards).
+#: Validated by the OOC config-update path and setup flow.
+ALLOWED_RANGES_BY_STYLE: dict[InteractionStyle, frozenset[BranchCountRange] | None] = {
+    InteractionStyle.FREEFORM_ONLY: None,
+    InteractionStyle.HYBRID: frozenset(
+        {
+            BranchCountRange.ONE_TO_TWO,
+            BranchCountRange.TWO_TO_THREE,
+            BranchCountRange.THREE_TO_FOUR,
+        }
+    ),
+    InteractionStyle.TRUE_CYOA: frozenset(
+        {
+            BranchCountRange.TWO_TO_THREE,
+            BranchCountRange.TWO_TO_FOUR,
+            BranchCountRange.TWO_TO_FIVE,
+        }
+    ),
+}
+
+
+@dataclass
+class BranchingWriterConfig:
+    model: str = _DEFAULT_BRANCHING_WRITER_MODEL
+    api_key_env: str = "ANTHROPIC_API_KEY"
+    extended_ttl: bool = True
+
+    @classmethod
+    def from_env(cls) -> BranchingWriterConfig:
+        model = os.environ.get(
+            "AFTERWORLDS_BRANCHING_WRITER_MODEL", _DEFAULT_BRANCHING_WRITER_MODEL
+        )
+        api_key_env = os.environ.get(
+            "AFTERWORLDS_BRANCHING_WRITER_API_KEY_ENV", "ANTHROPIC_API_KEY"
+        )
+        ttl_str = os.environ.get(
+            "AFTERWORLDS_BRANCHING_WRITER_EXTENDED_TTL", "true"
+        ).lower()
+        extended_ttl = ttl_str not in ("0", "false", "no")
+        return cls(model=model, api_key_env=api_key_env, extended_ttl=extended_ttl)
+
+
+__all__ = [
+    "ALLOWED_RANGES_BY_STYLE",
+    "BRANCH_COUNT_RANGE_BOUNDS",
+    "BRANCHING_WRITER_MAX_TOKENS",
+    "BranchingWriterConfig",
+]

--- a/src/afterworlds/pipeline/branching/models.py
+++ b/src/afterworlds/pipeline/branching/models.py
@@ -1,0 +1,220 @@
+"""Typed payloads and exceptions for the Branching Writer pass — CRD Issue 16."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    BranchPresentationState,
+    InteractionRejectionReason,
+    InteractionStyle,
+    LengthPreference,
+)
+
+
+class ProposedBranchOption(BaseModel):
+    """Branch option as proposed by the model via forced tool use.
+
+    The model proposes ``action_text`` only.  ``option_id`` is code-assigned
+    after validation; it must not appear in the tool schema.
+    """
+
+    action_text: str
+
+
+class BranchOption(BaseModel):
+    """Branch option with code-assigned identity, ready for delivery.
+
+    ``option_id`` is assigned by code (sequential ``opt_1``, ``opt_2``, …).
+    ``action_text`` comes from the model proposal after range validation.
+    """
+
+    option_id: str
+    action_text: str
+
+
+class BranchingWriterProposal(BaseModel):
+    """Raw output from the forced-tool call, before code stamps config fields.
+
+    Fields the model may propose:
+    - ``narrative_text``: prose narrative for this beat.
+    - ``branch_options_text``: list of action labels for presented branch options.
+      The model proposes prose labels only; option_id is code-assigned.
+    - ``branch_presentation_state``: whether to show, hold, or omit branch cards
+      this beat.  Code validates against session state.
+    - ``pacing_stage_hint``: optional advisory hint about current arc stage.
+      Code does not trust this; it is advisory context only.
+
+    Fields the model must NOT propose (enforced by schema shape — absent from
+    the tool input_schema):
+    - interaction_style (code-owned from session state)
+    - branching_cadence (code-owned from session state)
+    - freeform_available (code-derived from interaction_style)
+    - branch_count_range (code-owned from session state)
+    - option_id for any option (code-assigned sequential)
+    """
+
+    narrative_text: str
+    branch_options_text: list[str]
+    branch_presentation_state: str
+    pacing_stage_hint: str | None = None
+
+
+class BranchingPassResult(BaseModel):
+    """Complete result returned by ``BranchingWriterService.write()``.
+
+    Code stamps all affordance fields from session state after validating the
+    model's proposal.  The model contributes only ``narrative_text`` and the
+    action-text labels for branch options.
+
+    ``branch_options`` is empty for ``FREEFORM_ONLY`` turns (which bypass
+    this service entirely and use the prose Writer).
+    """
+
+    narrative_text: str
+    interaction_style: InteractionStyle
+    branching_cadence: BranchingCadence
+    length_preference: LengthPreference | None
+    freeform_available: bool
+    branch_count_range: BranchCountRange | None
+    branch_options: list[BranchOption]
+    branch_presentation_state: str
+
+    provider: str | None = None
+    model_identifier: str | None = None
+    model_tier: str | None = None
+    latency_ms: int = 0
+    input_token_count: int | None = None
+    output_token_count: int | None = None
+    cache_read_token_count: int | None = None
+    cache_creation_token_count: int | None = None
+
+
+class BranchingPassError(Exception):
+    """Fail-closed exception for the Branching Writer pass.
+
+    Covers: no tool_use block, tool name mismatch, malformed proposal output,
+    branch-count range violation, provider exception, and schema validation
+    failure.  No DB state is committed when this is raised.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Branch-selection validation
+# ---------------------------------------------------------------------------
+
+
+class BranchSelectionValidationVerdict(StrEnum):
+    """Outcome of validating a BRANCH_CHOICE input against the current card set."""
+
+    ACCEPT = "accept"
+    REJECT = "reject"
+
+
+class BranchSelectionValidationResult(BaseModel):
+    """Result of validating a Sojourner's branch selection.
+
+    Populated after resolving a BRANCH_CHOICE intent against the most-recently-
+    presented option set.  On ACCEPT, ``selected_context`` is populated and
+    passed forward to the Writer.  On REJECT, ``rejection_reason`` and
+    ``rejection_message`` are populated for INTERACTION_REJECTED routing.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    verdict: BranchSelectionValidationVerdict
+    selected_context: SelectedBranchContext | None = None
+    rejection_reason: InteractionRejectionReason | None = None
+    rejection_message: str | None = None
+
+
+class SelectedBranchContext(BaseModel):
+    """Volatile pass-forward payload for a validated branch selection.
+
+    Created on ACCEPT from branch-selection validation; threaded through to
+    the Writer so the narrative can reference the chosen branch.
+
+    IMPORTANT invariants:
+    - Never use as a stable prefix or cache key (volatile per turn).
+    - Never persist to Node or Story Bible directly — use Node.branching_logic
+      for realized selection edges and Node.mode_metadata.branching for
+      selection metadata.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    option_id: str
+    action_text: str
+    annotation: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# OOC config update
+# ---------------------------------------------------------------------------
+
+
+class BranchingConfigUpdate(BaseModel):
+    """Structured config changes extracted by the OOC handler (CRD Issue 16).
+
+    Produced via forced-tool OOC pass when the Sojourner requests a branching
+    config update (e.g. "switch to Hybrid mode", "give me more branches").
+    All fields are optional; only non-None fields are applied.
+
+    Validation against ``ALLOWED_RANGES_BY_STYLE`` happens before persistence.
+    Transaction-scoped: commits only with OOC_HANDLED; rolls back on any
+    Output Safety block, provider refusal, or error.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    interaction_style: InteractionStyle | None = None
+    branching_cadence: BranchingCadence | None = None
+    branch_count_range: BranchCountRange | None = None
+    length_preference: LengthPreference | None = None
+
+
+# ---------------------------------------------------------------------------
+# Branching visible state
+# ---------------------------------------------------------------------------
+
+
+class BranchingVisibleState(BaseModel):
+    """Structured branching session state surfaced in OrchestrationResult.
+
+    Populated by ``BranchingVisibleStateService`` on every DELIVERED
+    BRANCHING-mode turn.  Carries the current config and the most-recently-
+    presented branch options so the frontend can render the branch card.
+
+    ``schema_version`` allows forward-compatible reads by callers.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    interaction_style: InteractionStyle
+    branching_cadence: BranchingCadence
+    branch_count_range: BranchCountRange | None
+    freeform_available: bool
+    length_preference: LengthPreference | None
+    last_branch_options: list[BranchOption] | None = None
+    last_presentation_state: BranchPresentationState | None = None
+
+
+__all__ = [
+    "BranchOption",
+    "BranchingConfigUpdate",
+    "BranchingPassError",
+    "BranchingPassResult",
+    "BranchingVisibleState",
+    "BranchingWriterProposal",
+    "BranchSelectionValidationResult",
+    "BranchSelectionValidationVerdict",
+    "ProposedBranchOption",
+    "SelectedBranchContext",
+]

--- a/src/afterworlds/pipeline/branching/models.py
+++ b/src/afterworlds/pipeline/branching/models.py
@@ -232,6 +232,29 @@ class BranchingOocConfigExtractorResult(BaseModel):
     cache_creation_token_count: int | None = None
 
 
+class BranchingOocExtractionUsageError(BranchingPassError):
+    """OOC config extraction failed *after* the provider returned a result.
+
+    Raised when the provider call succeeded (and therefore consumed tokens) but
+    a local validation step afterwards rejected the response — a missing
+    tool-use block, an unexpected tool name, or a schema validation failure.
+
+    The provider usage must not be erased just because the local parse failed,
+    so this error carries a usage-only ``BranchingOocConfigExtractorResult``
+    (provider/model/token/cache metrics populated, ``config_update`` all-null).
+    The orchestrator captures ``usage_result`` for settlement/audit before
+    swallowing the best-effort config-update failure. Provider-call failures
+    that raise *before* any result exists remain plain ``BranchingPassError``
+    with no fabricated usage.
+    """
+
+    def __init__(
+        self, message: str, usage_result: BranchingOocConfigExtractorResult
+    ) -> None:
+        super().__init__(message)
+        self.usage_result = usage_result
+
+
 # ---------------------------------------------------------------------------
 # Branching visible state
 # ---------------------------------------------------------------------------
@@ -263,6 +286,7 @@ __all__ = [
     "BranchOption",
     "BranchingConfigUpdate",
     "BranchingOocConfigExtractorResult",
+    "BranchingOocExtractionUsageError",
     "BranchingPassError",
     "BranchingPassResult",
     "BranchingVisibleState",

--- a/src/afterworlds/pipeline/branching/models.py
+++ b/src/afterworlds/pipeline/branching/models.py
@@ -61,7 +61,7 @@ class BranchingWriterProposal(BaseModel):
 
     narrative_text: str
     branch_options_text: list[str]
-    branch_presentation_state: str
+    branch_presentation_state: BranchPresentationState
     pacing_stage_hint: str | None = None
 
 

--- a/src/afterworlds/pipeline/branching/models.py
+++ b/src/afterworlds/pipeline/branching/models.py
@@ -180,6 +180,31 @@ class BranchingConfigUpdate(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# OOC config extractor result
+# ---------------------------------------------------------------------------
+
+
+class BranchingOocConfigExtractorResult(BaseModel):
+    """Result from the OOC config extractor pass (CRD Issue 16 Phase F).
+
+    Wraps the extracted config update with provider usage metrics so the
+    entitlement layer can include this pass in credit settlement.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    config_update: BranchingConfigUpdate
+    provider: str | None = None
+    model_identifier: str | None = None
+    model_tier: str | None = None
+    latency_ms: int = 0
+    input_token_count: int | None = None
+    output_token_count: int | None = None
+    cache_read_token_count: int | None = None
+    cache_creation_token_count: int | None = None
+
+
+# ---------------------------------------------------------------------------
 # Branching visible state
 # ---------------------------------------------------------------------------
 
@@ -209,6 +234,7 @@ class BranchingVisibleState(BaseModel):
 __all__ = [
     "BranchOption",
     "BranchingConfigUpdate",
+    "BranchingOocConfigExtractorResult",
     "BranchingPassError",
     "BranchingPassResult",
     "BranchingVisibleState",

--- a/src/afterworlds/pipeline/branching/models.py
+++ b/src/afterworlds/pipeline/branching/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from afterworlds.models.enums import (
     BranchCountRange,
@@ -63,6 +63,34 @@ class BranchingWriterProposal(BaseModel):
     branch_options_text: list[str]
     branch_presentation_state: BranchPresentationState
     pacing_stage_hint: str | None = None
+
+    @field_validator("narrative_text")
+    @classmethod
+    def _narrative_text_non_empty(cls, value: str) -> str:
+        """Reject blank prose; the model must author real narrative text."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("narrative_text must be non-empty after stripping")
+        return stripped
+
+    @field_validator("branch_options_text")
+    @classmethod
+    def _branch_option_labels_non_empty(cls, value: list[str]) -> list[str]:
+        """Reject blank option labels; an empty list ([]) stays valid.
+
+        Empty ``branch_options_text`` is allowed for ``held``/``omitted``
+        HYBRID turns.  When labels are present, each must be non-empty after
+        stripping; the stripped value is what code stamps onto ``option_id``.
+        """
+        cleaned: list[str] = []
+        for label in value:
+            stripped = label.strip()
+            if not stripped:
+                raise ValueError(
+                    "branch_options_text labels must be non-empty after stripping"
+                )
+            cleaned.append(stripped)
+        return cleaned
 
 
 class BranchingPassResult(BaseModel):

--- a/src/afterworlds/pipeline/branching/ooc_config_extractor.py
+++ b/src/afterworlds/pipeline/branching/ooc_config_extractor.py
@@ -28,6 +28,7 @@ from afterworlds.entitlement.enums import PipelinePassId
 from afterworlds.pipeline._stable_prefix_renderer import RenderedBlock
 from afterworlds.pipeline.branching.models import (
     BranchingConfigUpdate,
+    BranchingOocConfigExtractorResult,
     BranchingPassError,
 )
 from afterworlds.pipeline.provider._models import (
@@ -166,18 +167,19 @@ class BranchingOocConfigExtractorService:
         self,
         ctx: AssembledContext,
         provider: ProviderAdapter,
-    ) -> BranchingConfigUpdate:
-        """Run the config extraction pass and return a structured update.
+    ) -> BranchingOocConfigExtractorResult:
+        """Run the config extraction pass and return a typed result with metrics.
 
-        The returned ``BranchingConfigUpdate`` may have all-None fields when
-        the player's OOC message contained no config change request.
+        The ``config_update`` in the result may have all-None fields when the
+        player's OOC message contained no config change request.
 
         Args:
             ctx: AssembledContext for the current OOC turn.
             provider: ProviderAdapter for the forced-tool LLM call.
 
         Returns:
-            BranchingConfigUpdate with non-None fields for each change requested.
+            BranchingOocConfigExtractorResult with config_update and provider
+            usage metrics for entitlement settlement.
 
         Raises:
             BranchingPassError: on provider error, missing tool block, tool name
@@ -186,14 +188,16 @@ class BranchingOocConfigExtractorService:
         request = self._render(ctx)
 
         try:
-            result = provider.call(request)
+            call_result = provider.call(request)
         except Exception as exc:
             raise BranchingPassError(
                 f"Branching OOC config extractor provider call failed: {exc}"
             ) from exc
 
+        # Capture metrics immediately — before any validation that might raise —
+        # so the provider usage is available even if parsing later fails.
         tool_parts = [
-            p for p in result.content_parts if isinstance(p, ProviderToolCallPart)
+            p for p in call_result.content_parts if isinstance(p, ProviderToolCallPart)
         ]
         if not tool_parts:
             raise BranchingPassError(
@@ -214,7 +218,17 @@ class BranchingOocConfigExtractorService:
                 f" {exc}"
             ) from exc
 
-        return update
+        return BranchingOocConfigExtractorResult(
+            config_update=update,
+            provider=call_result.provider_name,
+            model_identifier=call_result.model_identifier,
+            model_tier=call_result.model_tier.value if call_result.model_tier else None,
+            latency_ms=call_result.latency_ms,
+            input_token_count=call_result.input_token_count,
+            output_token_count=call_result.output_token_count,
+            cache_read_token_count=call_result.cache_read_token_count,
+            cache_creation_token_count=call_result.cache_creation_token_count,
+        )
 
     def _render(self, ctx: AssembledContext) -> ProviderCallRequest:
         """Build a minimal ProviderCallRequest for the extraction pass."""

--- a/src/afterworlds/pipeline/branching/ooc_config_extractor.py
+++ b/src/afterworlds/pipeline/branching/ooc_config_extractor.py
@@ -29,6 +29,7 @@ from afterworlds.pipeline._stable_prefix_renderer import RenderedBlock
 from afterworlds.pipeline.branching.models import (
     BranchingConfigUpdate,
     BranchingOocConfigExtractorResult,
+    BranchingOocExtractionUsageError,
     BranchingPassError,
 )
 from afterworlds.pipeline.provider._models import (
@@ -182,8 +183,12 @@ class BranchingOocConfigExtractorService:
             usage metrics for entitlement settlement.
 
         Raises:
-            BranchingPassError: on provider error, missing tool block, tool name
-                mismatch, or schema validation failure.
+            BranchingPassError: on a provider error that raises before any result
+                exists (no usage consumed).
+            BranchingOocExtractionUsageError: on a missing tool block, tool name
+                mismatch, or schema validation failure *after* the provider
+                returned a result. Carries a usage-only result so already-consumed
+                provider usage is preserved for settlement.
         """
         request = self._render(ctx)
 
@@ -194,32 +199,11 @@ class BranchingOocConfigExtractorService:
                 f"Branching OOC config extractor provider call failed: {exc}"
             ) from exc
 
-        # Capture metrics immediately — before any validation that might raise —
-        # so the provider usage is available even if parsing later fails.
-        tool_parts = [
-            p for p in call_result.content_parts if isinstance(p, ProviderToolCallPart)
-        ]
-        if not tool_parts:
-            raise BranchingPassError(
-                "Branching OOC config extractor response missing tool-use block"
-            )
-        if tool_parts[0].tool_name != EXTRACT_CONFIG_UPDATE_TOOL_NAME:
-            raise BranchingPassError(
-                f"Branching OOC config extractor unexpected tool name:"
-                f" {tool_parts[0].tool_name!r};"
-                f" expected {EXTRACT_CONFIG_UPDATE_TOOL_NAME!r}"
-            )
-
-        try:
-            update = BranchingConfigUpdate.model_validate(tool_parts[0].tool_input)
-        except Exception as exc:
-            raise BranchingPassError(
-                f"Branching OOC config extractor tool input failed schema validation:"
-                f" {exc}"
-            ) from exc
-
-        return BranchingOocConfigExtractorResult(
-            config_update=update,
+        # The provider call returned, so tokens were consumed. Build a usage-only
+        # result now so any local validation failure below preserves the provider
+        # metrics for settlement (config_update stays all-null on failure).
+        usage_only = BranchingOocConfigExtractorResult(
+            config_update=BranchingConfigUpdate(),
             provider=call_result.provider_name,
             model_identifier=call_result.model_identifier,
             model_tier=call_result.model_tier.value if call_result.model_tier else None,
@@ -229,6 +213,33 @@ class BranchingOocConfigExtractorService:
             cache_read_token_count=call_result.cache_read_token_count,
             cache_creation_token_count=call_result.cache_creation_token_count,
         )
+
+        tool_parts = [
+            p for p in call_result.content_parts if isinstance(p, ProviderToolCallPart)
+        ]
+        if not tool_parts:
+            raise BranchingOocExtractionUsageError(
+                "Branching OOC config extractor response missing tool-use block",
+                usage_only,
+            )
+        if tool_parts[0].tool_name != EXTRACT_CONFIG_UPDATE_TOOL_NAME:
+            raise BranchingOocExtractionUsageError(
+                f"Branching OOC config extractor unexpected tool name:"
+                f" {tool_parts[0].tool_name!r};"
+                f" expected {EXTRACT_CONFIG_UPDATE_TOOL_NAME!r}",
+                usage_only,
+            )
+
+        try:
+            update = BranchingConfigUpdate.model_validate(tool_parts[0].tool_input)
+        except Exception as exc:
+            raise BranchingOocExtractionUsageError(
+                f"Branching OOC config extractor tool input failed schema validation:"
+                f" {exc}",
+                usage_only,
+            ) from exc
+
+        return usage_only.model_copy(update={"config_update": update})
 
     def _render(self, ctx: AssembledContext) -> ProviderCallRequest:
         """Build a minimal ProviderCallRequest for the extraction pass."""

--- a/src/afterworlds/pipeline/branching/ooc_config_extractor.py
+++ b/src/afterworlds/pipeline/branching/ooc_config_extractor.py
@@ -1,0 +1,239 @@
+"""Branching OOC config extractor — CRD Issue 16 Phase F.
+
+Extracts ``BranchingConfigUpdate`` from an OOC turn via forced tool use.
+Called after the OOC prose Writer succeeds, inside the same transaction.
+
+Responsibilities:
+  1. Build a minimal ``ProviderCallRequest`` using the user's OOC message as
+     content.  No stable-prefix reuse (short extraction pass, no cache needed).
+  2. Force-call the ``extract_branching_config_update`` tool.
+  3. Parse and validate the tool output into ``BranchingConfigUpdate``.
+  4. Raise ``BranchingPassError`` on provider, parse, or schema failures.
+
+The caller (orchestrator ``_ooc_persist``) is responsible for:
+  - Validating the result against ``ALLOWED_RANGES_BY_STYLE``.
+  - Applying the update inside the OOC transaction via
+    ``apply_branching_config_update``.
+  - Treating failures as best-effort (skipping persistence on error).
+
+V1 scope: extracts from user's OOC message only; does not see the writer's
+prose response.  Writer/validation reconciliation is deferred to v2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from afterworlds.entitlement.enums import PipelinePassId
+from afterworlds.pipeline._stable_prefix_renderer import RenderedBlock
+from afterworlds.pipeline.branching.models import (
+    BranchingConfigUpdate,
+    BranchingPassError,
+)
+from afterworlds.pipeline.provider._models import (
+    ProviderCallRequest,
+    ProviderToolCallPart,
+    ProviderToolDefinition,
+)
+
+if TYPE_CHECKING:
+    from afterworlds.models.context import AssembledContext
+    from afterworlds.pipeline.provider._protocol import ProviderAdapter
+
+
+# ---------------------------------------------------------------------------
+# Tool specification
+# ---------------------------------------------------------------------------
+
+EXTRACT_CONFIG_UPDATE_TOOL_NAME: str = "extract_branching_config_update"
+
+EXTRACT_CONFIG_UPDATE_TOOL_SPEC: dict[str, Any] = {
+    "name": EXTRACT_CONFIG_UPDATE_TOOL_NAME,
+    "description": (
+        "Extract any branching story configuration changes the player explicitly"
+        " requested in their out-of-character (OOC) message."
+        " Set each field to null if the player did not explicitly request that"
+        " field to change.  Do not infer changes that were not stated."
+        " Call this tool exactly once."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "interaction_style": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "enum": ["freeform_only", "hybrid", "true_cyoa"],
+                        "description": (
+                            "The requested interaction style."
+                            " 'freeform_only' = no branch cards, pure narrative prose."
+                            " 'hybrid' = narrative prose plus optional branch cards."
+                            " 'true_cyoa' = branch cards required every beat."
+                        ),
+                    },
+                    {"type": "null"},
+                ],
+                "description": "Null if the player did not request a style change.",
+            },
+            "branching_cadence": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "enum": ["interactive", "balanced", "immersive"],
+                        "description": (
+                            "'interactive' = branch cards every beat."
+                            " 'balanced' = branch cards most beats."
+                            " 'immersive' = branch cards selectively."
+                        ),
+                    },
+                    {"type": "null"},
+                ],
+                "description": "Null if the player did not request a cadence change.",
+            },
+            "branch_count_range": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "enum": ["1-2", "2-3", "3-4", "2-4", "2-5"],
+                        "description": (
+                            "Range of branch options per beat."
+                            " Hybrid supports: 1-2, 2-3, 3-4."
+                            " True CYOA supports: 2-3, 2-4, 2-5."
+                        ),
+                    },
+                    {"type": "null"},
+                ],
+                "description": (
+                    "Null if the player did not request a branch count change."
+                ),
+            },
+            "length_preference": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "enum": ["short_story", "novella", "novel"],
+                        "description": (
+                            "Preferred narrative response length per beat."
+                            " 'short_story' = concise."
+                            " 'novella' = moderate."
+                            " 'novel' = detailed."
+                        ),
+                    },
+                    {"type": "null"},
+                ],
+                "description": ("Null if the player did not request a length change."),
+            },
+        },
+        "required": [
+            "interaction_style",
+            "branching_cadence",
+            "branch_count_range",
+            "length_preference",
+        ],
+    },
+}
+
+_EXTRACT_TOOL_DEF = ProviderToolDefinition(
+    name=EXTRACT_CONFIG_UPDATE_TOOL_NAME,
+    description=EXTRACT_CONFIG_UPDATE_TOOL_SPEC["description"],
+    input_schema=EXTRACT_CONFIG_UPDATE_TOOL_SPEC["input_schema"],
+)
+
+_EXTRACTION_SYSTEM_PROMPT: str = (
+    "You are a configuration extractor for a branching interactive story system."
+    " The player has sent an out-of-character (OOC) message."
+    " Your task is to identify and extract any explicit branching configuration"
+    " changes the player requested."
+    " Use the extract_branching_config_update tool to report what was requested."
+    " Set fields to null for anything the player did not explicitly ask to change."
+)
+
+_MAX_OUTPUT_TOKENS: int = 256
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class BranchingOocConfigExtractorService:
+    """Extracts BranchingConfigUpdate from an OOC turn via forced tool use.
+
+    Stateless — construct once and reuse.
+    """
+
+    def extract(
+        self,
+        ctx: AssembledContext,
+        provider: ProviderAdapter,
+    ) -> BranchingConfigUpdate:
+        """Run the config extraction pass and return a structured update.
+
+        The returned ``BranchingConfigUpdate`` may have all-None fields when
+        the player's OOC message contained no config change request.
+
+        Args:
+            ctx: AssembledContext for the current OOC turn.
+            provider: ProviderAdapter for the forced-tool LLM call.
+
+        Returns:
+            BranchingConfigUpdate with non-None fields for each change requested.
+
+        Raises:
+            BranchingPassError: on provider error, missing tool block, tool name
+                mismatch, or schema validation failure.
+        """
+        request = self._render(ctx)
+
+        try:
+            result = provider.call(request)
+        except Exception as exc:
+            raise BranchingPassError(
+                f"Branching OOC config extractor provider call failed: {exc}"
+            ) from exc
+
+        tool_parts = [
+            p for p in result.content_parts if isinstance(p, ProviderToolCallPart)
+        ]
+        if not tool_parts:
+            raise BranchingPassError(
+                "Branching OOC config extractor response missing tool-use block"
+            )
+        if tool_parts[0].tool_name != EXTRACT_CONFIG_UPDATE_TOOL_NAME:
+            raise BranchingPassError(
+                f"Branching OOC config extractor unexpected tool name:"
+                f" {tool_parts[0].tool_name!r};"
+                f" expected {EXTRACT_CONFIG_UPDATE_TOOL_NAME!r}"
+            )
+
+        try:
+            update = BranchingConfigUpdate.model_validate(tool_parts[0].tool_input)
+        except Exception as exc:
+            raise BranchingPassError(
+                f"Branching OOC config extractor tool input failed schema validation:"
+                f" {exc}"
+            ) from exc
+
+        return update
+
+    def _render(self, ctx: AssembledContext) -> ProviderCallRequest:
+        """Build a minimal ProviderCallRequest for the extraction pass."""
+        vs = ctx.volatile_suffix
+        content_block = RenderedBlock(
+            text=f"Player (OOC): {vs.current_input}",
+        )
+        return ProviderCallRequest(
+            pass_id=PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR,
+            system_blocks=[RenderedBlock(text=_EXTRACTION_SYSTEM_PROMPT)],
+            rendered_blocks=[content_block],
+            max_output_tokens=_MAX_OUTPUT_TOKENS,
+            tool_definitions=[_EXTRACT_TOOL_DEF],
+            forced_tool_name=EXTRACT_CONFIG_UPDATE_TOOL_NAME,
+        )
+
+
+__all__ = [
+    "BranchingOocConfigExtractorService",
+    "EXTRACT_CONFIG_UPDATE_TOOL_NAME",
+    "EXTRACT_CONFIG_UPDATE_TOOL_SPEC",
+]

--- a/src/afterworlds/pipeline/branching/selection.py
+++ b/src/afterworlds/pipeline/branching/selection.py
@@ -5,10 +5,15 @@ presented on the current beat.  Pure-Python — no LLM call.
 
 Resolution algorithm (in order, first match wins):
 1. Exact option_id match: raw_input contains "opt_N" verbatim.
-2. Positional numeric: raw_input contains a bare number or "option N" /
-   "choice N" phrase that maps to "opt_N".
+2. Explicit numeric phrase: "option N" / "choice N" maps to "opt_N".
 3. Ordinal word: "first" → opt_1, "second" → opt_2, … (up to opt_5).
-4. No match → INVALID_BRANCH_SELECTION.
+4. Bare number: a lone "N" maps to "opt_N", but only when it is the operative
+   trailing selection token — an incidental number embedded in prose
+   ("take 2 torches") is not a selection.
+5. No match → INVALID_BRANCH_SELECTION.
+
+Explicit forms outrank bare numbers: "I use my 2 torches and choose option 1"
+resolves to opt_1, never opt_2.
 
 V1 scope note: material-rewrite detection (MATERIAL_BRANCH_REWRITE) requires
 LLM judgment and is not implemented here.  The verdict is ACCEPT for any
@@ -42,9 +47,10 @@ _ORDINALS: dict[str, int] = {
 }
 
 _OPT_ID_RE = re.compile(r"\bopt_(\d+)\b", re.IGNORECASE)
-_NUMERIC_PHRASE_RE = re.compile(
-    r"\b(?:option|choice)\s+(\d+)\b|\b(\d+)\b", re.IGNORECASE
-)
+# Explicit numeric selection phrase: "option 2" / "choice 3".  Outranks bare
+# numbers so an incidental quantity ("my 2 torches") cannot pre-empt an explicit
+# later selection ("choose option 1").
+_EXPLICIT_NUM_RE = re.compile(r"\b(?:option|choice)\s+(\d+)\b", re.IGNORECASE)
 # An ordinal may be followed by a neutral selection noun ("option"/"choice");
 # when present it is part of the selection phrase, not a trailing annotation, so
 # the whole match (group 0) is consumed.  Group 1 holds the ordinal word.
@@ -52,6 +58,11 @@ _ORDINAL_RE = re.compile(
     r"\b(first|second|third|fourth|fifth)\b(?:\s+(?:option|choice)\b)?",
     re.IGNORECASE,
 )
+# Bare number, accepted only as a last resort and only when it is the operative
+# trailing selection token (nothing but whitespace/punctuation follows it).  An
+# incidental number embedded in prose ("take 2 torches") is not a selection.
+_BARE_NUMBER_RE = re.compile(r"\b(\d+)\b")
+_WORD_RE = re.compile(r"\w")
 
 
 def _extract_annotation(raw_input: str, consumed_token: str) -> str | None:
@@ -115,13 +126,10 @@ class BranchSelectionValidationService:
                 resolved_id = candidate
                 consumed_token = m.group(0)
 
-        # 2. Numeric phrase ("option 2", "choice 3", or bare "2")
+        # 2. Explicit numeric phrase ("option 2", "choice 3")
         if resolved_id is None:
-            for m in _NUMERIC_PHRASE_RE.finditer(raw_input):
-                num_str = m.group(1) or m.group(2)
-                if num_str is None:
-                    continue
-                n = int(num_str)
+            for m in _EXPLICIT_NUM_RE.finditer(raw_input):
+                n = int(m.group(1))
                 candidate = f"opt_{n}"
                 if 1 <= n <= max_index and candidate in opt_map:
                     resolved_id = candidate
@@ -137,6 +145,20 @@ class BranchSelectionValidationService:
                 if 1 <= n <= max_index and candidate in opt_map:
                     resolved_id = candidate
                     consumed_token = m.group(0)
+
+        # 4. Bare number — lowest precedence, and only when it is the operative
+        #    trailing selection token.  A number followed by further words is an
+        #    incidental quantity, not a branch choice, and is skipped.
+        if resolved_id is None:
+            for m in _BARE_NUMBER_RE.finditer(raw_input):
+                if _WORD_RE.search(raw_input[m.end() :]):
+                    continue
+                n = int(m.group(1))
+                candidate = f"opt_{n}"
+                if 1 <= n <= max_index and candidate in opt_map:
+                    resolved_id = candidate
+                    consumed_token = m.group(0)
+                    break
 
         if resolved_id is None:
             opt_labels = ", ".join(

--- a/src/afterworlds/pipeline/branching/selection.py
+++ b/src/afterworlds/pipeline/branching/selection.py
@@ -1,0 +1,161 @@
+"""Branch-selection validation service — CRD Issue 16.
+
+Validates a Sojourner's BRANCH_CHOICE input against the set of options
+presented on the current beat.  Pure-Python — no LLM call.
+
+Resolution algorithm (in order, first match wins):
+1. Exact option_id match: raw_input contains "opt_N" verbatim.
+2. Positional numeric: raw_input contains a bare number or "option N" /
+   "choice N" phrase that maps to "opt_N".
+3. Ordinal word: "first" → opt_1, "second" → opt_2, … (up to opt_5).
+4. No match → INVALID_BRANCH_SELECTION.
+
+V1 scope note: material-rewrite detection (MATERIAL_BRANCH_REWRITE) requires
+LLM judgment and is not implemented here.  The verdict is ACCEPT for any
+resolved selection; annotation is recorded from any trailing text after the
+selection token.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from afterworlds.models.enums import InteractionRejectionReason
+from afterworlds.pipeline.branching.models import (
+    BranchSelectionValidationResult,
+    BranchSelectionValidationVerdict,
+    SelectedBranchContext,
+)
+
+if TYPE_CHECKING:
+    from afterworlds.models.node import PersistedBranchOption
+
+
+# Ordinal → index (1-based)
+_ORDINALS: dict[str, int] = {
+    "first": 1,
+    "second": 2,
+    "third": 3,
+    "fourth": 4,
+    "fifth": 5,
+}
+
+_OPT_ID_RE = re.compile(r"\bopt_(\d+)\b", re.IGNORECASE)
+_NUMERIC_PHRASE_RE = re.compile(
+    r"\b(?:option|choice)\s+(\d+)\b|\b(\d+)\b", re.IGNORECASE
+)
+_ORDINAL_RE = re.compile(r"\b(first|second|third|fourth|fifth)\b", re.IGNORECASE)
+
+
+def _extract_annotation(raw_input: str, consumed_token: str) -> str | None:
+    """Return any trailing text after the match token, stripped, or None."""
+    idx = raw_input.lower().find(consumed_token.lower())
+    if idx == -1:
+        return None
+    tail = raw_input[idx + len(consumed_token) :].strip()
+    # Strip common connectors
+    for prefix in ("but", "and", ",", ";", "—", "-"):
+        if tail.lower().startswith(prefix):
+            tail = tail[len(prefix) :].strip()
+    return tail if tail else None
+
+
+class BranchSelectionValidationService:
+    """Validates a BRANCH_CHOICE input against the current beat's branch cards.
+
+    Stateless — construct once and reuse across turns.
+    """
+
+    def validate(
+        self,
+        raw_input: str,
+        presented_options: list[PersistedBranchOption],
+    ) -> BranchSelectionValidationResult:
+        """Resolve and validate the Sojourner's branch selection.
+
+        Args:
+            raw_input: The raw user input string (from IntentClassificationResult).
+            presented_options: Branch options presented on the current beat,
+                from ``Node.mode_metadata.branching.branch_options``.
+
+        Returns:
+            BranchSelectionValidationResult with ACCEPT (and SelectedBranchContext)
+            or REJECT (with InteractionRejectionReason and rejection_message).
+        """
+        if not presented_options:
+            return BranchSelectionValidationResult(
+                verdict=BranchSelectionValidationVerdict.REJECT,
+                rejection_reason=InteractionRejectionReason.INVALID_BRANCH_SELECTION,
+                rejection_message=(
+                    "No branch options were presented for the current beat."
+                    " Branch selection is only valid after a branch card is shown."
+                ),
+            )
+
+        opt_map: dict[str, PersistedBranchOption] = {
+            o.option_id: o for o in presented_options
+        }
+        max_index = len(presented_options)
+
+        resolved_id: str | None = None
+        consumed_token: str = ""
+
+        # 1. Explicit opt_N match
+        m = _OPT_ID_RE.search(raw_input)
+        if m:
+            candidate = f"opt_{m.group(1)}"
+            if candidate in opt_map:
+                resolved_id = candidate
+                consumed_token = m.group(0)
+
+        # 2. Numeric phrase ("option 2", "choice 3", or bare "2")
+        if resolved_id is None:
+            for m in _NUMERIC_PHRASE_RE.finditer(raw_input):
+                num_str = m.group(1) or m.group(2)
+                if num_str is None:
+                    continue
+                n = int(num_str)
+                candidate = f"opt_{n}"
+                if 1 <= n <= max_index and candidate in opt_map:
+                    resolved_id = candidate
+                    consumed_token = m.group(0)
+                    break
+
+        # 3. Ordinal word
+        if resolved_id is None:
+            m = _ORDINAL_RE.search(raw_input)
+            if m:
+                n = _ORDINALS.get(m.group(1).lower(), 0)
+                candidate = f"opt_{n}"
+                if 1 <= n <= max_index and candidate in opt_map:
+                    resolved_id = candidate
+                    consumed_token = m.group(1)
+
+        if resolved_id is None:
+            opt_labels = ", ".join(
+                f"{o.option_id}: {o.action_text!r}" for o in presented_options
+            )
+            return BranchSelectionValidationResult(
+                verdict=BranchSelectionValidationVerdict.REJECT,
+                rejection_reason=InteractionRejectionReason.INVALID_BRANCH_SELECTION,
+                rejection_message=(
+                    "Your input did not match any of the available branch options."
+                    f" Please select one of: {opt_labels}."
+                ),
+            )
+
+        matched_option = opt_map[resolved_id]
+        annotation = _extract_annotation(raw_input, consumed_token)
+
+        return BranchSelectionValidationResult(
+            verdict=BranchSelectionValidationVerdict.ACCEPT,
+            selected_context=SelectedBranchContext(
+                option_id=resolved_id,
+                action_text=matched_option.action_text,
+                annotation=annotation,
+            ),
+        )
+
+
+__all__ = ["BranchSelectionValidationService"]

--- a/src/afterworlds/pipeline/branching/selection.py
+++ b/src/afterworlds/pipeline/branching/selection.py
@@ -45,7 +45,13 @@ _OPT_ID_RE = re.compile(r"\bopt_(\d+)\b", re.IGNORECASE)
 _NUMERIC_PHRASE_RE = re.compile(
     r"\b(?:option|choice)\s+(\d+)\b|\b(\d+)\b", re.IGNORECASE
 )
-_ORDINAL_RE = re.compile(r"\b(first|second|third|fourth|fifth)\b", re.IGNORECASE)
+# An ordinal may be followed by a neutral selection noun ("option"/"choice");
+# when present it is part of the selection phrase, not a trailing annotation, so
+# the whole match (group 0) is consumed.  Group 1 holds the ordinal word.
+_ORDINAL_RE = re.compile(
+    r"\b(first|second|third|fourth|fifth)\b(?:\s+(?:option|choice)\b)?",
+    re.IGNORECASE,
+)
 
 
 def _extract_annotation(raw_input: str, consumed_token: str) -> str | None:
@@ -130,7 +136,7 @@ class BranchSelectionValidationService:
                 candidate = f"opt_{n}"
                 if 1 <= n <= max_index and candidate in opt_map:
                     resolved_id = candidate
-                    consumed_token = m.group(1)
+                    consumed_token = m.group(0)
 
         if resolved_id is None:
             opt_labels = ", ".join(

--- a/src/afterworlds/pipeline/branching/selection.py
+++ b/src/afterworlds/pipeline/branching/selection.py
@@ -8,8 +8,9 @@ Resolution algorithm (in order, first match wins):
 2. Explicit numeric phrase: "option N" / "choice N" maps to "opt_N".
 3. Ordinal word: "first" → opt_1, "second" → opt_2, … (up to opt_5).
 4. Bare number: a lone "N" maps to "opt_N", but only when it is the operative
-   trailing selection token — an incidental number embedded in prose
-   ("take 2 torches") is not a selection.
+   selection token — either it leads the input ("2, but I do it cautiously")
+   or it trails it with nothing further ("I pick 2").  An incidental number
+   embedded in prose ("take 2 torches") is not a selection.
 5. No match → INVALID_BRANCH_SELECTION.
 
 Explicit forms outrank bare numbers: "I use my 2 torches and choose option 1"
@@ -59,22 +60,41 @@ _ORDINAL_RE = re.compile(
     re.IGNORECASE,
 )
 # Bare number, accepted only as a last resort and only when it is the operative
-# trailing selection token (nothing but whitespace/punctuation follows it).  An
-# incidental number embedded in prose ("take 2 torches") is not a selection.
+# selection token: either it leads the input ("2, but I do it cautiously") or it
+# trails it with nothing further ("I pick 2").  An incidental number embedded in
+# prose ("take 2 torches") is neither and is not a selection.
 _BARE_NUMBER_RE = re.compile(r"\b(\d+)\b")
 _WORD_RE = re.compile(r"\w")
+# Leading connectors / punctuation stripped from a captured annotation.  Word
+# connectors ("but"/"and") are only stripped on a word boundary so real words
+# ("butter", "andes") are preserved.
+_ANNOTATION_CONNECTORS: tuple[str, ...] = ("but", "and", ",", ";", "—", "-", ".")
 
 
-def _extract_annotation(raw_input: str, consumed_token: str) -> str | None:
-    """Return any trailing text after the match token, stripped, or None."""
-    idx = raw_input.lower().find(consumed_token.lower())
-    if idx == -1:
-        return None
-    tail = raw_input[idx + len(consumed_token) :].strip()
-    # Strip common connectors
-    for prefix in ("but", "and", ",", ";", "—", "-"):
-        if tail.lower().startswith(prefix):
+def _extract_annotation(tail: str) -> str | None:
+    """Return the trailing annotation text after a selection token, or None.
+
+    ``tail`` is the raw substring following the consumed match span.  Leading
+    connectors and punctuation are stripped repeatedly so that stacked
+    connectors collapse — e.g. "2, but I do it cautiously" yields the tail
+    ", but I do it cautiously", which reduces to "I do it cautiously" (both the
+    comma and "but" are removed), not "but I do it cautiously".
+    """
+    tail = tail.strip()
+    changed = True
+    while changed:
+        changed = False
+        for prefix in _ANNOTATION_CONNECTORS:
+            if not tail.lower().startswith(prefix):
+                continue
+            if prefix.isalpha():
+                # Only strip a word connector on a word boundary, so that
+                # "butter"/"andes" are not truncated to "ter"/"es".
+                after = tail[len(prefix) :]
+                if after[:1].isalnum():
+                    continue
             tail = tail[len(prefix) :].strip()
+            changed = True
     return tail if tail else None
 
 
@@ -116,7 +136,7 @@ class BranchSelectionValidationService:
         max_index = len(presented_options)
 
         resolved_id: str | None = None
-        consumed_token: str = ""
+        consumed_end: int = -1
 
         # 1. Explicit opt_N match
         m = _OPT_ID_RE.search(raw_input)
@@ -124,7 +144,7 @@ class BranchSelectionValidationService:
             candidate = f"opt_{m.group(1)}"
             if candidate in opt_map:
                 resolved_id = candidate
-                consumed_token = m.group(0)
+                consumed_end = m.end()
 
         # 2. Explicit numeric phrase ("option 2", "choice 3")
         if resolved_id is None:
@@ -133,7 +153,7 @@ class BranchSelectionValidationService:
                 candidate = f"opt_{n}"
                 if 1 <= n <= max_index and candidate in opt_map:
                     resolved_id = candidate
-                    consumed_token = m.group(0)
+                    consumed_end = m.end()
                     break
 
         # 3. Ordinal word
@@ -144,20 +164,26 @@ class BranchSelectionValidationService:
                 candidate = f"opt_{n}"
                 if 1 <= n <= max_index and candidate in opt_map:
                     resolved_id = candidate
-                    consumed_token = m.group(0)
+                    consumed_end = m.end()
 
         # 4. Bare number — lowest precedence, and only when it is the operative
-        #    trailing selection token.  A number followed by further words is an
-        #    incidental quantity, not a branch choice, and is skipped.
+        #    selection token.  A bare number qualifies when it *leads* the input
+        #    (only whitespace precedes it, so trailing annotation is allowed:
+        #    "2, but I do it cautiously") or when it *trails* the input with
+        #    nothing further ("I pick 2").  A number embedded mid-prose with
+        #    words on both sides ("take 2 torches") is an incidental quantity,
+        #    not a branch choice, and is skipped.
         if resolved_id is None:
             for m in _BARE_NUMBER_RE.finditer(raw_input):
-                if _WORD_RE.search(raw_input[m.end() :]):
+                is_leading = raw_input[: m.start()].strip() == ""
+                is_trailing = not _WORD_RE.search(raw_input[m.end() :])
+                if not (is_leading or is_trailing):
                     continue
                 n = int(m.group(1))
                 candidate = f"opt_{n}"
                 if 1 <= n <= max_index and candidate in opt_map:
                     resolved_id = candidate
-                    consumed_token = m.group(0)
+                    consumed_end = m.end()
                     break
 
         if resolved_id is None:
@@ -174,7 +200,7 @@ class BranchSelectionValidationService:
             )
 
         matched_option = opt_map[resolved_id]
-        annotation = _extract_annotation(raw_input, consumed_token)
+        annotation = _extract_annotation(raw_input[consumed_end:])
 
         return BranchSelectionValidationResult(
             verdict=BranchSelectionValidationVerdict.ACCEPT,

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -1,0 +1,344 @@
+"""Branching Writer pass service — CRD Issue 16.
+
+Responsibilities:
+  1. Load the branching mode prompt contract at init time.
+  2. Render AssembledContext + BranchingSessionState into a ProviderCallRequest
+     with forced tool use (``produce_branch_output``).
+  3. Call the LLM → ``BranchingWriterProposal``.
+  4. Validate branch option count against the session's ``branch_count_range``.
+     Fail-closed: out-of-range count raises ``BranchingPassError`` (never
+     clamp, pad, or truncate).
+  5. Code-stamp all affordance fields from session state:
+     - ``interaction_style`` (from session state)
+     - ``branching_cadence`` (from session state)
+     - ``freeform_available`` (derived: True iff style is not TRUE_CYOA)
+     - ``branch_count_range`` (from session state)
+     - ``option_id`` for each branch option (sequential: opt_1, opt_2, …)
+  6. Return ``BranchingPassResult`` with validated, code-stamped output.
+
+Architectural invariants:
+  - This service is called ONLY for HYBRID and TRUE_CYOA modes.
+    FREEFORM_ONLY stays on the prose WriterService (no branch cards).
+  - Code owns all affordances; the model proposes prose + labels only.
+  - Schema shape enforces the invariant: option_id / interaction_style /
+    branching_cadence / freeform_available / branch_count_range are all
+    absent from the tool input_schema.
+  - Fail-closed: BranchingPassError on any provider, parse, schema, or
+    range-validation failure.  No silent fallback.
+  - ProviderRefusalError is propagated unchanged (orchestrator routes to
+    REFUSED_BY_PROVIDER).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from afterworlds.entitlement.enums import PipelinePassId
+from afterworlds.models.context import AssembledContext
+from afterworlds.models.enums import InteractionStyle
+from afterworlds.pipeline._refusal import ProviderRefusalError
+from afterworlds.pipeline._stable_prefix_renderer import (
+    TTL_DEFAULT,
+    TTL_EXTENDED,
+    RenderedBlock,
+    render_stable_prefix_blocks,
+)
+from afterworlds.pipeline.branching.caller import (
+    PRODUCE_BRANCH_OUTPUT_TOOL_NAME,
+    PRODUCE_BRANCH_OUTPUT_TOOL_SPEC,
+)
+from afterworlds.pipeline.branching.config import (
+    BRANCH_COUNT_RANGE_BOUNDS,
+    BRANCHING_WRITER_MAX_TOKENS,
+    BranchingWriterConfig,
+)
+from afterworlds.pipeline.branching.models import (
+    BranchingPassError,
+    BranchingPassResult,
+    BranchingWriterProposal,
+    BranchOption,
+)
+from afterworlds.pipeline.provider._models import (
+    ProviderCallRequest,
+    ProviderToolCallPart,
+    ProviderToolDefinition,
+)
+
+if TYPE_CHECKING:
+    from afterworlds.models.session import BranchingSessionState
+    from afterworlds.pipeline.provider._protocol import ProviderAdapter
+
+# ---------------------------------------------------------------------------
+# Prompt loading
+# ---------------------------------------------------------------------------
+
+_PROMPT_DIR: Path = Path(__file__).parents[4] / "docs" / "prompts"
+
+
+class UnknownPromptError(ValueError):
+    """Raised when the branching writer prompt file is missing."""
+
+
+def load_branching_writer_prompt() -> str:
+    """Load the Branching Writer pass system prompt from docs/prompts/."""
+    prompt_path = _PROMPT_DIR / "branching_mode.md"
+    try:
+        return prompt_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise UnknownPromptError(
+            f"Branching writer prompt file not found at {prompt_path}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Module-level tool definition (built once)
+# ---------------------------------------------------------------------------
+
+_BRANCHING_TOOL_DEF = ProviderToolDefinition(
+    name=PRODUCE_BRANCH_OUTPUT_TOOL_NAME,
+    description=PRODUCE_BRANCH_OUTPUT_TOOL_SPEC["description"],
+    input_schema=PRODUCE_BRANCH_OUTPUT_TOOL_SPEC["input_schema"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Branch-count range validation helper
+# ---------------------------------------------------------------------------
+
+
+def _validate_branch_count(
+    branch_options_text: list[str],
+    branch_count_range: str | None,
+) -> None:
+    """Validate proposed branch option count against the session's range.
+
+    Raises ``BranchingPassError`` when:
+    - ``branch_count_range`` is set and the count is outside [min, max].
+    - ``branch_count_range`` is set but unknown (not in BRANCH_COUNT_RANGE_BOUNDS).
+
+    Never clamps, pads, or truncates.  Out-of-range is a hard fail-closed error.
+    """
+    if branch_count_range is None:
+        return
+    bounds = BRANCH_COUNT_RANGE_BOUNDS.get(branch_count_range)
+    if bounds is None:
+        raise BranchingPassError(f"Unknown branch_count_range {branch_count_range!r}")
+    min_opts, max_opts = bounds
+    n = len(branch_options_text)
+    if n < min_opts or n > max_opts:
+        raise BranchingPassError(
+            f"Model proposed {n} branch option(s) but session branch_count_range"
+            f" {branch_count_range!r} requires between {min_opts} and {max_opts}."
+            " Never clamp or pad — model output violates the range contract."
+        )
+
+
+# ---------------------------------------------------------------------------
+# BranchingWriterService
+# ---------------------------------------------------------------------------
+
+
+class BranchingWriterService:
+    """Branching Writer pass service.
+
+    Produces narrative text + code-stamped branch options via forced tool use.
+    Called ONLY for HYBRID and TRUE_CYOA interaction styles; FREEFORM_ONLY
+    turns bypass this service entirely and use the prose WriterService.
+
+    Args:
+        config: Branching writer config.  Defaults to BranchingWriterConfig.from_env().
+    """
+
+    def __init__(
+        self,
+        config: BranchingWriterConfig | None = None,
+    ) -> None:
+        self._config = config or BranchingWriterConfig.from_env()
+        self._system_prompt: str = load_branching_writer_prompt()
+
+    def write(
+        self,
+        built_context: AssembledContext,
+        session_state: BranchingSessionState,
+        *,
+        provider: ProviderAdapter,
+    ) -> BranchingPassResult:
+        """Execute one branching writer pass and return a typed result.
+
+        Args:
+            built_context: AssembledContext from the Context Builder.
+            session_state: Current BranchingSessionState with interaction config.
+            provider: ProviderAdapter for the LLM call.
+
+        Returns:
+            BranchingPassResult with code-stamped affordances and validated options.
+
+        Raises:
+            ProviderRefusalError: propagated unchanged for REFUSED_BY_PROVIDER.
+            BranchingPassError: LLM call failure, missing tool block, schema
+                validation failure, or branch-count range violation.
+        """
+        request = self._render(built_context, session_state)
+
+        try:
+            result = provider.call(request)
+        except ProviderRefusalError:
+            raise
+        except Exception as exc:
+            raise BranchingPassError(
+                f"Branching writer provider call failed: {exc}"
+            ) from exc
+
+        tool_parts = [
+            p for p in result.content_parts if isinstance(p, ProviderToolCallPart)
+        ]
+        if not tool_parts:
+            raise BranchingPassError("Branching writer response missing tool-use block")
+        if tool_parts[0].tool_name != PRODUCE_BRANCH_OUTPUT_TOOL_NAME:
+            raise BranchingPassError(
+                f"Branching writer unexpected tool name: {tool_parts[0].tool_name!r};"
+                f" expected {PRODUCE_BRANCH_OUTPUT_TOOL_NAME!r}"
+            )
+
+        try:
+            proposal = BranchingWriterProposal.model_validate(tool_parts[0].tool_input)
+        except Exception as exc:
+            raise BranchingPassError(
+                f"Branching writer tool input failed schema validation: {exc}"
+            ) from exc
+
+        # Validate branch option count before stamping — fail-closed.
+        branch_count_range_val = (
+            session_state.branch_count_range.value
+            if session_state.branch_count_range is not None
+            else None
+        )
+        _validate_branch_count(proposal.branch_options_text, branch_count_range_val)
+
+        # Code stamps: option_id assigned sequentially.
+        branch_options = [
+            BranchOption(option_id=f"opt_{i + 1}", action_text=text)
+            for i, text in enumerate(proposal.branch_options_text)
+        ]
+
+        # Code derives freeform_available from interaction_style.
+        interaction_style = session_state.interaction_style
+        if interaction_style is None:
+            raise BranchingPassError(
+                "BranchingWriterService called with interaction_style=None;"
+                " cannot produce branch output without a configured style."
+            )
+        freeform_available = interaction_style is not InteractionStyle.TRUE_CYOA
+
+        branching_cadence = session_state.branching_cadence
+        if branching_cadence is None:
+            raise BranchingPassError(
+                "BranchingWriterService called with branching_cadence=None;"
+                " cannot produce branch output without a configured cadence."
+            )
+
+        return BranchingPassResult(
+            narrative_text=proposal.narrative_text,
+            interaction_style=interaction_style,
+            branching_cadence=branching_cadence,
+            length_preference=session_state.length_preference,
+            freeform_available=freeform_available,
+            branch_count_range=session_state.branch_count_range,
+            branch_options=branch_options,
+            branch_presentation_state=proposal.branch_presentation_state,
+            provider=result.provider_name,
+            model_identifier=result.model_identifier,
+            model_tier=result.model_tier.value if result.model_tier else None,
+            latency_ms=result.latency_ms,
+            input_token_count=result.input_token_count,
+            output_token_count=result.output_token_count,
+            cache_read_token_count=result.cache_read_token_count,
+            cache_creation_token_count=result.cache_creation_token_count,
+        )
+
+    # -----------------------------------------------------------------------
+    # Prompt rendering
+    # -----------------------------------------------------------------------
+
+    def _render(
+        self,
+        built_context: AssembledContext,
+        session_state: BranchingSessionState,
+    ) -> ProviderCallRequest:
+        """Render AssembledContext into a ProviderCallRequest.
+
+        Stable-prefix blocks are shared with the Planner for cache reuse.
+        A session-state summary is appended to the volatile suffix so the model
+        knows the active interaction style, cadence, and branch count range
+        without those values appearing in the tool schema (they are code-owned).
+        """
+        ttl = TTL_EXTENDED if self._config.extended_ttl else TTL_DEFAULT
+        rendered_blocks: list[RenderedBlock] = list(
+            render_stable_prefix_blocks(built_context.stable_prefix, ttl)
+        )
+
+        ledger_text = built_context.pass_forward_ledger.render()
+        if ledger_text:
+            rendered_blocks.append(RenderedBlock(text=ledger_text))
+
+        vs = built_context.volatile_suffix
+        for turn in vs.recent_turns:
+            rendered_blocks.append(
+                RenderedBlock(
+                    text=(
+                        f"Player: {turn.user_input}\n"
+                        f"Narrator: {turn.assistant_output}"
+                    )
+                )
+            )
+
+        # Session-state context block: informs the model of active configuration
+        # so it can calibrate density/length/branch count — but code validates all.
+        _ss = session_state
+        _style_v = _ss.interaction_style.value if _ss.interaction_style else "not_set"
+        _cadence_v = _ss.branching_cadence.value if _ss.branching_cadence else "not_set"
+        _len_v = _ss.length_preference.value if _ss.length_preference else "not_set"
+        _range_v = _ss.branch_count_range.value if _ss.branch_count_range else "none"
+        _free_v = (
+            str(_ss.interaction_style is not InteractionStyle.TRUE_CYOA)
+            if _ss.interaction_style
+            else "unknown"
+        )
+        session_context_lines = [
+            "[Branching Session Configuration]",
+            f"interaction_style: {_style_v}",
+            f"branching_cadence: {_cadence_v}",
+            f"length_preference: {_len_v}",
+            f"branch_count_range: {_range_v}",
+            f"freeform_available: {_free_v}",
+        ]
+        rendered_blocks.append(RenderedBlock(text="\n".join(session_context_lines)))
+
+        rendered_blocks.append(
+            RenderedBlock(
+                text=(
+                    f"Player: {vs.current_input}\n"
+                    f"[Intent: {vs.classified_intent.intent_type.value}]"
+                )
+            )
+        )
+
+        return ProviderCallRequest(
+            pass_id=PipelinePassId.BRANCHING_WRITER,
+            system_blocks=[
+                RenderedBlock(text=self._system_prompt),
+                RenderedBlock(text=built_context.stable_prefix.system_prompt),
+            ],
+            rendered_blocks=rendered_blocks,
+            max_output_tokens=BRANCHING_WRITER_MAX_TOKENS,
+            tool_definitions=[_BRANCHING_TOOL_DEF],
+            forced_tool_name=PRODUCE_BRANCH_OUTPUT_TOOL_NAME,
+        )
+
+
+__all__ = [
+    "BranchingWriterService",
+    "UnknownPromptError",
+    "load_branching_writer_prompt",
+]

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -236,6 +236,24 @@ class BranchingWriterService:
                 " through setup/prose behavior before this pass."
             )
 
+        # Fail closed: interaction_style and branching_cadence are required,
+        # code-owned affordances; BranchingWriter cannot produce valid branch
+        # output without them.  Validate before _render()/provider.call() so no
+        # provider spend is wasted on a turn that cannot be delivered.  The
+        # narrowed locals are reused downstream (freeform_available, result).
+        interaction_style = session_state.interaction_style
+        if interaction_style is None:
+            raise BranchingPassError(
+                "BranchingWriterService called with interaction_style=None;"
+                " cannot produce branch output without a configured style."
+            )
+        branching_cadence = session_state.branching_cadence
+        if branching_cadence is None:
+            raise BranchingPassError(
+                "BranchingWriterService called with branching_cadence=None;"
+                " cannot produce branch output without a configured cadence."
+            )
+
         request = self._render(
             built_context,
             session_state,
@@ -288,21 +306,9 @@ class BranchingWriterService:
             for i, text in enumerate(proposal.branch_options_text)
         ]
 
-        # Code derives freeform_available from interaction_style.
-        interaction_style = session_state.interaction_style
-        if interaction_style is None:
-            raise BranchingPassError(
-                "BranchingWriterService called with interaction_style=None;"
-                " cannot produce branch output without a configured style."
-            )
+        # Code derives freeform_available from interaction_style (validated in
+        # the preflight block above, before any provider spend).
         freeform_available = interaction_style is not InteractionStyle.TRUE_CYOA
-
-        branching_cadence = session_state.branching_cadence
-        if branching_cadence is None:
-            raise BranchingPassError(
-                "BranchingWriterService called with branching_cadence=None;"
-                " cannot produce branch output without a configured cadence."
-            )
 
         return BranchingPassResult(
             narrative_text=proposal.narrative_text,

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -219,6 +219,25 @@ class BranchingWriterService:
             BranchingPassError: LLM call failure, missing tool block, schema
                 validation failure, or branch-count range violation.
         """
+        # Fail closed: HYBRID and TRUE_CYOA branch cards require a configured
+        # branch_count_range before any in-play branch-card output.  A partially
+        # configured session (range=None) must route through setup/prose
+        # behavior before reaching this service; arriving here is a misroute.
+        # Raise before the provider call so no spend is wasted on a turn that
+        # cannot be delivered.
+        if (
+            session_state.interaction_style
+            in (InteractionStyle.HYBRID, InteractionStyle.TRUE_CYOA)
+            and session_state.branch_count_range is None
+        ):
+            raise BranchingPassError(
+                "BranchingWriterService called for interaction_style="
+                f"{session_state.interaction_style} without a configured"
+                " branch_count_range; in-play branch-card styles require a valid"
+                " persisted range. Partially configured sessions must route"
+                " through setup/prose behavior before this pass."
+            )
+
         request = self._render(
             built_context,
             session_state,

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -1,20 +1,19 @@
 """Branching Writer pass service — CRD Issue 16.
 
 Responsibilities:
-  1. Load the branching mode prompt contract at init time.
-  2. Render AssembledContext + BranchingSessionState into a ProviderCallRequest
+  1. Render AssembledContext + BranchingSessionState into a ProviderCallRequest
      with forced tool use (``produce_branch_output``).
-  3. Call the LLM → ``BranchingWriterProposal``.
-  4. Validate branch option count against the session's ``branch_count_range``.
+  2. Call the LLM → ``BranchingWriterProposal``.
+  3. Validate branch option count against the session's ``branch_count_range``.
      Fail-closed: out-of-range count raises ``BranchingPassError`` (never
      clamp, pad, or truncate).
-  5. Code-stamp all affordance fields from session state:
+  4. Code-stamp all affordance fields from session state:
      - ``interaction_style`` (from session state)
      - ``branching_cadence`` (from session state)
      - ``freeform_available`` (derived: True iff style is not TRUE_CYOA)
      - ``branch_count_range`` (from session state)
      - ``option_id`` for each branch option (sequential: opt_1, opt_2, …)
-  6. Return ``BranchingPassResult`` with validated, code-stamped output.
+  5. Return ``BranchingPassResult`` with validated, code-stamped output.
 
 Architectural invariants:
   - This service is called ONLY for HYBRID and TRUE_CYOA modes.
@@ -31,7 +30,6 @@ Architectural invariants:
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from afterworlds.entitlement.enums import PipelinePassId
@@ -69,28 +67,6 @@ if TYPE_CHECKING:
     from afterworlds.models.session import BranchingSessionState
     from afterworlds.pipeline.branching.models import SelectedBranchContext
     from afterworlds.pipeline.provider._protocol import ProviderAdapter
-
-# ---------------------------------------------------------------------------
-# Prompt loading
-# ---------------------------------------------------------------------------
-
-_PROMPT_DIR: Path = Path(__file__).parents[4] / "docs" / "prompts"
-
-
-class UnknownPromptError(ValueError):
-    """Raised when the branching writer prompt file is missing."""
-
-
-def load_branching_writer_prompt() -> str:
-    """Load the Branching Writer pass system prompt from docs/prompts/."""
-    prompt_path = _PROMPT_DIR / "branching_mode.md"
-    try:
-        return prompt_path.read_text(encoding="utf-8")
-    except FileNotFoundError as exc:
-        raise UnknownPromptError(
-            f"Branching writer prompt file not found at {prompt_path}"
-        ) from exc
-
 
 # ---------------------------------------------------------------------------
 # Module-level tool definition (built once)
@@ -191,7 +167,6 @@ class BranchingWriterService:
         config: BranchingWriterConfig | None = None,
     ) -> None:
         self._config = config or BranchingWriterConfig.from_env()
-        self._system_prompt: str = load_branching_writer_prompt()
 
     def write(
         self,
@@ -416,8 +391,12 @@ class BranchingWriterService:
 
         return ProviderCallRequest(
             pass_id=PipelinePassId.BRANCHING_WRITER,
+            # The BRANCHING mode contract is the BranchingWriter's system prompt
+            # and is already assembled once into ``stable_prefix.system_prompt``
+            # (ContextBuilder.load_mode_contract).  Include it exactly once here,
+            # matching the prose WriterService convention; the forced-tool
+            # definition below carries the pass-specific output contract.
             system_blocks=[
-                RenderedBlock(text=self._system_prompt),
                 RenderedBlock(text=built_context.stable_prefix.system_prompt),
             ],
             rendered_blocks=rendered_blocks,
@@ -429,6 +408,4 @@ class BranchingWriterService:
 
 __all__ = [
     "BranchingWriterService",
-    "UnknownPromptError",
-    "load_branching_writer_prompt",
 ]

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -112,6 +112,7 @@ def _validate_branch_count(
     branch_options_text: list[str],
     branch_count_range: str | None,
     branch_presentation_state: str | None,
+    interaction_style: InteractionStyle | None = None,
 ) -> None:
     """Validate proposed branch option count against the session's range.
 
@@ -119,13 +120,32 @@ def _validate_branch_count(
     an empty list.  Non-empty options with those states are a contract violation
     (fail-closed).  For ``shown`` the configured [min, max] range applies.
 
+    True CYOA requires branch options on every delivered beat; ``held`` and
+    ``omitted`` are forbidden for that interaction style even with an empty list,
+    because there is no freeform input surface to fall back on.
+
     Raises ``BranchingPassError`` when:
+    - ``interaction_style`` is TRUE_CYOA and ``branch_presentation_state`` is
+      'held' or 'omitted' (always — regardless of option count).
     - ``branch_presentation_state`` is 'held'/'omitted' and options are non-empty.
     - ``branch_count_range`` is set and the count is outside [min, max] for 'shown'.
     - ``branch_count_range`` is set but unknown (not in BRANCH_COUNT_RANGE_BOUNDS).
 
     Never clamps, pads, or truncates.  Out-of-range is a hard fail-closed error.
     """
+    # TRUE_CYOA: held/omitted are forbidden — no freeform input surface to fall
+    # back on when branch cards are absent.
+    if (
+        interaction_style is InteractionStyle.TRUE_CYOA
+        and branch_presentation_state in ("held", "omitted")
+    ):
+        raise BranchingPassError(
+            f"True CYOA requires branch options on every in-play beat;"
+            f" branch_presentation_state={branch_presentation_state!r} is"
+            " not valid for TRUE_CYOA. Model must return 'shown' with valid"
+            " options on every TRUE_CYOA turn."
+        )
+
     if branch_presentation_state in ("held", "omitted"):
         if branch_options_text:
             raise BranchingPassError(
@@ -242,6 +262,7 @@ class BranchingWriterService:
             proposal.branch_options_text,
             branch_count_range_val,
             proposal.branch_presentation_state,
+            interaction_style=session_state.interaction_style,
         )
 
         # Code stamps: option_id assigned sequentially.

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -47,6 +47,7 @@ from afterworlds.pipeline.branching.caller import (
     PRODUCE_BRANCH_OUTPUT_TOOL_SPEC,
 )
 from afterworlds.pipeline.branching.config import (
+    ALLOWED_RANGES_BY_STYLE,
     BRANCH_COUNT_RANGE_BOUNDS,
     BRANCHING_WRITER_MAX_TOKENS,
     BranchingWriterConfig,
@@ -131,6 +132,28 @@ def _validate_branch_count(
                 " 'held' or 'omitted'."
             )
         return
+    # Shown path.  Persisted Branching config compatibility (PR #112 R14):
+    # for in-play HYBRID/TRUE_CYOA the persisted branch_count_range must be
+    # BOTH known and allowed for the active interaction_style.  A persisted
+    # style/range mismatch is corrupt runtime state and must fail closed
+    # before any shown branch cards are accepted — numeric min/max validation
+    # alone is insufficient.  Reuses the code-owned ALLOWED_RANGES_BY_STYLE
+    # table (never duplicate or clamp).
+    if (
+        interaction_style is InteractionStyle.HYBRID
+        or interaction_style is InteractionStyle.TRUE_CYOA
+    ):
+        allowed_ranges = ALLOWED_RANGES_BY_STYLE.get(interaction_style)
+        allowed_values = {r.value for r in allowed_ranges} if allowed_ranges else set()
+        if branch_count_range is None or branch_count_range not in allowed_values:
+            raise BranchingPassError(
+                f"Persisted branch_count_range {branch_count_range!r} is not"
+                f" allowed for interaction_style={interaction_style.value};"
+                f" allowed ranges: {sorted(allowed_values)}. A persisted"
+                " incompatible style/range combination is corrupt runtime"
+                " state — failing closed before delivering branch cards."
+            )
+
     if branch_count_range is None:
         return
     bounds = BRANCH_COUNT_RANGE_BOUNDS.get(branch_count_range)

--- a/src/afterworlds/pipeline/branching/service.py
+++ b/src/afterworlds/pipeline/branching/service.py
@@ -67,6 +67,7 @@ from afterworlds.pipeline.provider._models import (
 
 if TYPE_CHECKING:
     from afterworlds.models.session import BranchingSessionState
+    from afterworlds.pipeline.branching.models import SelectedBranchContext
     from afterworlds.pipeline.provider._protocol import ProviderAdapter
 
 # ---------------------------------------------------------------------------
@@ -110,15 +111,30 @@ _BRANCHING_TOOL_DEF = ProviderToolDefinition(
 def _validate_branch_count(
     branch_options_text: list[str],
     branch_count_range: str | None,
+    branch_presentation_state: str | None,
 ) -> None:
     """Validate proposed branch option count against the session's range.
 
+    For ``held`` and ``omitted`` presentation states the tool contract requires
+    an empty list.  Non-empty options with those states are a contract violation
+    (fail-closed).  For ``shown`` the configured [min, max] range applies.
+
     Raises ``BranchingPassError`` when:
-    - ``branch_count_range`` is set and the count is outside [min, max].
+    - ``branch_presentation_state`` is 'held'/'omitted' and options are non-empty.
+    - ``branch_count_range`` is set and the count is outside [min, max] for 'shown'.
     - ``branch_count_range`` is set but unknown (not in BRANCH_COUNT_RANGE_BOUNDS).
 
     Never clamps, pads, or truncates.  Out-of-range is a hard fail-closed error.
     """
+    if branch_presentation_state in ("held", "omitted"):
+        if branch_options_text:
+            raise BranchingPassError(
+                f"Model proposed {len(branch_options_text)} branch option(s) with"
+                f" branch_presentation_state={branch_presentation_state!r}."
+                " branch_options_text must be empty ([]) when presentation state is"
+                " 'held' or 'omitted'."
+            )
+        return
     if branch_count_range is None:
         return
     bounds = BRANCH_COUNT_RANGE_BOUNDS.get(branch_count_range)
@@ -163,6 +179,7 @@ class BranchingWriterService:
         session_state: BranchingSessionState,
         *,
         provider: ProviderAdapter,
+        selected_branch_context: SelectedBranchContext | None = None,
     ) -> BranchingPassResult:
         """Execute one branching writer pass and return a typed result.
 
@@ -170,6 +187,9 @@ class BranchingWriterService:
             built_context: AssembledContext from the Context Builder.
             session_state: Current BranchingSessionState with interaction config.
             provider: ProviderAdapter for the LLM call.
+            selected_branch_context: Resolved selection from a BRANCH_CHOICE turn,
+                rendered as a volatile block so the model can reference the chosen
+                branch.  Not part of the stable prefix or cache key.
 
         Returns:
             BranchingPassResult with code-stamped affordances and validated options.
@@ -179,7 +199,11 @@ class BranchingWriterService:
             BranchingPassError: LLM call failure, missing tool block, schema
                 validation failure, or branch-count range violation.
         """
-        request = self._render(built_context, session_state)
+        request = self._render(
+            built_context,
+            session_state,
+            selected_branch_context=selected_branch_context,
+        )
 
         try:
             result = provider.call(request)
@@ -214,7 +238,11 @@ class BranchingWriterService:
             if session_state.branch_count_range is not None
             else None
         )
-        _validate_branch_count(proposal.branch_options_text, branch_count_range_val)
+        _validate_branch_count(
+            proposal.branch_options_text,
+            branch_count_range_val,
+            proposal.branch_presentation_state,
+        )
 
         # Code stamps: option_id assigned sequentially.
         branch_options = [
@@ -265,6 +293,8 @@ class BranchingWriterService:
         self,
         built_context: AssembledContext,
         session_state: BranchingSessionState,
+        *,
+        selected_branch_context: SelectedBranchContext | None = None,
     ) -> ProviderCallRequest:
         """Render AssembledContext into a ProviderCallRequest.
 
@@ -272,6 +302,11 @@ class BranchingWriterService:
         A session-state summary is appended to the volatile suffix so the model
         knows the active interaction style, cadence, and branch count range
         without those values appearing in the tool schema (they are code-owned).
+
+        When ``selected_branch_context`` is present it is rendered as a volatile
+        block after the session-config block and before the player-input block,
+        so the model can reference which branch the Sojourner chose.  It must
+        not appear in stable-prefix or cache-warmable blocks.
         """
         ttl = TTL_EXTENDED if self._config.extended_ttl else TTL_DEFAULT
         rendered_blocks: list[RenderedBlock] = list(
@@ -314,6 +349,21 @@ class BranchingWriterService:
             f"freeform_available: {_free_v}",
         ]
         rendered_blocks.append(RenderedBlock(text="\n".join(session_context_lines)))
+
+        # Volatile: selected branch context from a BRANCH_CHOICE turn.
+        # Placed after session config and before player input so the model can
+        # reference the chosen branch in its narrative.  Must not be in any
+        # stable-prefix or cache-warmable block.
+        if selected_branch_context is not None:
+            _sbc = selected_branch_context
+            _sbc_lines = [
+                "[Selected Branch]",
+                f"option_id: {_sbc.option_id}",
+                f"action_text: {_sbc.action_text}",
+            ]
+            if _sbc.annotation is not None:
+                _sbc_lines.append(f"annotation: {_sbc.annotation}")
+            rendered_blocks.append(RenderedBlock(text="\n".join(_sbc_lines)))
 
         rendered_blocks.append(
             RenderedBlock(

--- a/src/afterworlds/pipeline/branching/visible_state.py
+++ b/src/afterworlds/pipeline/branching/visible_state.py
@@ -1,0 +1,85 @@
+"""BranchingVisibleStateService — CRD Issue 16.
+
+Builds the BranchingVisibleState snapshot surfaced in OrchestrationResult
+on every DELIVERED BRANCHING-mode turn.  Reads from BranchingSessionState
+plus the current turn's BranchingPassResult (if produced).
+
+FREEFORM_ONLY turns call BranchingWriterService only when producing branch
+cards; when the prose WriterService is used instead, ``branching_pass_result``
+is None and ``last_branch_options`` / ``last_presentation_state`` are absent
+from the snapshot.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from afterworlds.models.enums import BranchPresentationState, InteractionStyle
+from afterworlds.pipeline.branching.models import BranchingVisibleState
+
+if TYPE_CHECKING:
+    from afterworlds.models.session import BranchingSessionState
+    from afterworlds.pipeline.branching.models import BranchingPassResult
+
+
+class BranchingVisibleStateService:
+    """Builds BranchingVisibleState from session state and current pass result."""
+
+    def build(
+        self,
+        session_state: BranchingSessionState,
+        branching_pass_result: BranchingPassResult | None = None,
+    ) -> BranchingVisibleState:
+        """Return the Sojourner-visible branching snapshot.
+
+        Args:
+            session_state: Current BranchingSessionState (config axis).
+            branching_pass_result: Output from BranchingWriterService for this
+                turn, or None for FREEFORM_ONLY turns that used the prose Writer.
+
+        Returns:
+            BranchingVisibleState with code-derived ``freeform_available`` and
+            all session config fields populated.
+
+        Raises:
+            ValueError: if ``session_state.interaction_style`` or
+                ``session_state.branching_cadence`` is None (not yet configured).
+        """
+        if session_state.interaction_style is None:
+            raise ValueError(
+                "BranchingVisibleStateService.build called with interaction_style=None;"
+                " session must be configured before building visible state."
+            )
+        if session_state.branching_cadence is None:
+            raise ValueError(
+                "BranchingVisibleStateService.build called with branching_cadence=None;"
+                " session must be configured before building visible state."
+            )
+
+        freeform_available = (
+            session_state.interaction_style is not InteractionStyle.TRUE_CYOA
+        )
+
+        last_branch_options = None
+        last_presentation_state: BranchPresentationState | None = None
+
+        if branching_pass_result is not None:
+            last_branch_options = branching_pass_result.branch_options or None
+            raw_ps = branching_pass_result.branch_presentation_state
+            try:
+                last_presentation_state = BranchPresentationState(raw_ps)
+            except ValueError:
+                last_presentation_state = None
+
+        return BranchingVisibleState(
+            interaction_style=session_state.interaction_style,
+            branching_cadence=session_state.branching_cadence,
+            branch_count_range=session_state.branch_count_range,
+            freeform_available=freeform_available,
+            length_preference=session_state.length_preference,
+            last_branch_options=last_branch_options if last_branch_options else None,
+            last_presentation_state=last_presentation_state,
+        )
+
+
+__all__ = ["BranchingVisibleStateService"]

--- a/src/afterworlds/pipeline/orchestrator/models.py
+++ b/src/afterworlds/pipeline/orchestrator/models.py
@@ -19,11 +19,12 @@ result into a different disposition.
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from afterworlds.models.enums import InteractionRejectionReason
 from afterworlds.models.intent_classification import IntentClassificationResult
 from afterworlds.models.rpg import RpgVisibleState
 from afterworlds.pipeline._refusal import ProviderRefusal
@@ -65,6 +66,7 @@ class PipelineDisposition(StrEnum):
     BLOCKED_OUTPUT_SAFETY = "blocked_output_safety"
     BLOCKED_CONTRADICTION = "blocked_contradiction"
     BLOCKED_PENDING_ROLL = "blocked_pending_roll"
+    INTERACTION_REJECTED = "interaction_rejected"
     REFUSED_BY_PROVIDER = "refused_by_provider"
     PIPELINE_ERROR = "pipeline_error"
 
@@ -134,6 +136,25 @@ class OrchestrationResult(BaseModel):
     # None on all other dispositions.
     pending_roll_redirect_message: str | None = None
 
+    # Set on INTERACTION_REJECTED: typed reason and human-readable message why
+    # the input was rejected (non-billable; no Turn, no Node, no canon mutation).
+    # Both are None on all other dispositions; both are required (non-empty) on
+    # INTERACTION_REJECTED per CRD Issue 16.
+    interaction_rejection_reason: InteractionRejectionReason | None = None
+    interaction_rejection_message: str | None = None
+
+    # Additive Issue 16 field: full structured branching output for HYBRID/TRUE_CYOA
+    # turns.  Populated in place of writer_result for those modes; None otherwise.
+    # Type is BranchingPassResult from pipeline.branching.models — declared as Any
+    # here to avoid an import cycle; narrowed to BranchingPassResult by callers.
+    branching_pass_result: Any | None = None
+
+    # Additive Issue 16 field: branching session visible state for DELIVERED
+    # BRANCHING-mode turns.  None for all non-BRANCHING turns and non-DELIVERED
+    # dispositions.  Type is BranchingVisibleState from pipeline.branching.models —
+    # declared as Any here to avoid an import cycle.
+    branching_visible_state: Any | None = None
+
     @model_validator(mode="after")
     def _enforce_disposition_invariants(self) -> OrchestrationResult:
         """Enforce the per-disposition required / forbidden field matrix.
@@ -169,11 +190,16 @@ class OrchestrationResult(BaseModel):
         d = self.disposition
         is_ooc = self.intent_classification.intent_type == IntentType.OOC
 
-        # rpg_visible_state is only valid on successfully-delivered RPG turns.
+        # rpg_visible_state and branching_visible_state are only valid on
+        # successfully-delivered turns.
         if d is not PipelineDisposition.DELIVERED:
             self._forbid(
                 "rpg_visible_state absent on non-DELIVERED",
                 self.rpg_visible_state is not None,
+            )
+            self._forbid(
+                "branching_visible_state absent on non-DELIVERED",
+                self.branching_visible_state is not None,
             )
 
         if d is PipelineDisposition.DELIVERED:
@@ -344,6 +370,39 @@ class OrchestrationResult(BaseModel):
                 self.pipeline_error_summary is not None,
             )
 
+        elif d is PipelineDisposition.INTERACTION_REJECTED:
+            # Non-billable: no Turn, no Node, no canon mutation.
+            # Modeled on BLOCKED_PENDING_ROLL per 12c extension procedure.
+            self._require("delivered_output is None", self.delivered_output is None)
+            self._require("turn_id is None", self.turn_id is None)
+            self._require(
+                "interaction_rejection_reason non-empty",
+                self.interaction_rejection_reason is not None,
+            )
+            self._require(
+                "interaction_rejection_message non-empty",
+                self._non_empty_str(self.interaction_rejection_message),
+            )
+            self._forbid("planner_result absent", self.planner_result is not None)
+            self._forbid("writer_result absent", self.writer_result is not None)
+            self._forbid("extractor_result absent", self.extractor_result is not None)
+            self._forbid(
+                "contradiction_result absent",
+                self.contradiction_result is not None,
+            )
+            self._forbid(
+                "pending_roll_redirect_message absent on INTERACTION_REJECTED",
+                self.pending_roll_redirect_message is not None,
+            )
+            self._forbid(
+                "provider_refusal absent on INTERACTION_REJECTED",
+                self.provider_refusal is not None,
+            )
+            self._forbid(
+                "pipeline_error_summary absent on INTERACTION_REJECTED",
+                self.pipeline_error_summary is not None,
+            )
+
         elif d is PipelineDisposition.REFUSED_BY_PROVIDER:
             self._require("delivered_output is None", self.delivered_output is None)
             self._require("turn_id is None", self.turn_id is None)
@@ -358,6 +417,7 @@ class OrchestrationResult(BaseModel):
             failing_field_by_pass: dict[PassIdentifier, object] = {
                 PassIdentifier.PLANNER: self.planner_result,
                 PassIdentifier.RPG_ADJUDICATION: self.rpg_adjudication_result,
+                PassIdentifier.BRANCHING_WRITER: self.branching_pass_result,
                 PassIdentifier.WRITER: self.writer_result,
                 PassIdentifier.EXTRACTOR: self.extractor_result,
                 PassIdentifier.CONTRADICTION: self.contradiction_result,
@@ -421,6 +481,7 @@ SafetyPolicy = CapabilityProfileAwareSafetyPolicy
 
 __all__ = [
     "CapabilityProfileAwareSafetyPolicy",
+    "InteractionRejectionReason",
     "OrchestrationResult",
     "OrchestratorError",
     "PipelineDisposition",

--- a/src/afterworlds/pipeline/orchestrator/models.py
+++ b/src/afterworlds/pipeline/orchestrator/models.py
@@ -155,6 +155,12 @@ class OrchestrationResult(BaseModel):
     # declared as Any here to avoid an import cycle.
     branching_visible_state: Any | None = None
 
+    # Additive Issue 16 Round-2 field: OOC config extractor provider usage for
+    # entitlement settlement.  Populated when Phase F extraction succeeds (best-
+    # effort); None if extraction is skipped or fails.  Type is
+    # BranchingOocConfigExtractorResult — declared as Any to avoid import cycle.
+    branching_ooc_config_result: Any | None = None
+
     @model_validator(mode="after")
     def _enforce_disposition_invariants(self) -> OrchestrationResult:
         """Enforce the per-disposition required / forbidden field matrix.

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -692,6 +692,12 @@ class OrchestratorService:
                 BranchSelectionValidationVerdict,
             )
 
+            # A DB/session/crud failure while reading the presented option set
+            # is an operational fault, not invalid user input — surface it as
+            # PIPELINE_ERROR before any validate() call.  A successful read that
+            # yields no options (node missing, non-branching metadata, or empty
+            # branch_options) is a valid empty set; the validator then returns
+            # INVALID_BRANCH_SELECTION.
             _presented_options: list[PersistedBranchOption] = []
             try:
                 with self._session_factory() as _read_session:
@@ -704,8 +710,13 @@ class OrchestratorService:
                         _presented_options = list(
                             _current_node.mode_metadata.branch_options
                         )
-            except Exception:  # noqa: BLE001
-                pass  # No presented options available; validator will reject
+            except Exception as exc:  # noqa: BLE001
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branch-card read failed: {exc}",
+                )
 
             _sel_result = self._branching_selection_service.validate(
                 intent_result.raw_input,

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1431,6 +1431,7 @@ class OrchestratorService:
                     planner_result=planner_result,
                     writer_result=writer_result,
                     rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
                 )
             except Exception as exc:  # noqa: BLE001
                 return self._pipeline_error(
@@ -1442,6 +1443,7 @@ class OrchestratorService:
                     planner_result=planner_result,
                     writer_result=writer_result,
                     rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
                 )
 
         # 5c. Apply sheet effects (Fork B→B1) inside the outer transaction, then
@@ -1469,6 +1471,7 @@ class OrchestratorService:
                         planner_result=planner_result,
                         writer_result=writer_result,
                         rpg_adjudication_result=adj_result,
+                        branching_pass_result=branching_pass_result,
                     )
             if self._rpg_visible_state_service is not None:
                 try:
@@ -1483,6 +1486,7 @@ class OrchestratorService:
                         planner_result=planner_result,
                         writer_result=writer_result,
                         rpg_adjudication_result=adj_result,
+                        branching_pass_result=branching_pass_result,
                     )
 
         # 6. Output Safety Audit, conditional.

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -56,6 +56,7 @@ from afterworlds.models.context import (
     StablePrefix,
 )
 from afterworlds.models.enums import (
+    BranchingPlayStatus,
     IntentType,
     InteractionRejectionReason,
     InteractionStyle,
@@ -650,8 +651,12 @@ class OrchestratorService:
         # INTERACTION_REJECTED: True CYOA mode rejects non-OOC freeform input.
         # Runs after the OOC short-circuit (OOC is always valid) and after the
         # pending-roll intercept (RPG-only).  No LLM call, no Turn, no canon.
+        # Gated on in_play: during setup, TRUE_CYOA setup confirmation and
+        # clarification route through the ordinary prose Writer path per
+        # ADR-016 Decision 3; interaction-style enforcement is in-play only.
         if (
             pre_branching_state is not None
+            and pre_branching_state.play_status is BranchingPlayStatus.IN_PLAY
             and pre_branching_state.interaction_style is InteractionStyle.TRUE_CYOA
             and intent_result.intent_type is not IntentType.BRANCH_CHOICE
         ):
@@ -1053,9 +1058,12 @@ class OrchestratorService:
     ) -> OrchestrationResult:
         # Determine if this is a BRANCHING HYBRID/TRUE_CYOA turn (BranchingWriterService
         # replaces WriterService for these modes; FREEFORM_ONLY stays on prose Writer).
+        # Gated on in_play: during setup, HYBRID/TRUE_CYOA setup confirmation and
+        # clarification route through the prose Writer path per ADR-016 Decision 3.
         _use_branching_writer = (
             story_mode is StoryMode.BRANCHING
             and branching_state is not None
+            and branching_state.play_status is BranchingPlayStatus.IN_PLAY
             and branching_state.interaction_style
             in (
                 InteractionStyle.HYBRID,
@@ -1523,6 +1531,7 @@ class OrchestratorService:
                 extractor_result=exc.extractor_result,
                 provider_refusal=exc.refusal,
                 rpg_adjudication_result=adj_result,
+                branching_pass_result=branching_pass_result,
             )
         except ProviderRefusalError as exc:
             # Extractor-side refusal: the failing pass result must remain
@@ -1539,6 +1548,7 @@ class OrchestratorService:
                 output_safety_result=output_safety,
                 provider_refusal=exc.refusal,
                 rpg_adjudication_result=adj_result,
+                branching_pass_result=branching_pass_result,
             )
         except _ParallelSyncError as exc:
             return self._pipeline_error(

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1395,6 +1395,14 @@ class OrchestratorService:
                         _sel_node.mode_metadata.selected_option_id = (
                             selected_branch_context.option_id
                         )
+                        # Stable selection record: option_id alone is ambiguous
+                        # because IDs (opt_1, …) are reused every beat. Persist
+                        # the chosen action text so the selection stays
+                        # reconstructable after the next beat's branch_options
+                        # overwrite this metadata.
+                        _sel_node.mode_metadata.selected_action_text = (
+                            selected_branch_context.action_text
+                        )
                         _sel_node.mode_metadata.selection_annotation = (
                             selected_branch_context.annotation
                         )

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1888,6 +1888,7 @@ class OrchestratorService:
         ):
             try:
                 from afterworlds.models.enums import InteractionStyle as _IS
+                from afterworlds.models.session import BranchingSessionState as _BSS
                 from afterworlds.persistence.crud.session_state import (
                     apply_branching_config_update as _apply_cfg,
                 )
@@ -1908,6 +1909,7 @@ class OrchestratorService:
                 _cfg_update = _extract_result.config_update
 
                 # Determine the target interaction style for range validation.
+                _bss_row: _BSS | None = None
                 _target_style: _IS | None = _cfg_update.interaction_style
                 if _target_style is None:
                     _bss_row = _get_bss(session, story_id)
@@ -1915,8 +1917,12 @@ class OrchestratorService:
                         _bss_row.interaction_style if _bss_row is not None else None
                     )
 
+                # Separate "no range requested" from "explicit range requested but
+                # later found invalid" so the two cases get different treatment.
+                _requested_range = _cfg_update.branch_count_range
+
                 # Validate branch_count_range against the target style.
-                _validated_range = _cfg_update.branch_count_range
+                _validated_range = _requested_range
                 if _validated_range is not None and _target_style is not None:
                     _allowed_ranges = _ALLOWED.get(_target_style)
                     if (
@@ -1928,18 +1934,41 @@ class OrchestratorService:
                 # Determine persistence strategy for the style × range pair to
                 # avoid leaving the row in a mismatched configuration:
                 # • FREEFORM_ONLY: persist style, clear range to NULL.
-                # • HYBRID/TRUE_CYOA with valid range: persist both.
-                # • HYBRID/TRUE_CYOA without valid range: skip the style change
-                #   so the existing style stays in place (atomicity).
+                # • HYBRID/TRUE_CYOA with a valid requested range: persist both.
+                # • HYBRID/TRUE_CYOA, no range requested, persisted range
+                #   compatible with target style: persist style, keep existing range.
+                # • HYBRID/TRUE_CYOA, no range requested, persisted range
+                #   incompatible (or absent): suppress style change (atomicity).
+                # • HYBRID/TRUE_CYOA, explicit range requested but invalid:
+                #   suppress style change (do not fall back to persisted range).
                 _apply_style = _cfg_update.interaction_style
                 _should_clear_range = False
                 if _cfg_update.interaction_style is _IS.FREEFORM_ONLY:
                     _should_clear_range = True
-                elif (
-                    _cfg_update.interaction_style in (_IS.HYBRID, _IS.TRUE_CYOA)
-                    and _validated_range is None
-                ):
-                    _apply_style = None  # skip style; existing row stays intact
+                elif _cfg_update.interaction_style in (_IS.HYBRID, _IS.TRUE_CYOA):
+                    if _validated_range is not None:
+                        pass  # persist style + explicit valid range
+                    elif _requested_range is None:
+                        # No range requested — check if the persisted range is
+                        # valid for the target style before allowing the switch.
+                        if _bss_row is None:
+                            _bss_row = _get_bss(session, story_id)
+                        _persisted = (
+                            _bss_row.branch_count_range
+                            if _bss_row is not None
+                            else None
+                        )
+                        _target_allowed = _ALLOWED.get(_cfg_update.interaction_style)
+                        if (
+                            _persisted is None
+                            or _target_allowed is None
+                            or _persisted not in _target_allowed
+                        ):
+                            _apply_style = None  # incompatible persisted range
+                        # else: persisted range is valid for target — allow style
+                    else:
+                        # Explicit range was requested but is invalid; suppress.
+                        _apply_style = None
 
                 _apply_cfg(
                     session,

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -718,11 +718,16 @@ class OrchestratorService:
 
         # INTERACTION_REJECTED: validate BRANCH_CHOICE selection against the
         # presented option set from the current node's mode_metadata.branching.
-        # Runs for HYBRID and TRUE_CYOA when intent is BRANCH_CHOICE.
+        # Runs for in-play HYBRID and TRUE_CYOA when intent is BRANCH_CHOICE.
+        # Branch-choice validation is an in-play rail: a setup row routes through
+        # the prose setup-confirmation path per ADR-016 Decision 3 even when the
+        # selection service is wired and the classifier emits BRANCH_CHOICE, so
+        # this block is gated on IN_PLAY to match the missing-service guard above.
         # No LLM call, no Turn, no canon mutation on rejection.
         pre_selected_context: SelectedBranchContext | None = None
         if (
             pre_branching_state is not None
+            and pre_branching_state.play_status is BranchingPlayStatus.IN_PLAY
             and intent_result.intent_type is IntentType.BRANCH_CHOICE
             and pre_branching_state.interaction_style
             in (

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1881,6 +1881,7 @@ class OrchestratorService:
         # interaction-config changes the Sojourner requested and persist them
         # inside this transaction.  Best-effort — failure skips persistence
         # without blocking OOC_HANDLED.
+        _ooc_cfg_extractor_result: object | None = None
         if (
             story_mode is StoryMode.BRANCHING
             and self._branching_ooc_config_extractor is not None
@@ -1897,10 +1898,14 @@ class OrchestratorService:
                     ALLOWED_RANGES_BY_STYLE as _ALLOWED,
                 )
 
-                _cfg_update = self._branching_ooc_config_extractor.extract(
+                _extract_result = self._branching_ooc_config_extractor.extract(
                     ooc_ctx,
                     ScopedProviderAdapter(binding.adapter, sojourner_id),  # type: ignore[arg-type]
                 )
+                # Capture metrics immediately so usage is visible to settlement
+                # even if a later best-effort persistence step raises.
+                _ooc_cfg_extractor_result = _extract_result
+                _cfg_update = _extract_result.config_update
 
                 # Determine the target interaction style for range validation.
                 _target_style: _IS | None = _cfg_update.interaction_style
@@ -1958,6 +1963,7 @@ class OrchestratorService:
             output_safety_result=output_safety,
             delivered_output=writer_result.assistant_output,
             turn_id=writer_result.turn_id,
+            branching_ooc_config_result=_ooc_cfg_extractor_result,
         )
 
     # ------------------------------------------------------------------
@@ -2394,6 +2400,7 @@ class OrchestratorService:
         interaction_rejection_message: str | None = None,
         branching_pass_result: _BranchingPassResult | None = None,
         branching_visible_state: object | None = None,
+        branching_ooc_config_result: object | None = None,
     ) -> OrchestrationResult:
         total_ms = max(0, int((time.perf_counter() - turn_start) * 1000))
         cache_warmed = _any_cache_read(
@@ -2425,6 +2432,7 @@ class OrchestratorService:
             interaction_rejection_message=interaction_rejection_message,
             branching_pass_result=branching_pass_result,
             branching_visible_state=branching_visible_state,
+            branching_ooc_config_result=branching_ooc_config_result,
             total_latency_ms=total_ms,
             pass_latency_breakdown=dict(latency),
             stable_prefix_cache_warmed=cache_warmed,

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -2083,6 +2083,13 @@ class OrchestratorService:
         # output so the prose response cannot imply a style change that
         # persistence did not actually make (confirmation/persistence parity).
         _ooc_style_noop_note: str | None = None
+        # Set when an OOC request supplied an explicit branch_count_range that is
+        # invalid for the applicable style and is therefore discarded.  Surfaced
+        # for the range-only case (when no style switch was suppressed for the
+        # same reason) so the prose cannot imply a range change that did not
+        # persist.  Mutually exclusive with _ooc_style_noop_note to avoid
+        # contradictory duplicate corrections.
+        _ooc_range_noop_note: str | None = None
         if (
             story_mode is StoryMode.BRANCHING
             and self._branching_ooc_config_extractor is not None
@@ -2132,7 +2139,11 @@ class OrchestratorService:
                 # later found invalid" so the two cases get different treatment.
                 _requested_range = _cfg_update.branch_count_range
 
-                # Validate branch_count_range against the target style.
+                # Validate branch_count_range against the target style.  Track
+                # whether an explicitly requested range was rejected so the
+                # range-only case can surface a corrective note (the style-only
+                # suppression already carries its own note below).
+                _range_invalid = False
                 _validated_range = _requested_range
                 if _validated_range is not None and _target_style is not None:
                     _allowed_ranges = _ALLOWED.get(_target_style)
@@ -2140,7 +2151,8 @@ class OrchestratorService:
                         _allowed_ranges is None
                         or _validated_range not in _allowed_ranges
                     ):
-                        _validated_range = None  # discard invalid range silently
+                        _range_invalid = True
+                        _validated_range = None  # discard invalid range
 
                 # Determine persistence strategy for the style × range pair to
                 # avoid leaving the row in a mismatched configuration:
@@ -2202,6 +2214,49 @@ class OrchestratorService:
                         f"again.]"
                     )
 
+                # An explicitly requested branch-count range that is invalid for
+                # the applicable style is discarded (never persisted).  Surface a
+                # dedicated correction ONLY when the style switch was not itself
+                # suppressed for the same reason (that note already names the
+                # range and lists compatible ranges — a second note would be a
+                # contradictory duplicate) and the range is not being cleared by
+                # a deliberate FREEFORM_ONLY switch (a "not changed" note would be
+                # false there, since the switch clears it by design).
+                if (
+                    _range_invalid
+                    and _ooc_style_noop_note is None
+                    and not _should_clear_range
+                    and _requested_range is not None
+                ):
+                    _range_allowed = (
+                        _ALLOWED.get(_target_style)
+                        if _target_style is not None
+                        else None
+                    )
+                    _range_ranges_txt = (
+                        ", ".join(sorted(r.value for r in _range_allowed))
+                        if _range_allowed
+                        else ""
+                    )
+                    _range_style_txt = (
+                        _target_style.value
+                        if _target_style is not None
+                        else "the current interaction style"
+                    )
+                    if _range_ranges_txt:
+                        _ooc_range_noop_note = (
+                            f"[Branch-count range not changed: "
+                            f"{_requested_range.value} is not valid for "
+                            f"{_range_style_txt}. Set one of: {_range_ranges_txt} "
+                            f"and try again.]"
+                        )
+                    else:
+                        _ooc_range_noop_note = (
+                            f"[Branch-count range not changed: "
+                            f"{_requested_range.value} is not valid for "
+                            f"{_range_style_txt}.]"
+                        )
+
                 _apply_cfg(
                     session,
                     story_id,
@@ -2221,10 +2276,21 @@ class OrchestratorService:
                 pass  # Best-effort; OOC prose already delivered
 
         _ooc_delivered = writer_result.assistant_output
-        if _ooc_style_noop_note is not None:
-            _ooc_delivered = f"{_ooc_delivered}\n\n{_ooc_style_noop_note}"
-            # Keep the persisted OOC Turn truthful.  The corrective no-op note
-            # is appended to the delivered output because the requested style
+        # At most one of the corrective notes is set (they are mutually
+        # exclusive by construction), but compose a single correction block from
+        # whichever are present so the delivered prose can never imply a config
+        # change that persistence did not make.
+        _ooc_config_noop_notes = [
+            _note
+            for _note in (_ooc_style_noop_note, _ooc_range_noop_note)
+            if _note is not None
+        ]
+        if _ooc_config_noop_notes:
+            _ooc_delivered = (
+                _ooc_delivered + "\n\n" + "\n\n".join(_ooc_config_noop_notes)
+            )
+            # Keep the persisted OOC Turn truthful.  The corrective no-op note is
+            # appended to the delivered output because the requested style/range
             # change was suppressed; the raw writer prose alone could falsely
             # imply the change happened.  Persist the same corrected output to
             # the Turn row and mirror it onto the in-memory writer_result so

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -69,7 +69,10 @@ from afterworlds.pipeline._refusal import (
     ProviderRefusal,
     ProviderRefusalError,
 )
-from afterworlds.pipeline.branching.models import BranchingPassError
+from afterworlds.pipeline.branching.models import (
+    BranchingOocExtractionUsageError,
+    BranchingPassError,
+)
 from afterworlds.pipeline.branching.models import (
     BranchingPassResult as _BranchingPassResult,
 )
@@ -2173,6 +2176,12 @@ class OrchestratorService:
                     length_preference=_cfg_update.length_preference,
                     clear_branch_count_range=_should_clear_range,
                 )
+            except BranchingOocExtractionUsageError as _usage_exc:
+                # The provider call succeeded (tokens consumed) but a local
+                # validation step rejected the response.  Preserve the usage-only
+                # result for settlement/audit; the config update is skipped as
+                # best-effort, exactly like the generic swallow below.
+                _ooc_cfg_extractor_result = _usage_exc.usage_result
             except Exception:  # noqa: BLE001
                 pass  # Best-effort; OOC prose already delivered
 

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -55,12 +55,22 @@ from afterworlds.models.context import (
     PassForwardLedger,
     StablePrefix,
 )
-from afterworlds.models.enums import IntentType, RpgPlayStatus, StoryMode
+from afterworlds.models.enums import (
+    IntentType,
+    InteractionRejectionReason,
+    InteractionStyle,
+    RpgPlayStatus,
+    StoryMode,
+)
 from afterworlds.models.intent_classification import IntentClassificationResult
 from afterworlds.models.rules_package import RuleSliceRequest
 from afterworlds.pipeline._refusal import (
     ProviderRefusal,
     ProviderRefusalError,
+)
+from afterworlds.pipeline.branching.models import BranchingPassError
+from afterworlds.pipeline.branching.models import (
+    BranchingPassResult as _BranchingPassResult,
 )
 from afterworlds.pipeline.rpg.models import AdjudicationPassError
 from afterworlds.pipeline.rpg.pending import PendingRollDuplicateError
@@ -68,7 +78,20 @@ from afterworlds.pipeline.rpg.pending import PendingRollDuplicateError
 if TYPE_CHECKING:
     from afterworlds.models.character_sheet import Dnd5eCharacterSheet
     from afterworlds.models.rpg import PendingRollRequest, RpgVisibleState, SheetEffect
-    from afterworlds.models.session import RpgSessionState
+    from afterworlds.models.session import BranchingSessionState, RpgSessionState
+    from afterworlds.pipeline.branching.models import (
+        SelectedBranchContext,
+    )
+    from afterworlds.pipeline.branching.ooc_config_extractor import (
+        BranchingOocConfigExtractorService,
+    )
+    from afterworlds.pipeline.branching.selection import (
+        BranchSelectionValidationService,
+    )
+    from afterworlds.pipeline.branching.service import BranchingWriterService
+    from afterworlds.pipeline.branching.visible_state import (
+        BranchingVisibleStateService,
+    )
     from afterworlds.pipeline.rpg.dice import DiceService
     from afterworlds.pipeline.rpg.models import AdjudicationPassResult
     from afterworlds.pipeline.rpg.pending import PendingRollRequestService
@@ -154,6 +177,12 @@ def load_ooc_handler_prompt() -> str:
 def load_rpg_ooc_handler_prompt() -> str:
     """Load the RPG-mode OOC handler from docs/prompts/rpg_ooc_handler.md."""
     prompt_path = _PROMPT_DIR / "rpg_ooc_handler.md"
+    return prompt_path.read_text(encoding="utf-8")
+
+
+def load_branching_ooc_handler_prompt() -> str:
+    """Load the Branching-mode OOC handler from docs/prompts/branching_ooc_handler.md."""  # noqa: E501
+    prompt_path = _PROMPT_DIR / "branching_ooc_handler.md"
     return prompt_path.read_text(encoding="utf-8")
 
 
@@ -286,6 +315,15 @@ class OrchestratorService:
         rpg_dice_service: DiceService | None = None,
         rpg_pending_roll_service: PendingRollRequestService | None = None,
         rpg_visible_state_service: RpgVisibleStateService | None = None,
+        branching_writer_service: BranchingWriterService | None = None,
+        branching_session_resolver: (
+            Callable[[UUID], BranchingSessionState | None] | None
+        ) = None,
+        branching_visible_state_service: BranchingVisibleStateService | None = None,
+        branching_selection_service: BranchSelectionValidationService | None = None,
+        branching_ooc_config_extractor: (
+            BranchingOocConfigExtractorService | None
+        ) = None,
     ) -> None:
         self._intent_classifier = intent_classifier
         self._context_builder = context_builder
@@ -305,6 +343,11 @@ class OrchestratorService:
         self._rpg_dice_service = rpg_dice_service
         self._rpg_pending_roll_service = rpg_pending_roll_service
         self._rpg_visible_state_service = rpg_visible_state_service
+        self._branching_writer_service = branching_writer_service
+        self._branching_session_resolver = branching_session_resolver
+        self._branching_visible_state_service = branching_visible_state_service
+        self._branching_selection_service = branching_selection_service
+        self._branching_ooc_config_extractor = branching_ooc_config_extractor
         self._provided_executor = executor
         # Owned executor is created once and reused for the lifetime of
         # this instance — see the Executor-lifecycle contract above.
@@ -319,6 +362,7 @@ class OrchestratorService:
         self._timeout = parallel_pass_timeout_seconds
         self._ooc_handler_prompt: str = load_ooc_handler_prompt()
         self._rpg_ooc_handler_prompt: str = load_rpg_ooc_handler_prompt()
+        self._branching_ooc_handler_prompt: str = load_branching_ooc_handler_prompt()
 
     def close(self) -> None:
         """Release the orchestrator-owned executor.
@@ -585,6 +629,102 @@ class OrchestratorService:
                     ),
                 )
 
+        # Pre-resolve Branching session state once for INTERACTION_REJECTED check
+        # and for the narrative path (HYBRID/TRUE_CYOA).  Modeled on the RPG
+        # pre_session_state pattern: resolve once, thread through as _pre_branching_state.  # noqa: E501
+        pre_branching_state: BranchingSessionState | None = None
+        if (
+            story_mode is StoryMode.BRANCHING
+            and self._branching_session_resolver is not None
+        ):
+            try:
+                pre_branching_state = self._branching_session_resolver(story_id)
+            except Exception as exc:  # noqa: BLE001
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branching session resolution failed: {exc}",
+                )
+
+        # INTERACTION_REJECTED: True CYOA mode rejects non-OOC freeform input.
+        # Runs after the OOC short-circuit (OOC is always valid) and after the
+        # pending-roll intercept (RPG-only).  No LLM call, no Turn, no canon.
+        if (
+            pre_branching_state is not None
+            and pre_branching_state.interaction_style is InteractionStyle.TRUE_CYOA
+            and intent_result.intent_type is not IntentType.BRANCH_CHOICE
+        ):
+            return self._build_result(
+                PipelineDisposition.INTERACTION_REJECTED,
+                intent_result,
+                latency,
+                turn_start,
+                interaction_rejection_reason=InteractionRejectionReason.INVALID_FOR_INTERACTION_STYLE,
+                interaction_rejection_message=(
+                    "True CYOA mode requires explicit branch selection"
+                    " (e.g., 'I choose option 2')."
+                    " Freeform narrative input is not valid in this mode."
+                    " Use [OOC] to switch to Hybrid mode."
+                ),
+            )
+
+        # INTERACTION_REJECTED: validate BRANCH_CHOICE selection against the
+        # presented option set from the current node's mode_metadata.branching.
+        # Runs for HYBRID and TRUE_CYOA when intent is BRANCH_CHOICE.
+        # No LLM call, no Turn, no canon mutation on rejection.
+        pre_selected_context: SelectedBranchContext | None = None
+        if (
+            pre_branching_state is not None
+            and intent_result.intent_type is IntentType.BRANCH_CHOICE
+            and pre_branching_state.interaction_style
+            in (
+                InteractionStyle.HYBRID,
+                InteractionStyle.TRUE_CYOA,
+            )
+            and self._branching_selection_service is not None
+        ):
+            from afterworlds.models.node import (
+                BranchingNodeMetadata,
+                PersistedBranchOption,
+            )
+            from afterworlds.pipeline.branching.models import (
+                BranchSelectionValidationVerdict,
+            )
+
+            _presented_options: list[PersistedBranchOption] = []
+            try:
+                with self._session_factory() as _read_session:
+                    from afterworlds.persistence.crud.node import get_node as _get_node
+
+                    _current_node = _get_node(_read_session, node_id)
+                    if _current_node is not None and isinstance(
+                        _current_node.mode_metadata, BranchingNodeMetadata
+                    ):
+                        _presented_options = list(
+                            _current_node.mode_metadata.branch_options
+                        )
+            except Exception:  # noqa: BLE001
+                pass  # No presented options available; validator will reject
+
+            _sel_result = self._branching_selection_service.validate(
+                intent_result.raw_input,
+                _presented_options,
+            )
+            if _sel_result.verdict is BranchSelectionValidationVerdict.REJECT:
+                return self._build_result(
+                    PipelineDisposition.INTERACTION_REJECTED,
+                    intent_result,
+                    latency,
+                    turn_start,
+                    interaction_rejection_reason=_sel_result.rejection_reason,
+                    interaction_rejection_message=(
+                        _sel_result.rejection_message
+                        or "Branch selection was rejected."
+                    ),
+                )
+            pre_selected_context = _sel_result.selected_context
+
         return self._run_narrative(
             ctx,
             story_id,
@@ -600,6 +740,8 @@ class OrchestratorService:
             player_reported_total=player_reported_total,
             _pre_session_state=pre_session_state,
             _pre_sheet=pre_sheet,
+            _pre_branching_state=pre_branching_state,
+            _pre_selected_context=pre_selected_context,
         )
 
     # ------------------------------------------------------------------
@@ -623,6 +765,8 @@ class OrchestratorService:
         player_reported_total: int | None = None,
         _pre_session_state: RpgSessionState | None = None,
         _pre_sheet: Dnd5eCharacterSheet | None = None,
+        _pre_branching_state: BranchingSessionState | None = None,
+        _pre_selected_context: SelectedBranchContext | None = None,
     ) -> OrchestrationResult:
         # 3. Input Safety Preflight, conditional.
         input_safety: SafetyResult | None = None
@@ -859,6 +1003,9 @@ class OrchestratorService:
                 rpg_character_id=rpg_character_id,
                 pending_roll_consumed=pending_roll,
                 rpg_sheet=rpg_sheet,
+                branching_state=_pre_branching_state,
+                story_mode=story_mode,
+                selected_branch_context=_pre_selected_context,
             ),
             intent_result,
             latency,
@@ -889,7 +1036,23 @@ class OrchestratorService:
         rpg_character_id: UUID | None = None,
         pending_roll_consumed: PendingRollRequest | None = None,
         rpg_sheet: Dnd5eCharacterSheet | None = None,
+        branching_state: BranchingSessionState | None = None,
+        story_mode: StoryMode = StoryMode.WRITING,
+        selected_branch_context: SelectedBranchContext | None = None,
     ) -> OrchestrationResult:
+        # Determine if this is a BRANCHING HYBRID/TRUE_CYOA turn (BranchingWriterService
+        # replaces WriterService for these modes; FREEFORM_ONLY stays on prose Writer).
+        _use_branching_writer = (
+            story_mode is StoryMode.BRANCHING
+            and branching_state is not None
+            and branching_state.interaction_style
+            in (
+                InteractionStyle.HYBRID,
+                InteractionStyle.TRUE_CYOA,
+            )
+            and self._branching_writer_service is not None
+        )
+
         # 5. Writer persists provisional Turn inside the outer transaction.
         #
         # writer_turn_id is pre-allocated by _run_narrative so the adjudication
@@ -897,53 +1060,235 @@ class OrchestratorService:
         # transaction opens.  RefusalFallbackRouter also carries the same id so
         # refusal-log rows are consistent with the Turn row on success.  On
         # failure no Turn is persisted; the log row still carries the candidate id.
-        try:
-            writer_result, ms = _timed(
-                lambda: self._writer_service.write(
-                    ctx,
-                    story_id,
-                    node_id,
-                    provider=ScopedProviderAdapter(
-                        binding.adapter,  # type: ignore[arg-type]
-                        sojourner_id,
-                        turn_id=writer_turn_id,
-                    ),
-                    session=session,
-                    turn_id=writer_turn_id,
+        branching_pass_result: _BranchingPassResult | None = None
+        if _use_branching_writer:
+            # 5a-branching: BranchingWriterService produces narrative + branch cards.
+            # Fail-closed: BranchingPassError + ProviderRefusalError both abort the turn.  # noqa: E501
+            assert branching_state is not None  # noqa: S101 — narrowed above
+            assert (
+                self._branching_writer_service is not None
+            )  # noqa: S101 — narrowed above
+            _branching_svc = self._branching_writer_service
+            try:
+                branching_pass_result, ms = _timed(
+                    lambda: _branching_svc.write(
+                        ctx,
+                        branching_state,
+                        provider=ScopedProviderAdapter(
+                            binding.adapter,  # type: ignore[arg-type]
+                            sojourner_id,
+                            turn_id=writer_turn_id,
+                        ),
+                    )
                 )
+                latency["branching_writer"] = ms
+            except ProviderRefusalError as exc:
+                return self._build_result(
+                    PipelineDisposition.REFUSED_BY_PROVIDER,
+                    intent_result,
+                    latency,
+                    turn_start,
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    provider_refusal=exc.refusal,
+                )
+            except BranchingPassError as exc:
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branching writer pass failed: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                )
+            except Exception as exc:  # noqa: BLE001 — see boundary docstring
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branching writer unexpected error: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                )
+            # Persist Turn row with branching narrative_text inside the outer
+            # transaction.  Turn creation uses the same CRUD as WriterService.
+            assert branching_pass_result is not None  # noqa: S101 — mypy narrowing
+            _bpr = branching_pass_result
+            from datetime import UTC, datetime
+
+            from afterworlds.models.turn import Turn
+            from afterworlds.persistence.crud.node import create_turn
+
+            try:
+                _icr = ctx.volatile_suffix.classified_intent
+                _branching_turn = Turn(
+                    turn_id=writer_turn_id,
+                    user_input=ctx.volatile_suffix.current_input,
+                    assistant_output=_bpr.narrative_text,
+                    timestamp=datetime.now(UTC),
+                    intent_classification=IntentType(_icr.intent_type.value),
+                    node_id=node_id,
+                    intent_classification_result=_icr,
+                )
+                create_turn(session, _branching_turn)
+            except Exception as exc:  # noqa: BLE001
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branching turn persistence failed: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                )
+            # Phase G: persist branch options to Node.mode_metadata.branching.
+            # Best-effort: failure logs to pipeline_error but we continue since
+            # metadata persistence is non-critical for the current turn's DELIVER.
+            try:
+                from afterworlds.models.node import (
+                    BranchingNodeMetadata,
+                    PersistedBranchOption,
+                )
+                from afterworlds.persistence.crud.node import (
+                    get_node as _gn,
+                )
+                from afterworlds.persistence.crud.node import (
+                    update_node as _un,
+                )
+
+                _node_to_update = _gn(session, node_id)
+                if _node_to_update is not None:
+                    _existing_mm = _node_to_update.mode_metadata
+                    _ps_str = _bpr.branch_presentation_state
+                    _new_mm = BranchingNodeMetadata(
+                        pacing_stage_at_beat=(
+                            _existing_mm.pacing_stage_at_beat
+                            if isinstance(_existing_mm, BranchingNodeMetadata)
+                            else None
+                        ),
+                        interaction_style=(
+                            branching_state.interaction_style
+                            if branching_state
+                            else None
+                        ),
+                        branching_cadence=(
+                            branching_state.branching_cadence
+                            if branching_state
+                            else None
+                        ),
+                        freeform_available=_bpr.freeform_available,
+                        branch_count_range=(
+                            branching_state.branch_count_range.value
+                            if branching_state and branching_state.branch_count_range
+                            else None
+                        ),
+                        branch_options=[
+                            PersistedBranchOption(
+                                option_id=o.option_id,
+                                action_text=o.action_text,
+                            )
+                            for o in _bpr.branch_options
+                        ],
+                        branch_presentation_state=_ps_str,
+                    )
+                    _node_to_update.mode_metadata = _new_mm
+                    _un(session, _node_to_update)
+            except Exception:  # noqa: BLE001
+                pass  # Non-critical; node metadata update best-effort
+
+            # Phase G (selection edge): persist the resolved selection into the
+            # node's mode_metadata.branching so callers can replay what was chosen.
+            # Best-effort — failure does not block turn delivery.
+            if selected_branch_context is not None:
+                try:
+                    from afterworlds.models.node import (
+                        BranchingNodeMetadata as _BNM,
+                    )
+                    from afterworlds.persistence.crud.node import (
+                        get_node as _gn2,
+                    )
+                    from afterworlds.persistence.crud.node import (
+                        update_node as _un2,
+                    )
+
+                    _sel_node = _gn2(session, node_id)
+                    if _sel_node is not None and isinstance(
+                        _sel_node.mode_metadata, _BNM
+                    ):
+                        _sel_node.mode_metadata.selected_option_id = (
+                            selected_branch_context.option_id
+                        )
+                        _sel_node.mode_metadata.selection_annotation = (
+                            selected_branch_context.annotation
+                        )
+                        _un2(session, _sel_node)
+                except Exception:  # noqa: BLE001
+                    pass  # Non-critical for current turn delivery
+
+            # Build a thin WriterResult from branching output for downstream passes
+            # (Extractor, Contradiction, Output Safety).  These passes need the
+            # narrative text; branch_options live in branching_pass_result.
+            from afterworlds.pipeline.writer.models import WriterResult as _WriterResult
+
+            writer_result = _WriterResult(
+                turn_id=writer_turn_id,
+                assistant_output=_bpr.narrative_text,
+                model_identifier=_bpr.model_identifier or "",
+                latency_ms=_bpr.latency_ms,
+                input_token_count=_bpr.input_token_count,
+                output_token_count=_bpr.output_token_count,
+                cache_read_token_count=_bpr.cache_read_token_count,
+                cache_creation_token_count=_bpr.cache_creation_token_count,
+                provider=_bpr.provider,
+                model_tier=_bpr.model_tier or "",
             )
-            latency["writer"] = ms
-        except ProviderRefusalError as exc:
-            return self._build_result(
-                PipelineDisposition.REFUSED_BY_PROVIDER,
-                intent_result,
-                latency,
-                turn_start,
-                input_safety_result=input_safety,
-                planner_result=planner_result,
-                provider_refusal=exc.refusal,
-                rpg_adjudication_result=adj_result,
-            )
-        except WriterPassError as exc:
-            return self._pipeline_error(
-                intent_result,
-                latency,
-                turn_start,
-                f"writer pass failed: {exc}",
-                input_safety_result=input_safety,
-                planner_result=planner_result,
-                rpg_adjudication_result=adj_result,
-            )
-        except Exception as exc:  # noqa: BLE001 — see boundary docstring
-            return self._pipeline_error(
-                intent_result,
-                latency,
-                turn_start,
-                f"writer unexpected error: {exc}",
-                input_safety_result=input_safety,
-                planner_result=planner_result,
-                rpg_adjudication_result=adj_result,
-            )
+        else:
+            try:
+                writer_result, ms = _timed(
+                    lambda: self._writer_service.write(
+                        ctx,
+                        story_id,
+                        node_id,
+                        provider=ScopedProviderAdapter(
+                            binding.adapter,  # type: ignore[arg-type]
+                            sojourner_id,
+                            turn_id=writer_turn_id,
+                        ),
+                        session=session,
+                        turn_id=writer_turn_id,
+                    )
+                )
+                latency["writer"] = ms
+            except ProviderRefusalError as exc:
+                return self._build_result(
+                    PipelineDisposition.REFUSED_BY_PROVIDER,
+                    intent_result,
+                    latency,
+                    turn_start,
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    provider_refusal=exc.refusal,
+                    rpg_adjudication_result=adj_result,
+                )
+            except WriterPassError as exc:
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"writer pass failed: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    rpg_adjudication_result=adj_result,
+                )
+            except Exception as exc:  # noqa: BLE001 — see boundary docstring
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"writer unexpected error: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    rpg_adjudication_result=adj_result,
+                )
 
         # 5b. [RPG only] Write adjudication audit rows, consume/announce pending
         # roll, inside the outer transaction (Fork B→B1).  Runs only when
@@ -1184,6 +1529,21 @@ class OrchestratorService:
                 rpg_adjudication_result=adj_result,
             )
 
+        # Build branching visible state for BRANCHING-mode DELIVERED turns.
+        branching_visible_state = None
+        if (
+            story_mode is StoryMode.BRANCHING
+            and branching_state is not None
+            and self._branching_visible_state_service is not None
+        ):
+            try:
+                branching_visible_state = self._branching_visible_state_service.build(
+                    branching_state,
+                    branching_pass_result,
+                )
+            except Exception:  # noqa: BLE001
+                branching_visible_state = None
+
         # ALLOW → commit Turn + Extractor writes.  Outer transaction context
         # manager will commit on normal exit; no explicit commit needed.
         return self._build_result(
@@ -1199,6 +1559,8 @@ class OrchestratorService:
             contradiction_result=contradiction_result,
             rpg_adjudication_result=adj_result,
             rpg_visible_state=rpg_visible_state,
+            branching_pass_result=branching_pass_result,
+            branching_visible_state=branching_visible_state,
             delivered_output=writer_result.assistant_output,
             turn_id=writer_result.turn_id,
         )
@@ -1313,12 +1675,13 @@ class OrchestratorService:
                     input_safety_result=input_safety,
                 )
 
-        # Select mode-specific OOC handler; RPG mode has a dedicated prompt.
-        ooc_prompt = (
-            self._rpg_ooc_handler_prompt
-            if story_mode is StoryMode.RPG
-            else self._ooc_handler_prompt
-        )
+        # Select mode-specific OOC handler; RPG and Branching have dedicated prompts.
+        if story_mode is StoryMode.RPG:
+            ooc_prompt = self._rpg_ooc_handler_prompt
+        elif story_mode is StoryMode.BRANCHING:
+            ooc_prompt = self._branching_ooc_handler_prompt
+        else:
+            ooc_prompt = self._ooc_handler_prompt
         ooc_ctx = _swap_system_prompt(ctx, ooc_prompt)
 
         if story_mode is StoryMode.RPG:
@@ -1347,6 +1710,7 @@ class OrchestratorService:
                 request_risk_signal,
                 latency,
                 turn_start,
+                story_mode=story_mode,
             ),
             intent_result,
             latency,
@@ -1369,6 +1733,8 @@ class OrchestratorService:
         request_risk_signal: bool,
         latency: dict[str, int],
         turn_start: float,
+        *,
+        story_mode: StoryMode,
     ) -> OrchestrationResult:
         ooc_turn_id = uuid4()
         try:
@@ -1465,6 +1831,60 @@ class OrchestratorService:
                     writer_result=writer_result,
                     output_safety_result=output_safety,
                 )
+
+        # Phase F (OOC config extraction): for BRANCHING turns, extract any
+        # interaction-config changes the Sojourner requested and persist them
+        # inside this transaction.  Best-effort — failure skips persistence
+        # without blocking OOC_HANDLED.
+        if (
+            story_mode is StoryMode.BRANCHING
+            and self._branching_ooc_config_extractor is not None
+        ):
+            try:
+                from afterworlds.models.enums import InteractionStyle as _IS
+                from afterworlds.persistence.crud.session_state import (
+                    apply_branching_config_update as _apply_cfg,
+                )
+                from afterworlds.persistence.crud.session_state import (
+                    get_branching_session_state_by_story as _get_bss,
+                )
+                from afterworlds.pipeline.branching.config import (
+                    ALLOWED_RANGES_BY_STYLE as _ALLOWED,
+                )
+
+                _cfg_update = self._branching_ooc_config_extractor.extract(
+                    ooc_ctx,
+                    ScopedProviderAdapter(binding.adapter, sojourner_id),  # type: ignore[arg-type]
+                )
+
+                # Determine the target interaction style for range validation.
+                _target_style: _IS | None = _cfg_update.interaction_style
+                if _target_style is None:
+                    _bss_row = _get_bss(session, story_id)
+                    _target_style = (
+                        _bss_row.interaction_style if _bss_row is not None else None
+                    )
+
+                # Validate branch_count_range against the target style.
+                _validated_range = _cfg_update.branch_count_range
+                if _validated_range is not None and _target_style is not None:
+                    _allowed_ranges = _ALLOWED.get(_target_style)
+                    if (
+                        _allowed_ranges is None
+                        or _validated_range not in _allowed_ranges
+                    ):
+                        _validated_range = None  # discard invalid range silently
+
+                _apply_cfg(
+                    session,
+                    story_id,
+                    interaction_style=_cfg_update.interaction_style,
+                    branching_cadence=_cfg_update.branching_cadence,
+                    branch_count_range=_validated_range,
+                    length_preference=_cfg_update.length_preference,
+                )
+            except Exception:  # noqa: BLE001
+                pass  # Best-effort; OOC prose already delivered
 
         return self._build_result(
             PipelineDisposition.OOC_HANDLED,
@@ -1908,6 +2328,10 @@ class OrchestratorService:
         provider_refusal: ProviderRefusal | None = None,
         pipeline_error_summary: str | None = None,
         pending_roll_redirect_message: str | None = None,
+        interaction_rejection_reason: InteractionRejectionReason | None = None,
+        interaction_rejection_message: str | None = None,
+        branching_pass_result: _BranchingPassResult | None = None,
+        branching_visible_state: object | None = None,
     ) -> OrchestrationResult:
         total_ms = max(0, int((time.perf_counter() - turn_start) * 1000))
         cache_warmed = _any_cache_read(
@@ -1935,6 +2359,10 @@ class OrchestratorService:
             provider_refusal=provider_refusal,
             pipeline_error_summary=pipeline_error_summary,
             pending_roll_redirect_message=pending_roll_redirect_message,
+            interaction_rejection_reason=interaction_rejection_reason,
+            interaction_rejection_message=interaction_rejection_message,
+            branching_pass_result=branching_pass_result,
+            branching_visible_state=branching_visible_state,
             total_latency_ms=total_ms,
             pass_latency_breakdown=dict(latency),
             stable_prefix_cache_warmed=cache_warmed,

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -705,23 +705,46 @@ class OrchestratorService:
             # branch_options) is a valid empty set; the validator then returns
             # INVALID_BRANCH_SELECTION.
             _presented_options: list[PersistedBranchOption] = []
+            _lineage_ok = True
             try:
                 with self._session_factory() as _read_session:
-                    from afterworlds.persistence.crud.node import get_node as _get_node
+                    from afterworlds.persistence.crud.node import (
+                        get_node as _get_node,
+                    )
+                    from afterworlds.persistence.crud.node import (
+                        node_belongs_to_story as _nbs,
+                    )
 
-                    _current_node = _get_node(_read_session, node_id)
-                    if _current_node is not None and isinstance(
-                        _current_node.mode_metadata, BranchingNodeMetadata
-                    ):
-                        _presented_options = list(
-                            _current_node.mode_metadata.branch_options
-                        )
+                    # Lineage guard: never read branch-card options for a node
+                    # that does not belong to this story.  Foreign-story option
+                    # labels must not reach the selection validator or any
+                    # rejection text — fail closed with a generic lineage error
+                    # before the options are read.
+                    if not _nbs(_read_session, node_id, story_id):
+                        _lineage_ok = False
+                    else:
+                        _current_node = _get_node(_read_session, node_id)
+                        if _current_node is not None and isinstance(
+                            _current_node.mode_metadata, BranchingNodeMetadata
+                        ):
+                            _presented_options = list(
+                                _current_node.mode_metadata.branch_options
+                            )
             except Exception as exc:  # noqa: BLE001
                 return self._pipeline_error(
                     intent_result,
                     latency,
                     turn_start,
                     f"branch-card read failed: {exc}",
+                )
+
+            if not _lineage_ok:
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branch-choice lineage check failed: node {node_id} does"
+                    f" not belong to story {story_id}",
                 )
 
             _sel_result = self._branching_selection_service.validate(
@@ -1188,6 +1211,7 @@ class OrchestratorService:
                     f"branching turn persistence failed: {exc}",
                     input_safety_result=input_safety,
                     planner_result=planner_result,
+                    branching_pass_result=branching_pass_result,
                 )
             # Phase G: persist branch options to Node.mode_metadata.branching.
             # For shown branch-card turns the persisted option set is the
@@ -1263,6 +1287,7 @@ class OrchestratorService:
                         f"branch-card persistence failed: {exc}",
                         input_safety_result=input_safety,
                         planner_result=planner_result,
+                        branching_pass_result=branching_pass_result,
                     )
                 # Held/omitted turns carry no selectable cards; node metadata
                 # persistence is non-critical, so continue best-effort.
@@ -1494,6 +1519,7 @@ class OrchestratorService:
                     planner_result=planner_result,
                     writer_result=writer_result,
                     rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
                 )
             except Exception as exc:  # noqa: BLE001 — see boundary docstring
                 return self._pipeline_error(
@@ -1505,6 +1531,7 @@ class OrchestratorService:
                     planner_result=planner_result,
                     writer_result=writer_result,
                     rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
                 )
             assert output_safety is not None  # noqa: S101 — mypy narrowing
             if output_safety.verdict is SafetyVerdict.BLOCK:
@@ -1518,6 +1545,7 @@ class OrchestratorService:
                     writer_result=writer_result,
                     output_safety_result=output_safety,
                     rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
                 )
 
         # 7. Extractor || Contradiction (parallel sync, asymmetric).
@@ -1585,6 +1613,7 @@ class OrchestratorService:
                 writer_result=writer_result,
                 output_safety_result=output_safety,
                 rpg_adjudication_result=adj_result,
+                branching_pass_result=branching_pass_result,
             )
         except Exception as exc:  # noqa: BLE001 — see boundary docstring
             # Defense-in-depth: ``_run_parallel_sync`` already maps every
@@ -1601,6 +1630,7 @@ class OrchestratorService:
                 writer_result=writer_result,
                 output_safety_result=output_safety,
                 rpg_adjudication_result=adj_result,
+                branching_pass_result=branching_pass_result,
             )
 
         # 8. Gate on Contradiction.
@@ -1617,6 +1647,7 @@ class OrchestratorService:
                 extractor_result=extractor_result,
                 contradiction_result=contradiction_result,
                 rpg_adjudication_result=adj_result,
+                branching_pass_result=branching_pass_result,
             )
 
         # Build branching visible state for BRANCHING-mode DELIVERED turns.
@@ -1927,6 +1958,11 @@ class OrchestratorService:
         # inside this transaction.  Best-effort — failure skips persistence
         # without blocking OOC_HANDLED.
         _ooc_cfg_extractor_result: object | None = None
+        # Set when a requested switch to HYBRID/TRUE_CYOA is suppressed because no
+        # compatible branch-count range exists.  Appended to the delivered OOC
+        # output so the prose response cannot imply a style change that
+        # persistence did not actually make (confirmation/persistence parity).
+        _ooc_style_noop_note: str | None = None
         if (
             story_mode is StoryMode.BRANCHING
             and self._branching_ooc_config_extractor is not None
@@ -2025,6 +2061,27 @@ class OrchestratorService:
                         # Explicit range was requested but is invalid; suppress.
                         _apply_style = None
 
+                # If a switch to HYBRID/TRUE_CYOA was requested but suppressed
+                # (no compatible range), the style is NOT persisted.  Record an
+                # explicit non-confirmation so the OOC prose cannot silently
+                # imply the change happened.
+                if _apply_style is None and _cfg_update.interaction_style in (
+                    _IS.HYBRID,
+                    _IS.TRUE_CYOA,
+                ):
+                    _allowed_for_note = _ALLOWED.get(_cfg_update.interaction_style)
+                    _ranges_txt = (
+                        ", ".join(sorted(r.value for r in _allowed_for_note))
+                        if _allowed_for_note
+                        else ""
+                    )
+                    _ooc_style_noop_note = (
+                        f"[Interaction style not changed: switching to "
+                        f"{_cfg_update.interaction_style.value} needs a compatible "
+                        f"branch-count range. Set one of: {_ranges_txt} and try "
+                        f"again.]"
+                    )
+
                 _apply_cfg(
                     session,
                     story_id,
@@ -2037,6 +2094,10 @@ class OrchestratorService:
             except Exception:  # noqa: BLE001
                 pass  # Best-effort; OOC prose already delivered
 
+        _ooc_delivered = writer_result.assistant_output
+        if _ooc_style_noop_note is not None:
+            _ooc_delivered = f"{_ooc_delivered}\n\n{_ooc_style_noop_note}"
+
         return self._build_result(
             PipelineDisposition.OOC_HANDLED,
             intent_result,
@@ -2045,7 +2106,7 @@ class OrchestratorService:
             input_safety_result=input_safety,
             writer_result=writer_result,
             output_safety_result=output_safety,
-            delivered_output=writer_result.assistant_output,
+            delivered_output=_ooc_delivered,
             turn_id=writer_result.turn_id,
             branching_ooc_config_result=_ooc_cfg_extractor_result,
         )
@@ -2534,6 +2595,7 @@ class OrchestratorService:
         writer_result: WriterResult | None = None,
         output_safety_result: SafetyResult | None = None,
         rpg_adjudication_result: AdjudicationPassResult | None = None,
+        branching_pass_result: _BranchingPassResult | None = None,
     ) -> OrchestrationResult:
         return self._build_result(
             PipelineDisposition.PIPELINE_ERROR,
@@ -2546,6 +2608,7 @@ class OrchestratorService:
             output_safety_result=output_safety_result,
             pipeline_error_summary=summary,
             rpg_adjudication_result=rpg_adjudication_result,
+            branching_pass_result=branching_pass_result,
         )
 
     def _run_with_transaction(

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -57,6 +57,7 @@ from afterworlds.models.context import (
 )
 from afterworlds.models.enums import (
     BranchingPlayStatus,
+    BranchPresentationState,
     IntentType,
     InteractionRejectionReason,
     InteractionStyle,
@@ -1189,8 +1190,16 @@ class OrchestratorService:
                     planner_result=planner_result,
                 )
             # Phase G: persist branch options to Node.mode_metadata.branching.
-            # Best-effort: failure logs to pipeline_error but we continue since
-            # metadata persistence is non-critical for the current turn's DELIVER.
+            # For shown branch-card turns the persisted option set is the
+            # authoritative source for later BRANCH_CHOICE validation, so it must
+            # be committed in the same transaction that delivers the cards.  If
+            # persistence fails on a shown turn we fail closed (PIPELINE_ERROR ->
+            # rollback) rather than deliver selectable cards backed by an
+            # unpersisted option set.  Held/omitted turns carry no selectable
+            # cards, so their metadata persistence remains best-effort.
+            _cards_shown = (
+                _bpr.branch_presentation_state == BranchPresentationState.SHOWN.value
+            )
             try:
                 from afterworlds.models.node import (
                     BranchingNodeMetadata,
@@ -1204,44 +1213,59 @@ class OrchestratorService:
                 )
 
                 _node_to_update = _gn(session, node_id)
-                if _node_to_update is not None:
-                    _existing_mm = _node_to_update.mode_metadata
-                    _ps_str = _bpr.branch_presentation_state
-                    _new_mm = BranchingNodeMetadata(
-                        pacing_stage_at_beat=(
-                            _existing_mm.pacing_stage_at_beat
-                            if isinstance(_existing_mm, BranchingNodeMetadata)
-                            else None
-                        ),
-                        interaction_style=(
-                            branching_state.interaction_style
-                            if branching_state
-                            else None
-                        ),
-                        branching_cadence=(
-                            branching_state.branching_cadence
-                            if branching_state
-                            else None
-                        ),
-                        freeform_available=_bpr.freeform_available,
-                        branch_count_range=(
-                            branching_state.branch_count_range.value
-                            if branching_state and branching_state.branch_count_range
-                            else None
-                        ),
-                        branch_options=[
-                            PersistedBranchOption(
-                                option_id=o.option_id,
-                                action_text=o.action_text,
-                            )
-                            for o in _bpr.branch_options
-                        ],
-                        branch_presentation_state=_ps_str,
+                if _node_to_update is None:
+                    raise RuntimeError(
+                        f"node {node_id} not found for branch-option persistence"
                     )
-                    _node_to_update.mode_metadata = _new_mm
-                    _un(session, _node_to_update)
-            except Exception:  # noqa: BLE001
-                pass  # Non-critical; node metadata update best-effort
+                _existing_mm = _node_to_update.mode_metadata
+                _ps_str = _bpr.branch_presentation_state
+                _new_mm = BranchingNodeMetadata(
+                    pacing_stage_at_beat=(
+                        _existing_mm.pacing_stage_at_beat
+                        if isinstance(_existing_mm, BranchingNodeMetadata)
+                        else None
+                    ),
+                    interaction_style=(
+                        branching_state.interaction_style if branching_state else None
+                    ),
+                    branching_cadence=(
+                        branching_state.branching_cadence if branching_state else None
+                    ),
+                    freeform_available=_bpr.freeform_available,
+                    branch_count_range=(
+                        branching_state.branch_count_range.value
+                        if branching_state and branching_state.branch_count_range
+                        else None
+                    ),
+                    branch_options=[
+                        PersistedBranchOption(
+                            option_id=o.option_id,
+                            action_text=o.action_text,
+                        )
+                        for o in _bpr.branch_options
+                    ],
+                    branch_presentation_state=_ps_str,
+                )
+                _node_to_update.mode_metadata = _new_mm
+                if _un(session, _node_to_update) is None:
+                    raise RuntimeError(
+                        f"node {node_id} update returned no row during "
+                        "branch-option persistence"
+                    )
+            except Exception as exc:  # noqa: BLE001
+                if _cards_shown:
+                    # Shown cards without a persisted option set would leave later
+                    # BRANCH_CHOICE validation with no authoritative source.
+                    return self._pipeline_error(
+                        intent_result,
+                        latency,
+                        turn_start,
+                        f"branch-card persistence failed: {exc}",
+                        input_safety_result=input_safety,
+                        planner_result=planner_result,
+                    )
+                # Held/omitted turns carry no selectable cards; node metadata
+                # persistence is non-critical, so continue best-effort.
 
             # Phase G (selection edge): persist the resolved selection into the
             # node's mode_metadata.branching so callers can replay what was chosen.

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1069,6 +1069,34 @@ class OrchestratorService:
                 self._branching_writer_service is not None
             )  # noqa: S101 — narrowed above
             _branching_svc = self._branching_writer_service
+            # Lineage guard: verify node/story lineage before the LLM call so no
+            # provider spend is wasted on a turn that cannot be persisted.
+            from afterworlds.persistence.crud.node import (
+                node_belongs_to_story as _nbs,
+            )
+
+            if not _nbs(session, node_id, story_id):
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branching writer: node {node_id} does not belong to story"
+                    f" {story_id}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                )
+            _ctx_story_id = ctx.stable_prefix.story_bible_context.story_id
+            if _ctx_story_id != story_id:
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branching writer: assembled context story {_ctx_story_id}"
+                    f" != target story {story_id}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                )
+            _sel_ctx = selected_branch_context
             try:
                 branching_pass_result, ms = _timed(
                     lambda: _branching_svc.write(
@@ -1079,6 +1107,7 @@ class OrchestratorService:
                             sojourner_id,
                             turn_id=writer_turn_id,
                         ),
+                        selected_branch_context=_sel_ctx,
                     )
                 )
                 latency["branching_writer"] = ms
@@ -1242,6 +1271,22 @@ class OrchestratorService:
                 model_tier=_bpr.model_tier or "",
             )
         else:
+            # Thread selected branch context into the ledger when the branching
+            # writer is not active (partially-wired orchestrator: selection service
+            # wired, branching writer service not).  The prose WriterService renders
+            # the ledger as a volatile block, so selected context reaches the model.
+            if selected_branch_context is not None:
+                _sbc = selected_branch_context
+                _sbc_lines = [
+                    "[Selected Branch]",
+                    f"option_id: {_sbc.option_id}",
+                    f"action_text: {_sbc.action_text}",
+                ]
+                if _sbc.annotation is not None:
+                    _sbc_lines.append(f"annotation: {_sbc.annotation}")
+                ctx.pass_forward_ledger.add(
+                    "branching_selection", "\n".join(_sbc_lines)
+                )
             try:
                 writer_result, ms = _timed(
                     lambda: self._writer_service.write(
@@ -1875,13 +1920,30 @@ class OrchestratorService:
                     ):
                         _validated_range = None  # discard invalid range silently
 
+                # Determine persistence strategy for the style × range pair to
+                # avoid leaving the row in a mismatched configuration:
+                # • FREEFORM_ONLY: persist style, clear range to NULL.
+                # • HYBRID/TRUE_CYOA with valid range: persist both.
+                # • HYBRID/TRUE_CYOA without valid range: skip the style change
+                #   so the existing style stays in place (atomicity).
+                _apply_style = _cfg_update.interaction_style
+                _should_clear_range = False
+                if _cfg_update.interaction_style is _IS.FREEFORM_ONLY:
+                    _should_clear_range = True
+                elif (
+                    _cfg_update.interaction_style in (_IS.HYBRID, _IS.TRUE_CYOA)
+                    and _validated_range is None
+                ):
+                    _apply_style = None  # skip style; existing row stays intact
+
                 _apply_cfg(
                     session,
                     story_id,
-                    interaction_style=_cfg_update.interaction_style,
+                    interaction_style=_apply_style,
                     branching_cadence=_cfg_update.branching_cadence,
                     branch_count_range=_validated_range,
                     length_preference=_cfg_update.length_preference,
+                    clear_branch_count_range=_should_clear_range,
                 )
             except Exception:  # noqa: BLE001
                 pass  # Best-effort; OOC prose already delivered

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1444,6 +1444,33 @@ class OrchestratorService:
                 ctx.pass_forward_ledger.add(
                     "branching_selection", "\n".join(_sbc_lines)
                 )
+            # In-play FREEFORM_ONLY Branching turns use the prose Writer (no
+            # branch cards), but the code-owned Branching session configuration
+            # still governs storyteller response density.  Surface it as a
+            # volatile ledger block so cadence/length preference reaches the
+            # model.  Configuration context only: no branch cards or affordances
+            # are created here, and this block is never sent on non-Branching
+            # stories or for HYBRID/TRUE_CYOA (those use BranchingWriter).
+            if (
+                story_mode is StoryMode.BRANCHING
+                and branching_state is not None
+                and branching_state.play_status is BranchingPlayStatus.IN_PLAY
+                and branching_state.interaction_style is InteractionStyle.FREEFORM_ONLY
+            ):
+                _cfg_lines = [
+                    "[Branching Session Configuration]",
+                    f"interaction_style: {branching_state.interaction_style.value}",
+                ]
+                if branching_state.branching_cadence is not None:
+                    _cfg_lines.append(
+                        f"branching_cadence: {branching_state.branching_cadence.value}"
+                    )
+                if branching_state.length_preference is not None:
+                    _cfg_lines.append(
+                        "length_preference: "
+                        f"{branching_state.length_preference.value}"
+                    )
+                ctx.pass_forward_ledger.add("branching_config", "\n".join(_cfg_lines))
             try:
                 writer_result, ms = _timed(
                     lambda: self._writer_service.write(

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -2658,6 +2658,10 @@ class OrchestratorService:
             extractor_result,
             contradiction_result,
             rpg_adjudication_result,
+            # Branching provider results are stable-prefix-backed calls
+            # equivalent to planner/writer/extractor for cache observability.
+            branching_pass_result,
+            branching_ooc_config_result,
         )
         return OrchestrationResult(
             disposition=disposition,

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -634,10 +634,24 @@ class OrchestratorService:
         # and for the narrative path (HYBRID/TRUE_CYOA).  Modeled on the RPG
         # pre_session_state pattern: resolve once, thread through as _pre_branching_state.  # noqa: E501
         pre_branching_state: BranchingSessionState | None = None
-        if (
-            story_mode is StoryMode.BRANCHING
-            and self._branching_session_resolver is not None
-        ):
+        if story_mode is StoryMode.BRANCHING:
+            # In-play interaction-style enforcement (TRUE_CYOA freeform
+            # rejection, BRANCH_CHOICE validation) and writer routing all depend
+            # on the resolved Branching session state to distinguish setup,
+            # FREEFORM_ONLY, HYBRID, TRUE_CYOA, and play status.  Without the
+            # resolver we cannot prove the turn is one of the "unchanged" paths,
+            # so fail closed before any interaction-style enforcement or
+            # writer-routing decision rather than silently proceeding with
+            # pre_branching_state=None (which would skip in-play HYBRID/TRUE_CYOA
+            # enforcement and downgrade to the prose Writer).
+            if self._branching_session_resolver is None:
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    "branching session resolver not wired for BRANCHING turn;"
+                    " cannot determine interaction style or play status",
+                )
             try:
                 pre_branching_state = self._branching_session_resolver(story_id)
             except Exception as exc:  # noqa: BLE001
@@ -672,6 +686,34 @@ class OrchestratorService:
                     " Freeform narrative input is not valid in this mode."
                     " Use [OOC] to switch to Hybrid mode."
                 ),
+            )
+
+        # Fail closed: an in-play HYBRID/TRUE_CYOA BRANCH_CHOICE requires the
+        # BranchSelectionValidationService.  Without it we cannot validate the
+        # selection against the presented option set; treating the choice as
+        # freeform narrative input would bypass the typed branch-card contract
+        # and proceed to generation with selected_branch_context=None.  This
+        # guard is in-play only, so setup rows stay on the existing wired-only
+        # validation path ("setup unchanged").  Must precede any LLM call, Turn
+        # persistence, canon mutation, or provider billing.
+        if (
+            pre_branching_state is not None
+            and pre_branching_state.play_status is BranchingPlayStatus.IN_PLAY
+            and intent_result.intent_type is IntentType.BRANCH_CHOICE
+            and pre_branching_state.interaction_style
+            in (
+                InteractionStyle.HYBRID,
+                InteractionStyle.TRUE_CYOA,
+            )
+            and self._branching_selection_service is None
+        ):
+            return self._pipeline_error(
+                intent_result,
+                latency,
+                turn_start,
+                "branch selection validation service not wired for in-play"
+                " HYBRID/TRUE_CYOA branch choice; refusing unvalidated"
+                " selection",
             )
 
         # INTERACTION_REJECTED: validate BRANCH_CHOICE selection against the

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -57,7 +57,6 @@ from afterworlds.models.context import (
 )
 from afterworlds.models.enums import (
     BranchingPlayStatus,
-    BranchPresentationState,
     IntentType,
     InteractionRejectionReason,
     InteractionStyle,
@@ -1084,7 +1083,13 @@ class OrchestratorService:
         # replaces WriterService for these modes; FREEFORM_ONLY stays on prose Writer).
         # Gated on in_play: during setup, HYBRID/TRUE_CYOA setup confirmation and
         # clarification route through the prose Writer path per ADR-016 Decision 3.
-        _use_branching_writer = (
+        # An in-play HYBRID/TRUE_CYOA turn REQUIRES the BranchingWriterService.
+        # The service-wiring check is split out from _use_branching_writer so a
+        # missing service fails closed (below) rather than silently falling
+        # through to the prose Writer, which would bypass the typed branch-card
+        # contract and omit branching_pass_result.  Setup turns and
+        # FREEFORM_ONLY still route through the prose Writer per ADR-016 Dec. 3.
+        _branching_required = (
             story_mode is StoryMode.BRANCHING
             and branching_state is not None
             and branching_state.play_status is BranchingPlayStatus.IN_PLAY
@@ -1093,7 +1098,19 @@ class OrchestratorService:
                 InteractionStyle.HYBRID,
                 InteractionStyle.TRUE_CYOA,
             )
-            and self._branching_writer_service is not None
+        )
+        if _branching_required and self._branching_writer_service is None:
+            return self._pipeline_error(
+                intent_result,
+                latency,
+                turn_start,
+                "branching writer service not wired for in-play"
+                " HYBRID/TRUE_CYOA session; refusing prose-writer downgrade",
+                input_safety_result=input_safety,
+                planner_result=planner_result,
+            )
+        _use_branching_writer = (
+            _branching_required and self._branching_writer_service is not None
         )
 
         # 5. Writer persists provisional Turn inside the outer transaction.
@@ -1213,17 +1230,16 @@ class OrchestratorService:
                     planner_result=planner_result,
                     branching_pass_result=branching_pass_result,
                 )
-            # Phase G: persist branch options to Node.mode_metadata.branching.
-            # For shown branch-card turns the persisted option set is the
-            # authoritative source for later BRANCH_CHOICE validation, so it must
-            # be committed in the same transaction that delivers the cards.  If
-            # persistence fails on a shown turn we fail closed (PIPELINE_ERROR ->
-            # rollback) rather than deliver selectable cards backed by an
-            # unpersisted option set.  Held/omitted turns carry no selectable
-            # cards, so their metadata persistence remains best-effort.
-            _cards_shown = (
-                _bpr.branch_presentation_state == BranchPresentationState.SHOWN.value
-            )
+            # Phase G: persist branch options + presentation state to
+            # Node.mode_metadata.branching.  This metadata is the authoritative
+            # surface the next BRANCH_CHOICE turn validates against, so it must be
+            # committed in the same transaction that delivers the turn — for
+            # held/omitted just as much as for shown.  A shown turn needs its
+            # option set persisted; a held/omitted turn needs the prior beat's
+            # branch_options cleared (held/omitted always carry an empty option
+            # set) so stale cards cannot be selected.  If this write fails we fail
+            # closed (PIPELINE_ERROR -> rollback) rather than deliver a turn whose
+            # next valid choice surface cannot be trusted.
             try:
                 from afterworlds.models.node import (
                     BranchingNodeMetadata,
@@ -1277,20 +1293,20 @@ class OrchestratorService:
                         "branch-option persistence"
                     )
             except Exception as exc:  # noqa: BLE001
-                if _cards_shown:
-                    # Shown cards without a persisted option set would leave later
-                    # BRANCH_CHOICE validation with no authoritative source.
-                    return self._pipeline_error(
-                        intent_result,
-                        latency,
-                        turn_start,
-                        f"branch-card persistence failed: {exc}",
-                        input_safety_result=input_safety,
-                        planner_result=planner_result,
-                        branching_pass_result=branching_pass_result,
-                    )
-                # Held/omitted turns carry no selectable cards; node metadata
-                # persistence is non-critical, so continue best-effort.
+                # Authoritative branch-choice surface failed to persist (shown
+                # options unsaved, or stale held/omitted options not cleared).
+                # Fail closed so the next turn cannot validate against a surface
+                # that was never committed.  The BranchingWriter already ran, so
+                # branching_pass_result is preserved for settlement/audit.
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"branch-card metadata persistence failed: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    branching_pass_result=branching_pass_result,
+                )
 
             # Phase G (selection edge): persist the resolved selection into the
             # node's mode_metadata.branching so callers can replay what was chosen.

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1910,9 +1910,19 @@ class OrchestratorService:
                     ALLOWED_RANGES_BY_STYLE as _ALLOWED,
                 )
 
+                # Scope the extractor's provider call to the OOC prose-writer's
+                # turn so any refusal/fallback/provider-call audit row is
+                # reconstructable from that same turn (post-writer convention,
+                # mirroring the output-audit call above).  turn_id may be None
+                # if the writer did not produce one — ScopedProviderAdapter
+                # omits it safely in that case.
                 _extract_result = self._branching_ooc_config_extractor.extract(
                     ooc_ctx,
-                    ScopedProviderAdapter(binding.adapter, sojourner_id),  # type: ignore[arg-type]
+                    ScopedProviderAdapter(
+                        binding.adapter,  # type: ignore[arg-type]
+                        sojourner_id,
+                        turn_id=writer_result.turn_id,
+                    ),
                 )
                 # Capture metrics immediately so usage is visible to settlement
                 # even if a later best-effort persistence step raises.

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -661,6 +661,21 @@ class OrchestratorService:
                     turn_start,
                     f"branching session resolution failed: {exc}",
                 )
+            # A wired resolver returning None means the Branching session
+            # row/state is missing or corrupt.  Fail closed: without state we
+            # cannot prove the turn is setup, FREEFORM_ONLY, HYBRID, or
+            # TRUE_CYOA, so treating None as "setup" or "FREEFORM_ONLY" would
+            # silently skip in-play enforcement and downgrade to the prose
+            # Writer.  Error before any interaction-style enforcement,
+            # branch-choice validation, writer routing, or LLM call.
+            if pre_branching_state is None:
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    "branching session state missing or corrupt for BRANCHING"
+                    " turn; resolver returned None",
+                )
 
         # INTERACTION_REJECTED: True CYOA mode rejects non-OOC freeform input.
         # Runs after the OOC short-circuit (OOC is always valid) and after the
@@ -2164,6 +2179,26 @@ class OrchestratorService:
         _ooc_delivered = writer_result.assistant_output
         if _ooc_style_noop_note is not None:
             _ooc_delivered = f"{_ooc_delivered}\n\n{_ooc_style_noop_note}"
+            # Keep the persisted OOC Turn truthful.  The corrective no-op note
+            # is appended to the delivered output because the requested style
+            # change was suppressed; the raw writer prose alone could falsely
+            # imply the change happened.  Persist the same corrected output to
+            # the Turn row and mirror it onto the in-memory writer_result so
+            # delivered output, returned writer_result, and future recent-turn
+            # context all agree.  Done inside this transaction; a write failure
+            # rolls the whole OOC turn back rather than persisting a false
+            # confirmation.
+            if writer_result.turn_id is not None:
+                from afterworlds.persistence.crud.node import (
+                    update_turn_assistant_output,
+                )
+
+                update_turn_assistant_output(
+                    session, writer_result.turn_id, _ooc_delivered
+                )
+            writer_result = writer_result.model_copy(
+                update={"assistant_output": _ooc_delivered}
+            )
 
         return self._build_result(
             PipelineDisposition.OOC_HANDLED,
@@ -2828,6 +2863,19 @@ class OrchestratorService:
                     extractor_result=inner_result.extractor_result,
                     contradiction_result=inner_result.contradiction_result,
                     rpg_adjudication_result=inner_result.rpg_adjudication_result,
+                    # Preserve usage-carrying Branching pass results.  A
+                    # BranchingWriter or Branching OOC-config extractor that ran
+                    # before the failed commit already consumed provider tokens;
+                    # the disposition changes to PIPELINE_ERROR but that
+                    # successful provider-usage evidence must survive so cost
+                    # settlement (BRANCHING_WRITER / BRANCHING_OOC_CONFIG_
+                    # EXTRACTOR) and audit can reconstruct the spend.  Delivery
+                    # is gated by the PIPELINE_ERROR disposition, not by nulling
+                    # these records.
+                    branching_pass_result=inner_result.branching_pass_result,
+                    branching_ooc_config_result=(
+                        inner_result.branching_ooc_config_result
+                    ),
                     pipeline_error_summary=(
                         f"transaction commit failed after "
                         f"{success_disposition.value}: {commit_exc}"

--- a/src/afterworlds/pipeline/provider/adapters/_anthropic.py
+++ b/src/afterworlds/pipeline/provider/adapters/_anthropic.py
@@ -407,11 +407,13 @@ class AnthropicDirectAdapter:
 def _pass_id_to_pass_identifier(pass_id: PipelinePassId) -> PassIdentifier:
     """Map a PipelinePassId to the 12c PassIdentifier for ProviderRefusal.
 
-    BRANCHING_OOC_CONFIG_EXTRACTOR is intentionally absent: the extractor
-    service wraps ProviderRefusalError as BranchingPassError (best-effort),
-    so a refusal from that pass never reaches this function.  Omitting it
-    ensures any future change that accidentally exposes it surfaces as a
-    loud KeyError rather than a silent PLANNER misattribution.
+    Every provider-backed pass that an adapter may classify as a refusal MUST
+    have an entry here.  The adapter resolves the identity *before* it can
+    construct ``ProviderRefusalError`` (see ``call``), so an omission surfaces
+    as a ``KeyError`` inside the adapter — losing the typed refusal entirely
+    and defeating fallback/refusal logging.  BRANCHING_OOC_CONFIG_EXTRACTOR is
+    included for exactly this reason: the extractor service only wraps refusals
+    *after* the adapter has already attempted this mapping.
     """
     _MAP: dict[PipelinePassId, PassIdentifier] = {
         PipelinePassId.PLANNER: PassIdentifier.PLANNER,
@@ -422,6 +424,9 @@ def _pass_id_to_pass_identifier(pass_id: PipelinePassId) -> PassIdentifier:
         PipelinePassId.OUTPUT_SAFETY: PassIdentifier.PLANNER,  # see note below
         PipelinePassId.RPG_ADJUDICATION: PassIdentifier.RPG_ADJUDICATION,
         PipelinePassId.BRANCHING_WRITER: PassIdentifier.BRANCHING_WRITER,
+        PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR: (
+            PassIdentifier.BRANCHING_OOC_CONFIG_EXTRACTOR
+        ),
     }
     return _MAP[pass_id]
 

--- a/src/afterworlds/pipeline/provider/adapters/_anthropic.py
+++ b/src/afterworlds/pipeline/provider/adapters/_anthropic.py
@@ -86,6 +86,11 @@ _PASS_PROFILE: dict[PipelinePassId, tuple[str, ModelTier]] = {
     PipelinePassId.INPUT_SAFETY: (_DEFAULT_HAIKU_MODEL, ModelTier.HAIKU),
     PipelinePassId.OUTPUT_SAFETY: (_DEFAULT_HAIKU_MODEL, ModelTier.HAIKU),
     PipelinePassId.RPG_ADJUDICATION: (_DEFAULT_HAIKU_MODEL, ModelTier.HAIKU),
+    PipelinePassId.BRANCHING_WRITER: (_DEFAULT_SONNET_MODEL, ModelTier.SONNET),
+    PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR: (
+        _DEFAULT_HAIKU_MODEL,
+        ModelTier.HAIKU,
+    ),
 }
 
 
@@ -400,7 +405,14 @@ class AnthropicDirectAdapter:
 
 
 def _pass_id_to_pass_identifier(pass_id: PipelinePassId) -> PassIdentifier:
-    """Map a PipelinePassId to the 12c PassIdentifier for ProviderRefusal."""
+    """Map a PipelinePassId to the 12c PassIdentifier for ProviderRefusal.
+
+    BRANCHING_OOC_CONFIG_EXTRACTOR is intentionally absent: the extractor
+    service wraps ProviderRefusalError as BranchingPassError (best-effort),
+    so a refusal from that pass never reaches this function.  Omitting it
+    ensures any future change that accidentally exposes it surfaces as a
+    loud KeyError rather than a silent PLANNER misattribution.
+    """
     _MAP: dict[PipelinePassId, PassIdentifier] = {
         PipelinePassId.PLANNER: PassIdentifier.PLANNER,
         PipelinePassId.WRITER: PassIdentifier.WRITER,
@@ -409,8 +421,9 @@ def _pass_id_to_pass_identifier(pass_id: PipelinePassId) -> PassIdentifier:
         PipelinePassId.INPUT_SAFETY: PassIdentifier.PLANNER,  # Safety→PIPELINE_ERROR
         PipelinePassId.OUTPUT_SAFETY: PassIdentifier.PLANNER,  # see note below
         PipelinePassId.RPG_ADJUDICATION: PassIdentifier.RPG_ADJUDICATION,
+        PipelinePassId.BRANCHING_WRITER: PassIdentifier.BRANCHING_WRITER,
     }
-    return _MAP.get(pass_id, PassIdentifier.PLANNER)
+    return _MAP[pass_id]
 
 
 def _extract_excerpt(response: object) -> str:

--- a/tests/entitlement/test_policy.py
+++ b/tests/entitlement/test_policy.py
@@ -526,6 +526,156 @@ def test_extract_snapshots_rpg_adjudication_partial_token_not_silently_skipped()
         TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
 
 
+# ---------------------------------------------------------------------------
+# Round 2 (CRD Issue 16): BRANCHING_WRITER and BRANCHING_OOC_CONFIG_EXTRACTOR
+# in PASS_TIER_DEFAULTS and extract_snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_pass_tier_defaults_includes_branching_writer() -> None:
+    """BRANCHING_WRITER must be in PASS_TIER_DEFAULTS at SONNET tier."""
+    from afterworlds.entitlement.enums import ModelTier
+    from afterworlds.entitlement.policy import PASS_TIER_DEFAULTS
+
+    assert PipelinePassId.BRANCHING_WRITER in PASS_TIER_DEFAULTS
+    assert PASS_TIER_DEFAULTS[PipelinePassId.BRANCHING_WRITER] is ModelTier.SONNET
+
+
+def test_pass_tier_defaults_includes_branching_ooc_extractor() -> None:
+    """BRANCHING_OOC_CONFIG_EXTRACTOR must be in PASS_TIER_DEFAULTS at HAIKU tier."""
+    from afterworlds.entitlement.enums import ModelTier
+    from afterworlds.entitlement.policy import PASS_TIER_DEFAULTS
+
+    assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR in PASS_TIER_DEFAULTS
+    assert (
+        PASS_TIER_DEFAULTS[PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR]
+        is ModelTier.HAIKU
+    )
+
+
+def _make_branching_writer_result(
+    input_token_count: int | None = 100,
+    output_token_count: int | None = 50,
+) -> object:
+    """Minimal OrchestrationResult (PIPELINE_ERROR) with branching_pass_result set."""
+    from afterworlds.models.enums import (
+        BranchingCadence,
+        IntentType,
+        InteractionStyle,
+    )
+    from afterworlds.models.intent_classification import IntentClassificationResult
+    from afterworlds.pipeline.branching.models import BranchingPassResult
+    from afterworlds.pipeline.orchestrator.models import (
+        OrchestrationResult,
+        PipelineDisposition,
+    )
+
+    bpr = BranchingPassResult(
+        narrative_text="test",
+        interaction_style=InteractionStyle.HYBRID,
+        branching_cadence=BranchingCadence.BALANCED,
+        length_preference=None,
+        freeform_available=True,
+        branch_count_range=None,
+        branch_options=[],
+        branch_presentation_state="held",
+        provider="anthropic",
+        model_identifier="claude-sonnet-4-5",
+        model_tier="sonnet",
+        latency_ms=100,
+        input_token_count=input_token_count,
+        output_token_count=output_token_count,
+    )
+    return OrchestrationResult(
+        disposition=PipelineDisposition.PIPELINE_ERROR,
+        delivered_output=None,
+        turn_id=None,
+        intent_classification=IntentClassificationResult(
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            confidence=1.0,
+            raw_input="",
+            ambiguous=False,
+        ),
+        pipeline_error_summary="branching writer billing test",
+        total_latency_ms=0,
+        pass_latency_breakdown={},
+        branching_pass_result=bpr,
+    )
+
+
+def _make_ooc_extractor_result(
+    input_token_count: int | None = 50,
+    output_token_count: int | None = 20,
+) -> object:
+    """Minimal OrchestrationResult (PIPELINE_ERROR) with ooc_config_result set."""
+    from afterworlds.models.enums import IntentType
+    from afterworlds.models.intent_classification import IntentClassificationResult
+    from afterworlds.pipeline.branching.models import (
+        BranchingConfigUpdate,
+        BranchingOocConfigExtractorResult,
+    )
+    from afterworlds.pipeline.orchestrator.models import (
+        OrchestrationResult,
+        PipelineDisposition,
+    )
+
+    bocr = BranchingOocConfigExtractorResult(
+        config_update=BranchingConfigUpdate(),
+        provider="anthropic",
+        model_identifier="claude-haiku-4-5-20251001",
+        model_tier="haiku",
+        latency_ms=30,
+        input_token_count=input_token_count,
+        output_token_count=output_token_count,
+    )
+    return OrchestrationResult(
+        disposition=PipelineDisposition.PIPELINE_ERROR,
+        delivered_output=None,
+        turn_id=None,
+        intent_classification=IntentClassificationResult(
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            confidence=1.0,
+            raw_input="",
+            ambiguous=False,
+        ),
+        pipeline_error_summary="ooc extractor billing test",
+        total_latency_ms=0,
+        pass_latency_breakdown={},
+        branching_ooc_config_result=bocr,
+    )
+
+
+def test_extract_snapshots_includes_branching_writer() -> None:
+    """BRANCHING_WRITER snapshot is produced when branching_pass_result is set."""
+    result = _make_branching_writer_result()
+    snapshots = TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+    pass_ids = [s.pass_id for s in snapshots]
+    assert PipelinePassId.BRANCHING_WRITER in pass_ids
+
+
+def test_extract_snapshots_branching_writer_nil_input_tokens_raises() -> None:
+    """Missing input_token_count on branching_pass_result raises settlement error."""
+    result = _make_branching_writer_result(input_token_count=None)
+    with pytest.raises(EntitlementSettlementError):
+        TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+
+
+def test_extract_snapshots_includes_branching_ooc_extractor() -> None:
+    """BRANCHING_OOC_CONFIG_EXTRACTOR snapshot produced when ooc result is set."""
+    result = _make_ooc_extractor_result()
+    snapshots = TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+    pass_ids = [s.pass_id for s in snapshots]
+    assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR in pass_ids
+
+
+def test_extract_snapshots_skips_branching_ooc_extractor_when_none() -> None:
+    """No OOC extractor snapshot when branching_ooc_config_result is None."""
+    result = _make_branching_writer_result()
+    snapshots = TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+    pass_ids = [s.pass_id for s in snapshots]
+    assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR not in pass_ids
+
+
 # Forward declarations to satisfy mypy in the last test
 from uuid import UUID  # noqa: E402
 

--- a/tests/entitlement/test_policy.py
+++ b/tests/entitlement/test_policy.py
@@ -676,6 +676,104 @@ def test_extract_snapshots_skips_branching_ooc_extractor_when_none() -> None:
     assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR not in pass_ids
 
 
+# ---------------------------------------------------------------------------
+# Round 3: WRITER snapshot skipped when branching_pass_result present
+# ---------------------------------------------------------------------------
+
+
+def _make_branching_writer_both() -> object:
+    """PIPELINE_ERROR result with BOTH writer_result and branching_pass_result.
+
+    Simulates the synthetic WriterResult stamped for downstream prose-consuming
+    passes alongside the real BranchingPassResult.  Used to verify no double-charge.
+    """
+    from uuid import uuid4
+
+    from afterworlds.models.enums import BranchingCadence, IntentType, InteractionStyle
+    from afterworlds.models.intent_classification import IntentClassificationResult
+    from afterworlds.pipeline.branching.models import BranchingPassResult
+    from afterworlds.pipeline.orchestrator.models import (
+        OrchestrationResult,
+        PipelineDisposition,
+    )
+    from afterworlds.pipeline.writer.models import WriterResult
+
+    bpr = BranchingPassResult(
+        narrative_text="test",
+        interaction_style=InteractionStyle.HYBRID,
+        branching_cadence=BranchingCadence.BALANCED,
+        length_preference=None,
+        freeform_available=True,
+        branch_count_range=None,
+        branch_options=[],
+        branch_presentation_state="held",
+        provider="anthropic",
+        model_identifier="claude-sonnet-4-5",
+        model_tier="sonnet",
+        latency_ms=100,
+        input_token_count=100,
+        output_token_count=50,
+    )
+    wr = WriterResult(
+        turn_id=uuid4(),
+        assistant_output="prose",
+        model_identifier="claude-sonnet-4-5",
+        latency_ms=10,
+        input_token_count=200,
+        output_token_count=80,
+        cache_read_token_count=None,
+        cache_creation_token_count=None,
+        provider="anthropic",
+        model_tier="sonnet",
+    )
+    return OrchestrationResult(
+        disposition=PipelineDisposition.PIPELINE_ERROR,
+        delivered_output=None,
+        turn_id=None,
+        intent_classification=IntentClassificationResult(
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            confidence=1.0,
+            raw_input="",
+            ambiguous=False,
+        ),
+        pipeline_error_summary="double-charge regression test",
+        total_latency_ms=0,
+        pass_latency_breakdown={},
+        writer_result=wr,
+        branching_pass_result=bpr,
+    )
+
+
+def test_extract_snapshots_prose_writer_emits_writer_snapshot() -> None:
+    """Prose Writer turn (no branching_pass_result) still emits WRITER snapshot."""
+    from uuid import uuid4
+
+    from tests.entitlement.test_settlement import _make_delivered_result
+
+    result = _make_delivered_result(uuid4())
+    snapshots = TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+    pass_ids = [s.pass_id for s in snapshots]
+    assert PipelinePassId.WRITER in pass_ids
+
+
+def test_extract_snapshots_branching_writer_turn_no_writer_snapshot() -> None:
+    """Branching turn: BRANCHING_WRITER present, WRITER absent (no double-charge)."""
+    result = _make_branching_writer_both()
+    snapshots = TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+    pass_ids = [s.pass_id for s in snapshots]
+    assert PipelinePassId.BRANCHING_WRITER in pass_ids
+    assert PipelinePassId.WRITER not in pass_ids
+
+
+def test_extract_snapshots_branching_writer_no_duplicate_snapshots() -> None:
+    """No duplicate WRITER/BRANCHING_WRITER when both result fields are present."""
+    result = _make_branching_writer_both()
+    snapshots = TurnCostPolicy.extract_snapshots(result)  # type: ignore[arg-type]
+    pass_ids = [s.pass_id for s in snapshots]
+    assert pass_ids.count(PipelinePassId.WRITER) == 0
+    assert pass_ids.count(PipelinePassId.BRANCHING_WRITER) == 1
+
+
 # Forward declarations to satisfy mypy in the last test
 from uuid import UUID  # noqa: E402
 

--- a/tests/persistence/test_crud_session.py
+++ b/tests/persistence/test_crud_session.py
@@ -8,7 +8,9 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 
 from afterworlds.models.enums import (
+    BranchCountRange,
     DiceHandling,
+    InteractionStyle,
     PacingStage,
     RpgPlayStatus,
     RpgSessionType,
@@ -27,6 +29,7 @@ from afterworlds.models.session import (
 )
 from afterworlds.persistence.crud.character_sheet import create_rpg_base_sheet
 from afterworlds.persistence.crud.session_state import (
+    apply_branching_config_update,
     create_branching_session_state,
     create_rpg_session_state,
     create_writing_session_state,
@@ -34,6 +37,7 @@ from afterworlds.persistence.crud.session_state import (
     delete_rpg_session_state,
     delete_writing_session_state,
     get_branching_session_state,
+    get_branching_session_state_by_story,
     get_rpg_session_state,
     get_writing_session_state,
     update_rpg_session_state,
@@ -474,3 +478,117 @@ def test_branching_current_node_id_fk_enforced(session):  # type: ignore[no-unty
     session.add(row)
     with pytest.raises(IntegrityError):
         session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: apply_branching_config_update — clear_branch_count_range semantics
+# ---------------------------------------------------------------------------
+
+
+def _make_branching_state_with_range(
+    story_id: str,
+    interaction_style: InteractionStyle = InteractionStyle.HYBRID,
+    branch_count_range: BranchCountRange = BranchCountRange.TWO_TO_THREE,
+) -> BranchingSessionState:
+    return BranchingSessionState(
+        story_id=UUID(story_id),
+        pacing_stage=PacingStage.ESCALATION,
+        interaction_style=interaction_style,
+        branch_count_range=branch_count_range,
+    )
+
+
+def test_clear_branch_count_range_sets_null(session):  # type: ignore[no-untyped-def]
+    """clear_branch_count_range=True sets branch_count_range to NULL."""
+    from afterworlds.models.enums import StoryMode
+
+    story = make_story(mode=StoryMode.BRANCHING)
+    create_story(session, story)
+    state = _make_branching_state_with_range(str(story.story_id))
+    create_branching_session_state(session, state)
+    session.commit()
+
+    # Confirm it has a range before clearing.
+    before = get_branching_session_state_by_story(session, story.story_id)
+    assert before is not None
+    assert before.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+    apply_branching_config_update(
+        session,
+        story.story_id,
+        clear_branch_count_range=True,
+    )
+    session.commit()
+
+    after = get_branching_session_state_by_story(session, story.story_id)
+    assert after is not None
+    assert after.branch_count_range is None
+
+
+def test_clear_branch_count_range_overrides_value_arg(session):  # type: ignore[no-untyped-def]
+    """clear_branch_count_range=True → NULL even when branch_count_range is also set."""
+    from afterworlds.models.enums import StoryMode
+
+    story = make_story(mode=StoryMode.BRANCHING)
+    create_story(session, story)
+    state = _make_branching_state_with_range(str(story.story_id))
+    create_branching_session_state(session, state)
+    session.commit()
+
+    apply_branching_config_update(
+        session,
+        story.story_id,
+        branch_count_range=BranchCountRange.THREE_TO_FOUR,
+        clear_branch_count_range=True,
+    )
+    session.commit()
+
+    after = get_branching_session_state_by_story(session, story.story_id)
+    assert after is not None
+    assert after.branch_count_range is None
+
+
+def test_default_false_leaves_none_unchanged(session):  # type: ignore[no-untyped-def]
+    """clear_branch_count_range=False (default): None branch_count_range → no change."""
+    from afterworlds.models.enums import StoryMode
+
+    story = make_story(mode=StoryMode.BRANCHING)
+    create_story(session, story)
+    state = _make_branching_state_with_range(str(story.story_id))
+    create_branching_session_state(session, state)
+    session.commit()
+
+    apply_branching_config_update(
+        session,
+        story.story_id,
+        # branch_count_range omitted → no change
+    )
+    session.commit()
+
+    after = get_branching_session_state_by_story(session, story.story_id)
+    assert after is not None
+    assert after.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+
+def test_apply_style_with_range(session):  # type: ignore[no-untyped-def]
+    """Setting style + range together works; row is not left in mismatched config."""
+    from afterworlds.models.enums import StoryMode
+
+    story = make_story(mode=StoryMode.BRANCHING)
+    create_story(session, story)
+    state = _make_branching_state_with_range(str(story.story_id))
+    create_branching_session_state(session, state)
+    session.commit()
+
+    apply_branching_config_update(
+        session,
+        story.story_id,
+        interaction_style=InteractionStyle.TRUE_CYOA,
+        branch_count_range=BranchCountRange.THREE_TO_FOUR,
+    )
+    session.commit()
+
+    after = get_branching_session_state_by_story(session, story.story_id)
+    assert after is not None
+    assert after.interaction_style is InteractionStyle.TRUE_CYOA
+    assert after.branch_count_range is BranchCountRange.THREE_TO_FOUR

--- a/tests/pipeline/branching/test_models.py
+++ b/tests/pipeline/branching/test_models.py
@@ -475,3 +475,37 @@ class TestAllowedRangesByStyle:
         assert BranchCountRange.TWO_TO_FIVE in cyoa_ranges
         assert BranchCountRange.ONE_TO_TWO not in cyoa_ranges
         assert BranchCountRange.THREE_TO_FOUR not in cyoa_ranges
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingWriterConfig.from_env
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingWriterConfigFromEnv:
+    def test_defaults_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from afterworlds.pipeline.branching.config import BranchingWriterConfig
+
+        monkeypatch.delenv("AFTERWORLDS_BRANCHING_WRITER_MODEL", raising=False)
+        monkeypatch.delenv("AFTERWORLDS_BRANCHING_WRITER_API_KEY_ENV", raising=False)
+        monkeypatch.delenv("AFTERWORLDS_BRANCHING_WRITER_EXTENDED_TTL", raising=False)
+        cfg = BranchingWriterConfig.from_env()
+        assert cfg.model != ""
+        assert cfg.api_key_env == "ANTHROPIC_API_KEY"
+        assert cfg.extended_ttl is True
+
+    def test_model_override_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from afterworlds.pipeline.branching.config import BranchingWriterConfig
+
+        monkeypatch.setenv("AFTERWORLDS_BRANCHING_WRITER_MODEL", "custom-model")
+        cfg = BranchingWriterConfig.from_env()
+        assert cfg.model == "custom-model"
+
+    def test_extended_ttl_false_when_set_to_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from afterworlds.pipeline.branching.config import BranchingWriterConfig
+
+        monkeypatch.setenv("AFTERWORLDS_BRANCHING_WRITER_EXTENDED_TTL", "false")
+        cfg = BranchingWriterConfig.from_env()
+        assert cfg.extended_ttl is False

--- a/tests/pipeline/branching/test_models.py
+++ b/tests/pipeline/branching/test_models.py
@@ -1,0 +1,477 @@
+"""Unit tests for Issue 16 models and validators — CRD Issue 16.
+
+Coverage:
+- PipelineDisposition.INTERACTION_REJECTED validator (required / forbidden fields).
+- BranchingCadence is distinct from PacingStage (no overlapping values).
+- BranchCountRange members cover all five configured ranges.
+- InteractionStyle members.
+- BranchingPlayStatus members.
+- OrchestrationResult accepts INTERACTION_REJECTED with correct fields.
+- InteractionRejectionReason enum values (four values).
+- BranchPresentationState enum values.
+- BranchingVisibleState schema.
+- BranchTree dormancy (must not be used, repurposed, or deleted).
+- ALLOWED_RANGES_BY_STYLE per-style mapping.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    BranchingPlayStatus,
+    IntentType,
+    InteractionRejectionReason,
+    InteractionStyle,
+    PacingStage,
+)
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.pipeline._refusal import PassIdentifier, ProviderRefusal
+from afterworlds.pipeline.orchestrator.models import (
+    OrchestrationResult,
+    OrchestratorError,
+    PipelineDisposition,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal OrchestrationResult field kit for INTERACTION_REJECTED
+# ---------------------------------------------------------------------------
+
+
+def _base_intent(
+    intent: IntentType = IntentType.IN_CHARACTER_ACTION,
+) -> IntentClassificationResult:
+    return IntentClassificationResult(
+        intent_type=intent,
+        confidence=0.95,
+        raw_input="I cross the bridge",
+        ambiguous=False,
+    )
+
+
+_DEFAULT_REASON = InteractionRejectionReason.INVALID_FOR_INTERACTION_STYLE
+
+
+def _interaction_rejected(
+    reason: InteractionRejectionReason = _DEFAULT_REASON,
+    message: str = "True CYOA mode requires explicit branch selection.",
+    **overrides: object,
+) -> OrchestrationResult:
+    """Build a minimal valid INTERACTION_REJECTED OrchestrationResult."""
+    kwargs: dict = {
+        "disposition": PipelineDisposition.INTERACTION_REJECTED,
+        "delivered_output": None,
+        "turn_id": None,
+        "intent_classification": _base_intent(),
+        "interaction_rejection_reason": reason,
+        "interaction_rejection_message": message,
+        "total_latency_ms": 5,
+        "pass_latency_breakdown": {},
+    }
+    kwargs.update(overrides)
+    return OrchestrationResult(**kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Test: INTERACTION_REJECTED validator
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionRejectedValidator:
+    """OrchestrationResult enforces field invariants for INTERACTION_REJECTED."""
+
+    def test_valid_construction_succeeds(self) -> None:
+        result = _interaction_rejected()
+        assert result.disposition is PipelineDisposition.INTERACTION_REJECTED
+        assert (
+            result.interaction_rejection_reason
+            is InteractionRejectionReason.INVALID_FOR_INTERACTION_STYLE
+        )
+        assert result.interaction_rejection_message is not None
+
+    def test_none_reason_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="interaction_rejection_reason"):
+            _interaction_rejected(reason=None)  # type: ignore[arg-type]
+
+    def test_empty_message_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="interaction_rejection_message"):
+            _interaction_rejected(message="")
+
+    def test_none_message_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="interaction_rejection_message"):
+            _interaction_rejected(message=None)  # type: ignore[arg-type]
+
+    def test_turn_id_present_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="turn_id"):
+            _interaction_rejected(turn_id=uuid4())
+
+    def test_delivered_output_present_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="delivered_output"):
+            _interaction_rejected(delivered_output="some output")
+
+    def test_planner_result_present_raises(self) -> None:
+        from afterworlds.pipeline.planner.models import PlannerOutput, PlannerResult
+
+        planner_result = PlannerResult(
+            plan=PlannerOutput(
+                scene_goal="reach the bridge",
+                next_beat="cross safely",
+                facts_needed=["bridge condition"],
+            ),
+            model_identifier="fake-model",
+            latency_ms=5,
+            input_token_count=None,
+            output_token_count=None,
+            cache_read_token_count=None,
+            cache_creation_token_count=None,
+        )
+        with pytest.raises(OrchestratorError, match="planner_result absent"):
+            _interaction_rejected(planner_result=planner_result)
+
+    def test_writer_result_present_raises(self) -> None:
+        from uuid import uuid4
+
+        from afterworlds.pipeline.writer.models import WriterResult
+
+        writer_result = WriterResult(
+            turn_id=uuid4(),
+            assistant_output="narrative",
+            model_identifier="fake-model",
+            latency_ms=10,
+            input_token_count=None,
+            output_token_count=None,
+            cache_read_token_count=None,
+            cache_creation_token_count=None,
+        )
+        with pytest.raises(OrchestratorError, match="writer_result absent"):
+            _interaction_rejected(writer_result=writer_result)
+
+    def test_pending_roll_redirect_message_present_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="pending_roll_redirect_message"):
+            _interaction_rejected(
+                pending_roll_redirect_message="Please roll your attack."
+            )
+
+    def test_provider_refusal_present_raises(self) -> None:
+        refusal = ProviderRefusal(
+            provider="fake",
+            pass_identifier=PassIdentifier.WRITER,
+            coarse_reason="policy",
+        )
+        with pytest.raises(OrchestratorError, match="provider_refusal"):
+            _interaction_rejected(provider_refusal=refusal)
+
+    def test_pipeline_error_summary_present_raises(self) -> None:
+        with pytest.raises(OrchestratorError, match="pipeline_error_summary"):
+            _interaction_rejected(pipeline_error_summary="something broke")
+
+
+# ---------------------------------------------------------------------------
+# Test: PipelineDisposition contains INTERACTION_REJECTED
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineDispositionEnum:
+    def test_interaction_rejected_present(self) -> None:
+        assert "interaction_rejected" in [d.value for d in PipelineDisposition]
+
+    def test_all_nine_dispositions_present(self) -> None:
+        values = {d.value for d in PipelineDisposition}
+        assert values == {
+            "delivered",
+            "ooc_handled",
+            "blocked_input_safety",
+            "blocked_output_safety",
+            "blocked_contradiction",
+            "blocked_pending_roll",
+            "interaction_rejected",
+            "refused_by_provider",
+            "pipeline_error",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingCadence is distinct from PacingStage
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingCadenceDistinctFromPacingStage:
+    """BranchingCadence and PacingStage are orthogonal — no overlapping values."""
+
+    def test_no_overlapping_values(self) -> None:
+        cadence_values = {c.value for c in BranchingCadence}
+        pacing_values = {p.value for p in PacingStage}
+        assert cadence_values.isdisjoint(
+            pacing_values
+        ), f"Overlap detected: {cadence_values & pacing_values}"
+
+    def test_branching_cadence_members(self) -> None:
+        assert BranchingCadence.INTERACTIVE.value == "interactive"
+        assert BranchingCadence.BALANCED.value == "balanced"
+        assert BranchingCadence.IMMERSIVE.value == "immersive"
+
+    def test_pacing_stage_members_unchanged(self) -> None:
+        assert PacingStage.SETUP.value == "setup"
+        assert PacingStage.ESCALATION.value == "escalation"
+        assert PacingStage.REVERSAL.value == "reversal"
+        assert PacingStage.CLIMAX.value == "climax"
+        assert PacingStage.AFTERMATH.value == "aftermath"
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchCountRange values
+# ---------------------------------------------------------------------------
+
+
+class TestBranchCountRangeValues:
+    def test_all_five_ranges(self) -> None:
+        assert BranchCountRange.ONE_TO_TWO.value == "1-2"
+        assert BranchCountRange.TWO_TO_THREE.value == "2-3"
+        assert BranchCountRange.THREE_TO_FOUR.value == "3-4"
+        assert BranchCountRange.TWO_TO_FOUR.value == "2-4"
+        assert BranchCountRange.TWO_TO_FIVE.value == "2-5"
+
+    def test_five_members(self) -> None:
+        assert len(list(BranchCountRange)) == 5
+
+
+# ---------------------------------------------------------------------------
+# Test: InteractionStyle values
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionStyleValues:
+    def test_three_styles(self) -> None:
+        assert InteractionStyle.FREEFORM_ONLY.value == "freeform_only"
+        assert InteractionStyle.HYBRID.value == "hybrid"
+        assert InteractionStyle.TRUE_CYOA.value == "true_cyoa"
+
+    def test_three_members(self) -> None:
+        assert len(list(InteractionStyle)) == 3
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingPlayStatus values
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingPlayStatusValues:
+    def test_two_statuses(self) -> None:
+        assert BranchingPlayStatus.SETUP.value == "setup"
+        assert BranchingPlayStatus.IN_PLAY.value == "in_play"
+
+
+# ---------------------------------------------------------------------------
+# Test: InteractionRejectionReason enum
+# ---------------------------------------------------------------------------
+
+
+class TestInteractionRejectionReasonEnum:
+    def test_four_members(self) -> None:
+        values = {r.value for r in InteractionRejectionReason}
+        assert values == {
+            "invalid_for_interaction_style",
+            "invalid_branch_selection",
+            "material_branch_rewrite",
+            "canon_or_genre_contradiction",
+        }
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(InteractionRejectionReason.INVALID_BRANCH_SELECTION, str)
+
+
+# ---------------------------------------------------------------------------
+# Test: SelectedBranchContext
+# ---------------------------------------------------------------------------
+
+
+class TestSelectedBranchContext:
+    def test_accepts_valid_fields(self) -> None:
+        from afterworlds.pipeline.branching.models import SelectedBranchContext
+
+        ctx = SelectedBranchContext(
+            option_id="opt_1",
+            action_text="Take the bridge",
+            annotation="but stop for the sword",
+        )
+        assert ctx.option_id == "opt_1"
+        assert ctx.action_text == "Take the bridge"
+        assert ctx.annotation == "but stop for the sword"
+
+    def test_annotation_optional(self) -> None:
+        from afterworlds.pipeline.branching.models import SelectedBranchContext
+
+        ctx = SelectedBranchContext(option_id="opt_2", action_text="Wade the river")
+        assert ctx.annotation is None
+
+    def test_extra_fields_forbidden(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import SelectedBranchContext
+
+        with pytest.raises(ValidationError):
+            SelectedBranchContext(  # type: ignore[call-arg]
+                option_id="opt_1",
+                action_text="Take the bridge",
+                unknown_field="boom",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingConfigUpdate
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingConfigUpdate:
+    def test_all_none_is_valid(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        update = BranchingConfigUpdate()
+        assert update.interaction_style is None
+        assert update.branching_cadence is None
+        assert update.branch_count_range is None
+        assert update.length_preference is None
+
+    def test_accepts_valid_interaction_style(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        update = BranchingConfigUpdate(interaction_style=InteractionStyle.HYBRID)
+        assert update.interaction_style is InteractionStyle.HYBRID
+
+    def test_accepts_valid_branch_count_range(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        update = BranchingConfigUpdate(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        assert update.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+    def test_extra_fields_forbidden(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        with pytest.raises(ValidationError):
+            BranchingConfigUpdate(unknown_field="boom")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchPresentationState enum
+# ---------------------------------------------------------------------------
+
+
+class TestBranchPresentationStateEnum:
+    def test_three_members(self) -> None:
+        from afterworlds.models.enums import BranchPresentationState
+
+        assert BranchPresentationState.SHOWN.value == "shown"
+        assert BranchPresentationState.HELD.value == "held"
+        assert BranchPresentationState.OMITTED.value == "omitted"
+
+    def test_disjoint_from_branching_play_status(self) -> None:
+        from afterworlds.models.enums import BranchPresentationState
+
+        ps_vals = {v.value for v in BranchPresentationState}
+        bps_vals = {v.value for v in BranchingPlayStatus}
+        assert ps_vals.isdisjoint(bps_vals)
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingVisibleState schema
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingVisibleState:
+    def test_schema_version_defaults_to_1(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingVisibleState
+
+        vs = BranchingVisibleState(
+            interaction_style=InteractionStyle.HYBRID,
+            branching_cadence=BranchingCadence.BALANCED,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+            freeform_available=True,
+            length_preference=None,
+        )
+        assert vs.schema_version == 1
+
+    def test_extra_fields_forbidden(self) -> None:
+        import pytest
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingVisibleState
+
+        with pytest.raises(ValidationError):
+            BranchingVisibleState(  # type: ignore[call-arg]
+                interaction_style=InteractionStyle.HYBRID,
+                branching_cadence=BranchingCadence.BALANCED,
+                branch_count_range=None,
+                freeform_available=True,
+                length_preference=None,
+                unexpected_field="boom",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchTree dormancy
+# ---------------------------------------------------------------------------
+
+
+class TestBranchTreeDormancy:
+    """BranchTree must remain dormant: not used, repurposed, or deleted (ADR-016)."""
+
+    def test_branch_tree_type_exists(self) -> None:
+        from afterworlds.models.session import BranchTree
+
+        assert BranchTree is not None
+
+    def test_branch_tree_is_default_on_session(self) -> None:
+        from afterworlds.models.enums import PacingStage
+        from afterworlds.models.session import BranchingSessionState, BranchTree
+
+        state = BranchingSessionState(
+            story_id=uuid4(),
+            pacing_stage=PacingStage.SETUP,
+        )
+        assert isinstance(state.branch_tree, BranchTree)
+
+    def test_branch_tree_has_no_active_children(self) -> None:
+        from afterworlds.models.session import BranchTree
+
+        tree = BranchTree()
+        assert not hasattr(tree, "nodes") or len(getattr(tree, "nodes", [])) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: ALLOWED_RANGES_BY_STYLE
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedRangesByStyle:
+    def test_freeform_only_has_no_range(self) -> None:
+        from afterworlds.pipeline.branching.config import ALLOWED_RANGES_BY_STYLE
+
+        assert ALLOWED_RANGES_BY_STYLE[InteractionStyle.FREEFORM_ONLY] is None
+
+    def test_hybrid_allowed_ranges(self) -> None:
+        from afterworlds.pipeline.branching.config import ALLOWED_RANGES_BY_STYLE
+
+        hybrid_ranges = ALLOWED_RANGES_BY_STYLE[InteractionStyle.HYBRID]
+        assert hybrid_ranges is not None
+        assert BranchCountRange.ONE_TO_TWO in hybrid_ranges
+        assert BranchCountRange.TWO_TO_THREE in hybrid_ranges
+        assert BranchCountRange.THREE_TO_FOUR in hybrid_ranges
+        assert BranchCountRange.TWO_TO_FOUR not in hybrid_ranges
+        assert BranchCountRange.TWO_TO_FIVE not in hybrid_ranges
+
+    def test_true_cyoa_allowed_ranges(self) -> None:
+        from afterworlds.pipeline.branching.config import ALLOWED_RANGES_BY_STYLE
+
+        cyoa_ranges = ALLOWED_RANGES_BY_STYLE[InteractionStyle.TRUE_CYOA]
+        assert cyoa_ranges is not None
+        assert BranchCountRange.TWO_TO_THREE in cyoa_ranges
+        assert BranchCountRange.TWO_TO_FOUR in cyoa_ranges
+        assert BranchCountRange.TWO_TO_FIVE in cyoa_ranges
+        assert BranchCountRange.ONE_TO_TWO not in cyoa_ranges
+        assert BranchCountRange.THREE_TO_FOUR not in cyoa_ranges

--- a/tests/pipeline/branching/test_models.py
+++ b/tests/pipeline/branching/test_models.py
@@ -572,3 +572,69 @@ class TestBranchingWriterProposalPresentationState:
                 branch_options_text=[],
                 branch_presentation_state="",
             )
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingWriterProposal — non-empty narrative / option labels (Round 4)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingWriterProposalNonEmptyContent:
+    """Blank narrative prose and blank option labels fail closed."""
+
+    def test_whitespace_only_narrative_fails(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        with pytest.raises(ValidationError):
+            BranchingWriterProposal(
+                narrative_text="   \n\t ",
+                branch_options_text=["opt 1"],
+                branch_presentation_state="shown",
+            )
+
+    def test_empty_narrative_fails(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        with pytest.raises(ValidationError):
+            BranchingWriterProposal(
+                narrative_text="",
+                branch_options_text=["opt 1"],
+                branch_presentation_state="shown",
+            )
+
+    def test_whitespace_only_option_label_fails(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        with pytest.raises(ValidationError):
+            BranchingWriterProposal(
+                narrative_text="prose",
+                branch_options_text=["Take the bridge", "  "],
+                branch_presentation_state="shown",
+            )
+
+    def test_narrative_and_labels_are_stripped(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        p = BranchingWriterProposal(
+            narrative_text="  prose  ",
+            branch_options_text=["  Take the bridge  ", "Wade the river"],
+            branch_presentation_state="shown",
+        )
+        assert p.narrative_text == "prose"
+        assert p.branch_options_text == ["Take the bridge", "Wade the river"]
+
+    def test_empty_option_list_remains_valid_for_held(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        p = BranchingWriterProposal(
+            narrative_text="prose",
+            branch_options_text=[],
+            branch_presentation_state="held",
+        )
+        assert p.branch_options_text == []

--- a/tests/pipeline/branching/test_models.py
+++ b/tests/pipeline/branching/test_models.py
@@ -509,3 +509,66 @@ class TestBranchingWriterConfigFromEnv:
         monkeypatch.setenv("AFTERWORLDS_BRANCHING_WRITER_EXTENDED_TTL", "false")
         cfg = BranchingWriterConfig.from_env()
         assert cfg.extended_ttl is False
+
+
+# ---------------------------------------------------------------------------
+# Test: BranchingWriterProposal — branch_presentation_state validation (Round 3)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingWriterProposalPresentationState:
+    """BranchingWriterProposal rejects invalid branch_presentation_state values."""
+
+    def test_shown_is_valid(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        p = BranchingWriterProposal(
+            narrative_text="prose",
+            branch_options_text=["opt 1", "opt 2"],
+            branch_presentation_state="shown",
+        )
+        assert p.branch_presentation_state == "shown"
+
+    def test_held_is_valid(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        p = BranchingWriterProposal(
+            narrative_text="prose",
+            branch_options_text=[],
+            branch_presentation_state="held",
+        )
+        assert p.branch_presentation_state == "held"
+
+    def test_omitted_is_valid(self) -> None:
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        p = BranchingWriterProposal(
+            narrative_text="prose",
+            branch_options_text=[],
+            branch_presentation_state="omitted",
+        )
+        assert p.branch_presentation_state == "omitted"
+
+    def test_invalid_value_fails_schema_validation(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        with pytest.raises(ValidationError):
+            BranchingWriterProposal(
+                narrative_text="prose",
+                branch_options_text=["opt 1"],
+                branch_presentation_state="later",
+            )
+
+    def test_empty_string_fails_schema_validation(self) -> None:
+        from pydantic import ValidationError
+
+        from afterworlds.pipeline.branching.models import BranchingWriterProposal
+
+        with pytest.raises(ValidationError):
+            BranchingWriterProposal(
+                narrative_text="prose",
+                branch_options_text=[],
+                branch_presentation_state="",
+            )

--- a/tests/pipeline/branching/test_ooc_config_extractor.py
+++ b/tests/pipeline/branching/test_ooc_config_extractor.py
@@ -34,6 +34,7 @@ from afterworlds.models.intent_classification import IntentClassificationResult
 from afterworlds.models.story_bible import StoryBibleContext
 from afterworlds.pipeline.branching.models import (
     BranchingConfigUpdate,
+    BranchingOocConfigExtractorResult,
     BranchingPassError,
 )
 from afterworlds.pipeline.branching.ooc_config_extractor import (
@@ -191,40 +192,41 @@ class _WrongToolProvider:
 
 
 class TestHappyPath:
-    """BranchingOocConfigExtractorService returns BranchingConfigUpdate on success."""
+    """BranchingOocConfigExtractorService returns BranchingOocConfigExtractorResult."""
 
     def test_all_none_is_valid(self) -> None:
         svc = BranchingOocConfigExtractorService()
         result = svc.extract(_make_ctx(), _FakeProvider(_ALL_NONE_INPUT))
-        assert isinstance(result, BranchingConfigUpdate)
-        assert result.interaction_style is None
-        assert result.branching_cadence is None
-        assert result.branch_count_range is None
-        assert result.length_preference is None
+        assert isinstance(result, BranchingOocConfigExtractorResult)
+        assert isinstance(result.config_update, BranchingConfigUpdate)
+        assert result.config_update.interaction_style is None
+        assert result.config_update.branching_cadence is None
+        assert result.config_update.branch_count_range is None
+        assert result.config_update.length_preference is None
 
     def test_interaction_style_extracted(self) -> None:
         svc = BranchingOocConfigExtractorService()
         tool_input = {**_ALL_NONE_INPUT, "interaction_style": "true_cyoa"}
         result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
-        assert result.interaction_style is InteractionStyle.TRUE_CYOA
+        assert result.config_update.interaction_style is InteractionStyle.TRUE_CYOA
 
     def test_branching_cadence_extracted(self) -> None:
         svc = BranchingOocConfigExtractorService()
         tool_input = {**_ALL_NONE_INPUT, "branching_cadence": "interactive"}
         result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
-        assert result.branching_cadence is BranchingCadence.INTERACTIVE
+        assert result.config_update.branching_cadence is BranchingCadence.INTERACTIVE
 
     def test_branch_count_range_extracted(self) -> None:
         svc = BranchingOocConfigExtractorService()
         tool_input = {**_ALL_NONE_INPUT, "branch_count_range": "2-3"}
         result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
-        assert result.branch_count_range is BranchCountRange.TWO_TO_THREE
+        assert result.config_update.branch_count_range is BranchCountRange.TWO_TO_THREE
 
     def test_length_preference_extracted(self) -> None:
         svc = BranchingOocConfigExtractorService()
         tool_input = {**_ALL_NONE_INPUT, "length_preference": "novella"}
         result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
-        assert result.length_preference is LengthPreference.NOVELLA
+        assert result.config_update.length_preference is LengthPreference.NOVELLA
 
     def test_multiple_fields_extracted(self) -> None:
         svc = BranchingOocConfigExtractorService()
@@ -235,10 +237,22 @@ class TestHappyPath:
             "length_preference": "short_story",
         }
         result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
-        assert result.interaction_style is InteractionStyle.HYBRID
-        assert result.branching_cadence is BranchingCadence.BALANCED
-        assert result.branch_count_range is BranchCountRange.THREE_TO_FOUR
-        assert result.length_preference is LengthPreference.SHORT_STORY
+        assert result.config_update.interaction_style is InteractionStyle.HYBRID
+        assert result.config_update.branching_cadence is BranchingCadence.BALANCED
+        assert result.config_update.branch_count_range is BranchCountRange.THREE_TO_FOUR
+        assert result.config_update.length_preference is LengthPreference.SHORT_STORY
+
+    def test_provider_metrics_surfaced_in_result(self) -> None:
+        """extract() returns provider usage metrics for entitlement settlement."""
+        svc = BranchingOocConfigExtractorService()
+        result = svc.extract(_make_ctx(), _FakeProvider(_ALL_NONE_INPUT))
+        # _FakeProvider returns provider_name="fake", model_tier=ModelTier.SONNET,
+        # input_token_count=50, output_token_count=20, latency_ms=5.
+        assert result.provider == "fake"
+        assert result.input_token_count == 50
+        assert result.output_token_count == 20
+        assert result.latency_ms == 5
+        assert result.model_tier == ModelTier.SONNET.value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/branching/test_ooc_config_extractor.py
+++ b/tests/pipeline/branching/test_ooc_config_extractor.py
@@ -1,0 +1,318 @@
+"""Unit tests for BranchingOocConfigExtractorService — CRD Issue 16 Phase F.
+
+Coverage:
+- Happy path: returns BranchingConfigUpdate with requested fields.
+- All-None result: no config changes requested.
+- Provider call failure → raises BranchingPassError.
+- Missing tool block → raises BranchingPassError.
+- Wrong tool name → raises BranchingPassError.
+- Schema validation failure → raises BranchingPassError.
+- _render: correct pass_id, forced tool, system prompt present.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.entitlement.enums import ModelTier, PipelinePassId
+from afterworlds.models.context import (
+    AssembledContext,
+    PassForwardLedger,
+    StablePrefix,
+    VolatileSuffix,
+)
+from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    IntentType,
+    InteractionStyle,
+    LengthPreference,
+)
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.story_bible import StoryBibleContext
+from afterworlds.pipeline.branching.models import (
+    BranchingConfigUpdate,
+    BranchingPassError,
+)
+from afterworlds.pipeline.branching.ooc_config_extractor import (
+    EXTRACT_CONFIG_UPDATE_TOOL_NAME,
+    BranchingOocConfigExtractorService,
+)
+from afterworlds.pipeline.provider._models import (
+    ProviderCallRequest,
+    ProviderCallResult,
+    ProviderToolCallPart,
+)
+
+_STORY_ID = uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(ooc_input: str = "Switch to true CYOA mode please") -> AssembledContext:
+    sbc = StoryBibleContext(
+        story_id=_STORY_ID,
+        setting=None,
+        cast=(),
+        locked_facts=(),
+        forbidden_facts=(),
+        relationship_ledger=(),
+        active_plot_threads=(),
+        events=(),
+    )
+    prefix = StablePrefix(
+        system_prompt="branching ooc extractor test", story_bible_context=sbc
+    )
+    intent = IntentClassificationResult(
+        intent_type=IntentType.OOC,
+        confidence=0.99,
+        raw_input=ooc_input,
+        ambiguous=False,
+    )
+    suffix = VolatileSuffix(
+        recent_turns=[],
+        current_input=ooc_input,
+        classified_intent=intent,
+    )
+    return AssembledContext(
+        stable_prefix=prefix,
+        volatile_suffix=suffix,
+        pass_forward_ledger=PassForwardLedger(),
+    )
+
+
+def _make_result(tool_input: dict) -> ProviderCallResult:  # type: ignore[type-arg]
+    return ProviderCallResult(
+        pass_id=PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR,
+        provider_name="fake",
+        model_identifier="fake-model",
+        model_tier=ModelTier.SONNET,
+        content_parts=[
+            ProviderToolCallPart(
+                tool_name=EXTRACT_CONFIG_UPDATE_TOOL_NAME,
+                tool_input=tool_input,
+            )
+        ],
+        input_token_count=50,
+        output_token_count=20,
+        cache_read_token_count=None,
+        cache_creation_token_count=None,
+        cache_warmed=False,
+        latency_ms=5,
+    )
+
+
+_ALL_NONE_INPUT = {
+    "interaction_style": None,
+    "branching_cadence": None,
+    "branch_count_range": None,
+    "length_preference": None,
+}
+
+
+class _FakeProvider:
+    def __init__(self, tool_input: dict) -> None:  # type: ignore[type-arg]
+        self._tool_input = tool_input
+        self.last_request: ProviderCallRequest | None = None
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        self.last_request = request
+        return _make_result(self._tool_input)
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _FailingProvider:
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        raise RuntimeError("network error")
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _NoToolProvider:
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        return ProviderCallResult(
+            pass_id=PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR,
+            provider_name="fake",
+            model_identifier="fake-model",
+            model_tier=ModelTier.SONNET,
+            content_parts=[],
+            input_token_count=50,
+            output_token_count=10,
+            cache_read_token_count=None,
+            cache_creation_token_count=None,
+            cache_warmed=False,
+            latency_ms=5,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _WrongToolProvider:
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        return ProviderCallResult(
+            pass_id=PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR,
+            provider_name="fake",
+            model_identifier="fake-model",
+            model_tier=ModelTier.SONNET,
+            content_parts=[
+                ProviderToolCallPart(
+                    tool_name="wrong_tool",
+                    tool_input=_ALL_NONE_INPUT,
+                )
+            ],
+            input_token_count=50,
+            output_token_count=10,
+            cache_read_token_count=None,
+            cache_creation_token_count=None,
+            cache_warmed=False,
+            latency_ms=5,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+# ---------------------------------------------------------------------------
+# Tests: happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    """BranchingOocConfigExtractorService returns BranchingConfigUpdate on success."""
+
+    def test_all_none_is_valid(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        result = svc.extract(_make_ctx(), _FakeProvider(_ALL_NONE_INPUT))
+        assert isinstance(result, BranchingConfigUpdate)
+        assert result.interaction_style is None
+        assert result.branching_cadence is None
+        assert result.branch_count_range is None
+        assert result.length_preference is None
+
+    def test_interaction_style_extracted(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        tool_input = {**_ALL_NONE_INPUT, "interaction_style": "true_cyoa"}
+        result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
+        assert result.interaction_style is InteractionStyle.TRUE_CYOA
+
+    def test_branching_cadence_extracted(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        tool_input = {**_ALL_NONE_INPUT, "branching_cadence": "interactive"}
+        result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
+        assert result.branching_cadence is BranchingCadence.INTERACTIVE
+
+    def test_branch_count_range_extracted(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        tool_input = {**_ALL_NONE_INPUT, "branch_count_range": "2-3"}
+        result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
+        assert result.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+    def test_length_preference_extracted(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        tool_input = {**_ALL_NONE_INPUT, "length_preference": "novella"}
+        result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
+        assert result.length_preference is LengthPreference.NOVELLA
+
+    def test_multiple_fields_extracted(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        tool_input = {
+            "interaction_style": "hybrid",
+            "branching_cadence": "balanced",
+            "branch_count_range": "3-4",
+            "length_preference": "short_story",
+        }
+        result = svc.extract(_make_ctx(), _FakeProvider(tool_input))
+        assert result.interaction_style is InteractionStyle.HYBRID
+        assert result.branching_cadence is BranchingCadence.BALANCED
+        assert result.branch_count_range is BranchCountRange.THREE_TO_FOUR
+        assert result.length_preference is LengthPreference.SHORT_STORY
+
+
+# ---------------------------------------------------------------------------
+# Tests: fail paths
+# ---------------------------------------------------------------------------
+
+
+class TestProviderFailurePaths:
+    """BranchingOocConfigExtractorService raises BranchingPassError on errors."""
+
+    def test_provider_call_failure_raises(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        with pytest.raises(BranchingPassError, match="provider call failed"):
+            svc.extract(_make_ctx(), _FailingProvider())
+
+    def test_no_tool_block_raises(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        with pytest.raises(BranchingPassError, match="missing tool-use block"):
+            svc.extract(_make_ctx(), _NoToolProvider())
+
+    def test_wrong_tool_name_raises(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        with pytest.raises(BranchingPassError, match="unexpected tool name"):
+            svc.extract(_make_ctx(), _WrongToolProvider())
+
+    def test_schema_validation_failure_raises(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        bad_input = {
+            "interaction_style": "not_a_valid_style",
+            "branching_cadence": None,
+            "branch_count_range": None,
+            "length_preference": None,
+        }
+        with pytest.raises(BranchingPassError, match="schema validation"):
+            svc.extract(_make_ctx(), _FakeProvider(bad_input))
+
+
+# ---------------------------------------------------------------------------
+# Tests: _render — verify request structure
+# ---------------------------------------------------------------------------
+
+
+class TestRenderRequestStructure:
+    """The ProviderCallRequest produced by _render has the correct shape."""
+
+    def test_forced_tool_name_set(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        provider = _FakeProvider(_ALL_NONE_INPUT)
+        svc.extract(_make_ctx("change to true cyoa"), provider)
+        assert provider.last_request is not None
+        assert provider.last_request.forced_tool_name == EXTRACT_CONFIG_UPDATE_TOOL_NAME
+
+    def test_pass_id_is_branching_ooc_config_extractor(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        provider = _FakeProvider(_ALL_NONE_INPUT)
+        svc.extract(_make_ctx("change to true cyoa"), provider)
+        assert provider.last_request is not None
+        assert (
+            provider.last_request.pass_id
+            is PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR
+        )
+
+    def test_system_blocks_present(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        provider = _FakeProvider(_ALL_NONE_INPUT)
+        svc.extract(_make_ctx("change to true cyoa"), provider)
+        assert provider.last_request is not None
+        assert len(provider.last_request.system_blocks) >= 1
+
+    def test_ooc_input_in_rendered_blocks(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        provider = _FakeProvider(_ALL_NONE_INPUT)
+        ooc_msg = "Switch to true CYOA with 3 choices per beat"
+        svc.extract(_make_ctx(ooc_msg), provider)
+        assert provider.last_request is not None
+        all_text = " ".join(b.text for b in provider.last_request.rendered_blocks)
+        assert ooc_msg in all_text

--- a/tests/pipeline/branching/test_ooc_config_extractor.py
+++ b/tests/pipeline/branching/test_ooc_config_extractor.py
@@ -35,6 +35,7 @@ from afterworlds.models.story_bible import StoryBibleContext
 from afterworlds.pipeline.branching.models import (
     BranchingConfigUpdate,
     BranchingOocConfigExtractorResult,
+    BranchingOocExtractionUsageError,
     BranchingPassError,
 )
 from afterworlds.pipeline.branching.ooc_config_extractor import (
@@ -288,6 +289,80 @@ class TestProviderFailurePaths:
         }
         with pytest.raises(BranchingPassError, match="schema validation"):
             svc.extract(_make_ctx(), _FakeProvider(bad_input))
+
+
+# ---------------------------------------------------------------------------
+# Tests: post-provider local failure preserves provider usage
+# ---------------------------------------------------------------------------
+
+
+class TestUsagePreservedOnLocalFailure:
+    """Local validation failures *after* a provider result preserve usage.
+
+    When the provider call returns (consuming tokens) but a later local step
+    rejects the response, the extractor raises BranchingOocExtractionUsageError
+    carrying a usage-only result so settlement still sees the consumed tokens.
+    The config_update on that usage result is all-null (no mutation implied).
+    """
+
+    def test_no_tool_block_preserves_usage(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        with pytest.raises(BranchingOocExtractionUsageError) as exc_info:
+            svc.extract(_make_ctx(), _NoToolProvider())
+        usage = exc_info.value.usage_result
+        # _NoToolProvider: provider="fake", input=50, output=10, no cache tokens.
+        assert isinstance(usage, BranchingOocConfigExtractorResult)
+        assert usage.provider == "fake"
+        assert usage.input_token_count == 50
+        assert usage.output_token_count == 10
+        assert usage.model_tier == ModelTier.SONNET.value
+        # config_update is all-null: no mutation is implied by a failed parse.
+        assert usage.config_update.interaction_style is None
+        assert usage.config_update.branching_cadence is None
+        assert usage.config_update.branch_count_range is None
+        assert usage.config_update.length_preference is None
+
+    def test_wrong_tool_name_preserves_usage(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        with pytest.raises(BranchingOocExtractionUsageError) as exc_info:
+            svc.extract(_make_ctx(), _WrongToolProvider())
+        usage = exc_info.value.usage_result
+        # _WrongToolProvider: provider="fake", input=50, output=10.
+        assert usage.provider == "fake"
+        assert usage.input_token_count == 50
+        assert usage.output_token_count == 10
+        assert usage.config_update.interaction_style is None
+        assert usage.config_update.branch_count_range is None
+
+    def test_schema_validation_failure_preserves_usage(self) -> None:
+        svc = BranchingOocConfigExtractorService()
+        bad_input = {
+            "interaction_style": "not_a_valid_style",
+            "branching_cadence": None,
+            "branch_count_range": None,
+            "length_preference": None,
+        }
+        with pytest.raises(BranchingOocExtractionUsageError) as exc_info:
+            svc.extract(_make_ctx(), _FakeProvider(bad_input))
+        usage = exc_info.value.usage_result
+        # _FakeProvider via _make_result: provider="fake", input=50, output=20.
+        assert usage.provider == "fake"
+        assert usage.input_token_count == 50
+        assert usage.output_token_count == 20
+        # The malformed style is discarded — config_update stays all-null.
+        assert usage.config_update.interaction_style is None
+
+    def test_provider_call_failure_carries_no_usage(self) -> None:
+        """A provider-call exception before any result is a plain error.
+
+        No result was returned, so no usage was consumed — the extractor must
+        not fabricate a usage payload (raises BranchingPassError, not the
+        usage-carrying subclass).
+        """
+        svc = BranchingOocConfigExtractorService()
+        with pytest.raises(BranchingPassError) as exc_info:
+            svc.extract(_make_ctx(), _FailingProvider())
+        assert not isinstance(exc_info.value, BranchingOocExtractionUsageError)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/branching/test_selection.py
+++ b/tests/pipeline/branching/test_selection.py
@@ -231,3 +231,68 @@ class TestSelectionPrecedence:
             result.rejection_reason
             is InteractionRejectionReason.INVALID_BRANCH_SELECTION
         )
+
+
+class TestLeadingBareNumberAnnotation:
+    """Round 19: a leading bare number is the operative choice even when
+    followed by annotation; incidental embedded numbers still do not resolve."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_leading_number_comma_but_annotation(self) -> None:
+        result = self.svc.validate("2, but I do it cautiously", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+        assert result.selected_context.annotation == "I do it cautiously"
+
+    def test_leading_number_but_annotation(self) -> None:
+        result = self.svc.validate("2 but I do it cautiously", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+        assert result.selected_context.annotation == "I do it cautiously"
+
+    def test_leading_number_dash_annotation(self) -> None:
+        result = self.svc.validate("2 - cautiously", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+        assert result.selected_context.annotation == "cautiously"
+
+    def test_leading_number_no_annotation(self) -> None:
+        result = self.svc.validate("2", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+        assert result.selected_context.annotation is None
+
+    def test_leading_number_trailing_period_no_annotation(self) -> None:
+        result = self.svc.validate("2.", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+        assert result.selected_context.annotation is None
+
+    def test_embedded_quantity_does_not_resolve(self) -> None:
+        result = self.svc.validate("I use my 2 torches", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+
+    def test_embedded_quantity_with_trailing_prose_does_not_resolve(self) -> None:
+        result = self.svc.validate("I use my 2 torches and move carefully", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+
+    def test_explicit_phrase_outranks_leading_embedded_number(self) -> None:
+        result = self.svc.validate("I use my 2 torches and choose option 1", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"

--- a/tests/pipeline/branching/test_selection.py
+++ b/tests/pipeline/branching/test_selection.py
@@ -122,6 +122,27 @@ class TestOrdinalReference:
         result = self.svc.validate("third", TWO_OPTS)
         assert result.verdict is BranchSelectionValidationVerdict.REJECT
 
+    def test_first_option_phrase_no_annotation(self) -> None:
+        result = self.svc.validate("Take the first option", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"
+        assert result.selected_context.annotation is None
+
+    def test_second_choice_phrase_no_annotation(self) -> None:
+        result = self.svc.validate("I choose the second choice", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+        assert result.selected_context.annotation is None
+
+    def test_first_option_phrase_preserves_real_modifier(self) -> None:
+        result = self.svc.validate("Take the first option cautiously", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"
+        assert result.selected_context.annotation == "cautiously"
+
 
 class TestNoMatch:
     """Inputs that don't match any option are rejected."""

--- a/tests/pipeline/branching/test_selection.py
+++ b/tests/pipeline/branching/test_selection.py
@@ -1,0 +1,171 @@
+"""Tests for BranchSelectionValidationService — CRD Issue 16 Phase D."""
+
+from __future__ import annotations
+
+from afterworlds.models.enums import InteractionRejectionReason
+from afterworlds.models.node import PersistedBranchOption
+from afterworlds.pipeline.branching.models import (
+    BranchSelectionValidationVerdict,
+)
+from afterworlds.pipeline.branching.selection import BranchSelectionValidationService
+
+
+def _opts(
+    *labels: str,
+) -> list[PersistedBranchOption]:
+    return [
+        PersistedBranchOption(option_id=f"opt_{i + 1}", action_text=label)
+        for i, label in enumerate(labels)
+    ]
+
+
+TWO_OPTS = _opts("Take the bridge", "Wade the river")
+THREE_OPTS = _opts("Take the bridge", "Wade the river", "Turn back")
+
+
+class TestExplicitOptionId:
+    """Exact opt_N token in the user's input resolves correctly."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_opt_1_matches_first_option(self) -> None:
+        result = self.svc.validate("opt_1", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"
+
+    def test_opt_2_matches_second_option(self) -> None:
+        result = self.svc.validate("I choose opt_2", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+
+    def test_out_of_range_opt_id_rejects(self) -> None:
+        result = self.svc.validate("opt_5", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+
+    def test_accepted_action_text_preserved(self) -> None:
+        result = self.svc.validate("opt_1", TWO_OPTS)
+        assert result.selected_context is not None
+        assert result.selected_context.action_text == "Take the bridge"
+
+
+class TestNumericReference:
+    """Numeric phrase ("option 2", "choice 3", or bare "2") resolves correctly."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_bare_number_matches_option(self) -> None:
+        result = self.svc.validate("2", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+
+    def test_option_n_phrase_matches(self) -> None:
+        result = self.svc.validate("option 1", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"
+
+    def test_choice_n_phrase_matches(self) -> None:
+        result = self.svc.validate("choice 2", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+
+    def test_number_out_of_range_rejects(self) -> None:
+        result = self.svc.validate("option 3", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+
+    def test_three_opts_third_resolves(self) -> None:
+        result = self.svc.validate("I pick 3", THREE_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_3"
+
+
+class TestOrdinalReference:
+    """Ordinal words ("first", "second", …) resolve to opt_N."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_first_resolves_to_opt_1(self) -> None:
+        result = self.svc.validate("Take the first option", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"
+
+    def test_second_resolves_to_opt_2(self) -> None:
+        result = self.svc.validate("I want the second", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+
+    def test_third_resolves_with_three_options(self) -> None:
+        result = self.svc.validate("third", THREE_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_3"
+
+    def test_third_out_of_range_rejects(self) -> None:
+        result = self.svc.validate("third", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+
+
+class TestNoMatch:
+    """Inputs that don't match any option are rejected."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_generic_freeform_rejects(self) -> None:
+        result = self.svc.validate("I do something completely different", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+
+    def test_rejection_message_is_non_empty(self) -> None:
+        result = self.svc.validate("random text", TWO_OPTS)
+        assert result.rejection_message is not None
+        assert len(result.rejection_message) > 0
+
+    def test_empty_presented_options_rejects(self) -> None:
+        result = self.svc.validate("opt_1", [])
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+
+
+class TestAnnotation:
+    """Trailing text after the selection token is captured as annotation."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_trailing_text_captured_as_annotation(self) -> None:
+        result = self.svc.validate("opt_1 but I stop to grab the sword first", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.annotation is not None
+        assert "sword" in result.selected_context.annotation
+
+    def test_no_trailing_text_yields_none_annotation(self) -> None:
+        result = self.svc.validate("opt_1", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.annotation is None

--- a/tests/pipeline/branching/test_selection.py
+++ b/tests/pipeline/branching/test_selection.py
@@ -190,3 +190,44 @@ class TestAnnotation:
         assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
         assert result.selected_context is not None
         assert result.selected_context.annotation is None
+
+
+class TestSelectionPrecedence:
+    """Explicit selection forms outrank incidental bare numbers."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchSelectionValidationService()
+
+    def test_explicit_option_outranks_incidental_bare_number(self) -> None:
+        result = self.svc.validate("I use my 2 torches and choose option 1", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_1"
+
+    def test_explicit_choice_outranks_trailing_bare_number(self) -> None:
+        result = self.svc.validate(
+            "I choose choice 3 after checking 2 doors", THREE_OPTS
+        )
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_3"
+
+    def test_bare_number_still_resolves(self) -> None:
+        result = self.svc.validate("2", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+
+    def test_trailing_bare_number_selection_resolves(self) -> None:
+        result = self.svc.validate("I pick 2", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.ACCEPT
+        assert result.selected_context is not None
+        assert result.selected_context.option_id == "opt_2"
+
+    def test_incidental_quantity_does_not_resolve(self) -> None:
+        result = self.svc.validate("Take 2 torches", TWO_OPTS)
+        assert result.verdict is BranchSelectionValidationVerdict.REJECT
+        assert (
+            result.rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -451,8 +451,13 @@ class TestBranchCountRangeValidation:
         assert len(result.branch_options) == 4
 
     def test_two_five_range_extreme(self) -> None:
-        # 2-5 range: 5 options is valid
-        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_FIVE)
+        # 2-5 range: 5 options is valid.  "2-5" is a TRUE_CYOA-allowed range
+        # (not allowed for HYBRID), so this numeric-extreme case must use
+        # TRUE_CYOA to remain a compatible persisted style/range combination.
+        session = _make_session(
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            branch_count_range=BranchCountRange.TWO_TO_FIVE,
+        )
         service = BranchingWriterService(config=_make_config())
         result = service.write(
             _make_assembled(),
@@ -881,3 +886,85 @@ class TestValidateBranchCountDirect:
     def test_none_style_held_empty_still_passes(self) -> None:
         """interaction_style=None preserves legacy behaviour — held + [] passes."""
         _validate_branch_count([], "2-3", "held")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Test: PR #112 R14 — persisted branch_count_range / interaction_style
+# compatibility.  A shown HYBRID/TRUE_CYOA turn must fail closed when the
+# persisted range is not allowed for the active style, even if the option
+# count is numerically in-bounds.  Held/omitted behavior is unchanged
+# (those paths early-return before the compatibility check).
+# ---------------------------------------------------------------------------
+
+
+class TestPersistedRangeStyleCompatibility:
+    """branch_count_range must be known AND allowed for interaction_style."""
+
+    def test_hybrid_allowed_range_shown_passes(self) -> None:
+        """HYBRID + allowed range ("1-2"/"2-3"/"3-4") accepts valid counts."""
+        _validate_branch_count(["A"], "1-2", "shown", InteractionStyle.HYBRID)
+        _validate_branch_count(["A", "B"], "2-3", "shown", InteractionStyle.HYBRID)
+        _validate_branch_count(
+            ["A", "B", "C"], "3-4", "shown", InteractionStyle.HYBRID
+        )  # must not raise
+
+    def test_true_cyoa_allowed_range_shown_passes(self) -> None:
+        """TRUE_CYOA + allowed range ("2-3"/"2-4"/"2-5") accepts valid counts."""
+        _validate_branch_count(["A", "B"], "2-3", "shown", InteractionStyle.TRUE_CYOA)
+        _validate_branch_count(
+            ["A", "B", "C", "D"], "2-4", "shown", InteractionStyle.TRUE_CYOA
+        )
+        _validate_branch_count(
+            ["A", "B", "C", "D", "E"], "2-5", "shown", InteractionStyle.TRUE_CYOA
+        )  # must not raise
+
+    def test_hybrid_disallowed_range_shown_fails_closed(self) -> None:
+        """HYBRID + "2-4"/"2-5" is disallowed even with in-bounds count."""
+        with pytest.raises(BranchingPassError, match="not.*allowed"):
+            _validate_branch_count(["A", "B"], "2-4", "shown", InteractionStyle.HYBRID)
+        with pytest.raises(BranchingPassError, match="not.*allowed"):
+            _validate_branch_count(["A", "B"], "2-5", "shown", InteractionStyle.HYBRID)
+
+    def test_true_cyoa_disallowed_range_shown_fails_closed(self) -> None:
+        """TRUE_CYOA + "1-2"/"3-4" is disallowed even with in-bounds count."""
+        with pytest.raises(BranchingPassError, match="not.*allowed"):
+            _validate_branch_count(
+                ["A", "B"], "1-2", "shown", InteractionStyle.TRUE_CYOA
+            )
+        with pytest.raises(BranchingPassError, match="not.*allowed"):
+            _validate_branch_count(
+                ["A", "B", "C"], "3-4", "shown", InteractionStyle.TRUE_CYOA
+            )
+
+    def test_unknown_range_shown_fails_closed(self) -> None:
+        """An unknown persisted range fails closed for in-play styles."""
+        with pytest.raises(BranchingPassError):
+            _validate_branch_count(["A", "B"], "9-9", "shown", InteractionStyle.HYBRID)
+        with pytest.raises(BranchingPassError):
+            _validate_branch_count(
+                ["A", "B"], "9-9", "shown", InteractionStyle.TRUE_CYOA
+            )
+
+    def test_none_range_shown_fails_closed(self) -> None:
+        """A missing persisted range fails closed for in-play styles (shown)."""
+        with pytest.raises(BranchingPassError, match="not.*allowed"):
+            _validate_branch_count(["A", "B"], None, "shown", InteractionStyle.HYBRID)
+
+    def test_disallowed_range_held_still_valid(self) -> None:
+        """Held/omitted early-return before the compatibility check.
+
+        HYBRID held with an empty list stays valid even when the persisted
+        range would be disallowed for shown delivery — held/omitted behavior
+        is unchanged by the compatibility guard.
+        """
+        _validate_branch_count(
+            [], "2-4", "held", InteractionStyle.HYBRID
+        )  # must not raise
+        _validate_branch_count(
+            [], "2-4", "omitted", InteractionStyle.HYBRID
+        )  # must not raise
+
+    def test_true_cyoa_held_still_invalid(self) -> None:
+        """TRUE_CYOA held/omitted remains invalid (unchanged), even allowed range."""
+        with pytest.raises(BranchingPassError, match="True CYOA"):
+            _validate_branch_count([], "2-3", "held", InteractionStyle.TRUE_CYOA)

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -751,3 +751,37 @@ class TestValidateBranchCountDirect:
     def test_shown_below_min_raises(self) -> None:
         with pytest.raises(BranchingPassError):
             _validate_branch_count(["A"], "2-3", "shown")
+
+    # Fix 3 (Round 2): TRUE_CYOA forbids held/omitted even with empty options.
+
+    def test_true_cyoa_held_empty_raises(self) -> None:
+        """TRUE_CYOA + held + [] must fail — no freeform fallback surface."""
+        with pytest.raises(BranchingPassError, match="True CYOA"):
+            _validate_branch_count([], "2-3", "held", InteractionStyle.TRUE_CYOA)
+
+    def test_true_cyoa_omitted_empty_raises(self) -> None:
+        """TRUE_CYOA + omitted + [] must fail."""
+        with pytest.raises(BranchingPassError, match="True CYOA"):
+            _validate_branch_count([], "2-3", "omitted", InteractionStyle.TRUE_CYOA)
+
+    def test_true_cyoa_shown_within_range_passes(self) -> None:
+        """TRUE_CYOA + shown + valid count must succeed."""
+        _validate_branch_count(
+            ["A", "B"], "2-3", "shown", InteractionStyle.TRUE_CYOA
+        )  # must not raise
+
+    def test_hybrid_held_empty_still_passes(self) -> None:
+        """HYBRID + held + [] is valid — Hybrid allows deferred cards."""
+        _validate_branch_count(
+            [], "2-3", "held", InteractionStyle.HYBRID
+        )  # must not raise
+
+    def test_hybrid_omitted_empty_still_passes(self) -> None:
+        """HYBRID + omitted + [] is valid."""
+        _validate_branch_count(
+            [], "2-3", "omitted", InteractionStyle.HYBRID
+        )  # must not raise
+
+    def test_none_style_held_empty_still_passes(self) -> None:
+        """interaction_style=None preserves legacy behaviour — held + [] passes."""
+        _validate_branch_count([], "2-3", "held")  # must not raise

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -182,6 +182,22 @@ class _FailingProvider:
         return "fake"
 
 
+class _MustNotCallProvider:
+    """Stub ProviderAdapter that fails the test if call() is ever reached.
+
+    Used to prove a fail-closed guard fires before any provider spend.
+    """
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        raise AssertionError(
+            "provider.call() must not be reached when the writer fails closed"
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
 class _NoToolProvider:
     """Returns a ProviderCallResult with no tool-use blocks."""
 
@@ -395,16 +411,33 @@ class TestBranchCountRangeValidation:
                 provider=_FakeProvider(_valid_tool_input(["A", "B", "C", "D", "E"])),
             )
 
-    def test_none_range_skips_validation(self) -> None:
-        # None branch_count_range: any count is accepted
-        session = _make_session(branch_count_range=None)
-        service = BranchingWriterService(config=_make_config())
-        result = service.write(
-            _make_assembled(),
-            session,
-            provider=_FakeProvider(_valid_tool_input(["A", "B", "C", "D", "E"])),
+    def test_hybrid_none_range_fails_closed(self) -> None:
+        # HYBRID branch cards require a configured range; None is a misroute and
+        # must fail closed before the provider call (Round 5 Fix 2).
+        session = _make_session(
+            interaction_style=InteractionStyle.HYBRID, branch_count_range=None
         )
-        assert len(result.branch_options) == 5
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="branch_count_range"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_MustNotCallProvider(),
+            )
+
+    def test_true_cyoa_none_range_fails_closed(self) -> None:
+        # TRUE_CYOA branch cards require a configured range; None must fail closed
+        # before the provider call (Round 5 Fix 2).
+        session = _make_session(
+            interaction_style=InteractionStyle.TRUE_CYOA, branch_count_range=None
+        )
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="branch_count_range"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_MustNotCallProvider(),
+            )
 
     def test_three_four_range_max_boundary(self) -> None:
         # 3-4 range: 4 options is valid

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -476,24 +476,47 @@ class TestNullSessionConfigRaises:
     """interaction_style=None or branching_cadence=None raises BranchingPassError."""
 
     def test_interaction_style_none_raises(self) -> None:
+        # Required-config validation must fire before any provider spend
+        # (Round 17 Finding 2): _MustNotCallProvider proves the preflight raises
+        # before _render()/provider.call().
         session = _make_session(interaction_style=None)
         service = BranchingWriterService(config=_make_config())
         with pytest.raises(BranchingPassError, match="interaction_style=None"):
             service.write(
                 _make_assembled(),
                 session,
-                provider=_FakeProvider(_valid_tool_input()),
+                provider=_MustNotCallProvider(),
             )
 
     def test_branching_cadence_none_raises(self) -> None:
+        # Required-config validation must fire before any provider spend
+        # (Round 17 Finding 2): _MustNotCallProvider proves the preflight raises
+        # before _render()/provider.call().
         session = _make_session(branching_cadence=None)
         service = BranchingWriterService(config=_make_config())
         with pytest.raises(BranchingPassError, match="branching_cadence=None"):
             service.write(
                 _make_assembled(),
                 session,
-                provider=_FakeProvider(_valid_tool_input()),
+                provider=_MustNotCallProvider(),
             )
+
+    def test_pre_provider_failure_carries_no_usage_or_result(self) -> None:
+        # Pre-provider config failures must not fabricate a BranchingPassResult
+        # or cost snapshot (Round 17 Finding 2): the raised error is a plain
+        # BranchingPassError, not a usage-carrying subclass, and exposes no
+        # result/usage payload for settlement.
+        session = _make_session(branching_cadence=None)
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError) as excinfo:
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_MustNotCallProvider(),
+            )
+        assert type(excinfo.value) is BranchingPassError
+        assert not hasattr(excinfo.value, "result")
+        assert not hasattr(excinfo.value, "usage")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -1,0 +1,501 @@
+"""Unit tests for BranchingWriterService — CRD Issue 16.
+
+Coverage:
+- Code-owns-affordances: option_id sequential, style/cadence/freeform from session.
+- freeform_available derivation (HYBRID → True, TRUE_CYOA → False).
+- branch_count_range validation: within bounds, below min, above max, unknown range,
+  None range (no validation).
+- Fail-closed error paths: no tool block, wrong tool name, schema failure.
+- ProviderRefusalError propagates unchanged.
+- None interaction_style / None branching_cadence raise BranchingPassError.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.entitlement.enums import ModelTier, PipelinePassId
+from afterworlds.models.context import (
+    AssembledContext,
+    PassForwardLedger,
+    StablePrefix,
+    VolatileSuffix,
+)
+from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    BranchingPlayStatus,
+    IntentType,
+    InteractionStyle,
+    LengthPreference,
+    PacingStage,
+)
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.session import BranchingSessionState
+from afterworlds.models.story_bible import StoryBibleContext
+from afterworlds.pipeline._refusal import (
+    PassIdentifier,
+    ProviderRefusal,
+    ProviderRefusalError,
+)
+from afterworlds.pipeline.branching.caller import PRODUCE_BRANCH_OUTPUT_TOOL_NAME
+from afterworlds.pipeline.branching.config import BranchingWriterConfig
+from afterworlds.pipeline.branching.models import BranchingPassError
+from afterworlds.pipeline.branching.service import BranchingWriterService
+from afterworlds.pipeline.provider._models import (
+    ProviderCallRequest,
+    ProviderCallResult,
+    ProviderToolCallPart,
+)
+
+_STORY_ID = uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> BranchingWriterConfig:
+    return BranchingWriterConfig(
+        model="claude-sonnet-4-6",
+        api_key_env="ANTHROPIC_API_KEY",
+        extended_ttl=False,
+    )
+
+
+def _make_session(
+    interaction_style: InteractionStyle | None = InteractionStyle.HYBRID,
+    branching_cadence: BranchingCadence | None = BranchingCadence.BALANCED,
+    branch_count_range: BranchCountRange | None = BranchCountRange.TWO_TO_THREE,
+    length_preference: LengthPreference | None = LengthPreference.NOVELLA,
+) -> BranchingSessionState:
+    return BranchingSessionState(
+        story_id=_STORY_ID,
+        pacing_stage=PacingStage.ESCALATION,
+        interaction_style=interaction_style,
+        branching_cadence=branching_cadence,
+        branch_count_range=branch_count_range,
+        length_preference=length_preference,
+        play_status=BranchingPlayStatus.IN_PLAY,
+    )
+
+
+def _make_assembled() -> AssembledContext:
+    sbc = StoryBibleContext(
+        story_id=_STORY_ID,
+        setting=None,
+        cast=(),
+        locked_facts=(),
+        forbidden_facts=(),
+        relationship_ledger=(),
+        active_plot_threads=(),
+        events=(),
+    )
+    prefix = StablePrefix(system_prompt="branching mode test", story_bible_context=sbc)
+    intent = IntentClassificationResult(
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        confidence=0.9,
+        raw_input="I take the left path",
+        ambiguous=False,
+    )
+    suffix = VolatileSuffix(
+        recent_turns=[],
+        current_input="I take the left path",
+        classified_intent=intent,
+    )
+    return AssembledContext(
+        stable_prefix=prefix,
+        volatile_suffix=suffix,
+        pass_forward_ledger=PassForwardLedger(),
+    )
+
+
+def _make_result(tool_input: dict) -> ProviderCallResult:  # type: ignore[type-arg]
+    return ProviderCallResult(
+        pass_id=PipelinePassId.BRANCHING_WRITER,
+        provider_name="fake",
+        model_identifier="fake-model",
+        model_tier=ModelTier.SONNET,
+        content_parts=[
+            ProviderToolCallPart(
+                tool_name=PRODUCE_BRANCH_OUTPUT_TOOL_NAME,
+                tool_input=tool_input,
+            )
+        ],
+        input_token_count=100,
+        output_token_count=50,
+        cache_read_token_count=None,
+        cache_creation_token_count=None,
+        cache_warmed=False,
+        latency_ms=10,
+    )
+
+
+class _FakeProvider:
+    """Stub ProviderAdapter that returns a fixed tool call result."""
+
+    def __init__(self, tool_input: dict) -> None:  # type: ignore[type-arg]
+        self._tool_input = tool_input
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        return _make_result(self._tool_input)
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _RefusingProvider:
+    """Stub ProviderAdapter that raises ProviderRefusalError."""
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        raise ProviderRefusalError(
+            ProviderRefusal(
+                provider="fake",
+                pass_identifier=PassIdentifier.BRANCHING_WRITER,
+                coarse_reason="policy",
+            )
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _FailingProvider:
+    """Stub ProviderAdapter that raises a generic exception."""
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        raise RuntimeError("network error")
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _NoToolProvider:
+    """Returns a ProviderCallResult with no tool-use blocks."""
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        return ProviderCallResult(
+            pass_id=PipelinePassId.BRANCHING_WRITER,
+            provider_name="fake",
+            model_identifier="fake-model",
+            model_tier=ModelTier.SONNET,
+            content_parts=[],
+            input_token_count=50,
+            output_token_count=10,
+            cache_read_token_count=None,
+            cache_creation_token_count=None,
+            cache_warmed=False,
+            latency_ms=5,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+class _WrongToolProvider:
+    """Returns a ProviderCallResult with the wrong tool name."""
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        return ProviderCallResult(
+            pass_id=PipelinePassId.BRANCHING_WRITER,
+            provider_name="fake",
+            model_identifier="fake-model",
+            model_tier=ModelTier.SONNET,
+            content_parts=[
+                ProviderToolCallPart(
+                    tool_name="wrong_tool_name",
+                    tool_input={"narrative_text": "text"},
+                )
+            ],
+            input_token_count=50,
+            output_token_count=10,
+            cache_read_token_count=None,
+            cache_creation_token_count=None,
+            cache_warmed=False,
+            latency_ms=5,
+        )
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+def _valid_tool_input(options: list[str] | None = None) -> dict:  # type: ignore[type-arg]
+    if options is None:
+        options = ["Cross the rope bridge", "Take the forest path"]
+    return {
+        "narrative_text": "The path splits ahead.",
+        "branch_options_text": options,
+        "branch_presentation_state": "shown",
+        "pacing_stage_hint": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test: code-owns-affordances (option_id sequential, style/cadence from session)
+# ---------------------------------------------------------------------------
+
+
+class TestCodeOwnsAffordances:
+    """option_id is code-assigned sequential; affordances come from session state."""
+
+    def test_option_ids_sequential(self) -> None:
+        options = ["Cross the bridge", "Take the tunnel", "Turn back"]
+        session = _make_session(
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input(options)),
+        )
+        assert [o.option_id for o in result.branch_options] == [
+            "opt_1",
+            "opt_2",
+            "opt_3",
+        ]
+
+    def test_action_text_from_model(self) -> None:
+        options = ["Cross the bridge", "Take the tunnel"]
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input(options)),
+        )
+        assert [o.action_text for o in result.branch_options] == options
+
+    def test_interaction_style_from_session_not_model(self) -> None:
+        session = _make_session(interaction_style=InteractionStyle.HYBRID)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input()),
+        )
+        assert result.interaction_style is InteractionStyle.HYBRID
+
+    def test_branching_cadence_from_session(self) -> None:
+        session = _make_session(branching_cadence=BranchingCadence.IMMERSIVE)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input()),
+        )
+        assert result.branching_cadence is BranchingCadence.IMMERSIVE
+
+    def test_branch_count_range_from_session(self) -> None:
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input()),
+        )
+        assert result.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+    def test_length_preference_from_session(self) -> None:
+        session = _make_session(length_preference=LengthPreference.SHORT_STORY)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input()),
+        )
+        assert result.length_preference is LengthPreference.SHORT_STORY
+
+
+# ---------------------------------------------------------------------------
+# Test: freeform_available derivation
+# ---------------------------------------------------------------------------
+
+
+class TestFreeformAvailable:
+    """freeform_available is derived from interaction_style by code."""
+
+    def test_hybrid_freeform_available_true(self) -> None:
+        session = _make_session(interaction_style=InteractionStyle.HYBRID)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input()),
+        )
+        assert result.freeform_available is True
+
+    def test_true_cyoa_freeform_available_false(self) -> None:
+        session = _make_session(
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input()),
+        )
+        assert result.freeform_available is False
+
+
+# ---------------------------------------------------------------------------
+# Test: branch_count_range validation (fail-closed, never clamp/pad/truncate)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchCountRangeValidation:
+    """Fail-closed validation: out-of-range count raises BranchingPassError."""
+
+    def test_within_range_passes(self) -> None:
+        # 2-3 range: 2 options is valid
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input(["Option A", "Option B"])),
+        )
+        assert len(result.branch_options) == 2
+
+    def test_below_minimum_raises(self) -> None:
+        # 2-3 range: 1 option is invalid
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="1 branch option"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(_valid_tool_input(["Only one option"])),
+            )
+
+    def test_above_maximum_raises(self) -> None:
+        # 2-3 range: 5 options is invalid
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="5 branch option"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(_valid_tool_input(["A", "B", "C", "D", "E"])),
+            )
+
+    def test_none_range_skips_validation(self) -> None:
+        # None branch_count_range: any count is accepted
+        session = _make_session(branch_count_range=None)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input(["A", "B", "C", "D", "E"])),
+        )
+        assert len(result.branch_options) == 5
+
+    def test_three_four_range_max_boundary(self) -> None:
+        # 3-4 range: 4 options is valid
+        session = _make_session(branch_count_range=BranchCountRange.THREE_TO_FOUR)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input(["A", "B", "C", "D"])),
+        )
+        assert len(result.branch_options) == 4
+
+    def test_two_five_range_extreme(self) -> None:
+        # 2-5 range: 5 options is valid
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_FIVE)
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(_valid_tool_input(["A", "B", "C", "D", "E"])),
+        )
+        assert len(result.branch_options) == 5
+
+
+# ---------------------------------------------------------------------------
+# Test: fail-closed on None session config
+# ---------------------------------------------------------------------------
+
+
+class TestNullSessionConfigRaises:
+    """interaction_style=None or branching_cadence=None raises BranchingPassError."""
+
+    def test_interaction_style_none_raises(self) -> None:
+        session = _make_session(interaction_style=None)
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="interaction_style=None"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(_valid_tool_input()),
+            )
+
+    def test_branching_cadence_none_raises(self) -> None:
+        session = _make_session(branching_cadence=None)
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="branching_cadence=None"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(_valid_tool_input()),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: provider failure paths (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderFailurePaths:
+    """Provider errors are wrapped or propagated unchanged."""
+
+    def test_refusal_propagates_unchanged(self) -> None:
+        session = _make_session()
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(ProviderRefusalError):
+            service.write(_make_assembled(), session, provider=_RefusingProvider())
+
+    def test_generic_exception_wrapped_in_branching_pass_error(self) -> None:
+        session = _make_session()
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="provider call failed"):
+            service.write(_make_assembled(), session, provider=_FailingProvider())
+
+    def test_no_tool_block_raises(self) -> None:
+        session = _make_session()
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="missing tool-use block"):
+            service.write(_make_assembled(), session, provider=_NoToolProvider())
+
+    def test_wrong_tool_name_raises(self) -> None:
+        session = _make_session()
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="unexpected tool name"):
+            service.write(_make_assembled(), session, provider=_WrongToolProvider())
+
+    def test_invalid_schema_raises(self) -> None:
+        # Missing required 'branch_options_text' field → schema validation fails
+        session = _make_session()
+        service = BranchingWriterService(config=_make_config())
+        bad_input = {
+            "narrative_text": "Some narrative",
+            # branch_options_text missing
+            "branch_presentation_state": "shown",
+        }
+        with pytest.raises(BranchingPassError, match="schema validation"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(bad_input),
+            )

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -42,8 +42,14 @@ from afterworlds.pipeline._refusal import (
 )
 from afterworlds.pipeline.branching.caller import PRODUCE_BRANCH_OUTPUT_TOOL_NAME
 from afterworlds.pipeline.branching.config import BranchingWriterConfig
-from afterworlds.pipeline.branching.models import BranchingPassError
-from afterworlds.pipeline.branching.service import BranchingWriterService
+from afterworlds.pipeline.branching.models import (
+    BranchingPassError,
+    SelectedBranchContext,
+)
+from afterworlds.pipeline.branching.service import (
+    BranchingWriterService,
+    _validate_branch_count,
+)
 from afterworlds.pipeline.provider._models import (
     ProviderCallRequest,
     ProviderCallResult,
@@ -499,3 +505,249 @@ class TestProviderFailurePaths:
                 session,
                 provider=_FakeProvider(bad_input),
             )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for request inspection tests
+# ---------------------------------------------------------------------------
+
+
+class _CapturingProvider:
+    """FakeProvider that records the last ProviderCallRequest."""
+
+    def __init__(self, tool_input: dict) -> None:  # type: ignore[type-arg]
+        self._tool_input = tool_input
+        self.last_request: ProviderCallRequest | None = None
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        self.last_request = request
+        return _make_result(self._tool_input)
+
+    @property
+    def provider_name(self) -> str:
+        return "fake"
+
+
+def _all_block_text(request: ProviderCallRequest) -> str:
+    return "\n".join(b.text for b in request.rendered_blocks)
+
+
+def _stable_block_text(request: ProviderCallRequest) -> str:
+    # Stable-prefix blocks are identified by the cache-breakpoint signal.
+    # Only the last stable block has has_cache_breakpoint=True.  Collect
+    # everything up to AND including that block as the "stable region."
+    blocks = request.rendered_blocks
+    breakpoint_idx = next(
+        (i for i, b in enumerate(blocks) if b.has_cache_breakpoint), -1
+    )
+    if breakpoint_idx == -1:
+        return ""
+    return "\n".join(b.text for b in blocks[: breakpoint_idx + 1])
+
+
+# ---------------------------------------------------------------------------
+# Test: Fix 1 — SelectedBranchContext threaded into BranchingWriterService
+# ---------------------------------------------------------------------------
+
+
+class TestSelectedBranchContextRendering:
+    """SelectedBranchContext appears as volatile block in the provider payload."""
+
+    def test_action_text_and_annotation_in_rendered_blocks(self) -> None:
+        sbc = SelectedBranchContext(
+            option_id="opt_2",
+            action_text="Cross the bridge",
+            annotation="cautiously",
+        )
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        provider = _CapturingProvider(_valid_tool_input())
+        service = BranchingWriterService(config=_make_config())
+        service.write(
+            _make_assembled(),
+            session,
+            provider=provider,
+            selected_branch_context=sbc,
+        )
+        assert provider.last_request is not None
+        text = _all_block_text(provider.last_request)
+        assert "Cross the bridge" in text
+        assert "cautiously" in text
+
+    def test_selected_context_not_in_stable_prefix_blocks(self) -> None:
+        sbc = SelectedBranchContext(
+            option_id="opt_1",
+            action_text="Cross the bridge",
+            annotation="cautiously",
+        )
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        provider = _CapturingProvider(_valid_tool_input())
+        service = BranchingWriterService(
+            config=BranchingWriterConfig(
+                model="claude-sonnet-4-6",
+                api_key_env="ANTHROPIC_API_KEY",
+                extended_ttl=True,
+            )
+        )
+        service.write(
+            _make_assembled(),
+            session,
+            provider=provider,
+            selected_branch_context=sbc,
+        )
+        assert provider.last_request is not None
+        stable_text = _stable_block_text(provider.last_request)
+        assert "Cross the bridge" not in stable_text
+        assert "cautiously" not in stable_text
+
+    def test_annotation_line_absent_when_none(self) -> None:
+        sbc = SelectedBranchContext(
+            option_id="opt_1",
+            action_text="Cross the bridge",
+            annotation=None,
+        )
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        provider = _CapturingProvider(_valid_tool_input())
+        service = BranchingWriterService(config=_make_config())
+        service.write(
+            _make_assembled(),
+            session,
+            provider=provider,
+            selected_branch_context=sbc,
+        )
+        assert provider.last_request is not None
+        text = _all_block_text(provider.last_request)
+        assert "annotation:" not in text
+        assert "Cross the bridge" in text
+
+    def test_no_selected_context_no_selected_branch_block(self) -> None:
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        provider = _CapturingProvider(_valid_tool_input())
+        service = BranchingWriterService(config=_make_config())
+        service.write(
+            _make_assembled(),
+            session,
+            provider=provider,
+        )
+        assert provider.last_request is not None
+        text = _all_block_text(provider.last_request)
+        assert "[Selected Branch]" not in text
+
+
+# ---------------------------------------------------------------------------
+# Test: Fix 2 — held/omitted branch_presentation_state allows empty options
+# ---------------------------------------------------------------------------
+
+
+class TestHeldOmittedPresentationState:
+    """held/omitted with [] passes; held/omitted with non-empty fails-closed."""
+
+    def test_held_with_empty_options_passes(self) -> None:
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        tool_input = {
+            "narrative_text": "The story continues…",
+            "branch_options_text": [],
+            "branch_presentation_state": "held",
+            "pacing_stage_hint": None,
+        }
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(tool_input),
+        )
+        assert result.branch_options == []
+
+    def test_omitted_with_empty_options_passes(self) -> None:
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        tool_input = {
+            "narrative_text": "The story continues…",
+            "branch_options_text": [],
+            "branch_presentation_state": "omitted",
+            "pacing_stage_hint": None,
+        }
+        service = BranchingWriterService(config=_make_config())
+        result = service.write(
+            _make_assembled(),
+            session,
+            provider=_FakeProvider(tool_input),
+        )
+        assert result.branch_options == []
+
+    def test_held_with_nonempty_options_raises(self) -> None:
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        tool_input = {
+            "narrative_text": "The story continues…",
+            "branch_options_text": ["Option A", "Option B"],
+            "branch_presentation_state": "held",
+            "pacing_stage_hint": None,
+        }
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="held"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(tool_input),
+            )
+
+    def test_omitted_with_nonempty_options_raises(self) -> None:
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        tool_input = {
+            "narrative_text": "The story continues…",
+            "branch_options_text": ["Option A"],
+            "branch_presentation_state": "omitted",
+            "pacing_stage_hint": None,
+        }
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="omitted"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(tool_input),
+            )
+
+    def test_shown_with_zero_options_still_fails(self) -> None:
+        # 'shown' with a configured range still enforces count; zero violates min.
+        session = _make_session(branch_count_range=BranchCountRange.TWO_TO_THREE)
+        tool_input = {
+            "narrative_text": "The story continues…",
+            "branch_options_text": [],
+            "branch_presentation_state": "shown",
+            "pacing_stage_hint": None,
+        }
+        service = BranchingWriterService(config=_make_config())
+        with pytest.raises(BranchingPassError, match="0 branch option"):
+            service.write(
+                _make_assembled(),
+                session,
+                provider=_FakeProvider(tool_input),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: Fix 2 — _validate_branch_count unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBranchCountDirect:
+    """Direct tests for _validate_branch_count with branch_presentation_state."""
+
+    def test_held_empty_returns_none(self) -> None:
+        _validate_branch_count([], "2-3", "held")  # should not raise
+
+    def test_omitted_empty_returns_none(self) -> None:
+        _validate_branch_count([], "3-4", "omitted")  # should not raise
+
+    def test_held_nonempty_raises(self) -> None:
+        with pytest.raises(BranchingPassError, match="held"):
+            _validate_branch_count(["A", "B"], "2-3", "held")
+
+    def test_omitted_nonempty_raises(self) -> None:
+        with pytest.raises(BranchingPassError, match="omitted"):
+            _validate_branch_count(["A"], "2-3", "omitted")
+
+    def test_shown_within_range_passes(self) -> None:
+        _validate_branch_count(["A", "B"], "2-3", "shown")  # should not raise
+
+    def test_shown_below_min_raises(self) -> None:
+        with pytest.raises(BranchingPassError):
+            _validate_branch_count(["A"], "2-3", "shown")

--- a/tests/pipeline/branching/test_service.py
+++ b/tests/pipeline/branching/test_service.py
@@ -667,6 +667,69 @@ class TestSelectedBranchContextRendering:
 
 
 # ---------------------------------------------------------------------------
+# Test: Round 8 Finding 2 — no duplicate Branching mode contract
+# ---------------------------------------------------------------------------
+
+
+class TestNoDuplicateModeContract:
+    """The Branching mode contract is injected exactly once per provider call.
+
+    Regression for PR #112 Round 8: BranchingWriter previously emitted the
+    BRANCHING mode contract twice — once as its own ``_system_prompt`` (loaded
+    from ``branching_mode.md``) and again via ``stable_prefix.system_prompt``
+    (the same file, assembled once by ContextBuilder).  The pass now mirrors the
+    prose WriterService convention: the stable-prefix mode contract only.  The
+    sentinel "branching mode test" is the stable-prefix system_prompt set by
+    ``_make_assembled`` and stands in for ``branching_mode.md`` here.
+    """
+
+    _SENTINEL = "branching mode test"  # == stable_prefix.system_prompt
+
+    def _capture(self, session: BranchingSessionState) -> ProviderCallRequest:
+        provider = _CapturingProvider(_valid_tool_input())
+        service = BranchingWriterService(config=_make_config())
+        service.write(_make_assembled(), session, provider=provider)
+        assert provider.last_request is not None
+        return provider.last_request
+
+    def test_hybrid_contract_appears_exactly_once(self) -> None:
+        request = self._capture(
+            _make_session(interaction_style=InteractionStyle.HYBRID)
+        )
+        system_count = sum(b.text.count(self._SENTINEL) for b in request.system_blocks)
+        rendered_count = sum(
+            b.text.count(self._SENTINEL) for b in request.rendered_blocks
+        )
+        assert system_count == 1
+        # The mode contract must never be duplicated into the user-message region.
+        assert rendered_count == 0
+
+    def test_true_cyoa_contract_appears_exactly_once(self) -> None:
+        request = self._capture(
+            _make_session(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.TWO_TO_THREE,
+            )
+        )
+        system_count = sum(b.text.count(self._SENTINEL) for b in request.system_blocks)
+        assert system_count == 1
+
+    def test_stable_prefix_contract_is_the_single_system_block(self) -> None:
+        request = self._capture(_make_session())
+        # Stable prefix included exactly once, as the sole system block.
+        assert len(request.system_blocks) == 1
+        assert request.system_blocks[0].text == self._SENTINEL
+
+    def test_forced_tool_and_output_contract_still_present(self) -> None:
+        request = self._capture(_make_session())
+        # Output-format guidance survives via the forced-tool definition.
+        assert request.forced_tool_name == PRODUCE_BRANCH_OUTPUT_TOOL_NAME
+        assert any(
+            t.name == PRODUCE_BRANCH_OUTPUT_TOOL_NAME for t in request.tool_definitions
+        )
+
+
+# ---------------------------------------------------------------------------
 # Test: Fix 2 — held/omitted branch_presentation_state allows empty options
 # ---------------------------------------------------------------------------
 

--- a/tests/pipeline/branching/test_visible_state.py
+++ b/tests/pipeline/branching/test_visible_state.py
@@ -1,0 +1,141 @@
+"""Tests for BranchingVisibleStateService — CRD Issue 16 Phase C."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.models.enums import (
+    BranchCountRange,
+    BranchingCadence,
+    BranchingPlayStatus,
+    BranchPresentationState,
+    InteractionStyle,
+    LengthPreference,
+    PacingStage,
+)
+from afterworlds.models.session import BranchingSessionState
+from afterworlds.pipeline.branching.models import (
+    BranchingPassResult,
+    BranchOption,
+)
+from afterworlds.pipeline.branching.visible_state import BranchingVisibleStateService
+
+
+def _make_session_state(
+    interaction_style: InteractionStyle = InteractionStyle.HYBRID,
+    branching_cadence: BranchingCadence = BranchingCadence.BALANCED,
+    branch_count_range: BranchCountRange | None = BranchCountRange.TWO_TO_THREE,
+    length_preference: LengthPreference | None = LengthPreference.NOVELLA,
+) -> BranchingSessionState:
+    return BranchingSessionState(
+        story_id=uuid4(),
+        pacing_stage=PacingStage.ESCALATION,
+        play_status=BranchingPlayStatus.IN_PLAY,
+        interaction_style=interaction_style,
+        branching_cadence=branching_cadence,
+        branch_count_range=branch_count_range,
+        length_preference=length_preference,
+    )
+
+
+def _make_pass_result(
+    options: list[BranchOption] | None = None,
+    presentation_state: str = "shown",
+) -> BranchingPassResult:
+    opts = (
+        [
+            BranchOption(option_id="opt_1", action_text="Take the bridge"),
+            BranchOption(option_id="opt_2", action_text="Wade through the river"),
+        ]
+        if options is None
+        else options
+    )
+    return BranchingPassResult(
+        narrative_text="You stand at a crossing.",
+        interaction_style=InteractionStyle.HYBRID,
+        branching_cadence=BranchingCadence.BALANCED,
+        length_preference=LengthPreference.NOVELLA,
+        freeform_available=True,
+        branch_count_range=BranchCountRange.TWO_TO_THREE,
+        branch_options=opts,
+        branch_presentation_state=presentation_state,
+    )
+
+
+class TestBranchingVisibleStateService:
+    """BranchingVisibleStateService.build() returns typed, code-derived state."""
+
+    def setup_method(self) -> None:
+        self.svc = BranchingVisibleStateService()
+
+    def test_hybrid_freeform_available_true(self) -> None:
+        state = self.svc.build(_make_session_state(InteractionStyle.HYBRID))
+        assert state.freeform_available is True
+
+    def test_true_cyoa_freeform_available_false(self) -> None:
+        state = self.svc.build(_make_session_state(InteractionStyle.TRUE_CYOA))
+        assert state.freeform_available is False
+
+    def test_freeform_only_freeform_available_true(self) -> None:
+        state = self.svc.build(
+            _make_session_state(InteractionStyle.FREEFORM_ONLY, branch_count_range=None)
+        )
+        assert state.freeform_available is True
+
+    def test_session_fields_reflected(self) -> None:
+        session = _make_session_state(
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            branching_cadence=BranchingCadence.IMMERSIVE,
+            branch_count_range=BranchCountRange.TWO_TO_FIVE,
+            length_preference=LengthPreference.NOVEL,
+        )
+        state = self.svc.build(session)
+        assert state.interaction_style is InteractionStyle.TRUE_CYOA
+        assert state.branching_cadence is BranchingCadence.IMMERSIVE
+        assert state.branch_count_range is BranchCountRange.TWO_TO_FIVE
+        assert state.length_preference is LengthPreference.NOVEL
+
+    def test_schema_version_is_one(self) -> None:
+        state = self.svc.build(_make_session_state())
+        assert state.schema_version == 1
+
+    def test_no_pass_result_yields_no_last_options(self) -> None:
+        state = self.svc.build(_make_session_state(), branching_pass_result=None)
+        assert state.last_branch_options is None
+        assert state.last_presentation_state is None
+
+    def test_pass_result_populates_last_options(self) -> None:
+        pass_result = _make_pass_result(presentation_state="shown")
+        state = self.svc.build(_make_session_state(), branching_pass_result=pass_result)
+        assert state.last_branch_options is not None
+        assert len(state.last_branch_options) == 2
+        assert state.last_branch_options[0].option_id == "opt_1"
+
+    def test_pass_result_presentation_state_parsed(self) -> None:
+        pass_result = _make_pass_result(presentation_state="held")
+        state = self.svc.build(_make_session_state(), branching_pass_result=pass_result)
+        assert state.last_presentation_state is BranchPresentationState.HELD
+
+    def test_invalid_presentation_state_yields_none(self) -> None:
+        pass_result = _make_pass_result(presentation_state="unknown_value")
+        state = self.svc.build(_make_session_state(), branching_pass_result=pass_result)
+        assert state.last_presentation_state is None
+
+    def test_empty_branch_options_yields_no_last_options(self) -> None:
+        pass_result = _make_pass_result(options=[], presentation_state="omitted")
+        state = self.svc.build(_make_session_state(), branching_pass_result=pass_result)
+        assert state.last_branch_options is None
+
+    def test_none_interaction_style_raises(self) -> None:
+        session = _make_session_state()
+        session.interaction_style = None  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="interaction_style"):
+            self.svc.build(session)
+
+    def test_none_branching_cadence_raises(self) -> None:
+        session = _make_session_state()
+        session.branching_cadence = None  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="branching_cadence"):
+            self.svc.build(session)

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5573,3 +5573,209 @@ class TestBranchingWriterLineageGuard:
 
         assert result.disposition is PipelineDisposition.PIPELINE_ERROR
         assert fake_branching_writer.called is False
+
+
+# ---------------------------------------------------------------------------
+# Branch-card read path: operational fault vs invalid input (Round 4 Fix 1)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingBranchingWriterService:
+    """Records that write() was reached, then aborts with a sentinel error.
+
+    Used to prove a *valid* opt_N selection proceeds past branch-selection
+    validation into the branching writer pass (rather than being rejected),
+    without standing up a full DELIVERED branching pipeline.
+    """
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def write(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+        from afterworlds.pipeline.branching.models import BranchingPassError
+
+        self.called = True
+        raise BranchingPassError("sentinel-reached-branching-writer")
+
+
+def _seed_branching_story_with_options(
+    session: object,
+    option_labels: list[str],
+) -> tuple[UUID, UUID]:
+    """Seed a BRANCHING story + node, optionally carrying presented options."""
+    from datetime import UTC, datetime
+
+    from afterworlds.models.enums import IntentType, StoryMode
+    from afterworlds.models.node import (
+        BranchingNodeMetadata,
+        Node,
+        NodeMetadata,
+        PersistedBranchOption,
+        StateDelta,
+    )
+    from afterworlds.models.story import Arc, Chapter, Story
+    from afterworlds.persistence.crud.node import create_node
+    from afterworlds.persistence.crud.story import (
+        create_arc,
+        create_chapter,
+        create_story,
+    )
+
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    story = Story(
+        title="Branching read-path story",
+        mode=StoryMode.BRANCHING,
+        created_at=now,
+        updated_at=now,
+    )
+    create_story(session, story)  # type: ignore[arg-type]
+    arc = Arc(story_id=story.story_id, title="Arc", order=0)
+    create_arc(session, arc)  # type: ignore[arg-type]
+    chap = Chapter(arc_id=arc.arc_id, title="Chapter", order=0)
+    create_chapter(session, chap)  # type: ignore[arg-type]
+    options = [
+        PersistedBranchOption(option_id=f"opt_{i + 1}", action_text=label)
+        for i, label in enumerate(option_labels)
+    ]
+    node = Node(
+        chapter_id=chap.chapter_id,
+        content="",
+        state_delta=StateDelta(),
+        branching_logic=[],
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        metadata=NodeMetadata(timestamp=now),
+        mode_metadata=BranchingNodeMetadata(branch_options=options),
+    )
+    create_node(session, node)  # type: ignore[arg-type]
+    session.commit()  # type: ignore[union-attr]
+    return story.story_id, node.node_id
+
+
+def _make_branching_choice_orchestrator(
+    session_factory: object,
+    branching_writer: object,
+    raw_input: str,
+):  # type: ignore[no-untyped-def]
+    """Orchestrator wired for a HYBRID BRANCH_CHOICE turn with selection validation."""
+    from afterworlds.models.enums import (
+        BranchingCadence,
+        IntentType,
+        InteractionStyle,
+        PacingStage,
+        StoryMode,
+    )
+    from afterworlds.models.session import BranchingSessionState
+    from afterworlds.pipeline.branching.selection import (
+        BranchSelectionValidationService,
+    )
+
+    def _branching_resolver(sid: UUID) -> BranchingSessionState:
+        return BranchingSessionState(
+            story_id=sid,
+            pacing_stage=PacingStage.ESCALATION,
+            interaction_style=InteractionStyle.HYBRID,
+            branching_cadence=BranchingCadence.BALANCED,
+        )
+
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(IntentType.BRANCH_CHOICE, raw_input)
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        branching_session_resolver=_branching_resolver,
+        branching_selection_service=BranchSelectionValidationService(),
+    )
+
+
+class TestBranchCardReadPath:
+    """BRANCH_CHOICE branch-card read: DB faults are PIPELINE_ERROR, not rejection."""
+
+    def test_branch_card_read_failure_routes_to_pipeline_error(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A crud/session error reading presented options → PIPELINE_ERROR, no LLM."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _FakeBranchingWriterService()
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("synthetic branch-card read failure")
+
+        monkeypatch.setattr("afterworlds.persistence.crud.node.get_node", _boom)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "branch-card read failed" in summary, summary
+        assert "synthetic branch-card read failure" in summary, summary
+        # Operational fault is never reclassified as user-invalid input.
+        assert result.interaction_rejection_reason is None
+        # No LLM call on the failure path.
+        assert writer.called is False
+
+    def test_empty_presented_options_after_read_rejects(
+        self,
+        session_factory: object,
+        session: object,
+    ) -> None:
+        """Successful read with no options → INVALID_BRANCH_SELECTION, no LLM."""
+        from afterworlds.models.enums import InteractionRejectionReason
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _FakeBranchingWriterService()
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.INTERACTION_REJECTED
+        assert (
+            result.interaction_rejection_reason
+            is InteractionRejectionReason.INVALID_BRANCH_SELECTION
+        )
+        # No LLM call on the rejection path.
+        assert writer.called is False
+
+    def test_valid_opt_n_proceeds_to_branching_writer(
+        self,
+        session_factory: object,
+        session: object,
+    ) -> None:
+        """A valid opt_N selection passes validation and reaches the writer pass."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _RecordingBranchingWriterService()
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        # Not rejected: validation accepted and the narrative path was entered,
+        # reaching the branching writer (which aborts with a sentinel error).
+        assert writer.called is True
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "sentinel-reached-branching-writer" in (
+            result.pipeline_error_summary or ""
+        )
+        assert result.interaction_rejection_reason is None

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -1752,10 +1752,17 @@ class TestLedgerComposition:
             story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
         )
         derived = writer.calls[0][0]
-        assert len(derived.pass_forward_ledger.entries) == 1
-        assert derived.pass_forward_ledger.entries[0].pass_name == "planner"
+        # The default harness resolves an in-play FREEFORM_ONLY branching
+        # session, so the prose Writer ledger now carries a sibling
+        # ``branching_config`` block (Round 17 Finding 1) alongside the planner
+        # output.  Assert the planner entry is present rather than that it is the
+        # sole entry.
+        planner_entries = [
+            e for e in derived.pass_forward_ledger.entries if e.pass_name == "planner"
+        ]
+        assert len(planner_entries) == 1
         # PlannerOutput serializes as JSON; assert known fields are present.
-        ledger_text = derived.pass_forward_ledger.entries[0].content
+        ledger_text = planner_entries[0].content
         assert '"scene_goal"' in ledger_text
         assert '"next_beat"' in ledger_text
 
@@ -6497,6 +6504,70 @@ def _make_branching_routing_orchestrator(
     )
 
 
+def _make_branching_config_capture_orchestrator(
+    session_factory: object,
+    writer_service: object,
+    *,
+    interaction_style: object,
+    play_status: object,
+    branching_cadence: object,
+    length_preference: object,
+    mode: object,
+    intent_type: object,
+    raw_input: str,
+    branching_writer: object = None,
+):  # type: ignore[no-untyped-def]
+    """Orchestrator that captures the prose Writer's AssembledContext.
+
+    Unlike ``_make_branching_routing_orchestrator`` (hardcoded cadence, no
+    length_preference, BRANCHING-only), this lets a test set the persisted
+    cadence / length_preference and the story mode so the FREEFORM_ONLY
+    ``branching_config`` ledger block (Round 17 Finding 1) can be inspected on
+    the injected ``writer_service.calls``.
+    """
+    from afterworlds.models.enums import PacingStage
+    from afterworlds.models.session import BranchingSessionState
+
+    def _branching_resolver(sid: UUID) -> BranchingSessionState:
+        return BranchingSessionState(
+            story_id=sid,
+            pacing_stage=PacingStage.ESCALATION,
+            interaction_style=interaction_style,  # type: ignore[arg-type]
+            branching_cadence=branching_cadence,  # type: ignore[arg-type]
+            length_preference=length_preference,  # type: ignore[arg-type]
+            play_status=play_status,  # type: ignore[arg-type]
+        )
+
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(intent_type, raw_input)  # type: ignore[arg-type]
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=writer_service,  # type: ignore[arg-type]
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(mode),  # type: ignore[arg-type]
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        branching_session_resolver=_branching_resolver,
+    )
+
+
+def _ledger_block(writer_service: object, pass_name: str) -> str | None:
+    """Return the content of the first ledger entry with ``pass_name``, or None."""
+    calls = writer_service.calls  # type: ignore[attr-defined]
+    assert calls, "prose Writer was not invoked"
+    built_context = calls[0][0]
+    for entry in built_context.pass_forward_ledger.entries:
+        if entry.pass_name == pass_name:
+            return entry.content
+    return None
+
+
 class TestBranchingInPlayGating:
     """Interaction-style enforcement is gated on play_status == IN_PLAY."""
 
@@ -7505,6 +7576,252 @@ class TestBranchingWriterRequiredWhenInPlay:
         assert result.disposition is PipelineDisposition.DELIVERED
         assert writer.called is True
         assert result.branching_pass_result is not None
+
+
+class TestFreeformConfigLedgerBlock:
+    """Round 17 Finding 1: in-play FREEFORM_ONLY prose turns receive a
+    code-owned Branching session-configuration ledger block before the prose
+    WriterService runs.  Configuration context only — no branch cards.
+    """
+
+    def test_freeform_in_play_adds_config_block_with_cadence(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Persisted interaction_style + branching_cadence reach the ledger."""
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+            StoryMode,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = FakeWriterService()
+        orch = _make_branching_config_capture_orchestrator(
+            session_factory,
+            writer,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            branching_cadence=BranchingCadence.IMMERSIVE,
+            length_preference=None,
+            mode=StoryMode.BRANCHING,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I wander down the lane.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I wander down the lane.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        block = _ledger_block(writer, "branching_config")
+        assert block is not None
+        assert "interaction_style: freeform_only" in block
+        assert "branching_cadence: immersive" in block
+        # length_preference is absent on this session, so the line is omitted.
+        assert "length_preference" not in block
+
+    def test_freeform_in_play_config_block_includes_length_preference(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Persisted length_preference is included when present."""
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+            LengthPreference,
+            StoryMode,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = FakeWriterService()
+        orch = _make_branching_config_capture_orchestrator(
+            session_factory,
+            writer,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            branching_cadence=BranchingCadence.BALANCED,
+            length_preference=LengthPreference.NOVELLA,
+            mode=StoryMode.BRANCHING,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I keep walking.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I keep walking.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        block = _ledger_block(writer, "branching_config")
+        assert block is not None
+        assert "length_preference: novella" in block
+
+    def test_freeform_in_play_uses_prose_not_branching_writer(
+        self, session_factory: object, session: object
+    ) -> None:
+        """FREEFORM_ONLY in-play stays on the prose Writer path (no cards)."""
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+            StoryMode,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = FakeWriterService()
+        branching_writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_config_capture_orchestrator(
+            session_factory,
+            writer,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            branching_cadence=BranchingCadence.BALANCED,
+            length_preference=None,
+            mode=StoryMode.BRANCHING,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I look around.",
+            branching_writer=branching_writer,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I look around.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.calls, "prose Writer must run for FREEFORM_ONLY"
+        assert result.branching_pass_result is None
+
+    def test_hybrid_in_play_does_not_take_prose_config_path(
+        self, session_factory: object, session: object
+    ) -> None:
+        """HYBRID in-play uses BranchingWriter; the prose config block is absent."""
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+            StoryMode,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = FakeWriterService()
+        branching_writer = _SuccessfulBranchingWriterService()
+        orch = _make_branching_config_capture_orchestrator(
+            session_factory,
+            writer,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            branching_cadence=BranchingCadence.BALANCED,
+            length_preference=None,
+            mode=StoryMode.BRANCHING,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I push deeper.",
+            branching_writer=branching_writer,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I push deeper.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.branching_pass_result is not None
+        # BranchingWriter handled the turn; the prose Writer (and its config
+        # ledger block) was never reached.
+        assert not writer.calls
+
+    def test_freeform_setup_does_not_add_config_block(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Setup FREEFORM_ONLY rows are not treated as in-play cadence context."""
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+            StoryMode,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = FakeWriterService()
+        orch = _make_branching_config_capture_orchestrator(
+            session_factory,
+            writer,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.SETUP,
+            branching_cadence=BranchingCadence.IMMERSIVE,
+            length_preference=None,
+            mode=StoryMode.BRANCHING,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="What is this place?",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "What is this place?",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert _ledger_block(writer, "branching_config") is None
+
+    def test_non_branching_prose_call_has_no_config_block(
+        self, session_factory: object, session: object
+    ) -> None:
+        """WRITING-mode prose turns never receive the Branching config block."""
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+            StoryMode,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = FakeWriterService()
+        orch = _make_branching_config_capture_orchestrator(
+            session_factory,
+            writer,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            branching_cadence=BranchingCadence.IMMERSIVE,
+            length_preference=None,
+            mode=StoryMode.WRITING,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="The rain fell.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "The rain fell.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.calls, "prose Writer must run for WRITING mode"
+        assert _ledger_block(writer, "branching_config") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -8386,6 +8386,283 @@ class TestBranchingOocPersistedTruthfulness:
         assert _OOC_STYLE_NOOP_SENTINEL not in (persisted or "")
 
 
+_OOC_RANGE_NOOP_SENTINEL = "Branch-count range not changed"
+
+
+class TestBranchingOocRangeNoopSurfaced:
+    """A range-only OOC request with an invalid range is surfaced, not silent.
+
+    When an OOC request changes only ``branch_count_range`` to a value invalid
+    for the applicable style, the invalid range is discarded (never persisted)
+    and a dedicated correction is appended to the delivered/persisted output so
+    the prose cannot imply a range change that did not happen.  The range note
+    is mutually exclusive with the style non-confirmation note (a suppressed
+    style switch already names the needed range), so the two never produce
+    contradictory duplicates.
+    """
+
+    def test_hybrid_invalid_range_only_surfaces_correction(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID + invalid 2-5 (range only): not persisted, correction surfaced."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(branch_count_range=BranchCountRange.TWO_TO_FIVE),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Use 2-5 branches",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Persisted range unchanged …
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.HYBRID
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_THREE
+        # … and the correction names the rejected range, the style it is invalid
+        # for, and lists the compatible HYBRID ranges.
+        delivered = result.delivered_output or ""
+        assert _OOC_RANGE_NOOP_SENTINEL in delivered
+        assert "2-5" in delivered
+        assert "hybrid" in delivered
+        assert "1-2" in delivered
+        assert "2-3" in delivered
+        assert "3-4" in delivered
+        # No style note: this was a range-only request.
+        assert _OOC_STYLE_NOOP_SENTINEL not in delivered
+
+    def test_true_cyoa_invalid_range_only_surfaces_correction(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """TRUE_CYOA + invalid 3-4 (range only): not persisted, correction shown."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            branch_count_range=BranchCountRange.TWO_TO_FOUR,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(branch_count_range=BranchCountRange.THREE_TO_FOUR),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Use 3-4 branches",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_FOUR
+        delivered = result.delivered_output or ""
+        assert _OOC_RANGE_NOOP_SENTINEL in delivered
+        assert "3-4" in delivered
+        assert "true_cyoa" in delivered
+        # Lists the compatible TRUE_CYOA ranges.
+        assert "2-3" in delivered
+        assert "2-4" in delivered
+        assert "2-5" in delivered
+
+    def test_style_switch_plus_invalid_range_has_no_duplicate_range_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """Style switch + invalid range: style note only, range note suppressed."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.THREE_TO_FOUR,
+            ),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to CYOA with 3-4",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Neither style nor range persisted.
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.HYBRID
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_THREE
+        delivered = result.delivered_output or ""
+        # The style note is the single correction; the range note is suppressed
+        # to avoid a contradictory duplicate.
+        assert _OOC_STYLE_NOOP_SENTINEL in delivered
+        assert _OOC_RANGE_NOOP_SENTINEL not in delivered
+
+    def test_valid_range_only_update_persists_without_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """A valid range-only update persists and adds no correction note."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(branch_count_range=BranchCountRange.THREE_TO_FOUR),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Use 3-4 branches",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.branch_count_range is BranchCountRange.THREE_TO_FOUR
+        delivered = result.delivered_output or ""
+        assert _OOC_RANGE_NOOP_SENTINEL not in delivered
+        assert _OOC_STYLE_NOOP_SENTINEL not in delivered
+
+    def test_no_range_requested_adds_no_range_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """A valid style-only update (no range) adds no range correction note."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        delivered = result.delivered_output or ""
+        assert _OOC_RANGE_NOOP_SENTINEL not in delivered
+
+    def test_freeform_switch_with_range_adds_no_false_range_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """FREEFORM switch clears range by design; no false 'not changed' note."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.FREEFORM_ONLY,
+                branch_count_range=BranchCountRange.TWO_TO_FIVE,
+            ),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to freeform",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Style switch succeeds; range is cleared by the FREEFORM transition.
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.FREEFORM_ONLY
+        assert bss.branch_count_range is None
+        delivered = result.delivered_output or ""
+        # A "range not changed" note would be false — the switch cleared it.
+        assert _OOC_RANGE_NOOP_SENTINEL not in delivered
+
+    def test_corrected_range_only_output_agrees_across_all_three(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """Delivered, persisted Turn, and writer_result outputs all agree."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(branch_count_range=BranchCountRange.TWO_TO_FIVE),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Use 2-5 branches",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        persisted = _read_persisted_turn_output(session, result.turn_id)
+        delivered = result.delivered_output or ""
+        assert _OOC_RANGE_NOOP_SENTINEL in delivered
+        assert persisted == delivered
+        assert result.writer_result is not None
+        assert result.writer_result.assistant_output == delivered
+
+
 def _make_branching_orch_without_resolver(
     session_factory: object,
     *,

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5243,6 +5243,105 @@ class TestRpgAdjudicationCacheWarmed:
 
 
 # ---------------------------------------------------------------------------
+# PR #112 R14: Branching provider results reflected in stable_prefix_cache_warmed
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingCacheWarmed:
+    """_build_result must pass branching results to _any_cache_read.
+
+    BranchingWriter and the Branching OOC config extractor are stable-prefix-
+    backed provider calls; a non-zero cache_read_token_count on either must
+    warm stable_prefix_cache_warmed just like planner/writer/extractor.
+    """
+
+    @staticmethod
+    def _branching_pass_result(cache_read: int) -> object:
+        from afterworlds.models.enums import BranchingCadence, InteractionStyle
+        from afterworlds.pipeline.branching.models import (
+            BranchingPassResult,
+            BranchOption,
+        )
+
+        return BranchingPassResult(
+            narrative_text="The corridor forks before you.",
+            interaction_style=InteractionStyle.HYBRID,
+            branching_cadence=BranchingCadence.BALANCED,
+            length_preference=None,
+            freeform_available=True,
+            branch_count_range=None,
+            branch_options=[BranchOption(option_id="opt_1", action_text="Go left")],
+            branch_presentation_state="shown",
+            provider="anthropic",
+            model_identifier="claude-haiku-4-5",
+            model_tier="haiku",
+            latency_ms=7,
+            cache_read_token_count=cache_read,
+        )
+
+    @staticmethod
+    def _ooc_config_result(cache_read: int) -> object:
+        from afterworlds.pipeline.branching.models import (
+            BranchingConfigUpdate,
+            BranchingOocConfigExtractorResult,
+        )
+
+        return BranchingOocConfigExtractorResult(
+            config_update=BranchingConfigUpdate(),
+            provider="fake",
+            model_identifier="fake-haiku",
+            model_tier="haiku",
+            latency_ms=5,
+            cache_read_token_count=cache_read,
+        )
+
+    def test_cache_warmed_when_only_branching_writer_has_cache_tokens(
+        self, session_factory: object
+    ) -> None:
+        orch = _make_orchestrator(session_factory)[0]
+        result = orch._build_result(  # type: ignore[attr-defined]
+            PipelineDisposition.PIPELINE_ERROR,
+            make_intent(),
+            {},
+            0.0,
+            pipeline_error_summary="test",
+            branching_pass_result=self._branching_pass_result(7),
+        )
+        assert result.stable_prefix_cache_warmed is True
+
+    def test_cache_warmed_when_only_ooc_config_has_cache_tokens(
+        self, session_factory: object
+    ) -> None:
+        orch = _make_orchestrator(session_factory)[0]
+        result = orch._build_result(  # type: ignore[attr-defined]
+            PipelineDisposition.PIPELINE_ERROR,
+            make_intent(),
+            {},
+            0.0,
+            pipeline_error_summary="test",
+            branching_ooc_config_result=self._ooc_config_result(7),
+        )
+        assert result.stable_prefix_cache_warmed is True
+
+    def test_cache_not_warmed_when_branching_results_have_zero_cache(
+        self, session_factory: object
+    ) -> None:
+        # Both branching results report zero cache-read and no other pass is
+        # present — the only signal under test is the new branching plumbing.
+        orch = _make_orchestrator(session_factory)[0]
+        result = orch._build_result(  # type: ignore[attr-defined]
+            PipelineDisposition.PIPELINE_ERROR,
+            make_intent(),
+            {},
+            0.0,
+            pipeline_error_summary="test",
+            branching_pass_result=self._branching_pass_result(0),
+            branching_ooc_config_result=self._ooc_config_result(0),
+        )
+        assert result.stable_prefix_cache_warmed is False
+
+
+# ---------------------------------------------------------------------------
 # P2-1: Pending-roll consume path takes precedence over OOC routing (Round 11)
 # ---------------------------------------------------------------------------
 

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -180,6 +180,18 @@ def _make_fake_resolver(trusted: bool = False) -> object:
 # ---------------------------------------------------------------------------
 
 
+def _null_branching_resolver(_story_id: UUID) -> None:
+    """Default branching-session resolver for mode-agnostic orchestrator tests.
+
+    The harness mode defaults to ``StoryMode.BRANCHING``, which now requires a
+    wired ``branching_session_resolver`` (a missing resolver fails closed).
+    These generic pipeline tests carry no branching session, so resolution
+    yields ``None`` and the turn routes through the prose Writer exactly as it
+    did under the prior fail-open behavior.
+    """
+    return None
+
+
 def _make_orchestrator(  # type: ignore[no-untyped-def]
     session_factory,
     *,
@@ -233,6 +245,7 @@ def _make_orchestrator(  # type: ignore[no-untyped-def]
         safety_policy=safety_policy or CapabilityProfileAwareSafetyPolicy(),
         provider_resolver=resolver,  # type: ignore[arg-type]
         mode_resolver=fixed_mode_resolver(),
+        branching_session_resolver=_null_branching_resolver,
         executor=executor,
         parallel_pass_timeout_seconds=parallel_timeout,
     )
@@ -7375,3 +7388,310 @@ class TestBranchingOocStyleNoopSurfaced:
         assert bss.interaction_style is InteractionStyle.TRUE_CYOA
         assert bss.branch_count_range is BranchCountRange.TWO_TO_FOUR
         assert _OOC_STYLE_NOOP_SENTINEL not in (result.delivered_output or "")
+
+
+def _make_branching_orch_without_resolver(
+    session_factory: object,
+    *,
+    intent_type: object,
+    raw_input: str,
+):  # type: ignore[no-untyped-def]
+    """BRANCHING orchestrator with NO branching_session_resolver wired.
+
+    Exposes the prose writer and branching writer fakes so callers can prove
+    neither pass ran when the missing-resolver guard fails closed.
+    """
+    from afterworlds.models.enums import StoryMode
+    from afterworlds.pipeline.branching.selection import (
+        BranchSelectionValidationService,
+    )
+
+    writer = FakeWriterService()
+    branching_writer = _FakeBranchingWriterService()
+    orch = OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(intent_type, raw_input)  # type: ignore[arg-type]
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=writer,
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        # branching_session_resolver intentionally omitted (None).
+        branching_selection_service=BranchSelectionValidationService(),
+    )
+    return orch, writer, branching_writer
+
+
+class TestBranchingResolverRequired:
+    """A BRANCHING turn fails closed when branching_session_resolver is absent.
+
+    Without the resolver the orchestrator cannot distinguish setup,
+    FREEFORM_ONLY, HYBRID, TRUE_CYOA, or play status, so it must not proceed
+    with pre_branching_state=None and silently downgrade to the prose Writer.
+    """
+
+    def test_in_character_action_missing_resolver_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """In-character BRANCHING turn + no resolver → PIPELINE_ERROR, no writer."""
+        from afterworlds.models.enums import IntentType
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch, writer, branching_writer = _make_branching_orch_without_resolver(
+            session_factory,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I press onward.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I press onward.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "resolver not wired" in summary, summary
+        # Fail closed before any writer routing: neither pass ran, no Turn.
+        assert writer.calls == []
+        assert branching_writer.called is False
+
+    def test_branch_choice_missing_resolver_fails_closed_before_rejection(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BRANCH_CHOICE + no resolver → PIPELINE_ERROR, not INTERACTION_REJECTED.
+
+        Proves the guard precedes TRUE_CYOA freeform rejection and branch
+        selection validation, both of which depend on the resolved state.
+        """
+        from afterworlds.models.enums import IntentType
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch, writer, branching_writer = _make_branching_orch_without_resolver(
+            session_factory,
+            intent_type=IntentType.BRANCH_CHOICE,
+            raw_input="opt_1",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "resolver not wired" in (result.pipeline_error_summary or "")
+        # Not a user-input rejection: error precedes interaction-style checks.
+        assert result.interaction_rejection_reason is None
+        assert writer.calls == []
+        assert branching_writer.called is False
+
+    def test_wired_resolver_setup_hybrid_still_delivers(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Positive control: a wired resolver still permits the setup prose path."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.SETUP,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=_FakeBranchingWriterService(),
+            raw_input="Let's begin the tale.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Let's begin the tale.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.branching_pass_result is None
+
+
+def _make_branching_choice_orch_without_selection(
+    session_factory: object,
+    *,
+    interaction_style: object,
+    play_status: object,
+    raw_input: str,
+):  # type: ignore[no-untyped-def]
+    """In-play/SETUP BRANCH_CHOICE orchestrator with NO selection service wired.
+
+    Exposes the writer fakes so callers can prove no narrative pass ran when
+    the missing-selection-service guard fails closed.
+    """
+    from afterworlds.models.enums import (
+        BranchingCadence,
+        IntentType,
+        PacingStage,
+        StoryMode,
+    )
+    from afterworlds.models.session import BranchingSessionState
+
+    def _branching_resolver(sid: UUID) -> BranchingSessionState:
+        return BranchingSessionState(
+            story_id=sid,
+            pacing_stage=PacingStage.ESCALATION,
+            interaction_style=interaction_style,  # type: ignore[arg-type]
+            branching_cadence=BranchingCadence.BALANCED,
+            play_status=play_status,  # type: ignore[arg-type]
+        )
+
+    writer = FakeWriterService()
+    branching_writer = _FakeBranchingWriterService()
+    orch = OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(IntentType.BRANCH_CHOICE, raw_input)
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=writer,
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        branching_session_resolver=_branching_resolver,
+        # branching_selection_service intentionally omitted (None).
+    )
+    return orch, writer, branching_writer
+
+
+class TestBranchChoiceValidationServiceRequired:
+    """In-play HYBRID/TRUE_CYOA BRANCH_CHOICE fails closed without selection svc.
+
+    Without BranchSelectionValidationService the selection cannot be validated
+    against the presented option set; treating it as freeform narrative would
+    bypass the typed branch-card contract and bill a turn for an unvalidated
+    choice.  Setup rows stay on the existing wired-only path (guard is in-play
+    only).
+    """
+
+    def test_in_play_hybrid_missing_selection_service_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """In-play HYBRID BRANCH_CHOICE + no selection svc → PIPELINE_ERROR, no turn."""
+        from afterworlds.models.enums import BranchingPlayStatus, InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch, writer, branching_writer = _make_branching_choice_orch_without_selection(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            raw_input="opt_1",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "selection validation service not wired" in summary, summary
+        # No LLM call, no Turn, no billing: neither writer ran.
+        assert writer.calls == []
+        assert branching_writer.called is False
+        # Fail-closed wiring guard, not a user-input rejection.
+        assert result.interaction_rejection_reason is None
+
+    def test_in_play_true_cyoa_missing_selection_service_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """In-play TRUE_CYOA BRANCH_CHOICE + no selection svc → PIPELINE_ERROR."""
+        from afterworlds.models.enums import BranchingPlayStatus, InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch, writer, branching_writer = _make_branching_choice_orch_without_selection(
+            session_factory,
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            raw_input="opt_2",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_2", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "selection validation service not wired" in (
+            result.pipeline_error_summary or ""
+        )
+        assert writer.calls == []
+        assert branching_writer.called is False
+        assert result.interaction_rejection_reason is None
+
+    def test_setup_hybrid_missing_selection_service_unchanged(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Positive control: setup BRANCH_CHOICE + no selection svc → prose, no error.
+
+        The guard is in-play only, so setup behavior is unchanged: the missing
+        selection service does not fail the turn closed during setup.
+        """
+        from afterworlds.models.enums import BranchingPlayStatus, InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch, writer, branching_writer = _make_branching_choice_orch_without_selection(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.SETUP,
+            raw_input="opt_1",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        # Setup routes through the prose Writer, not the branching writer.
+        assert len(writer.calls) == 1
+        assert branching_writer.called is False
+
+    def test_wired_selection_service_invalid_choice_still_rejected(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Positive control: a wired service still returns INTERACTION_REJECTED."""
+        from afterworlds.models.enums import InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch = _make_branching_choice_orchestrator(
+            session_factory,
+            _FakeBranchingWriterService(),
+            "I wander off the map entirely",
+            interaction_style=InteractionStyle.HYBRID,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I wander off the map entirely",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.INTERACTION_REJECTED
+        assert result.interaction_rejection_reason is not None

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5952,6 +5952,51 @@ class _SuccessfulBranchingWriterService:
         )
 
 
+class _PresentationBranchingWriterService:
+    """Branching writer fake returning a chosen presentation state + option set.
+
+    Held/omitted beats always carry an empty option list (the branching
+    validator forbids non-empty held/omitted), so the orchestrator's node
+    metadata write must clear any prior beat's branch_options.
+    """
+
+    def __init__(
+        self,
+        presentation_state: str,
+        *,
+        options: list[tuple[str, str]] | None = None,
+    ) -> None:
+        self.called = False
+        self._presentation_state = presentation_state
+        self._options = options or []
+
+    def write(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+        from afterworlds.models.enums import BranchingCadence, InteractionStyle
+        from afterworlds.pipeline.branching.models import (
+            BranchingPassResult,
+            BranchOption,
+        )
+
+        self.called = True
+        return BranchingPassResult(
+            narrative_text="The corridor narrows; you hold your ground.",
+            interaction_style=InteractionStyle.HYBRID,
+            branching_cadence=BranchingCadence.BALANCED,
+            length_preference=None,
+            freeform_available=True,
+            branch_count_range=None,
+            branch_options=[
+                BranchOption(option_id=oid, action_text=txt)
+                for oid, txt in self._options
+            ],
+            branch_presentation_state=self._presentation_state,
+            provider="anthropic",
+            model_identifier="claude-haiku-4-5",
+            model_tier="haiku",
+            latency_ms=7,
+        )
+
+
 def _make_branching_routing_orchestrator(
     session_factory: object,
     *,
@@ -6411,7 +6456,7 @@ class TestBranchCardPersistenceFailClosed:
 
         assert result.disposition is PipelineDisposition.PIPELINE_ERROR
         summary = result.pipeline_error_summary or ""
-        assert "branch-card persistence failed" in summary, summary
+        assert "branch-card metadata persistence failed" in summary, summary
         assert "synthetic branch-option persistence failure" in summary, summary
         # Owner decision (Round 9): branching_pass_result records that
         # BranchingWriter ran and consumed provider tokens — it is a
@@ -6452,7 +6497,7 @@ class TestBranchCardPersistenceFailClosed:
 
         assert result.disposition is PipelineDisposition.PIPELINE_ERROR
         summary = result.pipeline_error_summary or ""
-        assert "branch-card persistence failed" in summary, summary
+        assert "branch-card metadata persistence failed" in summary, summary
         # Owner decision (Round 9): preserve the settlement/audit record; gate
         # delivery on PIPELINE_ERROR + absence of deliverable branch-card state.
         assert result.branching_pass_result is not None
@@ -6534,6 +6579,384 @@ class TestBranchCardPersistenceFailClosed:
         ]
         # … but the best-effort selection annotation was not.
         assert node.mode_metadata.selected_option_id is None
+
+
+# ---------------------------------------------------------------------------
+# Round 10 Finding 1: held/omitted node metadata is authoritative.
+#
+# A HYBRID held/omitted beat must clear any prior beat's branch_options and
+# record the new presentation state in the same transaction that delivers the
+# turn.  If that write fails the orchestrator fails closed (PIPELINE_ERROR ->
+# rollback, branching_pass_result preserved) rather than continue best-effort,
+# because leftover options would let the Sojourner select stale cards from a
+# prior shown beat.  (TRUE_CYOA forbids held/omitted entirely, so this rule is
+# exercised under HYBRID.)
+# ---------------------------------------------------------------------------
+
+
+class TestHeldOmittedBranchMetadataAuthoritative:
+    """Held/omitted clears stale options; a failed clear fails closed."""
+
+    def _make_held_omitted_orch(
+        self,
+        session_factory: object,
+        writer: object,
+        raw_input: str,
+    ):  # type: ignore[no-untyped-def]
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        return _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input=raw_input,
+        )
+
+    def test_held_after_shown_clears_branch_options(
+        self, session_factory: object, session: object
+    ) -> None:
+        """HYBRID held beat clears the prior shown beat's options, records held."""
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        # Prior beat left selectable cards on the node.
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _PresentationBranchingWriterService("held")
+        orch = self._make_held_omitted_orch(
+            session_factory, writer, "I hold my position."
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I hold my position.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is True
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        # Stale options cleared; new presentation state recorded.
+        assert node.mode_metadata.branch_options == []
+        assert node.mode_metadata.branch_presentation_state == "held"
+
+    def test_omitted_after_shown_clears_branch_options(
+        self, session_factory: object, session: object
+    ) -> None:
+        """HYBRID omitted beat clears the prior options and records omitted."""
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _PresentationBranchingWriterService("omitted")
+        orch = self._make_held_omitted_orch(
+            session_factory, writer, "I keep walking quietly."
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I keep walking quietly.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is True
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        assert node.mode_metadata.branch_options == []
+        assert node.mode_metadata.branch_presentation_state == "omitted"
+
+    def test_held_metadata_clear_failure_fails_closed(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A failed held-metadata clear → PIPELINE_ERROR, pass result preserved."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _PresentationBranchingWriterService("held")
+        orch = self._make_held_omitted_orch(
+            session_factory, writer, "I hold my position."
+        )
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("synthetic held-metadata clear failure")
+
+        # The only update_node on a HYBRID freeform held turn is the metadata
+        # clear (no selected-edge write without a BRANCH_CHOICE selection).
+        monkeypatch.setattr("afterworlds.persistence.crud.node.update_node", _boom)
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I hold my position.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Previously held/omitted persistence was best-effort; it now fails closed.
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "branch-card metadata persistence failed" in summary, summary
+        assert "synthetic held-metadata clear failure" in summary, summary
+        # BranchingWriter ran → settlement/audit record preserved (Round 9 rule).
+        assert result.branching_pass_result is not None
+        # No deliverable branch-card state on the failed turn.
+        assert result.branching_visible_state is None
+        # NOTE: the transaction rolls back, so the node still holds the prior
+        # shown beat's options.  The invariant is "no DELIVERED turn where a
+        # held state coexists with leftover selectable options" — enforced by
+        # the PIPELINE_ERROR rollback above, not by post-failure erasure, so we
+        # deliberately do not assert the prior options were removed.
+
+    def test_omitted_metadata_clear_failure_fails_closed(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A failed omitted-metadata clear also fails closed, preserving the record."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _PresentationBranchingWriterService("omitted")
+        orch = self._make_held_omitted_orch(
+            session_factory, writer, "I keep walking quietly."
+        )
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("synthetic omitted-metadata clear failure")
+
+        monkeypatch.setattr("afterworlds.persistence.crud.node.update_node", _boom)
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I keep walking quietly.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "branch-card metadata persistence failed" in (
+            result.pipeline_error_summary or ""
+        )
+        assert result.branching_pass_result is not None
+        assert result.branching_visible_state is None
+
+
+# ---------------------------------------------------------------------------
+# Round 10 Finding 2: in-play HYBRID/TRUE_CYOA require BranchingWriterService.
+#
+# A wiring gap must fail closed (PIPELINE_ERROR), never silently downgrade to
+# the prose Writer — that would bypass the typed branch-card contract and omit
+# branching_pass_result.  Setup turns and FREEFORM_ONLY still use prose Writer
+# per ADR-016 Decision 3.
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingWriterRequiredWhenInPlay:
+    """In-play HYBRID/TRUE_CYOA fail closed when BranchingWriterService is missing."""
+
+    def test_in_play_hybrid_missing_writer_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """In-play HYBRID without a branching writer → PIPELINE_ERROR, not prose."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=None,
+            raw_input="I push deeper.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "not wired" in summary, summary
+        assert "prose-writer downgrade" in summary, summary
+        # No branching writer ran → no settlement record (nothing to bill).
+        assert result.branching_pass_result is None
+
+    def test_in_play_true_cyoa_missing_writer_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """In-play TRUE_CYOA (valid BRANCH_CHOICE) without a writer → PIPELINE_ERROR."""
+        from afterworlds.models.enums import InteractionStyle
+
+        # TRUE_CYOA only reaches the writer gate via a valid BRANCH_CHOICE.
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch = _make_branching_choice_orchestrator(
+            session_factory,
+            None,
+            "opt_1",
+            interaction_style=InteractionStyle.TRUE_CYOA,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "not wired" in (result.pipeline_error_summary or "")
+        # Fail-closed wiring guard, not a user-input rejection (selection passed).
+        assert result.interaction_rejection_reason is None
+        assert result.branching_pass_result is None
+
+    def test_setup_hybrid_missing_writer_uses_prose(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Setup HYBRID without a branching writer still routes to prose Writer."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.SETUP,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=None,
+            raw_input="Yes, that premise sounds right.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Yes, that premise sounds right.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.branching_pass_result is None
+
+    def test_setup_true_cyoa_missing_writer_uses_prose(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Setup TRUE_CYOA freeform without a writer still routes to prose Writer."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            play_status=BranchingPlayStatus.SETUP,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=None,
+            raw_input="Make the tone darker, please.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Make the tone darker, please.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.branching_pass_result is None
+
+    def test_freeform_only_in_play_missing_writer_uses_prose(
+        self, session_factory: object, session: object
+    ) -> None:
+        """In-play FREEFORM_ONLY uses prose Writer regardless of branching wiring."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=None,
+            raw_input="I wander down the lane.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I wander down the lane.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.branching_pass_result is None
+
+    def test_in_play_hybrid_wired_writer_emits_branching_pass_result(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Properly wired in-play HYBRID uses BranchingWriter and emits the record."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _SuccessfulBranchingWriterService()
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input="I push deeper.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is True
+        assert result.branching_pass_result is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5199,3 +5199,125 @@ class TestRuleSlicePreContext:
         )
         assert len(spy.rule_slice_requests) == 1
         assert spy.rule_slice_requests[0] is None
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: Branching-writer lineage guard — cross-story node rejects before LLM call
+# ---------------------------------------------------------------------------
+
+
+class _FakeBranchingWriterService:
+    """Stub branching writer that must NOT be called if the lineage guard fires."""
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def write(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+        self.called = True
+        raise AssertionError(
+            "BranchingWriterService.write() must not be reached when the"
+            " lineage guard fires"
+        )
+
+
+class TestBranchingWriterLineageGuard:
+    """_narrative_persist lineage guard rejects cross-story node before LLM call."""
+
+    def test_cross_story_node_returns_pipeline_error(
+        self,
+        session_factory: object,
+        session: object,
+        seeded_story: tuple[UUID, UUID],
+    ) -> None:
+        """Using node_id from story B with story A's story_id → PIPELINE_ERROR."""
+        from datetime import UTC, datetime
+
+        from afterworlds.entitlement.enums import RuntimeAccessPath
+        from afterworlds.models.enums import (
+            BranchingCadence,
+            IntentType,
+            InteractionStyle,
+            PacingStage,
+            StoryMode,
+        )
+        from afterworlds.models.node import (
+            BranchingNodeMetadata,
+            Node,
+            NodeMetadata,
+            StateDelta,
+        )
+        from afterworlds.models.session import BranchingSessionState
+        from afterworlds.models.story import Arc, Chapter, Story
+        from afterworlds.persistence.crud.node import create_node
+        from afterworlds.persistence.crud.story import (
+            create_arc,
+            create_chapter,
+            create_story,
+        )
+
+        # story_A is the seeded fixture story.
+        story_a_id, _node_a_id = seeded_story
+
+        # Seed a second story (story_B) with its own node.
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        story_b = Story(
+            title="Story B (different story)",
+            mode=StoryMode.BRANCHING,
+            created_at=now,
+            updated_at=now,
+        )
+        create_story(session, story_b)  # type: ignore[arg-type]
+        arc_b = Arc(story_id=story_b.story_id, title="Arc B", order=0)
+        create_arc(session, arc_b)  # type: ignore[arg-type]
+        chap_b = Chapter(arc_id=arc_b.arc_id, title="Chapter B", order=0)
+        create_chapter(session, chap_b)  # type: ignore[arg-type]
+        node_b = Node(
+            chapter_id=chap_b.chapter_id,
+            content="",
+            state_delta=StateDelta(),
+            branching_logic=[],
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            metadata=NodeMetadata(timestamp=now),
+            mode_metadata=BranchingNodeMetadata(),
+        )
+        create_node(session, node_b)  # type: ignore[arg-type]
+        session.commit()  # type: ignore[union-attr]
+
+        def _branching_resolver(sid: UUID) -> BranchingSessionState:
+            return BranchingSessionState(
+                story_id=sid,
+                pacing_stage=PacingStage.ESCALATION,
+                interaction_style=InteractionStyle.HYBRID,
+                branching_cadence=BranchingCadence.BALANCED,
+            )
+
+        fake_branching_writer = _FakeBranchingWriterService()
+
+        orch = OrchestratorService(
+            intent_classifier=FakeIntentClassifier(
+                make_intent(IntentType.IN_CHARACTER_ACTION, "I cross the bridge.")
+            ),
+            context_builder=FakeContextBuilder(),
+            safety_service=FakeSafetyService(),
+            planner_service=FakePlannerService(),
+            writer_service=FakeWriterService(),
+            extractor_service=FakeExtractorService(),
+            contradiction_service=FakeContradictionService(),
+            session_factory=session_factory,  # type: ignore[arg-type]
+            safety_policy=CapabilityProfileAwareSafetyPolicy(),
+            provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+            mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+            branching_writer_service=fake_branching_writer,  # type: ignore[arg-type]
+            branching_session_resolver=_branching_resolver,
+        )
+
+        result = orch.orchestrate_turn(
+            story_a_id,  # story A
+            node_b.node_id,  # node belongs to story B — cross-story mismatch
+            "I cross the bridge.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert fake_branching_writer.called is False

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -180,16 +180,30 @@ def _make_fake_resolver(trusted: bool = False) -> object:
 # ---------------------------------------------------------------------------
 
 
-def _null_branching_resolver(_story_id: UUID) -> None:
+def _freeform_branching_resolver(_story_id: UUID):  # type: ignore[no-untyped-def]
     """Default branching-session resolver for mode-agnostic orchestrator tests.
 
     The harness mode defaults to ``StoryMode.BRANCHING``, which now requires a
-    wired ``branching_session_resolver`` (a missing resolver fails closed).
-    These generic pipeline tests carry no branching session, so resolution
-    yields ``None`` and the turn routes through the prose Writer exactly as it
-    did under the prior fail-open behavior.
+    wired ``branching_session_resolver`` that returns a real session state (a
+    missing resolver *and* a resolver that returns ``None`` both fail closed).
+    These generic pipeline tests exercise the prose path, so the harness
+    resolves a fully-configured in-play ``FREEFORM_ONLY`` session: in-play
+    HYBRID/TRUE_CYOA rails do not apply to FREEFORM_ONLY, so the turn routes
+    through the prose Writer exactly as it did under the prior behavior, while
+    no longer relying on the (now fail-closed) ``None`` session.
     """
-    return None
+    from afterworlds.models.enums import InteractionStyle, PacingStage
+    from afterworlds.models.session import (
+        BranchingPlayStatus,
+        BranchingSessionState,
+    )
+
+    return BranchingSessionState(
+        story_id=_story_id,
+        pacing_stage=PacingStage.ESCALATION,
+        interaction_style=InteractionStyle.FREEFORM_ONLY,
+        play_status=BranchingPlayStatus.IN_PLAY,
+    )
 
 
 def _make_orchestrator(  # type: ignore[no-untyped-def]
@@ -245,7 +259,7 @@ def _make_orchestrator(  # type: ignore[no-untyped-def]
         safety_policy=safety_policy or CapabilityProfileAwareSafetyPolicy(),
         provider_resolver=resolver,  # type: ignore[arg-type]
         mode_resolver=fixed_mode_resolver(),
-        branching_session_resolver=_null_branching_resolver,
+        branching_session_resolver=_freeform_branching_resolver,
         executor=executor,
         parallel_pass_timeout_seconds=parallel_timeout,
     )
@@ -3630,6 +3644,161 @@ class TestCommitFailureRoutesToPipelineError:
         # still inspectable there, just not promoted to delivered_output.
         assert result.writer_result is not None
         assert result.writer_result.assistant_output == candidate_prose
+
+
+class TestCommitFailurePreservesBranchingUsage:
+    """Commit-failure rebuild preserves usage-carrying Branching pass results.
+
+    A BranchingWriter or Branching OOC-config extractor that ran before a
+    failed commit already consumed provider tokens.  The rebuilt
+    PIPELINE_ERROR must keep ``branching_pass_result`` /
+    ``branching_ooc_config_result`` so cost settlement (BRANCHING_WRITER /
+    BRANCHING_OOC_CONFIG_EXTRACTOR) and audit can reconstruct the spend.
+    """
+
+    def test_branching_writer_usage_survives_commit_failure(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BranchingWriter success + commit failure → preserved pass result."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        failing_factory = _CommitFailingSessionFactory(
+            session_factory, RuntimeError("simulated disk full")
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(failing_factory)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "transaction commit failed" in (result.pipeline_error_summary or "")
+        assert branching_writer.called is True
+        # Successful provider-usage evidence must survive the rebuild.
+        assert result.branching_pass_result is not None
+        # Delivery is still gated by the PIPELINE_ERROR disposition.
+        assert result.delivered_output is None
+        assert result.turn_id is None
+        assert failing_factory.rollback_calls >= 1
+
+    def test_branching_writer_usage_visible_to_cost_policy_snapshot(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Cost-policy snapshot sees BRANCHING_WRITER on the rebuilt error."""
+        from afterworlds.entitlement.enums import PipelinePassId
+        from afterworlds.entitlement.policy import TurnCostPolicy
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        failing_factory = _CommitFailingSessionFactory(
+            session_factory, RuntimeError("simulated disk full")
+        )
+        orch, _ = _make_branching_refusal_orchestrator(failing_factory)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert result.branching_pass_result is not None
+        # The Fake Safety service and successful-branching-writer fake emit
+        # token-less results (production passes carry tokens); the real
+        # snapshot extractor requires tokens.  Strip the fake safety passes and
+        # stamp realistic tokens onto the preserved branching pass result so
+        # the assertion isolates the mapping invariant: a branching_pass_result
+        # preserved on a PIPELINE_ERROR rebuild yields a BRANCHING_WRITER
+        # snapshot (it is not skipped because the disposition is an error).
+        bpr = result.branching_pass_result.model_copy(
+            update={"input_token_count": 200, "output_token_count": 50}
+        )
+        snap_input = result.model_copy(
+            update={
+                "input_safety_result": None,
+                "output_safety_result": None,
+                "branching_pass_result": bpr,
+            }
+        )
+        snapshots = TurnCostPolicy.extract_snapshots(snap_input)
+        pass_ids = {snap.pass_id for snap in snapshots}
+        assert PipelinePassId.BRANCHING_WRITER in pass_ids
+        # branching_pass_result is non-None, so the prose Writer snapshot is
+        # not double-counted (BRANCHING_WRITER stands in its place).
+        assert PipelinePassId.WRITER not in pass_ids
+
+    def test_ooc_config_extractor_usage_survives_commit_failure(
+        self, session_factory: object, seeded_story: tuple[object, object], session
+    ) -> None:
+        """OOC config extractor success + commit failure → preserved result."""
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+        failing_factory = _CommitFailingSessionFactory(
+            session_factory, ConnectionError("simulated DB timeout")
+        )
+        orch = _make_ooc_cfg_orch(
+            failing_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.HYBRID),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "transaction commit failed" in (result.pipeline_error_summary or "")
+        # The OOC config extractor consumed tokens before the failed commit.
+        assert result.branching_ooc_config_result is not None
+        assert result.delivered_output is None
+        assert result.turn_id is None
+
+    def test_ooc_config_usage_visible_to_cost_policy_snapshot(
+        self, session_factory: object, seeded_story: tuple[object, object], session
+    ) -> None:
+        """Cost-policy snapshot sees BRANCHING_OOC_CONFIG_EXTRACTOR on rebuild."""
+        from afterworlds.entitlement.enums import PipelinePassId
+        from afterworlds.entitlement.policy import TurnCostPolicy
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+        failing_factory = _CommitFailingSessionFactory(
+            session_factory, ConnectionError("simulated DB timeout")
+        )
+        orch = _make_ooc_cfg_orch(
+            failing_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.HYBRID),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        # Drop token-less Fake Safety passes (see sibling test) so the
+        # assertion isolates the branching OOC-config usage invariant.
+        snap_input = result.model_copy(
+            update={"input_safety_result": None, "output_safety_result": None}
+        )
+        snapshots = TurnCostPolicy.extract_snapshots(snap_input)
+        pass_ids = {snap.pass_id for snap in snapshots}
+        assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR in pass_ids
 
 
 # ---------------------------------------------------------------------------
@@ -7397,6 +7566,150 @@ class TestBranchingOocStyleNoopSurfaced:
         assert _OOC_STYLE_NOOP_SENTINEL not in (result.delivered_output or "")
 
 
+def _read_persisted_turn_output(session: object, turn_id: object) -> str | None:
+    """Return the persisted assistant_output for a Turn, or None if absent."""
+    from afterworlds.persistence.crud.node import get_turn
+
+    session.expire_all()  # type: ignore[union-attr]
+    turn = get_turn(session, turn_id)  # type: ignore[arg-type]
+    return turn.assistant_output if turn is not None else None
+
+
+class TestBranchingOocPersistedTruthfulness:
+    """A suppressed OOC style switch must persist the same corrective note.
+
+    The corrective no-op note is appended to the delivered output; the
+    persisted Turn must carry the identical corrected output so future
+    recent-turn context cannot reintroduce a false confirmation of an
+    unapplied change.  Delivered output and persisted Turn output must agree.
+    """
+
+    def test_suppressed_freeform_to_hybrid_persists_corrective_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """FREEFORM_ONLY → HYBRID (no range): persisted Turn carries the note."""
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.HYBRID),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        persisted = _read_persisted_turn_output(session, result.turn_id)
+        assert _OOC_STYLE_NOOP_SENTINEL in (result.delivered_output or "")
+        # Persisted Turn carries the same correction, not raw confirming prose.
+        assert persisted == result.delivered_output
+        assert _OOC_STYLE_NOOP_SENTINEL in (persisted or "")
+
+    def test_suppressed_freeform_to_true_cyoa_persists_corrective_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """FREEFORM_ONLY → TRUE_CYOA (no range): persisted Turn carries the note."""
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        persisted = _read_persisted_turn_output(session, result.turn_id)
+        assert _OOC_STYLE_NOOP_SENTINEL in (result.delivered_output or "")
+        assert persisted == result.delivered_output
+
+    def test_invalid_explicit_range_persists_corrective_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID 2-3 → TRUE_CYOA + invalid 3-4: persisted Turn carries the note."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.THREE_TO_FOUR,
+            ),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to CYOA with 3-4",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        persisted = _read_persisted_turn_output(session, result.turn_id)
+        assert _OOC_STYLE_NOOP_SENTINEL in (result.delivered_output or "")
+        assert persisted == result.delivered_output
+
+    def test_valid_style_switch_persists_raw_prose_without_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """A valid OOC config change adds no note; persisted Turn is raw prose."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        persisted = _read_persisted_turn_output(session, result.turn_id)
+        assert _OOC_STYLE_NOOP_SENTINEL not in (result.delivered_output or "")
+        # No note: delivered and persisted both the unmodified writer prose.
+        assert persisted == result.delivered_output
+        assert _OOC_STYLE_NOOP_SENTINEL not in (persisted or "")
+
+
 def _make_branching_orch_without_resolver(
     session_factory: object,
     *,
@@ -7431,6 +7744,47 @@ def _make_branching_orch_without_resolver(
         mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
         branching_writer_service=branching_writer,  # type: ignore[arg-type]
         # branching_session_resolver intentionally omitted (None).
+        branching_selection_service=BranchSelectionValidationService(),
+    )
+    return orch, writer, branching_writer
+
+
+def _make_branching_orch_with_resolver(
+    session_factory: object,
+    *,
+    intent_type: object,
+    raw_input: str,
+    resolver,  # type: ignore[no-untyped-def]
+):  # type: ignore[no-untyped-def]
+    """BRANCHING orchestrator with an injected ``branching_session_resolver``.
+
+    Lets callers wire a resolver that returns ``None`` or raises, to prove the
+    fail-closed guard fires before any writer routing.  Exposes both writer
+    fakes so callers can assert no narrative pass ran.
+    """
+    from afterworlds.models.enums import StoryMode
+    from afterworlds.pipeline.branching.selection import (
+        BranchSelectionValidationService,
+    )
+
+    writer = FakeWriterService()
+    branching_writer = _FakeBranchingWriterService()
+    orch = OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(intent_type, raw_input)  # type: ignore[arg-type]
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=writer,
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        branching_session_resolver=resolver,
         branching_selection_service=BranchSelectionValidationService(),
     )
     return orch, writer, branching_writer
@@ -7528,6 +7882,167 @@ class TestBranchingResolverRequired:
 
         assert result.disposition is PipelineDisposition.DELIVERED
         assert result.branching_pass_result is None
+
+    def test_in_character_action_resolver_returns_none_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Wired resolver returning None → PIPELINE_ERROR, no writer.
+
+        A wired resolver returning ``None`` means the Branching session row is
+        missing or corrupt.  The orchestrator must fail closed rather than
+        treat None as setup/FREEFORM_ONLY and downgrade to the prose Writer.
+        """
+        from afterworlds.models.enums import IntentType
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+
+        def _none_resolver(_sid: UUID) -> None:
+            return None
+
+        orch, writer, branching_writer = _make_branching_orch_with_resolver(
+            session_factory,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I press onward.",
+            resolver=_none_resolver,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I press onward.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "missing or corrupt" in summary, summary
+        assert writer.calls == []
+        assert branching_writer.called is False
+
+    def test_branch_choice_resolver_returns_none_fails_closed_before_rejection(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BRANCH_CHOICE + resolver None → PIPELINE_ERROR, not INTERACTION_REJECTED.
+
+        The None guard must precede TRUE_CYOA freeform rejection and branch
+        selection validation, both of which depend on the resolved state.
+        """
+        from afterworlds.models.enums import IntentType
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+
+        def _none_resolver(_sid: UUID) -> None:
+            return None
+
+        orch, writer, branching_writer = _make_branching_orch_with_resolver(
+            session_factory,
+            intent_type=IntentType.BRANCH_CHOICE,
+            raw_input="opt_1",
+            resolver=_none_resolver,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "missing or corrupt" in (result.pipeline_error_summary or "")
+        assert result.interaction_rejection_reason is None
+        assert writer.calls == []
+        assert branching_writer.called is False
+
+    def test_resolver_raises_fails_closed(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Resolver raising → PIPELINE_ERROR, no writer (existing guard control)."""
+        from afterworlds.models.enums import IntentType
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+
+        def _raising_resolver(_sid: UUID):  # type: ignore[no-untyped-def]
+            raise RuntimeError("session store unavailable")
+
+        orch, writer, branching_writer = _make_branching_orch_with_resolver(
+            session_factory,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            raw_input="I press onward.",
+            resolver=_raising_resolver,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I press onward.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "resolution failed" in (result.pipeline_error_summary or "")
+        assert writer.calls == []
+        assert branching_writer.called is False
+
+    def test_wired_resolver_setup_true_cyoa_still_delivers(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Positive control: setup TRUE_CYOA still routes through prose setup."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            play_status=BranchingPlayStatus.SETUP,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=_FakeBranchingWriterService(),
+            raw_input="Let's begin the tale.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Let's begin the tale.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.branching_pass_result is None
+
+    def test_wired_resolver_inplay_hybrid_still_reaches_rails(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Positive control: the None guard does not block a real in-play state.
+
+        A wired resolver returning a real in-play HYBRID session must still
+        reach the in-play BranchingWriter rail (proves the guard fires only on
+        None, not on every BRANCHING turn).
+        """
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        branching_writer = _FakeBranchingWriterService()
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=branching_writer,
+            raw_input="I press onward.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I press onward.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        # The rail is reached (BranchingWriter invoked); the None guard does not
+        # fire for a real in-play state.  The fake writer aborts, so the error
+        # here is the writer's, never the "missing or corrupt" state guard.
+        assert branching_writer.called is True
+        assert "missing or corrupt" not in (result.pipeline_error_summary or "")
 
 
 def _make_branching_choice_orch_without_selection(

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5746,10 +5746,14 @@ def _make_branching_choice_orchestrator(
     branching_writer: object,
     raw_input: str,
     interaction_style: object = None,
+    play_status: object = None,
 ):  # type: ignore[no-untyped-def]
-    """Orchestrator wired for an in-play BRANCH_CHOICE turn with selection validation.
+    """Orchestrator wired for a BRANCH_CHOICE turn with selection validation.
 
-    Defaults to HYBRID; pass ``interaction_style`` to exercise TRUE_CYOA routing.
+    Defaults to in-play HYBRID; pass ``interaction_style`` to exercise TRUE_CYOA
+    routing and ``play_status`` to exercise the SETUP path (where the in-play
+    branch-choice validation rail must not run even though the selection service
+    is wired and the classifier emitted BRANCH_CHOICE).
     """
     from afterworlds.models.enums import (
         BranchingCadence,
@@ -5767,6 +5771,9 @@ def _make_branching_choice_orchestrator(
     resolved_style = (
         InteractionStyle.HYBRID if interaction_style is None else interaction_style
     )
+    resolved_status = (
+        BranchingPlayStatus.IN_PLAY if play_status is None else play_status
+    )
 
     def _branching_resolver(sid: UUID) -> BranchingSessionState:
         return BranchingSessionState(
@@ -5774,7 +5781,7 @@ def _make_branching_choice_orchestrator(
             pacing_stage=PacingStage.ESCALATION,
             interaction_style=resolved_style,  # type: ignore[arg-type]
             branching_cadence=BranchingCadence.BALANCED,
-            play_status=BranchingPlayStatus.IN_PLAY,
+            play_status=resolved_status,  # type: ignore[arg-type]
         )
 
     return OrchestratorService(
@@ -7695,3 +7702,71 @@ class TestBranchChoiceValidationServiceRequired:
 
         assert result.disposition is PipelineDisposition.INTERACTION_REJECTED
         assert result.interaction_rejection_reason is not None
+
+    def test_setup_hybrid_wired_selection_service_routes_through_prose(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Setup HYBRID + classifier BRANCH_CHOICE + wired svc → prose, not rejection.
+
+        Branch-choice validation is an in-play rail.  Same invalid input that the
+        in-play positive control rejects (``test_wired_selection_service_invalid_
+        choice_still_rejected``) must NOT be validated during setup even though
+        the selection service is wired and the classifier emitted BRANCH_CHOICE;
+        the setup row routes through the prose setup-confirmation path instead.
+        """
+        from afterworlds.models.enums import BranchingPlayStatus, InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch = _make_branching_choice_orchestrator(
+            session_factory,
+            _FakeBranchingWriterService(),
+            "I wander off the map entirely",
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.SETUP,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I wander off the map entirely",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Setup did not run the in-play branch-choice validation rail.
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.interaction_rejection_reason is None
+
+    def test_setup_true_cyoa_wired_selection_service_routes_through_prose(
+        self, session_factory: object, session: object
+    ) -> None:
+        """Setup TRUE_CYOA + classifier BRANCH_CHOICE + wired svc → prose path.
+
+        Same in-play-only invariant as the HYBRID case: a setup TRUE_CYOA row
+        routes through prose setup confirmation rather than branch validation.
+        """
+        from afterworlds.models.enums import BranchingPlayStatus, InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        orch = _make_branching_choice_orchestrator(
+            session_factory,
+            _FakeBranchingWriterService(),
+            "I wander off the map entirely",
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            play_status=BranchingPlayStatus.SETUP,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I wander off the map entirely",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.interaction_rejection_reason is None

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -836,6 +836,258 @@ class TestOOCShortCircuit:
 
 
 # ---------------------------------------------------------------------------
+# Branching OOC config persistence strategy (Round 3 Fix 2)
+# ---------------------------------------------------------------------------
+
+
+from dataclasses import dataclass as _dataclass  # noqa: E402
+
+
+@_dataclass
+class _FakeBranchingOocExtractor:
+    """Returns a fixed BranchingOocConfigExtractorResult; never calls the provider."""
+
+    config_update: object
+
+    def extract(self, ctx: object, provider: object) -> object:
+        from afterworlds.pipeline.branching.models import (
+            BranchingOocConfigExtractorResult,
+        )
+
+        return BranchingOocConfigExtractorResult(
+            config_update=self.config_update,  # type: ignore[arg-type]
+            provider="fake",
+            model_identifier="fake-haiku",
+            model_tier="haiku",
+            latency_ms=5,
+            input_token_count=10,
+            output_token_count=5,
+        )
+
+
+def _make_ooc_cfg_orch(
+    session_factory: object, config_update: object
+) -> OrchestratorService:
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(make_intent(IntentType.OOC)),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(),
+        branching_ooc_config_extractor=_FakeBranchingOocExtractor(  # type: ignore[arg-type]
+            config_update
+        ),
+    )
+
+
+class TestBranchingOocConfigPersistence:
+    """Round 3 Fix 2: style-only OOC transitions respect persisted range compat."""
+
+    def _seed_bss(
+        self,
+        session: object,
+        story_id: UUID,
+        *,
+        interaction_style: object,
+        branch_count_range: object = None,
+    ) -> None:
+        from afterworlds.models.enums import PacingStage
+        from afterworlds.models.session import BranchingSessionState
+        from afterworlds.persistence.crud.session_state import (
+            create_branching_session_state,
+        )
+
+        bss = BranchingSessionState(
+            story_id=story_id,
+            pacing_stage=PacingStage.SETUP,
+            interaction_style=interaction_style,  # type: ignore[arg-type]
+            branch_count_range=branch_count_range,  # type: ignore[arg-type]
+        )
+        create_branching_session_state(session, bss)  # type: ignore[arg-type]
+        session.commit()  # type: ignore[union-attr]
+
+    def _read_bss(self, session: object, story_id: UUID) -> object:
+        from afterworlds.persistence.crud.session_state import (
+            get_branching_session_state_by_story,
+        )
+
+        session.expire_all()  # type: ignore[union-attr]
+        return get_branching_session_state_by_story(session, story_id)  # type: ignore[arg-type]
+
+    def test_hybrid_2_3_to_true_cyoa_no_range_persists_style_and_keeps_range(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID 2-3 → TRUE_CYOA (no range): style changes to TRUE_CYOA, 2-3 kept."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        self._seed_bss(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = self._read_bss(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.TRUE_CYOA
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+    def test_hybrid_3_4_to_true_cyoa_no_range_suppresses_style_change(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID 3-4 → TRUE_CYOA (no range): suppressed — 3-4 invalid for TRUE_CYOA."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        self._seed_bss(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.THREE_TO_FOUR,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = self._read_bss(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.HYBRID
+        assert bss.branch_count_range is BranchCountRange.THREE_TO_FOUR
+
+    def test_explicit_invalid_range_suppresses_style_does_not_fallback_to_persisted(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """Explicit invalid range: suppress style; no fallback to persisted range."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        self._seed_bss(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.THREE_TO_FOUR,
+            ),
+        )
+        orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to CYOA with 3-4",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = self._read_bss(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.HYBRID
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_THREE
+
+    def test_freeform_only_clears_range_unchanged(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """FREEFORM_ONLY: persists style and clears branch count range."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        self._seed_bss(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.FREEFORM_ONLY),
+        )
+        orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to freeform",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = self._read_bss(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.FREEFORM_ONLY
+        assert bss.branch_count_range is None
+
+    def test_explicit_valid_range_persists_style_and_range(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """Explicit valid range for target style: persists both style and range."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        self._seed_bss(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=None,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.TWO_TO_FOUR,
+            ),
+        )
+        orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to CYOA with 2-4",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = self._read_bss(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.TRUE_CYOA
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_FOUR
+
+
+# ---------------------------------------------------------------------------
 # RPG OOC state grounding (Round 5 Fix 3)
 # ---------------------------------------------------------------------------
 

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -6299,3 +6299,218 @@ class TestBranchingPassResultPreservedOnRefusal:
         assert result.disposition is PipelineDisposition.REFUSED_BY_PROVIDER
         # No branching writer ran; the field stays None (behavior unchanged).
         assert result.branching_pass_result is None
+
+
+# ---------------------------------------------------------------------------
+# Round 8 Finding 1: branch-card persistence is fail-closed on shown turns.
+#
+# For HYBRID/TRUE_CYOA turns that DELIVER selectable branch cards, the option
+# set persisted on the node is the authoritative source for later BRANCH_CHOICE
+# validation.  If persistence fails on a shown turn the orchestrator must fail
+# closed (PIPELINE_ERROR -> rollback) rather than deliver unbacked cards.  The
+# Phase G selected-edge write stays best-effort.
+# ---------------------------------------------------------------------------
+
+
+class TestBranchCardPersistenceFailClosed:
+    """Shown branch-card turns persist the authoritative option set or fail closed."""
+
+    def test_hybrid_shown_turn_persists_options_before_delivery(
+        self, session_factory: object, session: object
+    ) -> None:
+        """HYBRID + in_play DELIVER persists the shown option set on the node."""
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch, branching_writer = _make_branching_refusal_orchestrator(session_factory)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert branching_writer.called is True
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        assert [o.option_id for o in node.mode_metadata.branch_options] == [
+            "opt_1",
+            "opt_2",
+        ]
+        assert node.mode_metadata.branch_presentation_state == "shown"
+
+    def test_true_cyoa_shown_turn_persists_options_before_delivery(
+        self, session_factory: object, session: object
+    ) -> None:
+        """TRUE_CYOA + valid BRANCH_CHOICE DELIVER persists the shown option set."""
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _SuccessfulBranchingWriterService()
+        orch = _make_branching_choice_orchestrator(
+            session_factory,
+            writer,
+            "opt_1",
+            interaction_style=InteractionStyle.TRUE_CYOA,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is True
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        assert [o.option_id for o in node.mode_metadata.branch_options] == [
+            "opt_1",
+            "opt_2",
+        ]
+        assert node.mode_metadata.branch_presentation_state == "shown"
+
+    def test_shown_turn_persistence_failure_fails_closed(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A persistence fault on a shown turn → PIPELINE_ERROR, no delivered cards."""
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch, branching_writer = _make_branching_refusal_orchestrator(session_factory)
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("synthetic branch-option persistence failure")
+
+        # The only update_node on a HYBRID freeform turn is the branch-card write.
+        monkeypatch.setattr("afterworlds.persistence.crud.node.update_node", _boom)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "branch-card persistence failed" in summary, summary
+        assert "synthetic branch-option persistence failure" in summary, summary
+        # Failing closed means NOT surfacing the selectable cards.
+        assert result.branching_pass_result is None
+        # Transaction rolled back: no option set committed to the node.
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        assert node.mode_metadata.branch_options == []
+
+    def test_shown_turn_missing_node_fails_closed(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """A get_node miss on a shown turn → PIPELINE_ERROR, no delivered cards."""
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch, _branching_writer = _make_branching_refusal_orchestrator(session_factory)
+
+        # The branch-card persistence block re-fetches the node before writing;
+        # a missing row must fail closed rather than deliver unpersisted cards.
+        monkeypatch.setattr(
+            "afterworlds.persistence.crud.node.get_node",
+            lambda *args, **kwargs: None,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "branch-card persistence failed" in summary, summary
+        assert result.branching_pass_result is None
+
+    def test_persisted_option_set_drives_later_branch_choice(
+        self, session_factory: object, session: object
+    ) -> None:
+        """A later BRANCH_CHOICE validates against the orchestrator-persisted set."""
+        # Turn 1: HYBRID shown turn — seed carries NO options; the turn persists
+        # opt_1/opt_2 onto the node.
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        orch1, writer1 = _make_branching_refusal_orchestrator(session_factory)
+        r1 = orch1.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+        assert r1.disposition is PipelineDisposition.DELIVERED
+        assert writer1.called is True
+
+        # Turn 2: a valid opt_1 BRANCH_CHOICE reads the persisted set and proceeds.
+        writer2 = _RecordingBranchingWriterService()
+        orch2 = _make_branching_choice_orchestrator(session_factory, writer2, "opt_1")
+        r2 = orch2.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        # The seed carried no options; only the persisted set makes opt_1 valid.
+        assert writer2.called is True
+        assert r2.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "sentinel-reached-branching-writer" in (r2.pipeline_error_summary or "")
+        assert r2.interaction_rejection_reason is None
+
+    def test_phase_g_selected_edge_failure_is_non_blocking(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Selected-edge persistence failure stays best-effort once cards persisted."""
+        import afterworlds.persistence.crud.node as _node_crud
+        from afterworlds.models.node import BranchingNodeMetadata
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _SuccessfulBranchingWriterService()
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        real_update = _node_crud.update_node
+        calls = {"n": 0}
+
+        def _fail_on_selected_edge(sess: object, node: object) -> object:
+            # First update_node = branch-card persistence (must succeed); second =
+            # Phase G selected-edge persistence (forced to fail, best-effort).
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise RuntimeError("synthetic selected-edge persistence failure")
+            return real_update(sess, node)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(
+            "afterworlds.persistence.crud.node.update_node", _fail_on_selected_edge
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        # Card persistence succeeded; the selected-edge failure does not block.
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert calls["n"] >= 2
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = _node_crud.get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        # Authoritative option set committed …
+        assert [o.option_id for o in node.mode_metadata.branch_options] == [
+            "opt_1",
+            "opt_2",
+        ]
+        # … but the best-effort selection annotation was not.
+        assert node.mode_metadata.selected_option_id is None

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5562,6 +5562,7 @@ class TestBranchingWriterLineageGuard:
         from afterworlds.entitlement.enums import RuntimeAccessPath
         from afterworlds.models.enums import (
             BranchingCadence,
+            BranchingPlayStatus,
             IntentType,
             InteractionStyle,
             PacingStage,
@@ -5616,6 +5617,7 @@ class TestBranchingWriterLineageGuard:
                 pacing_stage=PacingStage.ESCALATION,
                 interaction_style=InteractionStyle.HYBRID,
                 branching_cadence=BranchingCadence.BALANCED,
+                play_status=BranchingPlayStatus.IN_PLAY,
             )
 
         fake_branching_writer = _FakeBranchingWriterService()
@@ -5730,10 +5732,15 @@ def _make_branching_choice_orchestrator(
     session_factory: object,
     branching_writer: object,
     raw_input: str,
+    interaction_style: object = None,
 ):  # type: ignore[no-untyped-def]
-    """Orchestrator wired for a HYBRID BRANCH_CHOICE turn with selection validation."""
+    """Orchestrator wired for an in-play BRANCH_CHOICE turn with selection validation.
+
+    Defaults to HYBRID; pass ``interaction_style`` to exercise TRUE_CYOA routing.
+    """
     from afterworlds.models.enums import (
         BranchingCadence,
+        BranchingPlayStatus,
         IntentType,
         InteractionStyle,
         PacingStage,
@@ -5744,12 +5751,17 @@ def _make_branching_choice_orchestrator(
         BranchSelectionValidationService,
     )
 
+    resolved_style = (
+        InteractionStyle.HYBRID if interaction_style is None else interaction_style
+    )
+
     def _branching_resolver(sid: UUID) -> BranchingSessionState:
         return BranchingSessionState(
             story_id=sid,
             pacing_stage=PacingStage.ESCALATION,
-            interaction_style=InteractionStyle.HYBRID,
+            interaction_style=resolved_style,  # type: ignore[arg-type]
             branching_cadence=BranchingCadence.BALANCED,
+            play_status=BranchingPlayStatus.IN_PLAY,
         )
 
     return OrchestratorService(
@@ -5854,3 +5866,436 @@ class TestBranchCardReadPath:
             result.pipeline_error_summary or ""
         )
         assert result.interaction_rejection_reason is None
+
+    def test_true_cyoa_in_play_valid_choice_proceeds_to_branching_writer(
+        self,
+        session_factory: object,
+        session: object,
+    ) -> None:
+        """TRUE_CYOA + in_play + valid opt_N still routes to the branching writer.
+
+        Finding 1 enumerates "HYBRID/TRUE_CYOA + in_play uses BranchingWriter".
+        Under TRUE_CYOA the only path that reaches the writer is a valid
+        BRANCH_CHOICE (freeform is rejected), so this exercises the selection
+        harness rather than the freeform routing harness.
+        """
+        from afterworlds.models.enums import InteractionStyle
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _RecordingBranchingWriterService()
+        orch = _make_branching_choice_orchestrator(
+            session_factory,
+            writer,
+            "opt_1",
+            interaction_style=InteractionStyle.TRUE_CYOA,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert writer.called is True
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert "sentinel-reached-branching-writer" in (
+            result.pipeline_error_summary or ""
+        )
+        assert result.interaction_rejection_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Round 7 Finding 1: in_play gating of interaction-style enforcement.
+#
+# Branching interaction-style enforcement (TRUE_CYOA freeform rejection and
+# HYBRID/TRUE_CYOA BranchingWriter routing) applies only when
+# play_status == IN_PLAY.  During setup, confirmation/clarification routes
+# through the ordinary prose Writer path per ADR-016 Decision 3.
+# ---------------------------------------------------------------------------
+
+
+class _SuccessfulBranchingWriterService:
+    """Branching writer fake that returns a complete, valid pass result.
+
+    Lets a HYBRID/TRUE_CYOA in-play turn proceed past the writer into the
+    downstream Extractor/Contradiction passes (used by the refusal-preservation
+    tests below).
+    """
+
+    def __init__(self) -> None:
+        self.called = False
+
+    def write(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+        from afterworlds.models.enums import BranchingCadence, InteractionStyle
+        from afterworlds.pipeline.branching.models import (
+            BranchingPassResult,
+            BranchOption,
+        )
+
+        self.called = True
+        return BranchingPassResult(
+            narrative_text="The corridor forks before you.",
+            interaction_style=InteractionStyle.HYBRID,
+            branching_cadence=BranchingCadence.BALANCED,
+            length_preference=None,
+            freeform_available=True,
+            branch_count_range=None,
+            branch_options=[
+                BranchOption(option_id="opt_1", action_text="Go left"),
+                BranchOption(option_id="opt_2", action_text="Go right"),
+            ],
+            branch_presentation_state="shown",
+            provider="anthropic",
+            model_identifier="claude-haiku-4-5",
+            model_tier="haiku",
+            latency_ms=7,
+        )
+
+
+def _make_branching_routing_orchestrator(
+    session_factory: object,
+    *,
+    interaction_style: object,
+    play_status: object,
+    intent_type: object,
+    branching_writer: object,
+    raw_input: str,
+):  # type: ignore[no-untyped-def]
+    """Orchestrator wired for a BRANCHING turn at a given style/play_status."""
+    from afterworlds.models.enums import (
+        BranchingCadence,
+        PacingStage,
+        StoryMode,
+    )
+    from afterworlds.models.session import BranchingSessionState
+
+    def _branching_resolver(sid: UUID) -> BranchingSessionState:
+        return BranchingSessionState(
+            story_id=sid,
+            pacing_stage=PacingStage.ESCALATION,
+            interaction_style=interaction_style,  # type: ignore[arg-type]
+            branching_cadence=BranchingCadence.BALANCED,
+            play_status=play_status,  # type: ignore[arg-type]
+        )
+
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(intent_type, raw_input)  # type: ignore[arg-type]
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        branching_session_resolver=_branching_resolver,
+    )
+
+
+class TestBranchingInPlayGating:
+    """Interaction-style enforcement is gated on play_status == IN_PLAY."""
+
+    def test_true_cyoa_setup_freeform_not_rejected(
+        self, session_factory: object, session: object
+    ) -> None:
+        """TRUE_CYOA + setup + non-branch input → prose Writer, not rejected."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            play_status=BranchingPlayStatus.SETUP,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input="Make the tone darker, please.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Make the tone darker, please.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Setup clarification is NOT rejected and routes through prose Writer.
+        assert result.disposition is not PipelineDisposition.INTERACTION_REJECTED
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.interaction_rejection_reason is None
+        assert writer.called is False
+
+    def test_true_cyoa_in_play_freeform_rejected(
+        self, session_factory: object, session: object
+    ) -> None:
+        """TRUE_CYOA + in_play + non-branch input → INTERACTION_REJECTED."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionRejectionReason,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.TRUE_CYOA,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input="I wander off the path on my own.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I wander off the path on my own.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.INTERACTION_REJECTED
+        assert (
+            result.interaction_rejection_reason
+            is InteractionRejectionReason.INVALID_FOR_INTERACTION_STYLE
+        )
+        assert writer.called is False
+
+    def test_hybrid_setup_uses_prose_writer(
+        self, session_factory: object, session: object
+    ) -> None:
+        """HYBRID + setup → prose Writer, BranchingWriter not reached."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.SETUP,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input="Yes, that premise sounds right.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Yes, that premise sounds right.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is False
+
+    def test_hybrid_in_play_uses_branching_writer(
+        self, session_factory: object, session: object
+    ) -> None:
+        """HYBRID + in_play → BranchingWriter is reached."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _RecordingBranchingWriterService()  # records + aborts
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.HYBRID,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input="I push deeper into the corridor.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I push deeper into the corridor.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert writer.called is True
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+
+    def test_freeform_only_in_play_unchanged_uses_prose_writer(
+        self, session_factory: object, session: object
+    ) -> None:
+        """FREEFORM_ONLY + in_play → prose Writer (never BranchingWriter)."""
+        from afterworlds.models.enums import (
+            BranchingPlayStatus,
+            IntentType,
+            InteractionStyle,
+        )
+
+        story_id, node_id = _seed_branching_story_with_options(session, [])
+        writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_routing_orchestrator(
+            session_factory,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            branching_writer=writer,
+            raw_input="I improvise and follow the sound.",
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I improvise and follow the sound.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.interaction_rejection_reason is None
+        assert writer.called is False
+
+
+# ---------------------------------------------------------------------------
+# Round 7 Finding 2: preserve branching_pass_result on downstream refusal.
+#
+# After a successful BranchingWriter pass, a downstream provider refusal
+# (Extractor refusal, or Contradiction refusal after Extractor succeeded)
+# must preserve the upstream successful ``branching_pass_result``.  Only the
+# failing downstream pass result remains absent.
+# ---------------------------------------------------------------------------
+
+
+def _make_branching_refusal_orchestrator(
+    session_factory: object,
+    *,
+    extractor_exc: Exception | None = None,
+    contradiction_exc: Exception | None = None,
+):  # type: ignore[no-untyped-def]
+    """BRANCHING HYBRID in-play orchestrator with a successful BranchingWriter."""
+    from afterworlds.models.enums import (
+        BranchingCadence,
+        BranchingPlayStatus,
+        IntentType,
+        InteractionStyle,
+        PacingStage,
+        StoryMode,
+    )
+    from afterworlds.models.session import BranchingSessionState
+
+    def _branching_resolver(sid: UUID) -> BranchingSessionState:
+        return BranchingSessionState(
+            story_id=sid,
+            pacing_stage=PacingStage.ESCALATION,
+            interaction_style=InteractionStyle.HYBRID,
+            branching_cadence=BranchingCadence.BALANCED,
+            play_status=BranchingPlayStatus.IN_PLAY,
+        )
+
+    branching_writer = _SuccessfulBranchingWriterService()
+    orch = OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(IntentType.IN_CHARACTER_ACTION, "I push deeper.")
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(raise_exc=extractor_exc),
+        contradiction_service=FakeContradictionService(raise_exc=contradiction_exc),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_writer_service=branching_writer,  # type: ignore[arg-type]
+        branching_session_resolver=_branching_resolver,
+    )
+    return orch, branching_writer
+
+
+class TestBranchingPassResultPreservedOnRefusal:
+    """Downstream refusals preserve the upstream branching_pass_result."""
+
+    def test_extractor_refusal_preserves_branching_pass_result(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BranchingWriter success + Extractor refusal → result preserved."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(
+            session_factory,
+            extractor_exc=make_refusal(PassIdentifier.EXTRACTOR),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.REFUSED_BY_PROVIDER
+        assert result.provider_refusal is not None
+        assert result.provider_refusal.pass_identifier is PassIdentifier.EXTRACTOR
+        assert branching_writer.called is True
+        # Upstream success preserved …
+        assert result.branching_pass_result is not None
+        assert result.writer_result is not None
+        # … failing downstream pass result remains absent.
+        assert result.extractor_result is None
+
+    def test_contradiction_refusal_preserves_branching_pass_result(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BranchingWriter + Extractor success + Contradiction refusal."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(
+            session_factory,
+            contradiction_exc=make_refusal(PassIdentifier.CONTRADICTION),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.REFUSED_BY_PROVIDER
+        assert result.provider_refusal is not None
+        assert result.provider_refusal.pass_identifier is PassIdentifier.CONTRADICTION
+        assert branching_writer.called is True
+        # Upstream successes preserved, including the Extractor that completed.
+        assert result.branching_pass_result is not None
+        assert result.extractor_result is not None
+        # Failing pass (Contradiction) result absent.
+        assert result.contradiction_result is None
+
+    def test_prose_writer_refusal_leaves_branching_pass_result_none(
+        self, session_factory: object, seeded_story: tuple[object, object]
+    ) -> None:
+        """Prose-Writer path: Extractor refusal carries no branching_pass_result."""
+        story_id, node_id = seeded_story
+        orch, *_ = _make_orchestrator(
+            session_factory,
+            extractor_exc=make_refusal(PassIdentifier.EXTRACTOR),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.REFUSED_BY_PROVIDER
+        # No branching writer ran; the field stays None (behavior unchanged).
+        assert result.branching_pass_result is None

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -6185,8 +6185,15 @@ def _make_branching_refusal_orchestrator(
     *,
     extractor_exc: Exception | None = None,
     contradiction_exc: Exception | None = None,
+    safety_output: object | None = None,
+    contradiction_violations: object | None = None,
 ):  # type: ignore[no-untyped-def]
-    """BRANCHING HYBRID in-play orchestrator with a successful BranchingWriter."""
+    """BRANCHING HYBRID in-play orchestrator with a successful BranchingWriter.
+
+    ``safety_output`` and ``contradiction_violations`` let the same harness drive
+    the downstream terminal paths (output-safety BLOCK, contradiction BLOCK)
+    exercised by the Round 9 Finding 3 preservation tests.
+    """
     from afterworlds.models.enums import (
         BranchingCadence,
         BranchingPlayStatus,
@@ -6212,11 +6219,14 @@ def _make_branching_refusal_orchestrator(
             make_intent(IntentType.IN_CHARACTER_ACTION, "I push deeper.")
         ),
         context_builder=FakeContextBuilder(),
-        safety_service=FakeSafetyService(),
+        safety_service=FakeSafetyService(output_verdict=safety_output),
         planner_service=FakePlannerService(),
         writer_service=FakeWriterService(),
         extractor_service=FakeExtractorService(raise_exc=extractor_exc),
-        contradiction_service=FakeContradictionService(raise_exc=contradiction_exc),
+        contradiction_service=FakeContradictionService(
+            raise_exc=contradiction_exc,
+            violations=contradiction_violations,  # type: ignore[arg-type]
+        ),
         session_factory=session_factory,  # type: ignore[arg-type]
         safety_policy=CapabilityProfileAwareSafetyPolicy(),
         provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
@@ -6403,8 +6413,15 @@ class TestBranchCardPersistenceFailClosed:
         summary = result.pipeline_error_summary or ""
         assert "branch-card persistence failed" in summary, summary
         assert "synthetic branch-option persistence failure" in summary, summary
-        # Failing closed means NOT surfacing the selectable cards.
-        assert result.branching_pass_result is None
+        # Owner decision (Round 9): branching_pass_result records that
+        # BranchingWriter ran and consumed provider tokens — it is a
+        # settlement/audit record, NOT the branch-card delivery signal.  It is
+        # preserved on this fail-closed path; delivery is gated by the
+        # PIPELINE_ERROR disposition plus the absence of deliverable state.
+        assert result.branching_pass_result is not None
+        # Failing closed means NOT surfacing selectable cards: no deliverable
+        # branch-card visible state is built.
+        assert result.branching_visible_state is None
         # Transaction rolled back: no option set committed to the node.
         with session_factory() as read_session:  # type: ignore[operator]
             node = get_node(read_session, node_id)
@@ -6436,7 +6453,10 @@ class TestBranchCardPersistenceFailClosed:
         assert result.disposition is PipelineDisposition.PIPELINE_ERROR
         summary = result.pipeline_error_summary or ""
         assert "branch-card persistence failed" in summary, summary
-        assert result.branching_pass_result is None
+        # Owner decision (Round 9): preserve the settlement/audit record; gate
+        # delivery on PIPELINE_ERROR + absence of deliverable branch-card state.
+        assert result.branching_pass_result is not None
+        assert result.branching_visible_state is None
 
     def test_persisted_option_set_drives_later_branch_choice(
         self, session_factory: object, session: object
@@ -6514,3 +6534,421 @@ class TestBranchCardPersistenceFailClosed:
         ]
         # … but the best-effort selection annotation was not.
         assert node.mode_metadata.selected_option_id is None
+
+
+# ---------------------------------------------------------------------------
+# Round 9 Finding 1: BRANCH_CHOICE node/story lineage guard.
+#
+# Before reading a node's branch-card options for BRANCH_CHOICE validation, the
+# node must be confirmed to belong to the current story.  A node from another
+# story must never have its option labels passed to the selection validator or
+# echoed in rejection text; a mismatch fails closed with a generic lineage
+# PIPELINE_ERROR, NOT an INVALID_BRANCH_SELECTION carrying foreign labels.
+#
+# The complementary scenarios are already covered elsewhere:
+# • valid same-story node still validates → TestBranchCardReadPath
+#   .test_valid_opt_n_proceeds_to_branching_writer
+# • same-story empty options → INVALID_BRANCH_SELECTION → TestBranchCardReadPath
+#   .test_empty_presented_options_after_read_rejects
+# • DB/session read failure → PIPELINE_ERROR → TestBranchCardReadPath
+#   .test_branch_card_read_failure_routes_to_pipeline_error
+# ---------------------------------------------------------------------------
+
+
+class TestBranchChoiceLineageGuard:
+    """A BRANCH_CHOICE node from another story fails closed before validation."""
+
+    def test_foreign_story_node_does_not_expose_option_labels(
+        self, session_factory: object, session: object
+    ) -> None:
+        """opt labels of a foreign-story node never reach validation or output."""
+        # Story A is the caller's story; story B owns the node carrying the
+        # distinctive option labels that must never leak.
+        story_a_id, _node_a_id = _seed_branching_story_with_options(session, [])
+        _story_b_id, node_b_id = _seed_branching_story_with_options(
+            session, ["FOREIGNLABEL_BRIDGE", "FOREIGNLABEL_RIVER"]
+        )
+        writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        result = orch.orchestrate_turn(
+            story_a_id, node_b_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        # Fails closed as a generic lineage PIPELINE_ERROR, not user-invalid.
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert result.interaction_rejection_reason is None
+        assert result.interaction_rejection_message is None
+        summary = result.pipeline_error_summary or ""
+        assert "lineage" in summary, summary
+        # The foreign option labels never surface anywhere in the result.
+        assert "FOREIGNLABEL" not in summary, summary
+        assert "FOREIGNLABEL" not in (result.delivered_output or "")
+        # No LLM call on the lineage-failure path.
+        assert writer.called is False
+
+    def test_foreign_story_node_fails_before_validation(
+        self, session_factory: object, session: object
+    ) -> None:
+        """A foreign-story node is rejected as lineage failure, never as input."""
+        story_a_id, _node_a_id = _seed_branching_story_with_options(session, [])
+        _story_b_id, node_b_id = _seed_branching_story_with_options(
+            session, ["Take the bridge", "Wade the river"]
+        )
+        writer = _FakeBranchingWriterService()  # must-not-call stub
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        result = orch.orchestrate_turn(
+            story_a_id, node_b_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        # The lineage check precedes selection validation entirely.
+        assert result.disposition is not PipelineDisposition.INTERACTION_REJECTED
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert writer.called is False
+
+
+# ---------------------------------------------------------------------------
+# Round 9 Finding 3: branching_pass_result preserved on downstream terminals.
+#
+# Owner decision: branching_pass_result is the settlement/audit record that
+# BranchingWriter ran and consumed provider tokens — NOT the branch-card
+# delivery signal.  Once BranchingWriter succeeds, every later terminal path
+# (output-safety BLOCK, contradiction BLOCK, downstream pipeline error) must
+# preserve it so the BRANCHING_WRITER pass is billed.  Prose-Writer turns carry
+# no branching_pass_result, so those terminals stay unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TestBranchingPassResultPreservedOnTerminals:
+    """Post-BranchingWriter terminal paths preserve the settlement/audit record."""
+
+    def test_output_safety_block_preserves_branching_pass_result(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BranchingWriter success + output-safety BLOCK → result preserved."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(
+            session_factory,
+            safety_output=_block_safety(SafetyTarget.OUTPUT),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.BLOCKED_OUTPUT_SAFETY
+        assert branching_writer.called is True
+        assert result.branching_pass_result is not None
+
+    def test_contradiction_block_preserves_branching_pass_result(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BranchingWriter + Extractor success + Contradiction BLOCK → preserved."""
+        violations = [
+            ContradictionViolation(
+                category=ContradictionCategory.LOCKED_FACT_VIOLATED,
+                description="locked fact violated",
+                canon_reference="locked_fact_id=123",
+            )
+        ]
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(
+            session_factory,
+            contradiction_violations=violations,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.BLOCKED_CONTRADICTION
+        assert branching_writer.called is True
+        assert result.branching_pass_result is not None
+        assert result.contradiction_result is not None
+
+    def test_turn_persistence_failure_preserves_branching_pass_result(
+        self,
+        session_factory: object,
+        session: object,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """BranchingWriter success + Turn-persistence fault → preserved record."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(session_factory)
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("synthetic branching turn persistence failure")
+
+        monkeypatch.setattr("afterworlds.persistence.crud.node.create_turn", _boom)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        summary = result.pipeline_error_summary or ""
+        assert "branching turn persistence failed" in summary, summary
+        assert branching_writer.called is True
+        # Settlement/audit record preserved even when the Turn could not persist.
+        assert result.branching_pass_result is not None
+
+    def test_downstream_pipeline_error_preserves_branching_pass_result(
+        self, session_factory: object, session: object
+    ) -> None:
+        """BranchingWriter success + non-refusal downstream fault → preserved."""
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Go left", "Go right"]
+        )
+        orch, branching_writer = _make_branching_refusal_orchestrator(
+            session_factory,
+            extractor_exc=RuntimeError("synthetic downstream extractor fault"),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I push deeper.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert branching_writer.called is True
+        assert result.branching_pass_result is not None
+
+    def test_prose_writer_output_block_leaves_branching_pass_result_none(
+        self, session_factory: object, seeded_story: tuple[object, object]
+    ) -> None:
+        """Prose-Writer output BLOCK carries no branching_pass_result (unchanged)."""
+        story_id, node_id = seeded_story
+        orch, *_ = _make_orchestrator(
+            session_factory,
+            safety_output=_block_safety(SafetyTarget.OUTPUT),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.BLOCKED_OUTPUT_SAFETY
+        assert result.branching_pass_result is None
+
+
+# ---------------------------------------------------------------------------
+# Round 9 Finding 2: suppressed OOC style switch surfaces an explicit non-
+# confirmation so the delivered prose cannot imply a change persistence did not
+# make.  When a requested switch to HYBRID/TRUE_CYOA lacks a compatible branch
+# range, the style is NOT persisted AND the delivered OOC output carries a
+# visible "Interaction style not changed" note.  Valid switches that DO persist
+# carry no such note.
+# ---------------------------------------------------------------------------
+
+
+def _seed_branching_session_state(
+    session: object,
+    story_id: UUID,
+    *,
+    interaction_style: object,
+    branch_count_range: object = None,
+) -> None:
+    """Seed a BranchingSessionState row for OOC config no-op tests."""
+    from afterworlds.models.enums import PacingStage
+    from afterworlds.models.session import BranchingSessionState
+    from afterworlds.persistence.crud.session_state import (
+        create_branching_session_state,
+    )
+
+    bss = BranchingSessionState(
+        story_id=story_id,
+        pacing_stage=PacingStage.SETUP,
+        interaction_style=interaction_style,  # type: ignore[arg-type]
+        branch_count_range=branch_count_range,  # type: ignore[arg-type]
+    )
+    create_branching_session_state(session, bss)  # type: ignore[arg-type]
+    session.commit()  # type: ignore[union-attr]
+
+
+def _read_branching_session_state(session: object, story_id: UUID) -> object:
+    from afterworlds.persistence.crud.session_state import (
+        get_branching_session_state_by_story,
+    )
+
+    session.expire_all()  # type: ignore[union-attr]
+    return get_branching_session_state_by_story(session, story_id)  # type: ignore[arg-type]
+
+
+_OOC_STYLE_NOOP_SENTINEL = "Interaction style not changed"
+
+
+class TestBranchingOocStyleNoopSurfaced:
+    """A suppressed OOC style switch is surfaced, never silently confirmed."""
+
+    def test_freeform_to_hybrid_no_range_surfaces_non_confirmation(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """FREEFORM_ONLY → HYBRID (no range): not persisted, note surfaced."""
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.HYBRID),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        # Persistence unchanged …
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.FREEFORM_ONLY
+        # … and the delivered prose surfaces the non-confirmation explicitly.
+        assert _OOC_STYLE_NOOP_SENTINEL in (result.delivered_output or "")
+        assert "hybrid" in (result.delivered_output or "")
+
+    def test_freeform_to_true_cyoa_no_range_surfaces_non_confirmation(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """FREEFORM_ONLY → TRUE_CYOA (no range): not persisted, note surfaced."""
+        from afterworlds.models.enums import InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.FREEFORM_ONLY
+        assert _OOC_STYLE_NOOP_SENTINEL in (result.delivered_output or "")
+        assert "true_cyoa" in (result.delivered_output or "")
+
+    def test_invalid_explicit_range_surfaces_non_confirmation(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID 2-3 → TRUE_CYOA + invalid 3-4: suppressed and surfaced."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.THREE_TO_FOUR,
+            ),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to CYOA with 3-4",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.HYBRID
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_THREE
+        assert _OOC_STYLE_NOOP_SENTINEL in (result.delivered_output or "")
+
+    def test_valid_persisted_range_style_switch_carries_no_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID 2-3 → TRUE_CYOA (no range): persists, no non-confirmation note."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(interaction_style=InteractionStyle.TRUE_CYOA),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to true CYOA",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.TRUE_CYOA
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_THREE
+        assert _OOC_STYLE_NOOP_SENTINEL not in (result.delivered_output or "")
+
+    def test_valid_explicit_style_and_range_carries_no_note(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """HYBRID 2-3 → TRUE_CYOA + valid 2-4: persists both, no note."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+        from afterworlds.pipeline.branching.models import BranchingConfigUpdate
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        orch = _make_ooc_cfg_orch(
+            session_factory,
+            BranchingConfigUpdate(
+                interaction_style=InteractionStyle.TRUE_CYOA,
+                branch_count_range=BranchCountRange.TWO_TO_FOUR,
+            ),
+        )
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to CYOA with 2-4",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        bss = _read_branching_session_state(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.TRUE_CYOA
+        assert bss.branch_count_range is BranchCountRange.TWO_TO_FOUR
+        assert _OOC_STYLE_NOOP_SENTINEL not in (result.delivered_output or "")

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -865,6 +865,36 @@ class _FakeBranchingOocExtractor:
         )
 
 
+@_dataclass
+class _TurnCapturingOocExtractor:
+    """Records the turn_id on the ScopedProviderAdapter handed to extract().
+
+    Returns an all-None config update so the best-effort persistence path is a
+    no-op; the test only asserts on the provider scope.
+    """
+
+    captured_turn_id: object = None
+    called: bool = False
+
+    def extract(self, ctx: object, provider: object) -> object:
+        from afterworlds.pipeline.branching.models import (
+            BranchingConfigUpdate,
+            BranchingOocConfigExtractorResult,
+        )
+
+        self.called = True
+        self.captured_turn_id = getattr(provider, "_turn_id", "MISSING")
+        return BranchingOocConfigExtractorResult(
+            config_update=BranchingConfigUpdate(),
+            provider="fake",
+            model_identifier="fake-haiku",
+            model_tier="haiku",
+            latency_ms=5,
+            input_token_count=10,
+            output_token_count=5,
+        )
+
+
 def _make_ooc_cfg_orch(
     session_factory: object, config_update: object
 ) -> OrchestratorService:
@@ -1085,6 +1115,51 @@ class TestBranchingOocConfigPersistence:
         assert bss is not None
         assert bss.interaction_style is InteractionStyle.TRUE_CYOA
         assert bss.branch_count_range is BranchCountRange.TWO_TO_FOUR
+
+    def test_config_extractor_provider_scoped_to_ooc_writer_turn(
+        self, session_factory, seeded_story, session
+    ) -> None:
+        """Round 6 Fix 2: the extractor's provider call is scoped to
+        writer_result.turn_id so any refusal/fallback/provider-call audit row
+        is reconstructable from the OOC turn (not an unscoped None)."""
+        from afterworlds.models.enums import BranchCountRange, InteractionStyle
+
+        story_id, node_id = seeded_story
+        self._seed_bss(
+            session,
+            story_id,
+            interaction_style=InteractionStyle.HYBRID,
+            branch_count_range=BranchCountRange.TWO_TO_THREE,
+        )
+
+        extractor = _TurnCapturingOocExtractor()
+        orch = OrchestratorService(
+            intent_classifier=FakeIntentClassifier(make_intent(IntentType.OOC)),
+            context_builder=FakeContextBuilder(),
+            safety_service=FakeSafetyService(),
+            planner_service=FakePlannerService(),
+            writer_service=FakeWriterService(),
+            extractor_service=FakeExtractorService(),
+            contradiction_service=FakeContradictionService(),
+            session_factory=session_factory,  # type: ignore[arg-type]
+            safety_policy=CapabilityProfileAwareSafetyPolicy(),
+            provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+            mode_resolver=fixed_mode_resolver(),
+            branching_ooc_config_extractor=extractor,  # type: ignore[arg-type]
+        )
+        orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] no config change",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert extractor.called
+        # The scoped turn id must be the OOC writer's persisted turn — proving
+        # turn_id=writer_result.turn_id flowed into the ScopedProviderAdapter.
+        assert extractor.captured_turn_id not in (None, "MISSING")
+        assert session.get(TurnORM, str(extractor.captured_turn_id)) is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -306,7 +306,7 @@ class TestDispositionOOCHandled:
         assert contradiction.calls == []
         assert writer.calls and writer.calls[0][
             0
-        ].stable_prefix.system_prompt.startswith("# OOC Handler")
+        ].stable_prefix.system_prompt.startswith("# Branching Mode OOC Handler")
 
 
 class TestDispositionBlockedInputSafety:
@@ -721,7 +721,9 @@ class TestOOCShortCircuit:
         )
         assert len(writer.calls) == 1
         derived_ctx = writer.calls[0][0]
-        assert derived_ctx.stable_prefix.system_prompt.startswith("# OOC Handler")
+        assert derived_ctx.stable_prefix.system_prompt.startswith(
+            "# Branching Mode OOC Handler"
+        )
 
     def test_ooc_persists_turn_with_ooc_intent(
         self, session_factory, seeded_story, session
@@ -815,10 +817,10 @@ class TestOOCShortCircuit:
         derived_ctx = writer.calls[0][0]
         assert derived_ctx.stable_prefix.system_prompt.startswith("# RPG OOC Handler")
 
-    def test_non_rpg_ooc_uses_generic_handler_prompt(
+    def test_branching_ooc_uses_branching_handler_prompt(
         self, session_factory, seeded_story
     ) -> None:
-        """Non-RPG mode OOC turns must still use the generic ooc_handler.md."""
+        """Branching mode OOC turns use the branching-specific ooc handler."""
         story_id, node_id = seeded_story
         orch, *_, writer, _, _ = _make_orchestrator(
             session_factory, intent=IntentType.OOC
@@ -828,7 +830,9 @@ class TestOOCShortCircuit:
         )
         assert len(writer.calls) == 1
         derived_ctx = writer.calls[0][0]
-        assert derived_ctx.stable_prefix.system_prompt.startswith("# OOC Handler")
+        assert derived_ctx.stable_prefix.system_prompt.startswith(
+            "# Branching Mode OOC Handler"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -7037,6 +7037,99 @@ class TestBranchCardPersistenceFailClosed:
 
 
 # ---------------------------------------------------------------------------
+# Round 16: selection provenance survives the next beat's branch-card overwrite.
+#
+# Option IDs (opt_1, …) are reused every beat.  Once a BRANCH_CHOICE turn
+# persists the *new* beat's branch_options, the bare selected_option_id no
+# longer identifies which option the Sojourner actually chose (a new opt_1 has
+# different action_text).  Phase G therefore persists selected_action_text from
+# the SelectedBranchContext so the prior selection stays reconstructable
+# independently of the current branch_options list.
+# ---------------------------------------------------------------------------
+
+
+class TestSelectionProvenanceSurvivesOverwrite:
+    """Phase G stores stable selected branch context, not just a reused ID."""
+
+    def test_shown_next_beat_preserves_prior_selected_action_text(
+        self, session_factory: object, session: object
+    ) -> None:
+        """New beat reuses opt_1; selected_action_text still names the prior choice."""
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        # Prior beat: opt_1 = "Open the red door", opt_2 = "Take the stairs".
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Open the red door", "Take the stairs"]
+        )
+        # New beat shows a fresh card set that REUSES opt_1 for a different action.
+        # The trailing "but I sneak past" annotates the selection.
+        writer = _PresentationBranchingWriterService(
+            "shown",
+            options=[("opt_1", "Ask the guard"), ("opt_2", "Patrol the hall")],
+        )
+        orch = _make_branching_choice_orchestrator(
+            session_factory, writer, "opt_1 but I sneak past"
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "opt_1 but I sneak past",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is True
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        # The new beat's option surface is the next valid choice set …
+        assert [
+            (o.option_id, o.action_text) for o in node.mode_metadata.branch_options
+        ] == [("opt_1", "Ask the guard"), ("opt_2", "Patrol the hall")]
+        # … yet the prior selection remains reconstructable: the stored action
+        # text is the PRIOR opt_1 ("Open the red door"), not the new opt_1.
+        assert node.mode_metadata.selected_option_id == "opt_1"
+        assert node.mode_metadata.selected_action_text == "Open the red door"
+        assert node.mode_metadata.selection_annotation == "I sneak past"
+
+    def test_held_next_beat_clears_options_but_preserves_selection(
+        self, session_factory: object, session: object
+    ) -> None:
+        """A held next beat clears branch_options; selection record still survives."""
+        from afterworlds.models.node import BranchingNodeMetadata
+        from afterworlds.persistence.crud.node import get_node
+
+        story_id, node_id = _seed_branching_story_with_options(
+            session, ["Open the red door", "Take the stairs"]
+        )
+        # Held beat carries no options (validator forbids non-empty held/omitted).
+        writer = _PresentationBranchingWriterService("held")
+        orch = _make_branching_choice_orchestrator(session_factory, writer, "opt_1")
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "opt_1", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert writer.called is True
+        with session_factory() as read_session:  # type: ignore[operator]
+            node = get_node(read_session, node_id)
+        assert node is not None
+        assert isinstance(node.mode_metadata, BranchingNodeMetadata)
+        # Stale options cleared and held state recorded …
+        assert node.mode_metadata.branch_options == []
+        assert node.mode_metadata.branch_presentation_state == "held"
+        # … but the selection record (id + action text + annotation) survives.
+        assert node.mode_metadata.selected_option_id == "opt_1"
+        assert node.mode_metadata.selected_action_text == "Open the red door"
+        assert node.mode_metadata.selection_annotation is None
+
+
+# ---------------------------------------------------------------------------
 # Round 10 Finding 1: held/omitted node metadata is authoritative.
 #
 # A HYBRID held/omitted beat must clear any prior beat's branch_options and

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -922,8 +922,55 @@ class _TurnCapturingOocExtractor:
         )
 
 
-def _make_ooc_cfg_orch(
-    session_factory: object, config_update: object
+@_dataclass
+class _UsageFailingOocExtractor:
+    """Raises BranchingOocExtractionUsageError carrying a usage-only result.
+
+    Simulates a provider call that returned (consuming tokens) but whose
+    response failed a local validation step.  The usage result carries token
+    metrics with an all-null config_update — no mutation is implied.
+    """
+
+    def extract(self, ctx: object, provider: object) -> object:
+        from afterworlds.pipeline.branching.models import (
+            BranchingConfigUpdate,
+            BranchingOocConfigExtractorResult,
+            BranchingOocExtractionUsageError,
+        )
+
+        usage = BranchingOocConfigExtractorResult(
+            config_update=BranchingConfigUpdate(),
+            provider="fake",
+            model_identifier="fake-haiku",
+            model_tier="haiku",
+            latency_ms=5,
+            input_token_count=10,
+            output_token_count=5,
+        )
+        raise BranchingOocExtractionUsageError(
+            "Branching OOC config extractor response missing tool-use block",
+            usage,
+        )
+
+
+@_dataclass
+class _PlainFailingOocExtractor:
+    """Raises a plain BranchingPassError with no usage (pre-provider-result).
+
+    Simulates a provider-call exception before any result existed: no tokens
+    were consumed, so no usage may be fabricated.
+    """
+
+    def extract(self, ctx: object, provider: object) -> object:
+        from afterworlds.pipeline.branching.models import BranchingPassError
+
+        raise BranchingPassError(
+            "Branching OOC config extractor provider call failed: boom"
+        )
+
+
+def _make_ooc_cfg_orch_with_extractor(
+    session_factory: object, extractor: object
 ) -> OrchestratorService:
     return OrchestratorService(
         intent_classifier=FakeIntentClassifier(make_intent(IntentType.OOC)),
@@ -937,9 +984,16 @@ def _make_ooc_cfg_orch(
         safety_policy=CapabilityProfileAwareSafetyPolicy(),
         provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
         mode_resolver=fixed_mode_resolver(),
-        branching_ooc_config_extractor=_FakeBranchingOocExtractor(  # type: ignore[arg-type]
-            config_update
-        ),
+        branching_ooc_config_extractor=extractor,  # type: ignore[arg-type]
+    )
+
+
+def _make_ooc_cfg_orch(
+    session_factory: object, config_update: object
+) -> OrchestratorService:
+    return _make_ooc_cfg_orch_with_extractor(
+        session_factory,
+        _FakeBranchingOocExtractor(config_update),
     )
 
 
@@ -3799,6 +3853,119 @@ class TestCommitFailurePreservesBranchingUsage:
         snapshots = TurnCostPolicy.extract_snapshots(snap_input)
         pass_ids = {snap.pass_id for snap in snapshots}
         assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR in pass_ids
+
+
+class TestOocExtractorLocalFailurePreservesUsage:
+    """Local post-provider extraction failure preserves OOC extractor usage.
+
+    When the OOC config extractor reaches the provider and gets a result, but a
+    local validation step (missing tool block / wrong tool name / schema
+    failure) then rejects it, the consumed tokens must survive: the OOC turn
+    still settles as OOC_HANDLED, the config mutation is skipped, and
+    ``branching_ooc_config_result`` carries the usage so settlement/audit sees a
+    BRANCHING_OOC_CONFIG_EXTRACTOR result.  A provider-call failure *before* any
+    result must NOT fabricate usage.
+    """
+
+    def _read_bss(self, session: object, story_id: object) -> object:
+        from afterworlds.persistence.crud.session_state import (
+            get_branching_session_state_by_story,
+        )
+
+        session.expire_all()  # type: ignore[union-attr]
+        return get_branching_session_state_by_story(session, story_id)  # type: ignore[arg-type]
+
+    def test_local_failure_preserves_usage_and_skips_config(
+        self, session_factory: object, seeded_story: tuple[object, object], session
+    ) -> None:
+        """Post-provider local failure → OOC_HANDLED, usage kept, config unchanged."""
+        from afterworlds.models.enums import InteractionStyle
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+        orch = _make_ooc_cfg_orch_with_extractor(
+            session_factory, _UsageFailingOocExtractor()
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.OOC_HANDLED
+        # Usage consumed before the local failure survives for settlement.
+        assert result.branching_ooc_config_result is not None
+        assert result.branching_ooc_config_result.input_token_count == 10
+        assert result.branching_ooc_config_result.output_token_count == 5
+        # The config mutation was skipped — the persisted style is unchanged.
+        bss = self._read_bss(session, story_id)
+        assert bss is not None
+        assert bss.interaction_style is InteractionStyle.FREEFORM_ONLY
+
+    def test_local_failure_usage_visible_to_cost_policy_snapshot(
+        self, session_factory: object, seeded_story: tuple[object, object], session
+    ) -> None:
+        """Preserved usage yields a BRANCHING_OOC_CONFIG_EXTRACTOR snapshot."""
+        from afterworlds.entitlement.enums import PipelinePassId
+        from afterworlds.entitlement.policy import TurnCostPolicy
+        from afterworlds.models.enums import InteractionStyle
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+        orch = _make_ooc_cfg_orch_with_extractor(
+            session_factory, _UsageFailingOocExtractor()
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.OOC_HANDLED
+        # Drop token-less Fake Safety passes so the assertion isolates the
+        # preserved OOC-config usage invariant.
+        snap_input = result.model_copy(
+            update={"input_safety_result": None, "output_safety_result": None}
+        )
+        snapshots = TurnCostPolicy.extract_snapshots(snap_input)
+        pass_ids = {snap.pass_id for snap in snapshots}
+        assert PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR in pass_ids
+
+    def test_provider_call_failure_fabricates_no_usage(
+        self, session_factory: object, seeded_story: tuple[object, object], session
+    ) -> None:
+        """A pre-result provider failure leaves branching_ooc_config_result None."""
+        from afterworlds.models.enums import InteractionStyle
+
+        story_id, node_id = seeded_story
+        _seed_branching_session_state(
+            session, story_id, interaction_style=InteractionStyle.FREEFORM_ONLY
+        )
+        orch = _make_ooc_cfg_orch_with_extractor(
+            session_factory, _PlainFailingOocExtractor()
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "[OOC] Switch to hybrid",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.OOC_HANDLED
+        # No provider result existed, so no usage may be fabricated.
+        assert result.branching_ooc_config_result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/provider/test_adapters.py
+++ b/tests/pipeline/provider/test_adapters.py
@@ -990,3 +990,49 @@ def test_all_pipeline_pass_ids_have_pass_profile_entry() -> None:
             f"PipelinePassId.{pass_id} is missing from _PASS_PROFILE — "
             "add it before adding new passes to the pipeline"
         )
+
+
+# ---------------------------------------------------------------------------
+# Round 6 (CRD Issue 16): BRANCHING_OOC_CONFIG_EXTRACTOR refusal identity.
+# The adapter resolves the PassIdentifier *before* it can build
+# ProviderRefusalError, so an omission raised KeyError inside call(), losing
+# the typed refusal and defeating fallback/refusal logging.
+# ---------------------------------------------------------------------------
+
+
+def test_pass_identifier_branching_ooc_extractor_mapped() -> None:
+    """A refusal on BRANCHING_OOC_CONFIG_EXTRACTOR resolves to its own typed
+    identity (not a KeyError, not the PLANNER fallback)."""
+    from afterworlds.pipeline._refusal import PassIdentifier
+    from afterworlds.pipeline.provider.adapters._anthropic import (
+        _pass_id_to_pass_identifier,
+    )
+
+    result = _pass_id_to_pass_identifier(PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR)
+    assert result is PassIdentifier.BRANCHING_OOC_CONFIG_EXTRACTOR
+
+
+def test_all_pipeline_pass_ids_have_pass_identifier_mapping() -> None:
+    """Regression: every PipelinePassId an adapter may classify as a refusal must
+    map to a PassIdentifier so the shared _pass_id_to_pass_identifier never raises
+    KeyError mid-refusal.  Both the Anthropic and OpenRouter adapters use this
+    exact function, so this guards refusal identity on both paths."""
+    from afterworlds.pipeline.provider.adapters._anthropic import (
+        _pass_id_to_pass_identifier,
+    )
+
+    for pass_id in PipelinePassId:
+        # Must not raise KeyError.
+        assert _pass_id_to_pass_identifier(pass_id) is not None
+
+
+def test_openrouter_uses_same_pass_identifier_mapper() -> None:
+    """The OpenRouter adapter classifies refusals through the *same* mapper as
+    the Anthropic adapter, so the BRANCHING_OOC_CONFIG_EXTRACTOR identity (and
+    the no-KeyError guarantee) holds equivalently on the OpenRouter path."""
+    from afterworlds.pipeline.provider.adapters import _anthropic, _openrouter
+
+    assert (
+        _openrouter._pass_id_to_pass_identifier
+        is _anthropic._pass_id_to_pass_identifier
+    )

--- a/tests/pipeline/provider/test_adapters.py
+++ b/tests/pipeline/provider/test_adapters.py
@@ -931,3 +931,62 @@ def test_pass_identifier_rpg_adjudication_mapped() -> None:
 
     result = _pass_id_to_pass_identifier(PipelinePassId.RPG_ADJUDICATION)
     assert result is PassIdentifier.RPG_ADJUDICATION
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 (Round 2, CRD Issue 16): BRANCHING_WRITER and
+# BRANCHING_OOC_CONFIG_EXTRACTOR registered in all provider maps
+# ---------------------------------------------------------------------------
+
+
+def test_model_for_branching_writer_returns_sonnet_model() -> None:
+    """BRANCHING_WRITER must be in _PASS_PROFILE — no KeyError."""
+    profile = AnthropicCapabilityProfile()
+    model = profile.model_for(PipelinePassId.BRANCHING_WRITER)
+    assert "sonnet" in model.lower()
+
+
+def test_tier_for_branching_writer_returns_sonnet() -> None:
+    """BRANCHING_WRITER defaults to SONNET tier."""
+    profile = AnthropicCapabilityProfile()
+    assert profile.tier_for(PipelinePassId.BRANCHING_WRITER) is ModelTier.SONNET
+
+
+def test_model_for_branching_ooc_extractor_returns_haiku_model() -> None:
+    """BRANCHING_OOC_CONFIG_EXTRACTOR must be in _PASS_PROFILE — no KeyError."""
+    profile = AnthropicCapabilityProfile()
+    model = profile.model_for(PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR)
+    assert "haiku" in model.lower()
+
+
+def test_tier_for_branching_ooc_extractor_returns_haiku() -> None:
+    """BRANCHING_OOC_CONFIG_EXTRACTOR defaults to HAIKU tier."""
+    profile = AnthropicCapabilityProfile()
+    assert (
+        profile.tier_for(PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR)
+        is ModelTier.HAIKU
+    )
+
+
+def test_pass_identifier_branching_writer_explicitly_mapped() -> None:
+    """_pass_id_to_pass_identifier maps BRANCHING_WRITER to BRANCHING_WRITER
+    (not silently to the PLANNER default)."""
+    from afterworlds.pipeline._refusal import PassIdentifier
+    from afterworlds.pipeline.provider.adapters._anthropic import (
+        _pass_id_to_pass_identifier,
+    )
+
+    result = _pass_id_to_pass_identifier(PipelinePassId.BRANCHING_WRITER)
+    assert result is PassIdentifier.BRANCHING_WRITER
+
+
+def test_all_pipeline_pass_ids_have_pass_profile_entry() -> None:
+    """Regression: every PipelinePassId must have a _PASS_PROFILE entry so that
+    AnthropicCapabilityProfile.model_for() and tier_for() never raise KeyError."""
+    from afterworlds.pipeline.provider.adapters._anthropic import _PASS_PROFILE
+
+    for pass_id in PipelinePassId:
+        assert pass_id in _PASS_PROFILE, (
+            f"PipelinePassId.{pass_id} is missing from _PASS_PROFILE — "
+            "add it before adding new passes to the pipeline"
+        )

--- a/tests/pipeline/provider/test_refusal_log_writer.py
+++ b/tests/pipeline/provider/test_refusal_log_writer.py
@@ -616,3 +616,65 @@ def test_output_safety_refusal_log_row_has_writer_turn_id(sf) -> None:  # type: 
         assert row.fallback_outcome == "NO_FALLBACK_CONFIGURED"
         assert row.pass_id == "output_safety"
         assert row.turn_id == str(writer_turn_id)
+
+
+# ---------------------------------------------------------------------------
+# Round 6 (CRD Issue 16): Branching OOC config extractor refusal is logged with
+# its own pass identity (the literal "refusal/fallback logging receives the pass
+# identity" requirement, end-to-end through the router and writer).
+# ---------------------------------------------------------------------------
+
+
+class _RefusingBranchingOocExtractor:
+    """Primary that refuses a BRANCHING_OOC_CONFIG_EXTRACTOR call.
+
+    Stands in for the adapter once ``_pass_id_to_pass_identifier`` has resolved
+    the typed identity (no KeyError); this test exercises the logging half — that
+    the new pass_id value persists in the append-only ``provider_refusal_log``.
+    """
+
+    provider_name = "anthropic"
+
+    def call(self, request: ProviderCallRequest) -> ProviderCallResult:
+        raise ProviderRefusalError(
+            ProviderRefusal(
+                provider="anthropic",
+                model="claude-haiku-4-5",
+                pass_identifier=PassIdentifier.BRANCHING_OOC_CONFIG_EXTRACTOR,
+                refusal_category=RefusalCategory.CONTENT_POLICY,
+            )
+        )
+
+
+def test_branching_ooc_extractor_refusal_logged_with_pass_id(sf) -> None:  # type: ignore[no-untyped-def]
+    """A BRANCHING_OOC_CONFIG_EXTRACTOR refusal persists one log row whose pass_id
+    is the extractor's own value (proves the String(32) column accepts it and the
+    refusal/fallback logger receives this pass identity, scoped to the OOC turn)."""
+    from uuid import uuid4
+
+    sojourner_id = uuid4()
+    ooc_turn_id = uuid4()
+    log_fn = _build_refusal_log_fn(sf)
+    router = RefusalFallbackRouter(
+        primary=_RefusingBranchingOocExtractor(),
+        fallback=None,
+        refusal_log_fn=log_fn,
+    )
+    scoped = ScopedProviderAdapter(router, sojourner_id, turn_id=ooc_turn_id)
+    request = ProviderCallRequest(
+        pass_id=PipelinePassId.BRANCHING_OOC_CONFIG_EXTRACTOR,
+        system_blocks=[],
+        rendered_blocks=[],
+        max_output_tokens=1000,
+    )
+    with pytest.raises(ProviderRefusalError):
+        scoped.call(request)
+
+    assert _count_rows(sf) == 1
+    assert callable(sf)
+    with sf() as session:
+        row = session.execute(select(ProviderRefusalEvent)).scalar_one()
+        assert row.fallback_outcome == "NO_FALLBACK_CONFIGURED"
+        assert row.pass_id == "branching_ooc_config_extractor"
+        assert row.turn_id == str(ooc_turn_id)
+        assert row.sojourner_id == str(sojourner_id)


### PR DESCRIPTION
## What was built

CRD Issue 16 — Branching Mode Integration.  Ships the complete typed output
contract, code-owned affordance enforcement, persisted interaction
configuration, the general Branching rejection disposition, branch-choice
resolution, and the Branching OOC configuration path.

### Seven phases / seven decisions (ADR-016)

| Phase | Decision | What ships |
|---|---|---|
| A | 1 | `BranchingWriterService` (forced tool use, `produce_branch_output`) for HYBRID / TRUE_CYOA; FREEFORM_ONLY stays on prose `WriterService` |
| B | 2 | `PipelineDisposition.INTERACTION_REJECTED` with 4 typed `InteractionRejectionReason` values; non-billable; wired in orchestrator |
| C | 3 | Branching setup phase → ordinary `DELIVERED` turn (prose `WriterService`); no special disposition |
| D | 2 | `BranchSelectionValidationService` — deterministic 3-step resolution (explicit opt_N, numeric phrase, ordinal word); `SelectedBranchContext` threaded to Writer |
| E | 6 | `BranchingVisibleState` code-derived snapshot surfaced in `OrchestrationResult` on DELIVERED BRANCHING turns |
| F | 4 | `BranchingOocConfigExtractorService` — forced-tool extraction inside OOC transaction; validated against `ALLOWED_RANGES_BY_STYLE`; best-effort |
| G | 6 | Selection edge: writes `selected_option_id` + `selection_annotation` to `Node.mode_metadata.branching`; best-effort |

### New files (16)
`pipeline/branching/__init__.py`, `caller.py`, `config.py`, `models.py`,
`service.py`, `selection.py`, `ooc_config_extractor.py`, `visible_state.py`  
`docs/prompts/branching_ooc_handler.md`  
`docs/decisions/adr-016-branching-mode.md`  
`alembic/versions/0012_branching_mode.py`  
`tests/pipeline/branching/test_models.py`, `test_service.py`,
`test_selection.py`, `test_visible_state.py`, `test_ooc_config_extractor.py`

### Modified files (11)
`models/enums.py`, `models/node.py`, `models/session.py`,
`persistence/orm/session_state.py`, `persistence/crud/session_state.py`,
`entitlement/enums.py`, `pipeline/_refusal.py`,
`pipeline/orchestrator/models.py`, `pipeline/orchestrator/service.py`,
`docs/architecture/known_unknowns.md`, `pyproject.toml`

---

## Acceptance criteria coverage

| Criterion | Status |
|---|---|
| `BranchingWriterService` forced-tool pass for HYBRID/TRUE_CYOA | ✅ |
| `INTERACTION_REJECTED` disposition + 4 typed reasons | ✅ |
| `BranchSelectionValidationService` option-existence + annotation | ✅ |
| `SelectedBranchContext` threaded to Writer | ✅ |
| Phase G selection-edge persistence (mode_metadata.branching) | ✅ |
| `BranchingOocConfigExtractorService` Phase F + `ALLOWED_RANGES_BY_STYLE` | ✅ |
| `BranchingVisibleState` code-derived, surfaced in OrchestrationResult | ✅ |
| Migration 0012 conservative backfill (all new cols nullable) | ✅ |
| `BranchTree`/`BranchNode` left dormant, not activated | ✅ |
| `BranchingCadence` distinct from `PacingStage` (disjoint values) | ✅ |
| Branching OOC handler prompt wired (Known Unknown RESOLVED) | ✅ |
| ADR-016 written | ✅ |

---

## Test coverage summary

- **Total suite**: 1616 passed, 10 skipped, 88.32% coverage (gate ≥80% ✅)
- **Branching package** (`pipeline/branching/`): all files ≥94%
  - `ooc_config_extractor.py`: 100% (14 tests across happy path, fail paths, request shape)
  - `config.py`: 100%
  - `models.py`: 100%
  - `service.py`: 94%
  - `selection.py`: 97%
  - `visible_state.py`: 100%

---

## Architecture Notes

### No drift on load-bearing invariants

- **Invariant 9** (RPG sheets first-class): Branching adds a parallel first-class
  structure (`BranchingSessionState`, `BranchingNodeMetadata`). No RPG/Branching
  contamination.
- **Invariant 10** (deterministic rails code-owned): `option_id` sequential,
  `freeform_available` derived from `interaction_style`, affordances absent from
  tool schema. Code owns; model proposes prose only.
- **Invariant 7** (stable prefix assembled once): `BranchingWriterService._render`
  calls `render_stable_prefix_blocks` once and appends volatile suffix separately.
  No per-pass rebuild.

### Explicit v1 deferrals (per ADR-016)

1. **`BranchTree`/`BranchNode` graph traversal deferred** (ADR-016 Decision 6).
   Structurally present, not written to or read by the Issue 16 pipeline.
   Future-implementor labeled-edge shape documented in ADR:
   `{"option_id": "opt_1", "target_node_id": "<UUID>"}`.

2. **`Node.branching_logic` NOT written** (ADR-016 Decision 6).
   Phase G writes `selected_option_id` + `selection_annotation` to
   `Node.mode_metadata.branching` only. Full graph-edge realization is a future
   migration.

3. **`MATERIAL_BRANCH_REWRITE` and `CANON_OR_GENRE_CONTRADICTION` defined but not
   emitted in v1** (ADR-016 Decision 2). Both enum values are defined in
   `InteractionRejectionReason` so the rejection surface is stable; narrow
   forced-tool annotation validation is reserved for future expansion.

4. **`ClassificationHints` not wired** (ADR-016 Decision 2). The Issue 7
   classifier does not receive hints about interaction style. A Sojourner who
   writes "Cross the bridge" in TRUE_CYOA receives `INVALID_FOR_INTERACTION_STYLE`.
   Documented as Known Unknown.

5. **Phase F and Phase G are both best-effort** — extractor or node-update failure
   is swallowed with `except Exception: pass`. `OOC_HANDLED` / `DELIVERED` delivery
   is never blocked by these passes.

### Conservative backfill (ADR-016 Decision 5)
All 11 new interaction-configuration and setup-context columns added in migration
0012 are nullable with NULL server default (except `play_status` which defaults to
`"setup"`). Existing rows are never silently assigned `"freeform_only"`.

### Pre-existing CVEs (not introduced by this branch)
`pip-audit` reports `PYSEC-2026-141` and `PYSEC-2026-142` against `urllib3`.
These were present on `main` before this branch and are not introduced here.


### Round-2 remediation (commit fbbf317)

Three Codex P1/P2 findings corrected as in-scope Issue 16 defects:

**Fix 1 - Branching pass IDs registered in all provider-adapter maps**
`PipelinePassId.BRANCHING_WRITER` and `BRANCHING_OOC_CONFIG_EXTRACTOR` were absent from `_PASS_PROFILE` (AnthropicCapabilityProfile), `PASS_TIER_DEFAULTS` (entitlement/policy), and `_pass_id_to_pass_identifier` (used by both Anthropic and OpenRouter adapters). Absent entries cause a bare `dict[pass_id]` KeyError at call time. Both entries added; `.get(pass_id, PLANNER)` fallback replaced with bare `_MAP[pass_id]` to fail loudly on any future unknown ID. `BRANCHING_OOC_CONFIG_EXTRACTOR` is intentionally absent from the refusal map (the extractor service wraps `ProviderRefusalError` as `BranchingPassError`; omitting it means any future leakage surfaces as a loud KeyError, not a silent PLANNER misattribution).

**Fix 2 - OOC config extractor provider usage surfaced for settlement**
`BranchingOocConfigExtractorService.extract()` previously discarded all `ProviderCallResult` metrics and returned a bare `BranchingConfigUpdate`. Introduces `BranchingOocConfigExtractorResult` (provider + model + tier + latency + token counts) mirroring `BranchingPassResult`. `OrchestrationResult` gains `branching_ooc_config_result: Any | None`. `_ooc_persist()` stores the result immediately after the provider call so usage is visible to settlement even if a later best-effort persistence step fails. `TurnCostPolicy.extract_snapshots()` now produces `BRANCHING_WRITER` and `BRANCHING_OOC_CONFIG_EXTRACTOR` snapshots, closing the invariant-11 gap for both branching pass types.

**Fix 3 - True CYOA empty-card invariant enforced**
`_validate_branch_count()` accepted `held`/`omitted` + `[]` for any interaction style. For `TRUE_CYOA`, there is no freeform input surface when branch cards are absent; the model must always return `shown` with valid options on every in-play beat. `interaction_style: InteractionStyle | None = None` added; `BranchingPassError` is raised when `TRUE_CYOA` + `held`/`omitted` is detected. `HYBRID` + `held`/`omitted` + `[]` remains allowed (unchanged).
🤖 Generated with [Claude Code](https://claude.com/claude-code)

