### PR TITLE
feat(retrieval): implement ADR-018 Retrieval Memory (CRD Issue 18 Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,25 @@ jobs:
         # auditing, so we are temporarily ignoring this CVE to keep the audit gate
         # usable. Remove this ignore once pip ships a fixed release and CI is pinned
         # or upgraded to that version.
-        # CVE-2026-45829: vulnerability in chromadb 1.5.9. pip-audit currently reports
-        # no fix version — no patched ChromaDB release exists upstream as of 2026-06-05.
-        # ChromaDB is actively used by the ingestion subsystem (ingestion_service.py,
-        # vector_writer.py); removing it from [project].dependencies now would break
-        # those imports and the ingestion test suite. Owner decision (2026-06-05):
-        # defer this CVE to CRD Issue 18, which owns the chromadb dependency design
-        # and will resolve it — either by upgrading to a patched release or by scoping
-        # chromadb as an optional dependency with a defined safe deployment path.
-        # Remove this --ignore-vuln only when Issue 18 closes this out.
+        # CVE-2026-45829 / PYSEC-2026-311 / GHSA-f4j7-r4q5-qw2c: pre-auth code-injection
+        # in chromadb's HTTP server component — an unauthenticated attacker can run
+        # arbitrary code via a malicious model repository with trust_remote_code=True
+        # on the `/api/v2/tenants/{tenant}/databases/{db}/collections` endpoint. No
+        # patched release exists upstream as of 2026-07-05 (affects every chromadb
+        # release 1.0.0-1.5.9 inclusive).
+        #
+        # CRD Issue 18 / ADR-018 resolution (safe-deployment-path, dependency kept —
+        # not scoped optional, since Retrieval Memory is a first-class memory layer
+        # required on every access path per CLAUDE.md invariant 2 / the BYOK-parity
+        # business invariant): the vulnerable surface is chromadb's standalone HTTP
+        # server (`chromadb run` / `HttpClient`) plus trust_remote_code=True on an
+        # embedding function. Afterworlds never runs that server process and never
+        # sets trust_remote_code=True anywhere — every client is constructed via
+        # `pipeline/retrieval/client.py::build_chroma_client`, which only ever
+        # returns an embedded `PersistentClient`/`EphemeralClient`. See that module
+        # and `pipeline/retrieval/config.py::RetrievalMemoryConfig` for the enforced
+        # boundary, and this PR's Architecture Notes for the full write-up. Re-justified
+        # (not silently preserved) per ADR-018's Phase 2 CVE-closure requirement.
+        # Revisit if chromadb ships a patched release, or if a server-mode deployment
+        # is ever proposed (which would require a new safe-deployment review).
         run: pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -18,6 +18,7 @@ import afterworlds.persistence.orm.story_bible  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.rolling_summary  # noqa: F401
 import afterworlds.persistence.orm.rpg  # noqa: F401
+import afterworlds.persistence.orm.retrieval  # noqa: F401
 import afterworlds.entitlement.orm  # noqa: F401
 import afterworlds.pipeline.provider.credentials._metadata  # noqa: F401
 import afterworlds.pipeline.provider._route_config  # noqa: F401

--- a/alembic/versions/0015_retrieval_memory_markers.py
+++ b/alembic/versions/0015_retrieval_memory_markers.py
@@ -1,0 +1,82 @@
+"""Retrieval Memory — RPG turn-category markers + marker-era boundary.
+
+CRD Issue 18 / ADR-018 D6.
+
+Adds ``rpg_turn_retrieval_markers``, a sidecar table (not columns on ``turns``)
+recording, for each post-boundary RPG narrative-path DELIVERED turn, whether
+it is ordinary narrative, a roll-request announce turn, or a setup-
+confirmation turn. Only the retrieval-eligibility predicate reads this table.
+
+Also adds ``retrieval_marker_era_boundary``, a singleton row recording the
+maximum ``turns.timestamp`` observed at migration-apply time (or NULL if no
+turns exist yet). Turns at/before this boundary are legacy — a missing
+marker there is expected and is treated as ORDINARY_NARRATIVE. Turns after
+this boundary are required to have exactly one marker row; a markerless
+post-boundary narrative-path DELIVERED turn is a data-integrity error, never
+silently treated as ORDINARY_NARRATIVE.
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-07-05
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0015"
+down_revision: str | None = "0014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rpg_turn_retrieval_markers",
+        sa.Column("turn_id", sa.String(36), primary_key=True),
+        sa.Column("story_id", sa.String(36), nullable=False),
+        sa.Column("category", sa.String(32), nullable=False),
+        sa.Column("created_at", sa.String(64), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["turn_id"], ["turns.turn_id"], ondelete="CASCADE"
+        ),
+    )
+    op.create_index(
+        "ix_rpg_turn_retrieval_markers_story_id",
+        "rpg_turn_retrieval_markers",
+        ["story_id"],
+    )
+
+    op.create_table(
+        "retrieval_marker_era_boundary",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("boundary_timestamp", sa.String(64), nullable=True),
+    )
+
+    # Forward-only boundary snapshot: the maximum timestamp among turns that
+    # already exist as of this migration. Never re-run, never updated after
+    # this single insert — legacy turns are never retroactively stamped.
+    connection = op.get_bind()
+    max_timestamp = connection.execute(
+        sa.text("SELECT MAX(timestamp) FROM turns")
+    ).scalar()
+    connection.execute(
+        sa.text(
+            "INSERT INTO retrieval_marker_era_boundary (id, boundary_timestamp) "
+            "VALUES (1, :boundary_timestamp)"
+        ),
+        {"boundary_timestamp": max_timestamp},
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("retrieval_marker_era_boundary")
+    op.drop_index(
+        "ix_rpg_turn_retrieval_markers_story_id",
+        table_name="rpg_turn_retrieval_markers",
+    )
+    op.drop_table("rpg_turn_retrieval_markers")

--- a/scripts/retrieval_backfill.py
+++ b/scripts/retrieval_backfill.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""CLI script — backfill or reindex Retrieval Memory for one story.
+
+CRD Issue 18 / ADR-018 D7: recovery for a Chroma write failure is a re-run;
+this script is the idempotent manual backfill/reindex path.
+
+Usage
+-----
+    python scripts/retrieval_backfill.py --story-id <uuid> --mode backfill \\
+        --chroma-path .chroma_data --db-url sqlite:///afterworlds.db
+
+    python scripts/retrieval_backfill.py --story-id <uuid> --mode reindex \\
+        --chroma-path .chroma_data --db-url sqlite:///afterworlds.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from uuid import UUID
+
+# Ensure project src is on path when run from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Import all ORM models so Base.metadata is complete
+import afterworlds.persistence.orm.character_sheet  # noqa: E402, F401
+import afterworlds.persistence.orm.node  # noqa: E402, F401
+import afterworlds.persistence.orm.retrieval  # noqa: E402, F401
+import afterworlds.persistence.orm.rules_package  # noqa: E402, F401
+import afterworlds.persistence.orm.session_state  # noqa: E402, F401
+import afterworlds.persistence.orm.state  # noqa: E402, F401
+import afterworlds.persistence.orm.story  # noqa: E402, F401
+import afterworlds.persistence.orm.story_bible  # noqa: E402, F401
+from afterworlds.persistence.crud.story import get_story  # noqa: E402
+from afterworlds.persistence.database import (  # noqa: E402
+    create_engine,
+    create_session_factory,
+)
+from afterworlds.pipeline.retrieval.backfill import (  # noqa: E402
+    backfill_story,
+    reindex_story,
+)
+from afterworlds.pipeline.retrieval.client import build_chroma_client  # noqa: E402
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig  # noqa: E402
+from afterworlds.pipeline.retrieval.write_service import (  # noqa: E402
+    RetrievalMemoryWriteService,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill or reindex Retrieval Memory for one story."
+    )
+    parser.add_argument("--story-id", required=True, help="Story UUID")
+    parser.add_argument(
+        "--mode",
+        choices=["backfill", "reindex", "delete"],
+        default="backfill",
+        help="backfill: ingest missing eligible turns. "
+        "reindex: wipe and rebuild from SQLite ground truth. "
+        "delete: remove all chunks for the story (no rebuild).",
+    )
+    parser.add_argument("--chroma-path", default=".chroma_data")
+    parser.add_argument("--db-url", default="sqlite:///afterworlds.db")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    story_id = UUID(args.story_id)
+
+    engine = create_engine(args.db_url)
+    session_factory = create_session_factory(engine)
+    config = RetrievalMemoryConfig(persist_directory=args.chroma_path)
+    client = build_chroma_client(config)
+    write_service = RetrievalMemoryWriteService(client, config)
+
+    session = session_factory()
+    try:
+        story = get_story(session, story_id)
+        if story is None:
+            print(f"story {story_id} not found", file=sys.stderr)
+            raise SystemExit(1)
+        story_mode = story.mode
+        if args.mode == "delete":
+            remaining = write_service.delete_story(story_id)
+            print(f"deleted story chunks; remaining={remaining}")
+            if remaining != 0:
+                raise SystemExit(2)
+            return
+        if args.mode == "reindex":
+            report = reindex_story(session, write_service, story_id, story_mode)
+        else:
+            report = backfill_story(session, write_service, story_id, story_mode)
+    finally:
+        session.close()
+
+    print(
+        f"scanned={report.turns_scanned} ingested={report.turns_ingested} "
+        f"skipped={report.turns_skipped_ineligible} "
+        f"data_integrity_errors={list(report.data_integrity_errors)}"
+    )
+    if report.data_integrity_errors:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/retrieval_backfill.py
+++ b/scripts/retrieval_backfill.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import replace
 from pathlib import Path
 from uuid import UUID
 
@@ -61,9 +62,34 @@ def parse_args() -> argparse.Namespace:
         "reindex: wipe and rebuild from SQLite ground truth. "
         "delete: remove all chunks for the story (no rebuild).",
     )
-    parser.add_argument("--chroma-path", default=".chroma_data")
+    parser.add_argument(
+        "--chroma-path",
+        default=None,
+        help="Override persist_directory. Defaults to the same "
+        "environment-derived config the application uses "
+        "(AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY), so this only needs to "
+        "be passed to deliberately point at a different Chroma directory.",
+    )
     parser.add_argument("--db-url", default="sqlite:///afterworlds.db")
     return parser.parse_args()
+
+
+def build_effective_config(chroma_path: str | None) -> RetrievalMemoryConfig:
+    """Build the config this script uses for every mode (backfill/reindex/delete).
+
+    Starts from ``RetrievalMemoryConfig.from_env()`` -- the same
+    environment-derived config the running application uses -- rather than
+    dataclass defaults (Codex review, PR #119): a recovery script that
+    silently rebuilt with default ``embedding_model_id``/
+    ``chunk_char_ceiling``/etc. instead of the env-configured values could
+    recreate the exact mismatch it was meant to fix.
+    ``chroma_path`` overrides only ``persist_directory``, and only when
+    explicitly provided (``None`` leaves the env-derived value untouched).
+    """
+    config = RetrievalMemoryConfig.from_env()
+    if chroma_path is not None:
+        config = replace(config, persist_directory=chroma_path)
+    return config
 
 
 def main() -> None:
@@ -72,7 +98,7 @@ def main() -> None:
 
     engine = create_engine(args.db_url)
     session_factory = create_session_factory(engine)
-    config = RetrievalMemoryConfig(persist_directory=args.chroma_path)
+    config = build_effective_config(args.chroma_path)
     client = build_chroma_client(config)
     write_service = RetrievalMemoryWriteService(client, config)
 

--- a/src/afterworlds/models/enums.py
+++ b/src/afterworlds/models/enums.py
@@ -511,3 +511,47 @@ class SourceLocatorTypeEnum(StrEnum):
     HEADING_ANCHOR = "heading_anchor"
     SECTION_PATH = "section_path"
     RANGE = "range"
+
+
+# ---------------------------------------------------------------------------
+# Retrieval Memory enums — CRD Issue 18 / ADR-018
+# ---------------------------------------------------------------------------
+
+
+class RetrievalSourceType(StrEnum):
+    """Provenance/origin class of a story-memory chunk (ADR-018 D2).
+
+    Distinct from ``RetrievalChunkKind`` — this is *where the content came
+    from*, not its semantic shape.  ``DELIVERED_TURN_PROSE`` is the only
+    source type Issue 18 ingests.  The enum is reserved for future extension
+    (``STORY_BIBLE_ENTRY``, ``CANON_PACK``) so a later issue can add a new
+    source without a schema migration; reserving the field now does NOT
+    authorize ingesting anything beyond delivered turn prose in v1.
+    """
+
+    DELIVERED_TURN_PROSE = "delivered_turn_prose"
+
+
+class RetrievalChunkKind(StrEnum):
+    """Semantic kind of a story-memory chunk within its source (ADR-018 D2).
+
+    ``SCENE_PROSE`` is the only chunk kind Issue 18 produces (one chunk per
+    delivered turn's prose, per D3's one-chunk-per-turn policy).
+    """
+
+    SCENE_PROSE = "scene_prose"
+
+
+class RpgTurnRetrievalCategory(StrEnum):
+    """Typed category recorded per-turn in ``rpg_turn_retrieval_markers``.
+
+    Written once, at turn-creation time, inside the narrative-persist outer
+    transaction, for post-boundary RPG narrative-path DELIVERED turns only
+    (ADR-018 D6). There is deliberately no OOC category — RPG OOC_HANDLED
+    turns are persisted via a structurally separate path (``_ooc_persist``)
+    and never reach the marker-writing block.
+    """
+
+    ORDINARY_NARRATIVE = "ordinary_narrative"
+    ROLL_REQUEST = "roll_request"
+    SETUP_CONFIRMATION = "setup_confirmation"

--- a/src/afterworlds/models/retrieval.py
+++ b/src/afterworlds/models/retrieval.py
@@ -1,0 +1,169 @@
+"""Pydantic models and deterministic ID scheme for Retrieval Memory.
+
+CRD Issue 18 / ADR-018 (docs/decisions/adr-018-retrieval-memory.md).
+
+ChromaDB is a rebuildable projection of SQLite-authoritative content — never
+the sole home of any data, never an authority over narrative or mechanical
+canon (CLAUDE.md invariant 8: ``get_active_rule_slice`` remains the sole
+deterministic mechanical authority; vector rules retrieval is discovery-only).
+
+All chunk IDs in this module are semantic and derived, never random UUIDs
+(ADR-018 D11) — this is what makes upsert/delete/reindex idempotent and lets
+every write path (ingest, backfill, reindex, turn-delete) resolve through a
+single builder.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from afterworlds.models.enums import (
+    RetrievalChunkKind,
+    RetrievalSourceType,
+    SourceLocatorTypeEnum,
+)
+
+# ---------------------------------------------------------------------------
+# Deterministic ID builders (ADR-018 D11) — the single ID builder every
+# write/delete path must resolve IDs through (sibling-audit checkpoint #1).
+# ---------------------------------------------------------------------------
+
+
+def build_story_memory_chunk_id(story_id: UUID, turn_id: UUID, chunk_index: int) -> str:
+    """Deterministic chunk ID for a story-memory chunk.
+
+    Format fixed by ADR-018 D11: ``story:{story_id}:turn:{turn_id}:chunk:{index}``.
+    Re-ingesting the same turn produces byte-identical IDs (idempotent upsert).
+    """
+    return f"story:{story_id}:turn:{turn_id}:chunk:{chunk_index}"
+
+
+def build_story_memory_chunk_id_prefix(story_id: UUID, turn_id: UUID) -> str:
+    """Prefix shared by every chunk ID for one turn — used for delete-before-write.
+
+    ADR-018 D11: turn-level chunk-set replacement must delete all existing
+    chunks for ``turn_id`` before writing the current chunk set, because a
+    deterministic-ID upsert alone cannot remove chunks whose index no longer
+    exists in a shrunk chunk set.
+    """
+    return f"story:{story_id}:turn:{turn_id}:chunk:"
+
+
+def build_rules_corpus_chunk_id(
+    rules_package_id: UUID,
+    source_locator_type: SourceLocatorTypeEnum,
+    source_locator_value: str,
+    chunk_index: int,
+) -> str:
+    """Deterministic chunk ID for a rules-corpus chunk.
+
+    Derives from ``rules_package_id`` + the CRD Issue 5a chunk identity
+    (source locator type/value) + chunk index, per ADR-018 D11.
+    """
+    return (
+        f"rules:{rules_package_id}:loc:{source_locator_type.value}"
+        f":{source_locator_value}:chunk:{chunk_index}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Collection naming (ADR-018 D1)
+# ---------------------------------------------------------------------------
+
+#: Single shared collection name for all story-memory chunks across all
+#: stories.  Mandatory ``story_id`` metadata filter is required on every
+#: query against this collection — leakage is a query-gate property, not a
+#: topology property (ADR-018 D1 rationale).
+STORY_MEMORY_COLLECTION_NAME = "story_memory"
+
+
+def rules_corpus_collection_name(rules_package_id: UUID) -> str:
+    """Collection name for the finalized per-Rules-Package rules corpus.
+
+    One collection per published Rules Package (ADR-018 D1), absorbing the
+    CRD Issue 5b interim ``rp_chunks_interim_{package_id_hex}`` collection.
+    """
+    return f"rules_corpus_{rules_package_id.hex}"
+
+
+# ---------------------------------------------------------------------------
+# Metadata DTOs (ADR-018 D2)
+# ---------------------------------------------------------------------------
+
+
+class StoryMemoryChunkMetadata(BaseModel):
+    """Per-chunk metadata for the shared ``story_memory`` collection.
+
+    ``source_type`` and ``chunk_kind`` are distinct typed fields and must not
+    be collapsed into one (ADR-018 D2, Codex round-3 correction to the
+    original issue spec, which omitted ``source_type``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = 1
+    story_id: UUID
+    node_id: UUID | None
+    turn_id: UUID
+    mode: str
+    source_type: RetrievalSourceType = RetrievalSourceType.DELIVERED_TURN_PROSE
+    chunk_kind: RetrievalChunkKind = RetrievalChunkKind.SCENE_PROSE
+    chunk_index: int
+    chunk_count: int
+    created_at: str
+    content_hash: str
+    embedding_model_id: str
+
+
+class RulesCorpusChunkMetadata(BaseModel):
+    """Per-chunk metadata for a finalized ``rules_corpus_{package}`` collection.
+
+    Carries the CRD Issue 5a provenance fields plus the Issue 18 additions
+    (``rules_package_id``, ``subsystem``, ``embedding_model_id``,
+    ``schema_version``) per ADR-018 D2.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: int = 1
+    rules_package_id: UUID
+    subsystem: str
+    source_document: str
+    source_locator_type: SourceLocatorTypeEnum
+    source_locator_value: str
+    embedding_model_id: str
+
+
+# ---------------------------------------------------------------------------
+# Query request DTO (ADR-018 D8) — orchestrator-constructed, mirrors
+# RuleSliceRequest (models/rules_package.py).  Context Builder gains no
+# inference logic; this is built before context assembly and threaded through
+# ContextBuilderService.assemble() / build_stable_prefix().
+# ---------------------------------------------------------------------------
+
+
+class RetrievalQueryRequest(BaseModel):
+    """Typed parameter bundle for RetrievalMemoryProvider.retrieve().
+
+    ``query_text`` is fully composed by ``RetrievalQueryBuilder`` before this
+    request is constructed — the Context Builder does not compose or infer
+    query text itself (ADR-018 D8).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    story_id: UUID
+    query_text: str
+
+
+class RetrievalMatch(BaseModel):
+    """One normalized retrieval result, prior to StablePrefix rendering."""
+
+    model_config = ConfigDict(frozen=True)
+
+    chunk_id: str
+    document: str
+    normalized_similarity: float
+    metadata: dict[str, object] = Field(default_factory=dict)

--- a/src/afterworlds/models/retrieval.py
+++ b/src/afterworlds/models/retrieval.py
@@ -51,21 +51,22 @@ def build_story_memory_chunk_id_prefix(story_id: UUID, turn_id: UUID) -> str:
     return f"story:{story_id}:turn:{turn_id}:chunk:"
 
 
-def build_rules_corpus_chunk_id(
-    rules_package_id: UUID,
-    source_locator_type: SourceLocatorTypeEnum,
-    source_locator_value: str,
-    chunk_index: int,
-) -> str:
+def build_rules_corpus_chunk_id(rules_package_id: UUID, chunk_id: UUID) -> str:
     """Deterministic chunk ID for a rules-corpus chunk.
 
-    Derives from ``rules_package_id`` + the CRD Issue 5a chunk identity
-    (source locator type/value) + chunk index, per ADR-018 D11.
+    Derives from ``rules_package_id`` + the durable CRD Issue 5a
+    ``RuleChunkORM.chunk_id`` primary key, per ADR-018 D11.
+
+    Codex review (PR #119) round 4: an earlier version derived this ID from
+    (source locator type/value, per-run occurrence index) — a per-locator
+    ordinal assigned by SQL row-iteration order, not any durable property of
+    the row. Since ``RuleChunkORM.chunk_id`` is already the row's own
+    immutable primary key (assigned once, at CRD Issue 5a ingestion time),
+    it is what makes reindex idempotent and stable regardless of row order
+    or how many chunks share the same source locator — no synthetic
+    per-locator index is needed or safe to reconstruct at reindex time.
     """
-    return (
-        f"rules:{rules_package_id}:loc:{source_locator_type.value}"
-        f":{source_locator_value}:chunk:{chunk_index}"
-    )
+    return f"rules:{rules_package_id}:chunk:{chunk_id}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/afterworlds/persistence/crud/retrieval.py
+++ b/src/afterworlds/persistence/crud/retrieval.py
@@ -114,15 +114,22 @@ def get_turn_for_eligibility(session: Session, turn_id: UUID) -> Turn | None:
 
     Codex review (PR #119): ``persistence.crud.node.get_turn`` raises when a
     row's ``mode_metadata`` JSON cannot be validated into a ``ModeMetadata``
-    subtype (a corrupted or schema-drifted row). For Writing turns, ADR-018
-    D6 already defines that outcome as retrieval-*ineligible*, not a fatal
-    error — so a single malformed row must not abort query-tail building,
-    backfill, or reindex for an entire story. This read returns
-    ``mode_metadata=None`` when deserialization fails instead of raising;
-    the shared eligibility predicate already treats missing/non-Writing
-    ``mode_metadata`` as ineligible for Writing turns (see
-    ``decide_turn_eligibility``) and never reads ``mode_metadata`` at all
-    for RPG/Branching, so this is inert for those modes.
+    subtype (a corrupted or schema-drifted row) -- including a non-object
+    JSON value (list, string, number), which raises ``AttributeError`` from
+    ``.get("mode")`` before pydantic ever runs, not just a dict that fails
+    field validation (``ValueError``/pydantic ``ValidationError``). For
+    Writing turns, ADR-018 D6 already defines that outcome as
+    retrieval-*ineligible*, not a fatal error — so a single malformed row
+    must not abort query-tail building, backfill, or reindex for an entire
+    story. This read returns ``mode_metadata=None`` when deserialization
+    fails in either of those ways instead of raising; the shared eligibility
+    predicate already treats missing/non-Writing ``mode_metadata`` as
+    ineligible for Writing turns (see ``decide_turn_eligibility``) and never
+    reads ``mode_metadata`` at all for RPG/Branching, so this is inert for
+    those modes. ``intent_classification_result`` deserialization is
+    deliberately NOT covered by this tolerance -- a malformed row there is
+    unrelated data corruption outside ADR-018's Writing-metadata rule and
+    must still raise, same as a database access error.
 
     This is a retrieval-domain-local, tolerant read — it must never replace
     ``get_turn`` for any other caller (Writer, Extractor, general node CRUD
@@ -145,7 +152,13 @@ def get_turn_for_eligibility(session: Session, turn_id: UUID) -> Turn | None:
     if row.mode_metadata is not None:
         try:
             mode_metadata = _mode_metadata_from_dict(row.mode_metadata)
-        except ValueError:
+        except (ValueError, AttributeError):
+            # ValueError covers an unknown/missing "mode" key and pydantic's
+            # ValidationError (a ValueError subclass) for a malformed-but-
+            # dict-shaped row. AttributeError covers a non-object JSON value
+            # (e.g. mode_metadata stored as a list, string, or number) --
+            # `.get("mode")` on a non-dict raises AttributeError before
+            # pydantic ever runs (Codex review, PR #119 round 3).
             mode_metadata = None
 
     return Turn(

--- a/src/afterworlds/persistence/crud/retrieval.py
+++ b/src/afterworlds/persistence/crud/retrieval.py
@@ -13,6 +13,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import RpgTurnRetrievalCategory
+from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.node import _mode_metadata_from_dict
+from afterworlds.persistence.orm.node import TurnORM
 from afterworlds.persistence.orm.retrieval import (
     RetrievalMarkerEraBoundaryORM,
     RpgTurnRetrievalMarkerORM,
@@ -101,4 +105,56 @@ def has_pending_roll_request_originating_from_turn(
         .filter_by(originating_turn_id=str(turn_id))
         .first()
         is not None
+    )
+
+
+def get_turn_for_eligibility(session: Session, turn_id: UUID) -> Turn | None:
+    """Read a committed Turn for retrieval eligibility, tolerating a
+    malformed/undeserializable ``mode_metadata`` column.
+
+    Codex review (PR #119): ``persistence.crud.node.get_turn`` raises when a
+    row's ``mode_metadata`` JSON cannot be validated into a ``ModeMetadata``
+    subtype (a corrupted or schema-drifted row). For Writing turns, ADR-018
+    D6 already defines that outcome as retrieval-*ineligible*, not a fatal
+    error — so a single malformed row must not abort query-tail building,
+    backfill, or reindex for an entire story. This read returns
+    ``mode_metadata=None`` when deserialization fails instead of raising;
+    the shared eligibility predicate already treats missing/non-Writing
+    ``mode_metadata`` as ineligible for Writing turns (see
+    ``decide_turn_eligibility``) and never reads ``mode_metadata`` at all
+    for RPG/Branching, so this is inert for those modes.
+
+    This is a retrieval-domain-local, tolerant read — it must never replace
+    ``get_turn`` for any other caller (Writer, Extractor, general node CRUD
+    consumers): those must keep seeing a raised deserialization error as a
+    real data-integrity failure, not a silently-swallowed one. Only the
+    retrieval eligibility/ingestion/query-tail/backfill/reindex paths use
+    this function.
+    """
+    row = session.get(TurnORM, str(turn_id))
+    if row is None:
+        return None
+
+    icr: IntentClassificationResult | None = None
+    if row.intent_classification_result is not None:
+        icr = IntentClassificationResult.model_validate(
+            row.intent_classification_result
+        )
+
+    mode_metadata = None
+    if row.mode_metadata is not None:
+        try:
+            mode_metadata = _mode_metadata_from_dict(row.mode_metadata)
+        except ValueError:
+            mode_metadata = None
+
+    return Turn(
+        turn_id=UUID(row.turn_id),
+        node_id=UUID(row.node_id) if row.node_id is not None else None,
+        user_input=row.user_input,
+        assistant_output=row.assistant_output,
+        timestamp=row.timestamp,  # type: ignore[arg-type]
+        intent_classification=row.intent_classification,  # type: ignore[arg-type]
+        intent_classification_result=icr,
+        mode_metadata=mode_metadata,
     )

--- a/src/afterworlds/persistence/crud/retrieval.py
+++ b/src/afterworlds/persistence/crud/retrieval.py
@@ -17,6 +17,7 @@ from afterworlds.persistence.orm.retrieval import (
     RetrievalMarkerEraBoundaryORM,
     RpgTurnRetrievalMarkerORM,
 )
+from afterworlds.persistence.orm.rpg import PendingRollRequestORM
 
 
 def create_rpg_turn_retrieval_marker(
@@ -80,3 +81,24 @@ def is_post_boundary(turn_timestamp: str, boundary_timestamp: str | None) -> boo
     if boundary_timestamp is None:
         return True
     return turn_timestamp > boundary_timestamp
+
+
+def has_pending_roll_request_originating_from_turn(
+    session: Session, turn_id: UUID
+) -> bool:
+    """Return True if a ``PendingRollRequest`` row's ``originating_turn_id``
+    equals *turn_id* (any status).
+
+    Codex review (PR #119): a legacy pre-marker RPG turn that announced a
+    roll must still be excluded from retrieval eligibility even though it
+    predates the marker sidecar entirely and carries no marker row — the
+    era-boundary table (ADR-018 D6) makes ``PendingRollRequest`` the sole
+    signal for that shape. This reads only the persisted row; it never
+    inspects prose or ``RpgSessionState.play_status``.
+    """
+    return (
+        session.query(PendingRollRequestORM)
+        .filter_by(originating_turn_id=str(turn_id))
+        .first()
+        is not None
+    )

--- a/src/afterworlds/persistence/crud/retrieval.py
+++ b/src/afterworlds/persistence/crud/retrieval.py
@@ -1,0 +1,82 @@
+"""CRUD helpers for the Retrieval Memory RPG turn-marker sidecar.
+
+CRD Issue 18 / ADR-018 D6. See ``persistence/orm/retrieval.py`` for schema
+and ``pipeline/retrieval/eligibility.py`` for the eligibility predicate that
+consumes these helpers.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import RpgTurnRetrievalCategory
+from afterworlds.persistence.orm.retrieval import (
+    RetrievalMarkerEraBoundaryORM,
+    RpgTurnRetrievalMarkerORM,
+)
+
+
+def create_rpg_turn_retrieval_marker(
+    session: Session,
+    turn_id: UUID,
+    story_id: UUID,
+    category: RpgTurnRetrievalCategory,
+    created_at: str,
+) -> None:
+    """Insert a marker row. Must run inside the caller's outer transaction.
+
+    Raises on flush failure (e.g. duplicate ``turn_id``) — callers on the
+    mandatory narrative-persist path must catch and map to typed
+    PIPELINE_ERROR; this function does not swallow.
+    """
+    session.add(
+        RpgTurnRetrievalMarkerORM(
+            turn_id=str(turn_id),
+            story_id=str(story_id),
+            category=category.value,
+            created_at=created_at,
+        )
+    )
+    session.flush()
+
+
+def get_rpg_turn_retrieval_marker(
+    session: Session, turn_id: UUID
+) -> RpgTurnRetrievalCategory | None:
+    """Return the marker category for *turn_id*, or None if no row exists."""
+    row = session.get(RpgTurnRetrievalMarkerORM, str(turn_id))
+    if row is None:
+        return None
+    return RpgTurnRetrievalCategory(row.category)
+
+
+def get_era_boundary_timestamp(session: Session) -> str | None:
+    """Return the persisted marker-era boundary timestamp, or None.
+
+    None means either "no boundary row exists yet" (pre-migration DB, should
+    not occur once migration 0015 has run) or "no turns existed at
+    migration-apply time" (every turn is post-boundary).
+    """
+    row = session.execute(
+        select(RetrievalMarkerEraBoundaryORM).where(
+            RetrievalMarkerEraBoundaryORM.id == 1
+        )
+    ).scalar_one_or_none()
+    return row.boundary_timestamp if row is not None else None
+
+
+def is_post_boundary(turn_timestamp: str, boundary_timestamp: str | None) -> bool:
+    """Return True when *turn_timestamp* is strictly after the era boundary.
+
+    ISO-8601 UTC timestamps (as produced by ``datetime.isoformat()`` on a
+    UTC-aware datetime) sort correctly as plain strings — see
+    ``services/context_builder.py``'s timestamp-sort rationale. A None
+    boundary means no turns existed at migration time, so every turn is
+    post-boundary.
+    """
+    if boundary_timestamp is None:
+        return True
+    return turn_timestamp > boundary_timestamp

--- a/src/afterworlds/persistence/orm/retrieval.py
+++ b/src/afterworlds/persistence/orm/retrieval.py
@@ -1,0 +1,61 @@
+"""ORM models for Retrieval Memory's RPG turn-category sidecar.
+
+CRD Issue 18 / ADR-018 D6 (RPG turn-category marker) and the marker-era
+boundary. See migration 0015 for the corresponding schema.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from afterworlds.persistence.orm.base import Base
+
+
+class RpgTurnRetrievalMarkerORM(Base):
+    """One row per post-boundary RPG narrative-path DELIVERED turn.
+
+    Written once, inside the existing narrative-persist outer transaction,
+    at the same location/transaction-scoping as the Writing-mode metadata
+    block — but NOT with that block's best-effort swallow behavior. A
+    marker-write failure on an otherwise-deliverable turn must map to a
+    typed PIPELINE_ERROR and roll back with the turn (ADR-018 D6). Rows are
+    never updated after insert; deletion follows turn deletion.
+
+    Coverage is narrower than "every RPG turn": RPG OOC_HANDLED turns are
+    persisted via ``_ooc_persist`` and structurally never reach this table.
+    """
+
+    __tablename__ = "rpg_turn_retrieval_markers"
+
+    turn_id: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("turns.turn_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    story_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class RetrievalMarkerEraBoundaryORM(Base):
+    """Singleton row recording the persisted marker-era boundary.
+
+    ADR-018 D6 (round-7 addition): a post-boundary marker-write bug leaves
+    exactly the same SQLite shape as a legitimate legacy pre-marker turn (no
+    marker, no PendingRollRequest) — so the boundary itself must be
+    persisted in SQLite, not inferred from app state/timing, and never
+    retroactively applied to existing turns (forward-only).
+
+    ``boundary_timestamp`` is the maximum ``turns.timestamp`` (ISO-8601,
+    lexicographically sortable — see context_builder.py's timestamp-sort
+    rationale) observed across all turns at migration-apply time, or NULL
+    when no turns existed yet. A turn is post-boundary when its timestamp
+    is strictly greater than this value (or unconditionally post-boundary
+    when this value is NULL).
+    """
+
+    __tablename__ = "retrieval_marker_era_boundary"
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    boundary_timestamp: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -38,13 +38,14 @@ import them without dragging the service in.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from collections.abc import Callable
 from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeout
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Session
@@ -68,6 +69,7 @@ from afterworlds.models.enums import (
     WritingWorkProductKind,
 )
 from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.retrieval import RetrievalQueryRequest
 from afterworlds.models.rules_package import RuleSliceRequest
 from afterworlds.pipeline._refusal import (
     ProviderRefusal,
@@ -149,6 +151,8 @@ from afterworlds.pipeline.writer.service import WriterService
 from afterworlds.services.context_builder import ContextBuilderService
 from afterworlds.services.intent_classifier import IntentClassifierService
 
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -222,6 +226,39 @@ ModeResolver = Callable[[UUID], "Any"]
 
 def _noop_fn() -> None:
     pass
+
+
+# ---------------------------------------------------------------------------
+# Retrieval Memory ingestion seam (CRD Issue 18 / ADR-018 D6/D7)
+# ---------------------------------------------------------------------------
+
+
+class RetrievalIngestionServiceLike(Protocol):
+    """Narrow protocol for the retrieval-memory write path.
+
+    The orchestrator depends only on this shape, not on
+    ``RetrievalMemoryWriteService`` or ChromaDB directly — mirrors the
+    ``_RulesPackageServiceLike``-style narrow protocols in
+    ``services/context_builder.py``.
+    """
+
+    def ingest_turn(
+        self,
+        story_id: UUID,
+        turn_id: UUID,
+        node_id: UUID | None,
+        mode: str,
+        delivered_output: str,
+        created_at: str,
+    ) -> None: ...
+
+
+class RetrievalQueryBuilderLike(Protocol):
+    """Narrow protocol for ``pipeline.retrieval.query_builder.RetrievalQueryBuilder``."""  # noqa: E501
+
+    def build_query_request(
+        self, story_id: UUID, current_input: str, story_mode: StoryMode
+    ) -> RetrievalQueryRequest: ...
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +390,8 @@ class OrchestratorService:
         ) = None,
         writing_visible_state_service: WritingVisibleStateService | None = None,
         writing_ooc_config_extractor: WritingOocConfigExtractorService | None = None,
+        retrieval_write_service: RetrievalIngestionServiceLike | None = None,
+        retrieval_query_builder: RetrievalQueryBuilderLike | None = None,
     ) -> None:
         self._intent_classifier = intent_classifier
         self._context_builder = context_builder
@@ -380,6 +419,8 @@ class OrchestratorService:
         self._writing_session_resolver = writing_session_resolver
         self._writing_visible_state_service = writing_visible_state_service
         self._writing_ooc_config_extractor = writing_ooc_config_extractor
+        self._retrieval_write_service = retrieval_write_service
+        self._retrieval_query_builder = retrieval_query_builder
         self._provided_executor = executor
         # Owned executor is created once and reused for the lifetime of
         # this instance — see the Executor-lifecycle contract above.
@@ -534,6 +575,26 @@ class OrchestratorService:
                     # proceeds without a rule slice and produces "undetermined".
                     rule_slice_request = None
 
+        # 2a-retrieval. Build the retrieval query request before context
+        # assembly (ADR-018 D8) — orchestrator-owned and deterministic,
+        # mirroring the RuleSliceRequest pattern above. Best-effort: a
+        # query-build failure must not fail the turn, only omit retrieval
+        # memory for it (same as the Null-provider empty-payload behavior).
+        retrieval_query_request: RetrievalQueryRequest | None = None
+        if self._retrieval_query_builder is not None:
+            try:
+                retrieval_query_request = (
+                    self._retrieval_query_builder.build_query_request(
+                        story_id, user_input, story_mode
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "retrieval query build failed for story_id=%s: %s",
+                    story_id,
+                    exc,
+                )
+
         # 2b. Context assembly (once per turn).
         try:
             ctx, _, ctx_ms = self._build_context(
@@ -542,6 +603,7 @@ class OrchestratorService:
                 intent_result,
                 mode=story_mode,
                 rule_slice_request=rule_slice_request,
+                retrieval_query_request=retrieval_query_request,
             )
             latency["context"] = ctx_ms
         except Exception as exc:  # noqa: BLE001
@@ -1075,6 +1137,12 @@ class OrchestratorService:
         rpg_session_id: UUID | None = None
         rpg_character_id: UUID | None = None
         rpg_sheet: Dnd5eCharacterSheet | None = None
+        # Threaded to _narrative_persist for the RPG turn-retrieval-marker
+        # classification (ADR-018 D6). None only when RPG adjudication is
+        # not wired for an RPG-mode story; the marker-write block treats
+        # that as IN_PLAY/ORDINARY_NARRATIVE (the common case) rather than
+        # failing closed, since adjudication wiring is a separate concern.
+        rpg_play_status: RpgPlayStatus | None = None
 
         if story_mode == StoryMode.RPG and self._rpg_adjudication_service is not None:
             if (
@@ -1112,6 +1180,7 @@ class OrchestratorService:
             rpg_session_id = session_state.session_id
             rpg_character_id = sheet.sheet_id
             rpg_sheet = sheet
+            rpg_play_status = session_state.play_status
             # Gate: skip adjudication for setup turns and for sheets that
             # aren't fully configured.  play_status SETUP covers character
             # creation and world-setup turns that flow through _run_narrative
@@ -1201,7 +1270,7 @@ class OrchestratorService:
         # drift, and so every raw exception in that lifecycle is mapped to a
         # typed terminal state per the orchestrator's exhaustive
         # terminal-state contract (Issue 12c).
-        return self._run_with_transaction(
+        result = self._run_with_transaction(
             lambda session: self._narrative_persist(
                 session,
                 ctx,
@@ -1226,6 +1295,7 @@ class OrchestratorService:
                 selected_branch_context=_pre_selected_context,
                 writing_session_state=_pre_writing_state,
                 writing_turn_request=writing_turn_request,
+                rpg_play_status=rpg_play_status,
             ),
             intent_result,
             latency,
@@ -1234,6 +1304,17 @@ class OrchestratorService:
             pre_transaction_fn=binding.pre_transaction_fn,
             post_transaction_fn=binding.post_transaction_fn,
         )
+        # Retrieval Memory ingestion gate (ADR-018 §6): fires only after the
+        # outer transaction has committed successfully, on the post-
+        # finalization result — a returned DELIVERED disposition already IS
+        # proof of commit (commit failure maps to PIPELINE_ERROR inside
+        # _finalize_transaction). Session is closed by now; ingestion opens
+        # its own short-lived read, matching the backfill/reindex path.
+        # Best-effort and swallowed (D7) — the opposite of the mandatory RPG
+        # marker write above: a Chroma failure here must never change
+        # `result` or escape this method.
+        self._maybe_ingest_retrieval_memory(result, story_id, story_mode)
+        return result
 
     def _narrative_persist(
         self,
@@ -1261,6 +1342,7 @@ class OrchestratorService:
         selected_branch_context: SelectedBranchContext | None = None,
         writing_session_state: WritingSessionState | None = None,
         writing_turn_request: WritingTurnRequest | None = None,
+        rpg_play_status: RpgPlayStatus | None = None,
     ) -> OrchestrationResult:
         # Determine if this is a BRANCHING HYBRID/TRUE_CYOA turn (BranchingWriterService
         # replaces WriterService for these modes; FREEFORM_ONLY stays on prose Writer).
@@ -1677,17 +1759,26 @@ class OrchestratorService:
                     # writing_turn_request is supplied, default the recorded
                     # work-product kind from play_status rather than blindly to
                     # PROSE_CONTINUATION.
-                    if _wtr is not None:
-                        _wpk = _wtr.work_product_kind.value
-                    elif _wss.play_status is WritingPlayStatus.SETUP:
+                    # Durable setup-turn guard (ADR-018 D6, corrected from
+                    # Issue #117's withdrawn "structurally excluded" claim):
+                    # WritingTurnRequest carries no play-status field, so its
+                    # validator cannot reject a prose-like work_product_kind
+                    # + canon_eligibility_override=EXTRACTOR_ELIGIBLE request
+                    # constructed while the session is still in SETUP. Force
+                    # both fields on the persisted, durable per-turn record
+                    # whenever play_status is SETUP, regardless of what the
+                    # request carries — this is the record retrieval
+                    # eligibility reads, so it must never expose a
+                    # request-supplied override during setup.
+                    if _wss.play_status is WritingPlayStatus.SETUP:
                         _wpk = WritingWorkProductKind.SETUP_CONFIRMATION.value
+                        _ce = WritingCanonEligibility.NON_CANON_SUPPORT.value
+                    elif _wtr is not None:
+                        _wpk = _wtr.work_product_kind.value
+                        _ce = _wtr.effective_canon_eligibility.value
                     else:
                         _wpk = WritingWorkProductKind.PROSE_CONTINUATION.value
-                    _ce = (
-                        _wtr.effective_canon_eligibility.value
-                        if _wtr is not None
-                        else WritingCanonEligibility.NON_CANON_SUPPORT.value
-                    )
+                        _ce = WritingCanonEligibility.NON_CANON_SUPPORT.value
 
                     # Build authoring-controls snapshot.
                     _acs: dict[str, object] | None = None
@@ -1767,6 +1858,51 @@ class OrchestratorService:
                     )
             except Exception:  # noqa: BLE001
                 pass  # Provenance failure does not abort the turn
+
+        # 5a-rpg: [RPG only] Write the turn-category retrieval marker
+        # (ADR-018 D6) inside the outer transaction — same location/
+        # transaction-scoping as the Writing-mode block above, but NOT its
+        # best-effort swallow behavior. This write is mandatory: a
+        # marker-write failure on an otherwise-deliverable turn must map to
+        # a typed PIPELINE_ERROR and roll back with the turn (never commit
+        # markerless). Runs only on the narrative-persist path — the OOC
+        # persist path (_ooc_persist) structurally never reaches this block.
+        if story_mode is StoryMode.RPG:
+            from datetime import UTC, datetime  # noqa: PLC0415
+
+            from afterworlds.models.enums import (  # noqa: PLC0415
+                RpgTurnRetrievalCategory as _RTRC,
+            )
+            from afterworlds.persistence.crud.retrieval import (  # noqa: PLC0415
+                create_rpg_turn_retrieval_marker as _create_marker,
+            )
+
+            if rpg_play_status is RpgPlayStatus.SETUP:
+                _marker_category = _RTRC.SETUP_CONFIRMATION
+            elif adj_result is not None and adj_result.pending_roll_request is not None:
+                _marker_category = _RTRC.ROLL_REQUEST
+            else:
+                _marker_category = _RTRC.ORDINARY_NARRATIVE
+            try:
+                _create_marker(
+                    session,
+                    turn_id=writer_turn_id,
+                    story_id=story_id,
+                    category=_marker_category,
+                    created_at=datetime.now(UTC).isoformat(),
+                )
+            except Exception as exc:  # noqa: BLE001
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"rpg turn retrieval marker write failed: {exc}",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    writer_result=writer_result,
+                    rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
+                )
 
         # 5b. [RPG only] Write adjudication audit rows, consume/announce pending
         # roll, inside the outer transaction (Fork B→B1).  Runs only when
@@ -3285,6 +3421,7 @@ class OrchestratorService:
         *,
         mode: StoryMode | None = None,
         rule_slice_request: RuleSliceRequest | None = None,
+        retrieval_query_request: RetrievalQueryRequest | None = None,
     ) -> tuple[AssembledContext, StoryMode, int]:
         resolved_mode: StoryMode = (
             mode if mode is not None else self._mode_resolver(story_id)
@@ -3296,6 +3433,7 @@ class OrchestratorService:
                 current_input=user_input,
                 classified_intent=intent_result,
                 rule_slice_request=rule_slice_request,
+                retrieval_query_request=retrieval_query_request,
             )
         )
         return ctx, resolved_mode, ms
@@ -3575,6 +3713,63 @@ class OrchestratorService:
             with suppress(Exception):
                 session.rollback()
         return inner_result
+
+    def _maybe_ingest_retrieval_memory(
+        self, result: OrchestrationResult, story_id: UUID, story_mode: StoryMode
+    ) -> None:
+        """Fire the Retrieval Memory ingestion gate (ADR-018 §6/D6/D7).
+
+        Gates on the post-finalization ``OrchestrationResult`` — never a
+        provisional ``WriterResult.turn_id``, which can still roll back
+        before ``_finalize_transaction`` completes. Deny-list dispositions
+        (``BLOCKED_PENDING_ROLL``, ``INTERACTION_REJECTED``, all Safety/
+        Contradiction blocks, refusals, ``PIPELINE_ERROR``, any rolled-back
+        turn) never reach this method's body because they never produce a
+        ``DELIVERED`` disposition here.
+
+        Best-effort and swallowed (D7): a failure anywhere in this method
+        — including a D6-ineligible turn correctly declining to ingest —
+        must never change ``result`` or raise out of this method. This is
+        the deliberate opposite of the RPG marker write's mandatory,
+        typed-PIPELINE_ERROR semantics inside ``_narrative_persist``.
+        """
+        if self._retrieval_write_service is None:
+            return
+        if (
+            result.disposition is not PipelineDisposition.DELIVERED
+            or result.turn_id is None
+        ):
+            return
+        try:
+            from afterworlds.persistence.crud.node import get_turn
+            from afterworlds.pipeline.retrieval.eligibility import (
+                gather_turn_eligibility_for_turn,
+            )
+
+            session = self._session_factory()
+            try:
+                turn = get_turn(session, result.turn_id)
+                if turn is None:
+                    return
+                decision = gather_turn_eligibility_for_turn(session, turn, story_mode)
+                if not decision.eligible:
+                    return
+                self._retrieval_write_service.ingest_turn(
+                    story_id=story_id,
+                    turn_id=turn.turn_id,
+                    node_id=turn.node_id,
+                    mode=story_mode.value,
+                    delivered_output=turn.assistant_output,
+                    created_at=turn.timestamp.isoformat(),
+                )
+            finally:
+                session.close()
+        except Exception as exc:  # noqa: BLE001 — D7: log and swallow, never raise
+            logger.error(
+                "retrieval memory ingestion failed for turn_id=%s: %s",
+                result.turn_id,
+                exc,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -1138,10 +1138,13 @@ class OrchestratorService:
         rpg_character_id: UUID | None = None
         rpg_sheet: Dnd5eCharacterSheet | None = None
         # Threaded to _narrative_persist for the RPG turn-retrieval-marker
-        # classification (ADR-018 D6). None only when RPG adjudication is
-        # not wired for an RPG-mode story; the marker-write block treats
-        # that as IN_PLAY/ORDINARY_NARRATIVE (the common case) rather than
-        # failing closed, since adjudication wiring is a separate concern.
+        # classification (ADR-018 D6). Resolved independently of adjudication
+        # wiring below (Codex #119 P2) — a story can have Retrieval Memory
+        # enabled before RPG adjudication is wired, and marker classification
+        # must not silently default an unresolved SETUP turn to
+        # ORDINARY_NARRATIVE. Remains None only when no session/sheet
+        # resolver is wired at all, or resolution fails; the marker-write
+        # block below fails closed (typed PIPELINE_ERROR) in that case.
         rpg_play_status: RpgPlayStatus | None = None
 
         if story_mode == StoryMode.RPG and self._rpg_adjudication_service is not None:
@@ -1262,6 +1265,20 @@ class OrchestratorService:
                         planner_result=planner_result,
                         rpg_adjudication_result=adj_result,
                     )
+        elif story_mode == StoryMode.RPG:
+            # RPG adjudication is not wired for this story, but the mandatory
+            # turn-retrieval-marker write in _narrative_persist still needs
+            # rpg_play_status (ADR-018 D6) — resolved here directly from the
+            # session/sheet resolver, independent of adjudication wiring.
+            # Reads only the durable session record; never infers from
+            # Writer prose. Left None (fails closed at marker-write time) if
+            # no resolver is wired or resolution fails.
+            if self._rpg_session_sheet_resolver is not None:
+                try:
+                    _pre_ss, _ = self._rpg_session_sheet_resolver(story_id)
+                    rpg_play_status = _pre_ss.play_status
+                except Exception:  # noqa: BLE001
+                    rpg_play_status = None
         # -------------------------------------------------------------------------
 
         # Open outer transaction now: Writer is about to persist a Turn.
@@ -1879,10 +1896,33 @@ class OrchestratorService:
 
             if rpg_play_status is RpgPlayStatus.SETUP:
                 _marker_category = _RTRC.SETUP_CONFIRMATION
-            elif adj_result is not None and adj_result.pending_roll_request is not None:
-                _marker_category = _RTRC.ROLL_REQUEST
+            elif rpg_play_status is RpgPlayStatus.IN_PLAY:
+                if (
+                    adj_result is not None
+                    and adj_result.pending_roll_request is not None
+                ):
+                    _marker_category = _RTRC.ROLL_REQUEST
+                else:
+                    _marker_category = _RTRC.ORDINARY_NARRATIVE
             else:
-                _marker_category = _RTRC.ORDINARY_NARRATIVE
+                # RpgPlayStatus is a two-value enum (SETUP, IN_PLAY); None
+                # here means it could not be resolved at all -- no
+                # session/sheet resolver wired, or resolution failed. Fail
+                # closed rather than writing a misleading ORDINARY_NARRATIVE
+                # marker for an unclassified RPG turn (Codex #119 P2).
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    "RPG turn retrieval marker classification requires"
+                    " rpg_play_status, but it could not be resolved (no RPG"
+                    " session/sheet resolver wired, or resolution failed)",
+                    input_safety_result=input_safety,
+                    planner_result=planner_result,
+                    writer_result=writer_result,
+                    rpg_adjudication_result=adj_result,
+                    branching_pass_result=branching_pass_result,
+                )
             try:
                 _create_marker(
                     session,
@@ -3741,14 +3781,21 @@ class OrchestratorService:
         ):
             return
         try:
-            from afterworlds.persistence.crud.node import get_turn
+            from afterworlds.persistence.crud.retrieval import (
+                get_turn_for_eligibility,
+            )
             from afterworlds.pipeline.retrieval.eligibility import (
                 gather_turn_eligibility_for_turn,
             )
 
             session = self._session_factory()
             try:
-                turn = get_turn(session, result.turn_id)
+                # get_turn_for_eligibility (not the general-purpose get_turn)
+                # so a Writing turn with malformed persisted mode_metadata
+                # resolves cleanly to ineligible/not-ingested instead of
+                # raising here and being masked by this method's outer D7
+                # best-effort swallow (Codex review, PR #119).
+                turn = get_turn_for_eligibility(session, result.turn_id)
                 if turn is None:
                     return
                 decision = gather_turn_eligibility_for_turn(session, turn, story_mode)

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -257,7 +257,11 @@ class RetrievalQueryBuilderLike(Protocol):
     """Narrow protocol for ``pipeline.retrieval.query_builder.RetrievalQueryBuilder``."""  # noqa: E501
 
     def build_query_request(
-        self, story_id: UUID, current_input: str, story_mode: StoryMode
+        self,
+        story_id: UUID,
+        current_input: str,
+        story_mode: StoryMode,
+        classified_intent: IntentClassificationResult,
     ) -> RetrievalQueryRequest: ...
 
 
@@ -585,7 +589,7 @@ class OrchestratorService:
             try:
                 retrieval_query_request = (
                     self._retrieval_query_builder.build_query_request(
-                        story_id, user_input, story_mode
+                        story_id, user_input, story_mode, intent_result
                     )
                 )
             except Exception as exc:  # noqa: BLE001

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -581,9 +581,14 @@ class OrchestratorService:
 
         # 2a-retrieval. Build the retrieval query request before context
         # assembly (ADR-018 D8) — orchestrator-owned and deterministic,
-        # mirroring the RuleSliceRequest pattern above. Best-effort: a
-        # query-build failure must not fail the turn, only omit retrieval
-        # memory for it (same as the Null-provider empty-payload behavior).
+        # mirroring the RuleSliceRequest pattern above. This is a pre-context
+        # read/query-construction step, not the post-commit Chroma
+        # ingestion/write path (ADR-018 D7's best-effort swallow applies only
+        # to that write path) -- a query-build failure here is a
+        # context-assembly failure and must fail the turn with a typed
+        # PIPELINE_ERROR, not silently proceed with retrieval memory omitted
+        # (Codex review, PR #119 round 8). No configured builder at all
+        # (``None``) remains a valid no-retrieval turn.
         retrieval_query_request: RetrievalQueryRequest | None = None
         if self._retrieval_query_builder is not None:
             try:
@@ -593,10 +598,11 @@ class OrchestratorService:
                     )
                 )
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "retrieval query build failed for story_id=%s: %s",
-                    story_id,
-                    exc,
+                return self._pipeline_error(
+                    intent_result,
+                    latency,
+                    turn_start,
+                    f"retrieval query construction failed: {exc}",
                 )
 
         # 2b. Context assembly (once per turn).

--- a/src/afterworlds/pipeline/retrieval/backfill.py
+++ b/src/afterworlds/pipeline/retrieval/backfill.py
@@ -24,6 +24,16 @@ from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_f
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
 
 
+class RetrievalReindexWipeIncompleteError(RuntimeError):
+    """Raised when reindex_story()'s delete-before-rebuild phase leaves
+    chunks behind (ADR-018 D11). Rebuilding on top of an incomplete wipe
+    would leave stale chunks alongside the rebuilt set, so backfill must
+    never run in that case — this is distinct from a data-integrity error
+    (a per-turn marker/SQLite defect reported in ``BackfillReport``): this
+    is an operational failure of the delete phase itself.
+    """
+
+
 @dataclass(frozen=True)
 class BackfillReport:
     """Outcome of a backfill or reindex run for one story."""
@@ -116,6 +126,17 @@ def reindex_story(
     reflected (no stray chunks survive from a chunk-set that has since
     shrunk for reasons outside a single turn's re-ingestion, e.g. a turn
     deletion that predates this reindex run).
+
+    Raises:
+        RetrievalReindexWipeIncompleteError: if the delete phase leaves any
+            chunks behind — rebuild never runs on top of an incomplete wipe
+            (Codex review, PR #119 round 6).
     """
-    write_service.delete_story(story_id)
+    remaining = write_service.delete_story(story_id)
+    if remaining != 0:
+        raise RetrievalReindexWipeIncompleteError(
+            f"reindex aborted for story {story_id}: delete_story left"
+            f" {remaining} chunk(s) behind; refusing to rebuild on top of an"
+            " incomplete wipe"
+        )
     return backfill_story(session, write_service, story_id, story_mode)

--- a/src/afterworlds/pipeline/retrieval/backfill.py
+++ b/src/afterworlds/pipeline/retrieval/backfill.py
@@ -1,0 +1,116 @@
+"""Story-memory backfill / reindex / delete — CRD Issue 18 / ADR-018 D7/D11.
+
+Recovery for a Chroma write failure is a re-run (D7): v1 ships this
+idempotent manual backfill/reindex, not an automatic retry queue. All three
+operations here consult the single shared eligibility predicate
+(``pipeline.retrieval.eligibility``) — the same one the live ingestion gate
+uses — so live ingestion and offline backfill/reindex never disagree
+(ADR-018 sibling-audit checkpoint #5).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import StoryMode
+from afterworlds.persistence.crud.node import get_turn
+from afterworlds.persistence.orm.node import NodeORM, TurnORM
+from afterworlds.persistence.orm.story import ArcORM, ChapterORM
+from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
+from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
+
+
+@dataclass(frozen=True)
+class BackfillReport:
+    """Outcome of a backfill or reindex run for one story."""
+
+    turns_scanned: int
+    turns_ingested: int
+    turns_skipped_ineligible: int
+    data_integrity_errors: tuple[UUID, ...]
+
+
+def _all_turn_ids_for_story(session: Session, story_id: UUID) -> list[UUID]:
+    """Return every persisted Turn ID for *story_id*, oldest-first.
+
+    Unlike ``SQLiteRecentTurnsProvider.get_recent_turns``, this is
+    unbounded and includes every disposition (OOC included) — the
+    eligibility predicate is what filters, not this query.
+    """
+    stmt = (
+        select(TurnORM.turn_id)
+        .join(NodeORM, TurnORM.node_id == NodeORM.node_id)
+        .join(ChapterORM, NodeORM.chapter_id == ChapterORM.chapter_id)
+        .join(ArcORM, ChapterORM.arc_id == ArcORM.arc_id)
+        .where(ArcORM.story_id == str(story_id))
+        .order_by(TurnORM.timestamp.asc(), TurnORM.turn_id.asc())
+    )
+    return [UUID(row) for row in session.execute(stmt).scalars().all()]
+
+
+def backfill_story(
+    session: Session,
+    write_service: RetrievalMemoryWriteService,
+    story_id: UUID,
+    story_mode: StoryMode,
+) -> BackfillReport:
+    """Ingest every currently-eligible, not-yet-indexed turn for *story_id*.
+
+    Idempotent: re-running against an already-ingested turn is a no-op at
+    the vector layer (deterministic chunk IDs, D11) even though this
+    function re-calls ``ingest_turn`` unconditionally for every eligible
+    turn — upsert-by-deterministic-ID makes the re-write byte-identical.
+    """
+    turn_ids = _all_turn_ids_for_story(session, story_id)
+    ingested = 0
+    skipped = 0
+    integrity_errors: list[UUID] = []
+    for turn_id in turn_ids:
+        turn = get_turn(session, turn_id)
+        if turn is None:
+            continue
+        decision = gather_turn_eligibility_for_turn(session, turn, story_mode)
+        if decision.data_integrity_error:
+            integrity_errors.append(turn.turn_id)
+            skipped += 1
+            continue
+        if not decision.eligible:
+            skipped += 1
+            continue
+        write_service.ingest_turn(
+            story_id=story_id,
+            turn_id=turn.turn_id,
+            node_id=turn.node_id,
+            mode=story_mode.value,
+            delivered_output=turn.assistant_output,
+            created_at=turn.timestamp.isoformat(),
+        )
+        ingested += 1
+    return BackfillReport(
+        turns_scanned=len(turn_ids),
+        turns_ingested=ingested,
+        turns_skipped_ineligible=skipped,
+        data_integrity_errors=tuple(integrity_errors),
+    )
+
+
+def reindex_story(
+    session: Session,
+    write_service: RetrievalMemoryWriteService,
+    story_id: UUID,
+    story_mode: StoryMode,
+) -> BackfillReport:
+    """Wipe *story_id*'s chunks then rebuild from SQLite ground truth.
+
+    Full story-level reindex (ADR-018 D11): rebuild-from-source rather than
+    relying on upsert alone, so a shrunk or corrected history is exactly
+    reflected (no stray chunks survive from a chunk-set that has since
+    shrunk for reasons outside a single turn's re-ingestion, e.g. a turn
+    deletion that predates this reindex run).
+    """
+    write_service.delete_story(story_id)
+    return backfill_story(session, write_service, story_id, story_mode)

--- a/src/afterworlds/pipeline/retrieval/backfill.py
+++ b/src/afterworlds/pipeline/retrieval/backfill.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import StoryMode
-from afterworlds.persistence.crud.node import get_turn
+from afterworlds.persistence.crud.retrieval import get_turn_for_eligibility
 from afterworlds.persistence.orm.node import NodeORM, TurnORM
 from afterworlds.persistence.orm.story import ArcORM, ChapterORM
 from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
@@ -70,7 +70,12 @@ def backfill_story(
     skipped = 0
     integrity_errors: list[UUID] = []
     for turn_id in turn_ids:
-        turn = get_turn(session, turn_id)
+        # get_turn_for_eligibility (not the general-purpose get_turn) so a
+        # single Writing turn with malformed persisted mode_metadata cannot
+        # abort the whole story's backfill/reindex run (Codex review, PR
+        # #119) -- ADR-018 D6 already defines that shape as ineligible, not
+        # a fatal error.
+        turn = get_turn_for_eligibility(session, turn_id)
         if turn is None:
             continue
         decision = gather_turn_eligibility_for_turn(session, turn, story_mode)

--- a/src/afterworlds/pipeline/retrieval/chroma_provider.py
+++ b/src/afterworlds/pipeline/retrieval/chroma_provider.py
@@ -1,0 +1,74 @@
+"""ChromaRetrievalMemoryProvider — CRD Issue 18 / ADR-018 D1/D5.
+
+Implements ``services.context_builder.RetrievalMemoryProvider`` (the
+existing Issue 8 protocol seam — shape unchanged per ADR-018 D8). Every
+query is gated by a mandatory ``story_id`` metadata filter (D1); results are
+normalized to a similarity score and filtered by the configured inclusive
+threshold (D5) before being wrapped into the existing typed
+``RetrievalMemoryPayload``.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from chromadb.api import ClientAPI
+
+from afterworlds.models.context import RetrievalMemoryPayload
+from afterworlds.pipeline.retrieval.collections import get_story_memory_collection
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import RetrievalEmbeddingFunction
+from afterworlds.pipeline.retrieval.scoring import normalize_similarity
+
+
+class ChromaRetrievalMemoryProvider:
+    """Chroma-backed RetrievalMemoryProvider for the shared story_memory collection."""
+
+    def __init__(
+        self,
+        client: ClientAPI,
+        config: RetrievalMemoryConfig,
+        embedding_function: RetrievalEmbeddingFunction | None = None,
+    ) -> None:
+        self._client = client
+        self._config = config
+        self._embedding_function = embedding_function
+
+    def retrieve(self, story_id: UUID, query: str) -> RetrievalMemoryPayload:
+        if not query:
+            return RetrievalMemoryPayload()
+
+        collection = get_story_memory_collection(
+            self._client, self._config, self._embedding_function
+        )
+        count = collection.count()
+        if count == 0:
+            return RetrievalMemoryPayload()
+
+        n_results = min(self._config.top_k, count)
+        results = collection.query(
+            query_texts=[query],
+            n_results=n_results,
+            # Mandatory story_id filter (ADR-018 D1) — the single query gate
+            # every read path traverses. Never omitted, never bypassed.
+            where={"story_id": str(story_id)},
+        )
+
+        documents_lists = results.get("documents") or []
+        distances_lists = results.get("distances") or []
+        if not documents_lists or not documents_lists[0]:
+            return RetrievalMemoryPayload()
+
+        documents = documents_lists[0]
+        distances = distances_lists[0] if distances_lists else []
+
+        passages: list[str] = []
+        for i, document in enumerate(documents):
+            distance = distances[i] if i < len(distances) else 1.0
+            similarity = normalize_similarity(
+                float(distance), self._config.distance_metric
+            )
+            if similarity >= self._config.minimum_similarity_threshold:
+                passages.append(str(document))
+
+        return RetrievalMemoryPayload(passages=tuple(passages))

--- a/src/afterworlds/pipeline/retrieval/chunking.py
+++ b/src/afterworlds/pipeline/retrieval/chunking.py
@@ -1,0 +1,37 @@
+"""Chunking policy for story-memory ingestion — CRD Issue 18 / ADR-018 D3.
+
+One chunk per delivered turn's prose under a configured character ceiling;
+above it, split on paragraph boundaries. No semantic chunker, no overlap
+windows in v1.
+"""
+
+from __future__ import annotations
+
+
+def chunk_turn_prose(text: str, ceiling: int) -> list[str]:
+    """Split *text* into chunks of at most *ceiling* characters.
+
+    Splits on paragraph boundaries (blank-line-separated) when the full text
+    exceeds the ceiling. A single paragraph longer than the ceiling is kept
+    whole as its own chunk (no mid-paragraph splitting in v1) rather than
+    silently truncated. Returns ``[text]`` unchanged when it already fits.
+    """
+    if not text:
+        return [text]
+    if len(text) <= ceiling:
+        return [text]
+
+    paragraphs = [p for p in text.split("\n\n") if p]
+    chunks: list[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        candidate = f"{current}\n\n{paragraph}" if current else paragraph
+        if len(candidate) <= ceiling:
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+        current = paragraph
+    if current:
+        chunks.append(current)
+    return chunks or [text]

--- a/src/afterworlds/pipeline/retrieval/client.py
+++ b/src/afterworlds/pipeline/retrieval/client.py
@@ -1,0 +1,54 @@
+"""ChromaDB client construction — CRD Issue 18 / ADR-018.
+
+Single choke point for constructing a Chroma client. Always an embedded
+client (``PersistentClient``/``EphemeralClient``) — never ``HttpClient`` /
+a standalone ``chromadb run`` server process. This is the safe-deployment-
+path resolution for chromadb CVE-2026-45829 (PYSEC-2026-311): that
+vulnerability is a pre-auth code-injection path in chromadb's HTTP server
+component (``/api/v2/.../collections`` with an attacker-controlled model
+repository and ``trust_remote_code=True``). Afterworlds never runs that
+server component and never sets ``trust_remote_code=True`` anywhere, so the
+vulnerable code path is never reached. See this PR's Architecture Notes and
+the CI pip-audit step for the full re-justification.
+"""
+
+from __future__ import annotations
+
+from chromadb import EphemeralClient, PersistentClient
+from chromadb.api import ClientAPI
+
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+
+
+def build_chroma_client(config: RetrievalMemoryConfig) -> ClientAPI:
+    """Return an embedded ChromaDB client per *config*.
+
+    Always ``PersistentClient`` — durable, local, on-disk. Never
+    ``HttpClient``. Use :func:`build_ephemeral_chroma_client` for tests that
+    need a throwaway in-memory client.
+    """
+    return PersistentClient(path=config.persist_directory)
+
+
+def build_ephemeral_chroma_client() -> ClientAPI:
+    """Return an in-memory ChromaDB client for tests.
+
+    ChromaDB's ephemeral backend shares process-level state across separate
+    ``EphemeralClient()`` instances when no explicit path is given (verified
+    empirically against the pinned chromadb version) — two calls in the same
+    test process can observe each other's collections. Tests that need
+    isolation between runs (e.g. differing embedding-vector dimensions
+    against the same collection name) must use
+    :func:`build_isolated_test_chroma_client` instead.
+    """
+    return EphemeralClient()
+
+
+def build_isolated_test_chroma_client(path: str) -> ClientAPI:
+    """Return a fully isolated on-disk client rooted at *path* for tests.
+
+    Use with pytest's ``tmp_path`` fixture (a fresh directory per test) to
+    guarantee no shared state between tests, unlike
+    :func:`build_ephemeral_chroma_client`.
+    """
+    return PersistentClient(path=path)

--- a/src/afterworlds/pipeline/retrieval/collections.py
+++ b/src/afterworlds/pipeline/retrieval/collections.py
@@ -7,6 +7,8 @@ see ``eligibility.py`` and the query/write services, never bypassed here).
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 from chromadb.api import ClientAPI
 from chromadb.api.models.Collection import Collection
 from chromadb.errors import NotFoundError
@@ -144,6 +146,22 @@ def get_existing_story_memory_collection_for_delete(
         return client.get_collection(name=STORY_MEMORY_COLLECTION_NAME)
     except NotFoundError:
         return None
+
+
+def delete_collection_ignoring_absence(client: ClientAPI, collection_name: str) -> None:
+    """Delete *collection_name* if it exists; a genuinely absent collection is
+    a no-op.
+
+    Only ``chromadb.errors.NotFoundError`` is swallowed — the same narrow
+    exception type used by :func:`get_existing_story_memory_collection_for_delete`.
+    Any other Chroma/operational failure (locked store, corrupt store,
+    permission failure, client failure) propagates: a wipe-then-rebuild
+    caller must never proceed to recreate the collection or upsert on top of
+    a delete that may not have actually happened, since stale chunks would
+    then remain silently retrievable (Codex review, PR #119 round 7).
+    """
+    with suppress(NotFoundError):
+        client.delete_collection(collection_name)
 
 
 def get_rules_corpus_collection(

--- a/src/afterworlds/pipeline/retrieval/collections.py
+++ b/src/afterworlds/pipeline/retrieval/collections.py
@@ -17,6 +17,46 @@ from afterworlds.pipeline.retrieval.embedding import (
     resolve_default_embedding_function,
 )
 
+#: Collection-metadata key storing the embedding model a collection was
+#: created for (ADR-018 D2/D4). Distinct from the per-chunk
+#: ``embedding_model_id`` field on ``StoryMemoryChunkMetadata`` /
+#: ``RulesCorpusChunkMetadata`` — this is the collection-level identity
+#: check that lets ``_require_matching_embedding_model`` detect drift
+#: *before* any chunk is written or queried.
+_EMBEDDING_MODEL_ID_METADATA_KEY = "embedding_model_id"
+
+
+class RetrievalCollectionReindexRequiredError(RuntimeError):
+    """Raised when an existing Chroma collection's recorded embedding model
+    does not match the configured one (ADR-018 D4: a model change forces a
+    full reindex; mixed-model collections are a defect).
+
+    This includes a collection created before this guard existed (no
+    ``embedding_model_id`` in its metadata at all) — ADR-018 does not permit
+    silently assuming a legacy collection is compatible, so a missing key is
+    treated the same as a mismatch. Callers must run the manual reindex
+    command (`scripts/retrieval_backfill.py --mode reindex`) rather than
+    have this helper auto-wipe or auto-reindex on their behalf.
+    """
+
+
+def _require_matching_embedding_model(
+    collection: Collection, config: RetrievalMemoryConfig, collection_name: str
+) -> None:
+    existing = (
+        collection.metadata.get(_EMBEDDING_MODEL_ID_METADATA_KEY)
+        if collection.metadata
+        else None
+    )
+    if existing != config.embedding_model_id:
+        raise RetrievalCollectionReindexRequiredError(
+            f"Collection {collection_name!r} was created with embedding_model_id "
+            f"{existing!r} but the configured embedding_model_id is "
+            f"{config.embedding_model_id!r}. Mixed-model collections are a "
+            "defect (ADR-018 D4) — run a full reindex for this "
+            "story/rules-package before writing or querying again."
+        )
+
 
 def get_story_memory_collection(
     client: ClientAPI,
@@ -25,16 +65,30 @@ def get_story_memory_collection(
 ) -> Collection:
     """Return (creating if needed) the single shared story_memory collection.
 
-    The distance metric is set once at creation time via collection metadata
-    (ADR-018 D5) and is a no-op on subsequent calls once the collection
-    exists (Chroma ignores ``metadata=`` on an already-created collection).
+    The distance metric and ``embedding_model_id`` are set once at creation
+    time via collection metadata (ADR-018 D4/D5) and are a no-op on
+    subsequent calls once the collection exists (Chroma ignores
+    ``metadata=`` on an already-created collection) — which is exactly why
+    ``embedding_model_id`` must be checked explicitly here rather than
+    trusted to have been (re)applied.
+
+    Raises:
+        RetrievalCollectionReindexRequiredError: if an existing collection's
+            recorded ``embedding_model_id`` does not match (or is absent,
+            i.e. a pre-guard legacy collection) — never silently reused,
+            never auto-wiped, never auto-reindexed.
     """
     ef = embedding_function or resolve_default_embedding_function()
-    return client.get_or_create_collection(
+    collection = client.get_or_create_collection(
         name=STORY_MEMORY_COLLECTION_NAME,
-        metadata={"hnsw:space": config.distance_metric},
+        metadata={
+            "hnsw:space": config.distance_metric,
+            _EMBEDDING_MODEL_ID_METADATA_KEY: config.embedding_model_id,
+        },
         embedding_function=ef,  # type: ignore[arg-type]
     )
+    _require_matching_embedding_model(collection, config, STORY_MEMORY_COLLECTION_NAME)
+    return collection
 
 
 def get_rules_corpus_collection(
@@ -43,10 +97,23 @@ def get_rules_corpus_collection(
     config: RetrievalMemoryConfig,
     embedding_function: RetrievalEmbeddingFunction | None = None,
 ) -> Collection:
-    """Return (creating if needed) a per-Rules-Package rules_corpus collection."""
+    """Return (creating if needed) a per-Rules-Package rules_corpus collection.
+
+    See :func:`get_story_memory_collection` for the ``embedding_model_id``
+    guard rationale — applies identically here (Codex review, PR #119).
+
+    Raises:
+        RetrievalCollectionReindexRequiredError: if an existing collection's
+            recorded ``embedding_model_id`` does not match (or is absent).
+    """
     ef = embedding_function or resolve_default_embedding_function()
-    return client.get_or_create_collection(
+    collection = client.get_or_create_collection(
         name=collection_name,
-        metadata={"hnsw:space": config.distance_metric},
+        metadata={
+            "hnsw:space": config.distance_metric,
+            _EMBEDDING_MODEL_ID_METADATA_KEY: config.embedding_model_id,
+        },
         embedding_function=ef,  # type: ignore[arg-type]
     )
+    _require_matching_embedding_model(collection, config, collection_name)
+    return collection

--- a/src/afterworlds/pipeline/retrieval/collections.py
+++ b/src/afterworlds/pipeline/retrieval/collections.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from chromadb.api import ClientAPI
 from chromadb.api.models.Collection import Collection
+from chromadb.errors import NotFoundError
 
 from afterworlds.models.retrieval import STORY_MEMORY_COLLECTION_NAME
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
@@ -132,10 +133,16 @@ def get_existing_story_memory_collection_for_delete(
     both work), so embedding-model compatibility is irrelevant to a delete
     and must not block an operator from scrubbing a mismatched collection's
     story-scoped chunks ahead of a full reindex (Codex review, PR #119).
+
+    Only ``chromadb.errors.NotFoundError`` (collection genuinely absent) is
+    treated as "nothing to delete" — a locked store, corrupt store,
+    permission failure, or other operational error must propagate rather
+    than being silently reported as a missing collection (Codex review, PR
+    #119 round 6).
     """
     try:
         return client.get_collection(name=STORY_MEMORY_COLLECTION_NAME)
-    except Exception:  # noqa: BLE001 — chromadb's not-found error, no collection yet
+    except NotFoundError:
         return None
 
 

--- a/src/afterworlds/pipeline/retrieval/collections.py
+++ b/src/afterworlds/pipeline/retrieval/collections.py
@@ -1,0 +1,52 @@
+"""Chroma collection access helpers shared by write and query paths.
+
+CRD Issue 18 / ADR-018 D1. One shared ``story_memory`` collection across all
+stories (mandatory ``story_id`` metadata filter enforced by every caller —
+see ``eligibility.py`` and the query/write services, never bypassed here).
+"""
+
+from __future__ import annotations
+
+from chromadb.api import ClientAPI
+from chromadb.api.models.Collection import Collection
+
+from afterworlds.models.retrieval import STORY_MEMORY_COLLECTION_NAME
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import (
+    RetrievalEmbeddingFunction,
+    resolve_default_embedding_function,
+)
+
+
+def get_story_memory_collection(
+    client: ClientAPI,
+    config: RetrievalMemoryConfig,
+    embedding_function: RetrievalEmbeddingFunction | None = None,
+) -> Collection:
+    """Return (creating if needed) the single shared story_memory collection.
+
+    The distance metric is set once at creation time via collection metadata
+    (ADR-018 D5) and is a no-op on subsequent calls once the collection
+    exists (Chroma ignores ``metadata=`` on an already-created collection).
+    """
+    ef = embedding_function or resolve_default_embedding_function()
+    return client.get_or_create_collection(
+        name=STORY_MEMORY_COLLECTION_NAME,
+        metadata={"hnsw:space": config.distance_metric},
+        embedding_function=ef,  # type: ignore[arg-type]
+    )
+
+
+def get_rules_corpus_collection(
+    client: ClientAPI,
+    collection_name: str,
+    config: RetrievalMemoryConfig,
+    embedding_function: RetrievalEmbeddingFunction | None = None,
+) -> Collection:
+    """Return (creating if needed) a per-Rules-Package rules_corpus collection."""
+    ef = embedding_function or resolve_default_embedding_function()
+    return client.get_or_create_collection(
+        name=collection_name,
+        metadata={"hnsw:space": config.distance_metric},
+        embedding_function=ef,  # type: ignore[arg-type]
+    )

--- a/src/afterworlds/pipeline/retrieval/collections.py
+++ b/src/afterworlds/pipeline/retrieval/collections.py
@@ -48,14 +48,35 @@ def _require_matching_embedding_model(
         if collection.metadata
         else None
     )
-    if existing != config.embedding_model_id:
-        raise RetrievalCollectionReindexRequiredError(
-            f"Collection {collection_name!r} was created with embedding_model_id "
-            f"{existing!r} but the configured embedding_model_id is "
-            f"{config.embedding_model_id!r}. Mixed-model collections are a "
-            "defect (ADR-018 D4) — run a full reindex for this "
-            "story/rules-package before writing or querying again."
+    if existing == config.embedding_model_id:
+        return
+
+    if collection_name == STORY_MEMORY_COLLECTION_NAME:
+        # Shared across every story (ADR-018 D1) -- a single story's
+        # reindex_story() cannot repair a collection-level mismatch, since
+        # other stories' chunks in this same collection are still recorded
+        # under the old model. Do not let a caller believe a story-scoped
+        # operation fixed this; direct them to the explicit full-collection
+        # wipe (Codex review, PR #119).
+        guidance = (
+            "story_memory is shared across all stories -- a single story's "
+            "reindex cannot repair this collection-level mismatch. Wipe and "
+            "rebuild the entire collection "
+            "(RetrievalMemoryWriteService.wipe_collection(), then backfill "
+            "every story) before writing or querying again."
         )
+    else:
+        guidance = (
+            "run a full reindex for this rules package "
+            "(RulesCorpusService.reindex_from_sql) before writing or "
+            "querying again."
+        )
+    raise RetrievalCollectionReindexRequiredError(
+        f"Collection {collection_name!r} was created with embedding_model_id "
+        f"{existing!r} but the configured embedding_model_id is "
+        f"{config.embedding_model_id!r}. Mixed-model collections are a "
+        f"defect (ADR-018 D4) — {guidance}"
+    )
 
 
 def get_story_memory_collection(
@@ -89,6 +110,33 @@ def get_story_memory_collection(
     )
     _require_matching_embedding_model(collection, config, STORY_MEMORY_COLLECTION_NAME)
     return collection
+
+
+def get_existing_story_memory_collection_for_delete(
+    client: ClientAPI,
+) -> Collection | None:
+    """Open the existing ``story_memory`` collection for a metadata-only
+    delete operation, bypassing the ``embedding_model_id`` compatibility
+    guard entirely.
+
+    Returns ``None`` if the collection does not exist — callers must treat
+    "nothing to delete" as a no-op and must never create a collection as a
+    side effect of a delete-only operation (unlike
+    :func:`get_story_memory_collection`, which creates on first use).
+
+    This handle must only be used for metadata-filtered ``.get()``/
+    ``.delete()`` calls — never ``.upsert()`` or a semantic ``.query()``.
+    Deletion by ``story_id``/``turn_id`` metadata filter never invokes the
+    embedding function at all (verified against chromadb: ``.get()``/
+    ``.delete()`` with a ``where=`` filter and no embedding function bound
+    both work), so embedding-model compatibility is irrelevant to a delete
+    and must not block an operator from scrubbing a mismatched collection's
+    story-scoped chunks ahead of a full reindex (Codex review, PR #119).
+    """
+    try:
+        return client.get_collection(name=STORY_MEMORY_COLLECTION_NAME)
+    except Exception:  # noqa: BLE001 — chromadb's not-found error, no collection yet
+        return None
 
 
 def get_rules_corpus_collection(

--- a/src/afterworlds/pipeline/retrieval/config.py
+++ b/src/afterworlds/pipeline/retrieval/config.py
@@ -1,0 +1,116 @@
+"""Retrieval Memory configuration — CRD Issue 18 / ADR-018.
+
+Configuration is read from environment variables at call time via
+``RetrievalMemoryConfig.from_env()``, matching the per-pass config convention
+(see ``pipeline/writer/config.py``). No global singleton — callers construct
+a config object and pass it into the write/query services.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+#: Chroma distance metric used for the story_memory collection. Fixed and
+#: documented once here (ADR-018 D5 requires naming the metric once in the
+#: collection-config code, not per query). "cosine" produces a distance in
+#: [0, 2]; normalization to a [0, 1] similarity happens in the query path,
+#: never by comparing this raw distance directly against the threshold.
+STORY_MEMORY_DISTANCE_METRIC: str = "cosine"
+
+#: Character ceiling for one story-memory chunk before paragraph-boundary
+#: splitting (ADR-018 D3). Starting value per the ADR.
+DEFAULT_CHUNK_CHAR_CEILING: int = 4000
+
+#: Default number of results returned by a story-memory query (ADR-018 D5).
+DEFAULT_TOP_K: int = 4
+
+#: Default minimum normalized-similarity threshold (ADR-018 D5). Inclusive:
+#: a result is retained when normalized_similarity >= this value.
+DEFAULT_MINIMUM_SIMILARITY_THRESHOLD: float = 0.6
+
+#: ChromaDB embedding model identifier for the local deterministic ONNX
+#: MiniLM path (ADR-018 D4). Recorded per chunk and on the collection so a
+#: model change is detectable and forces a full reindex.
+DEFAULT_EMBEDDING_MODEL_ID: str = "chroma-onnx-minilm-l6-v2"
+
+#: Default on-disk path for the embedded ChromaDB PersistentClient. ADR-018's
+#: chromadb CVE-2026-45829 resolution requires embedded-client-only usage —
+#: never chromadb.HttpClient / a standalone chromadb server process (see
+#: RetrievalMemoryConfig docstring and pip-audit CI comment).
+DEFAULT_PERSIST_DIRECTORY: str = ".chroma_data"
+
+
+@dataclass
+class RetrievalMemoryConfig:
+    """Configuration for Retrieval Memory ingestion, query, and reindex.
+
+    Attributes:
+        top_k: number of story-memory results requested per query.
+        minimum_similarity_threshold: inclusive (>=) cutoff applied to the
+            normalized similarity, after mandatory story_id/eligibility
+            metadata filters and before rendering into StablePrefix.
+        chunk_char_ceiling: character ceiling for one story-memory chunk
+            before paragraph-boundary splitting.
+        embedding_model_id: identifier recorded per chunk and on the
+            collection metadata. Changing this forces a full reindex.
+        persist_directory: on-disk path for the embedded ChromaDB
+            PersistentClient. Never used to construct an HttpClient.
+        distance_metric: Chroma collection distance metric, fixed to
+            ``STORY_MEMORY_DISTANCE_METRIC``.
+
+    Security note (chromadb CVE-2026-45829 / PYSEC-2026-311): this config
+    intentionally exposes no server-mode / trust_remote_code knobs. The
+    vulnerability is a pre-auth code-injection path in chromadb's HTTP
+    server component (``/api/v2/.../collections`` with an attacker-supplied
+    model repository and ``trust_remote_code=True``). Afterworlds never runs
+    a chromadb server process and never sets ``trust_remote_code=True`` on
+    any embedding function — the embedded ``PersistentClient`` with the
+    default local ONNX MiniLM embedding function never reaches that code
+    path. See the CI pip-audit step and this PR's Architecture Notes for the
+    full re-justification of the retained ``--ignore-vuln``.
+    """
+
+    top_k: int = DEFAULT_TOP_K
+    minimum_similarity_threshold: float = DEFAULT_MINIMUM_SIMILARITY_THRESHOLD
+    chunk_char_ceiling: int = DEFAULT_CHUNK_CHAR_CEILING
+    embedding_model_id: str = DEFAULT_EMBEDDING_MODEL_ID
+    persist_directory: str = DEFAULT_PERSIST_DIRECTORY
+    distance_metric: str = STORY_MEMORY_DISTANCE_METRIC
+
+    @classmethod
+    def from_env(cls) -> RetrievalMemoryConfig:
+        """Build a RetrievalMemoryConfig from environment variables.
+
+        Environment variables:
+            AFTERWORLDS_RETRIEVAL_TOP_K
+            AFTERWORLDS_RETRIEVAL_MIN_SIMILARITY
+            AFTERWORLDS_RETRIEVAL_CHUNK_CHAR_CEILING
+            AFTERWORLDS_RETRIEVAL_EMBEDDING_MODEL_ID
+            AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY
+        """
+        return cls(
+            top_k=int(
+                os.environ.get("AFTERWORLDS_RETRIEVAL_TOP_K", str(DEFAULT_TOP_K))
+            ),
+            minimum_similarity_threshold=float(
+                os.environ.get(
+                    "AFTERWORLDS_RETRIEVAL_MIN_SIMILARITY",
+                    str(DEFAULT_MINIMUM_SIMILARITY_THRESHOLD),
+                )
+            ),
+            chunk_char_ceiling=int(
+                os.environ.get(
+                    "AFTERWORLDS_RETRIEVAL_CHUNK_CHAR_CEILING",
+                    str(DEFAULT_CHUNK_CHAR_CEILING),
+                )
+            ),
+            embedding_model_id=os.environ.get(
+                "AFTERWORLDS_RETRIEVAL_EMBEDDING_MODEL_ID",
+                DEFAULT_EMBEDDING_MODEL_ID,
+            ),
+            persist_directory=os.environ.get(
+                "AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY",
+                DEFAULT_PERSIST_DIRECTORY,
+            ),
+        )

--- a/src/afterworlds/pipeline/retrieval/eligibility.py
+++ b/src/afterworlds/pipeline/retrieval/eligibility.py
@@ -1,0 +1,149 @@
+"""Retrieval eligibility predicate — CRD Issue 18 / ADR-018 D6 / D8.
+
+The single eligibility predicate every consumer must share: the ingestion
+gate, the retrieval-query-tail builder, backfill, and reindex all call
+:func:`gather_turn_eligibility`, never a locally re-derived check (ADR-018
+sibling-audit checkpoint #5). The predicate reads only committed
+SQLite-reconstructable state — never a transient in-memory request object
+(e.g. ``WritingTurnRequest``) — so live ingestion and offline
+backfill/reindex always agree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import (
+    IntentType,
+    RpgTurnRetrievalCategory,
+    StoryMode,
+    WritingCanonEligibility,
+)
+from afterworlds.models.node import ModeMetadata, WritingNodeMetadata
+from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.node import get_turn
+from afterworlds.persistence.crud.retrieval import (
+    get_era_boundary_timestamp,
+    get_rpg_turn_retrieval_marker,
+)
+from afterworlds.persistence.crud.retrieval import is_post_boundary as _is_post_boundary
+from afterworlds.persistence.orm.node import TurnORM
+
+
+@dataclass(frozen=True)
+class EligibilityDecision:
+    """Outcome of the retrieval-eligibility predicate for one committed turn."""
+
+    eligible: bool
+    data_integrity_error: bool = False
+    reason: str = ""
+
+
+def decide_turn_eligibility(
+    *,
+    story_mode: StoryMode,
+    intent_classification: IntentType,
+    mode_metadata: ModeMetadata | None,
+    rpg_marker_category: RpgTurnRetrievalCategory | None,
+    is_post_boundary: bool,
+) -> EligibilityDecision:
+    """Pure decision function — no I/O. See module docstring for callers.
+
+    Mode-specific rules (ADR-018 D6/D8):
+      - OOC turns are always excluded, regardless of mode.
+      - Writing: eligible only when committed ``WritingNodeMetadata``
+        exists and its ``canon_eligibility`` reads ``EXTRACTOR_ELIGIBLE``.
+        Missing/malformed metadata (the Writing block's best-effort write
+        can fail silently) is treated as ineligible, never as eligible.
+      - RPG: eligible only for ``ORDINARY_NARRATIVE`` markers. A markerless
+        post-boundary turn is a data-integrity error (ineligible, flagged);
+        a markerless pre-boundary (legacy) turn is eligible.
+      - Branching (and any other mode): eligible by default once the OOC
+        filter above is applied — Branching setup confirmations remain
+        eligible as ordinary narrative turns (CRD Issue 16).
+    """
+    if intent_classification is IntentType.OOC:
+        return EligibilityDecision(eligible=False, reason="ooc turn")
+
+    if story_mode is StoryMode.WRITING:
+        if not isinstance(mode_metadata, WritingNodeMetadata):
+            return EligibilityDecision(
+                eligible=False,
+                reason="missing or malformed WritingNodeMetadata"
+                " (treated as ineligible per the best-effort-write safe default)",
+            )
+        if (
+            mode_metadata.canon_eligibility
+            != WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        ):
+            return EligibilityDecision(
+                eligible=False,
+                reason=f"canon_eligibility={mode_metadata.canon_eligibility!r}",
+            )
+        return EligibilityDecision(eligible=True)
+
+    if story_mode is StoryMode.RPG:
+        if rpg_marker_category is None:
+            if is_post_boundary:
+                return EligibilityDecision(
+                    eligible=False,
+                    data_integrity_error=True,
+                    reason="post-boundary RPG narrative-path turn missing marker row",
+                )
+            return EligibilityDecision(
+                eligible=True,
+                reason="pre-boundary legacy turn treated as ORDINARY_NARRATIVE",
+            )
+        if rpg_marker_category is RpgTurnRetrievalCategory.ORDINARY_NARRATIVE:
+            return EligibilityDecision(eligible=True)
+        return EligibilityDecision(
+            eligible=False, reason=f"rpg marker category={rpg_marker_category.value}"
+        )
+
+    return EligibilityDecision(eligible=True)
+
+
+def gather_turn_eligibility_for_turn(
+    session: Session, turn: Turn, story_mode: StoryMode
+) -> EligibilityDecision:
+    """Decide eligibility for an already-fetched *turn*.
+
+    Split from :func:`gather_turn_eligibility` so callers that already hold
+    the committed ``Turn`` (e.g. the ingestion gate, which also needs
+    ``turn.assistant_output``/``turn.node_id`` to build the chunk) do not
+    issue a second redundant read.
+    """
+    marker_category: RpgTurnRetrievalCategory | None = None
+    post_boundary = True
+    if story_mode is StoryMode.RPG:
+        marker_category = get_rpg_turn_retrieval_marker(session, turn.turn_id)
+        raw_row = session.get(TurnORM, str(turn.turn_id))
+        assert raw_row is not None  # noqa: S101 — caller-supplied turn exists
+        boundary = get_era_boundary_timestamp(session)
+        post_boundary = _is_post_boundary(raw_row.timestamp, boundary)
+
+    return decide_turn_eligibility(
+        story_mode=story_mode,
+        intent_classification=turn.intent_classification,
+        mode_metadata=turn.mode_metadata,
+        rpg_marker_category=marker_category,
+        is_post_boundary=post_boundary,
+    )
+
+
+def gather_turn_eligibility(
+    session: Session, turn_id: UUID, story_mode: StoryMode
+) -> EligibilityDecision:
+    """Read committed SQLite state for *turn_id* and decide eligibility.
+
+    Returns ``eligible=False`` with a reason when the turn does not exist
+    (e.g. already deleted) rather than raising, since callers (backfill,
+    reindex) iterate turn IDs that may no longer be present.
+    """
+    turn = get_turn(session, turn_id)
+    if turn is None:
+        return EligibilityDecision(eligible=False, reason="turn not found")
+    return gather_turn_eligibility_for_turn(session, turn, story_mode)

--- a/src/afterworlds/pipeline/retrieval/eligibility.py
+++ b/src/afterworlds/pipeline/retrieval/eligibility.py
@@ -60,15 +60,18 @@ def decide_turn_eligibility(
         exists and its ``canon_eligibility`` reads ``EXTRACTOR_ELIGIBLE``.
         Missing/malformed metadata (the Writing block's best-effort write
         can fail silently) is treated as ineligible, never as eligible.
-      - RPG: ``has_pending_roll_request`` (a persisted ``PendingRollRequest``
-        row whose ``originating_turn_id`` matches this turn) is checked
-        before marker classification and governs regardless of marker
-        category — this is what excludes a legacy pre-marker roll-request
-        turn, since it predates the marker sidecar entirely and carries no
-        marker row (ADR-018 D6 era-boundary table). Otherwise, eligible only
-        for ``ORDINARY_NARRATIVE`` markers. A markerless post-boundary turn
-        is a data-integrity error (ineligible, flagged); a markerless
-        pre-boundary (legacy) turn with no pending-roll row is eligible.
+      - RPG, pre-boundary (legacy): ``has_pending_roll_request`` alone
+        governs — a legacy pre-marker roll-request turn predates the marker
+        sidecar entirely and carries no marker row (ADR-018 D6 era-boundary
+        table), so it is excluded without a data-integrity flag; markerless
+        with no pending-roll row is eligible as legacy ``ORDINARY_NARRATIVE``.
+      - RPG, post-boundary: marker coverage is mandatory (ADR-018 D6 coverage
+        invariant) and must agree with ``has_pending_roll_request`` — a
+        disagreement between the two signals is a data-integrity error, not
+        an eligibility outcome. A missing marker, a ``PendingRollRequest``
+        row whose marker is not ``ROLL_REQUEST``, or a ``ROLL_REQUEST``
+        marker with no matching ``PendingRollRequest`` row are all flagged.
+        Otherwise eligible only for ``ORDINARY_NARRATIVE`` markers.
       - Branching (and any other mode): eligible by default once the OOC
         filter above is applied — Branching setup confirmations remain
         eligible as ordinary narrative turns (CRD Issue 16).
@@ -94,22 +97,58 @@ def decide_turn_eligibility(
         return EligibilityDecision(eligible=True)
 
     if story_mode is StoryMode.RPG:
+        if not is_post_boundary:
+            # Pre-boundary (legacy) turns predate the marker sidecar and are
+            # exempt from the coverage invariant -- PendingRollRequest alone
+            # governs, per the era-boundary table (ADR-018 D6).
+            if has_pending_roll_request:
+                return EligibilityDecision(
+                    eligible=False,
+                    reason="PendingRollRequest.originating_turn_id matches this"
+                    " turn (roll-request procedural output)",
+                )
+            return EligibilityDecision(
+                eligible=True,
+                reason="pre-boundary legacy turn treated as ORDINARY_NARRATIVE",
+            )
+
+        # Post-boundary: marker row is mandatory and must agree with
+        # has_pending_roll_request (ADR-018 D6 coverage invariant) -- any
+        # disagreement is a data-integrity error, not an eligibility outcome.
         if has_pending_roll_request:
+            if rpg_marker_category is None:
+                return EligibilityDecision(
+                    eligible=False,
+                    data_integrity_error=True,
+                    reason="post-boundary PendingRollRequest present but marker"
+                    " row missing (coverage invariant violated)",
+                )
+            if rpg_marker_category is not RpgTurnRetrievalCategory.ROLL_REQUEST:
+                return EligibilityDecision(
+                    eligible=False,
+                    data_integrity_error=True,
+                    reason="post-boundary PendingRollRequest present but marker"
+                    f" category={rpg_marker_category.value} (expected"
+                    " roll_request; coverage invariant violated)",
+                )
             return EligibilityDecision(
                 eligible=False,
                 reason="PendingRollRequest.originating_turn_id matches this turn"
                 " (roll-request procedural output)",
             )
         if rpg_marker_category is None:
-            if is_post_boundary:
-                return EligibilityDecision(
-                    eligible=False,
-                    data_integrity_error=True,
-                    reason="post-boundary RPG narrative-path turn missing marker row",
-                )
             return EligibilityDecision(
-                eligible=True,
-                reason="pre-boundary legacy turn treated as ORDINARY_NARRATIVE",
+                eligible=False,
+                data_integrity_error=True,
+                reason="post-boundary RPG narrative-path turn missing marker row",
+            )
+        if rpg_marker_category is RpgTurnRetrievalCategory.ROLL_REQUEST:
+            return EligibilityDecision(
+                eligible=False,
+                data_integrity_error=True,
+                reason="post-boundary marker category=roll_request but no"
+                " matching PendingRollRequest row (coverage invariant"
+                " violated)",
             )
         if rpg_marker_category is RpgTurnRetrievalCategory.ORDINARY_NARRATIVE:
             return EligibilityDecision(eligible=True)

--- a/src/afterworlds/pipeline/retrieval/eligibility.py
+++ b/src/afterworlds/pipeline/retrieval/eligibility.py
@@ -24,10 +24,10 @@ from afterworlds.models.enums import (
 )
 from afterworlds.models.node import ModeMetadata, WritingNodeMetadata
 from afterworlds.models.turn import Turn
-from afterworlds.persistence.crud.node import get_turn
 from afterworlds.persistence.crud.retrieval import (
     get_era_boundary_timestamp,
     get_rpg_turn_retrieval_marker,
+    get_turn_for_eligibility,
     has_pending_roll_request_originating_from_turn,
 )
 from afterworlds.persistence.crud.retrieval import is_post_boundary as _is_post_boundary
@@ -161,8 +161,15 @@ def gather_turn_eligibility(
     Returns ``eligible=False`` with a reason when the turn does not exist
     (e.g. already deleted) rather than raising, since callers (backfill,
     reindex) iterate turn IDs that may no longer be present.
+
+    Uses :func:`get_turn_for_eligibility` rather than the general-purpose
+    ``get_turn`` (Codex review, PR #119): a Writing turn with malformed
+    persisted ``mode_metadata`` must resolve to ``eligible=False``, not
+    abort this read with a deserialization error — a single corrupted row
+    must not stop query-tail building, backfill, or reindex for the rest of
+    a story.
     """
-    turn = get_turn(session, turn_id)
+    turn = get_turn_for_eligibility(session, turn_id)
     if turn is None:
         return EligibilityDecision(eligible=False, reason="turn not found")
     return gather_turn_eligibility_for_turn(session, turn, story_mode)

--- a/src/afterworlds/pipeline/retrieval/eligibility.py
+++ b/src/afterworlds/pipeline/retrieval/eligibility.py
@@ -28,6 +28,7 @@ from afterworlds.persistence.crud.node import get_turn
 from afterworlds.persistence.crud.retrieval import (
     get_era_boundary_timestamp,
     get_rpg_turn_retrieval_marker,
+    has_pending_roll_request_originating_from_turn,
 )
 from afterworlds.persistence.crud.retrieval import is_post_boundary as _is_post_boundary
 from afterworlds.persistence.orm.node import TurnORM
@@ -49,6 +50,7 @@ def decide_turn_eligibility(
     mode_metadata: ModeMetadata | None,
     rpg_marker_category: RpgTurnRetrievalCategory | None,
     is_post_boundary: bool,
+    has_pending_roll_request: bool = False,
 ) -> EligibilityDecision:
     """Pure decision function — no I/O. See module docstring for callers.
 
@@ -58,9 +60,15 @@ def decide_turn_eligibility(
         exists and its ``canon_eligibility`` reads ``EXTRACTOR_ELIGIBLE``.
         Missing/malformed metadata (the Writing block's best-effort write
         can fail silently) is treated as ineligible, never as eligible.
-      - RPG: eligible only for ``ORDINARY_NARRATIVE`` markers. A markerless
-        post-boundary turn is a data-integrity error (ineligible, flagged);
-        a markerless pre-boundary (legacy) turn is eligible.
+      - RPG: ``has_pending_roll_request`` (a persisted ``PendingRollRequest``
+        row whose ``originating_turn_id`` matches this turn) is checked
+        before marker classification and governs regardless of marker
+        category — this is what excludes a legacy pre-marker roll-request
+        turn, since it predates the marker sidecar entirely and carries no
+        marker row (ADR-018 D6 era-boundary table). Otherwise, eligible only
+        for ``ORDINARY_NARRATIVE`` markers. A markerless post-boundary turn
+        is a data-integrity error (ineligible, flagged); a markerless
+        pre-boundary (legacy) turn with no pending-roll row is eligible.
       - Branching (and any other mode): eligible by default once the OOC
         filter above is applied — Branching setup confirmations remain
         eligible as ordinary narrative turns (CRD Issue 16).
@@ -86,6 +94,12 @@ def decide_turn_eligibility(
         return EligibilityDecision(eligible=True)
 
     if story_mode is StoryMode.RPG:
+        if has_pending_roll_request:
+            return EligibilityDecision(
+                eligible=False,
+                reason="PendingRollRequest.originating_turn_id matches this turn"
+                " (roll-request procedural output)",
+            )
         if rpg_marker_category is None:
             if is_post_boundary:
                 return EligibilityDecision(
@@ -118,12 +132,16 @@ def gather_turn_eligibility_for_turn(
     """
     marker_category: RpgTurnRetrievalCategory | None = None
     post_boundary = True
+    has_pending_roll_request = False
     if story_mode is StoryMode.RPG:
         marker_category = get_rpg_turn_retrieval_marker(session, turn.turn_id)
         raw_row = session.get(TurnORM, str(turn.turn_id))
         assert raw_row is not None  # noqa: S101 — caller-supplied turn exists
         boundary = get_era_boundary_timestamp(session)
         post_boundary = _is_post_boundary(raw_row.timestamp, boundary)
+        has_pending_roll_request = has_pending_roll_request_originating_from_turn(
+            session, turn.turn_id
+        )
 
     return decide_turn_eligibility(
         story_mode=story_mode,
@@ -131,6 +149,7 @@ def gather_turn_eligibility_for_turn(
         mode_metadata=turn.mode_metadata,
         rpg_marker_category=marker_category,
         is_post_boundary=post_boundary,
+        has_pending_roll_request=has_pending_roll_request,
     )
 
 

--- a/src/afterworlds/pipeline/retrieval/embedding.py
+++ b/src/afterworlds/pipeline/retrieval/embedding.py
@@ -1,16 +1,17 @@
 """Embedding function seam for Retrieval Memory — CRD Issue 18 / ADR-018 D4.
 
-Local deterministic embedding behind an injectable ``EmbeddingFunction`` seam.
-No hosted/provider credentials required — BYOK and local-first embed
-identically (CLAUDE.md Business invariant: BYOK preserves full pipeline
-parity). Real-model CI runs stay behind an opt-in integration flag so the
-default test suite never needs network access or a downloaded model.
+Local deterministic embedding (ChromaDB's default ONNX MiniLM path) behind an
+injectable ``EmbeddingFunction`` seam. No hosted/provider credentials
+required — BYOK and local-first embed identically (CLAUDE.md Business
+invariant: BYOK preserves full pipeline parity). The real embedding function
+is the production default; the deterministic fake below exists solely for
+tests/CI to run offline and must always be injected explicitly by the
+caller — it is never selected implicitly by omission.
 """
 
 from __future__ import annotations
 
 import hashlib
-import os
 from typing import Protocol, runtime_checkable
 
 #: Fixed vector dimensionality for the deterministic fake embedding function.
@@ -18,9 +19,15 @@ from typing import Protocol, runtime_checkable
 #: within one Chroma collection.
 _FAKE_EMBEDDING_DIM = 32
 
-#: Opt-in flag gating the real ONNX MiniLM embedding function. Off by
-#: default so the standard test suite and CI run fully offline.
-REAL_EMBEDDING_FUNCTION_ENV = "AFTERWORLDS_RETRIEVAL_REAL_EMBEDDINGS"
+
+class RetrievalEmbeddingUnavailableError(RuntimeError):
+    """Raised when the real default embedding function cannot initialize.
+
+    Production/default code must fail clearly here rather than silently
+    substituting the deterministic fake — a fake-embedding fallback would
+    mean indexing/querying arbitrary hash vectors instead of semantic
+    embeddings (ADR-018 D4).
+    """
 
 
 @runtime_checkable
@@ -39,7 +46,9 @@ class DeterministicFakeEmbeddingFunction:
 
     Hashes each input string to a fixed-dimension float vector. Same input
     always produces the same vector; no model download, no network access.
-    Never used in production — see ``resolve_default_embedding_function``.
+    Never selected by default — callers (tests, offline fixtures) must
+    construct and inject this explicitly. See
+    ``resolve_default_embedding_function`` for the production default.
     """
 
     def __call__(self, input: list[str]) -> list[list[float]]:
@@ -67,23 +76,37 @@ class DeterministicFakeEmbeddingFunction:
 def resolve_default_embedding_function() -> RetrievalEmbeddingFunction:
     """Return the embedding function to use when none is injected.
 
-    Defaults to the deterministic fake unless the opt-in real-embeddings
-    integration flag is set, matching the existing pattern for other
-    provider-backed integration tests in this repo.
+    Always the real local ONNX MiniLM default (ADR-018 D4) — this is the
+    production default, not an opt-in. The deterministic fake is never
+    selected here; tests that need to run offline must construct
+    ``DeterministicFakeEmbeddingFunction()`` and inject it explicitly via
+    each call site's ``embedding_function`` parameter.
 
     Security note (ADR-018 CVE-2026-45829 resolution): whichever function is
     returned, callers must construct the Chroma client as an embedded
     ``PersistentClient``/``EphemeralClient`` — never ``HttpClient`` — and
     must never set ``trust_remote_code=True``. See
     ``pipeline/retrieval/config.py`` and this PR's Architecture Notes.
+
+    Raises:
+        RetrievalEmbeddingUnavailableError: if the real embedding function
+            cannot be constructed (e.g. the optional ONNX model dependency
+            failed to initialize). Callers must not fall back to the fake.
     """
-    if os.environ.get(REAL_EMBEDDING_FUNCTION_ENV, "").lower() in ("1", "true", "yes"):
+    try:
         from chromadb.utils.embedding_functions import (  # noqa: PLC0415
             DefaultEmbeddingFunction,
         )
 
         return DefaultEmbeddingFunction()  # type: ignore[return-value]
-    return DeterministicFakeEmbeddingFunction()
+    except Exception as exc:  # noqa: BLE001
+        raise RetrievalEmbeddingUnavailableError(
+            "Failed to initialize the real default embedding function "
+            "(ADR-018 D4 local ONNX MiniLM path). Retrieval Memory requires "
+            "a real embedding function in production; inject "
+            "DeterministicFakeEmbeddingFunction() explicitly only for "
+            "offline tests."
+        ) from exc
 
 
 def content_hash(text: str) -> str:

--- a/src/afterworlds/pipeline/retrieval/embedding.py
+++ b/src/afterworlds/pipeline/retrieval/embedding.py
@@ -1,0 +1,91 @@
+"""Embedding function seam for Retrieval Memory — CRD Issue 18 / ADR-018 D4.
+
+Local deterministic embedding behind an injectable ``EmbeddingFunction`` seam.
+No hosted/provider credentials required — BYOK and local-first embed
+identically (CLAUDE.md Business invariant: BYOK preserves full pipeline
+parity). Real-model CI runs stay behind an opt-in integration flag so the
+default test suite never needs network access or a downloaded model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Protocol, runtime_checkable
+
+#: Fixed vector dimensionality for the deterministic fake embedding function.
+#: Arbitrary but stable — the value only needs to be internally consistent
+#: within one Chroma collection.
+_FAKE_EMBEDDING_DIM = 32
+
+#: Opt-in flag gating the real ONNX MiniLM embedding function. Off by
+#: default so the standard test suite and CI run fully offline.
+REAL_EMBEDDING_FUNCTION_ENV = "AFTERWORLDS_RETRIEVAL_REAL_EMBEDDINGS"
+
+
+@runtime_checkable
+class RetrievalEmbeddingFunction(Protocol):
+    """Narrow protocol Afterworlds code depends on (subset of chromadb's)."""
+
+    def __call__(self, input: list[str]) -> list[list[float]]: ...
+
+    def name(self) -> str: ...
+
+    def embed_query(self, input: list[str]) -> list[list[float]]: ...
+
+
+class DeterministicFakeEmbeddingFunction:
+    """Deterministic, dependency-free embedding function for tests and CI.
+
+    Hashes each input string to a fixed-dimension float vector. Same input
+    always produces the same vector; no model download, no network access.
+    Never used in production — see ``resolve_default_embedding_function``.
+    """
+
+    def __call__(self, input: list[str]) -> list[list[float]]:
+        return [self._embed_one(text) for text in input]
+
+    def _embed_one(self, text: str) -> list[float]:
+        digest = hashlib.sha256(text.encode("utf-8")).digest()
+        # Repeat/trim the digest to the fixed dimension, unpack as floats
+        # scaled into [-1, 1] so cosine distance is meaningful.
+        raw = (digest * ((_FAKE_EMBEDDING_DIM // len(digest)) + 1))[
+            :_FAKE_EMBEDDING_DIM
+        ]
+        return [((b / 255.0) * 2.0) - 1.0 for b in raw]
+
+    def embed_query(self, input: list[str]) -> list[list[float]]:
+        return self(input)
+
+    def name(self) -> str:
+        return "afterworlds-deterministic-fake-v1"
+
+    def is_legacy(self) -> bool:
+        return True
+
+
+def resolve_default_embedding_function() -> RetrievalEmbeddingFunction:
+    """Return the embedding function to use when none is injected.
+
+    Defaults to the deterministic fake unless the opt-in real-embeddings
+    integration flag is set, matching the existing pattern for other
+    provider-backed integration tests in this repo.
+
+    Security note (ADR-018 CVE-2026-45829 resolution): whichever function is
+    returned, callers must construct the Chroma client as an embedded
+    ``PersistentClient``/``EphemeralClient`` — never ``HttpClient`` — and
+    must never set ``trust_remote_code=True``. See
+    ``pipeline/retrieval/config.py`` and this PR's Architecture Notes.
+    """
+    if os.environ.get(REAL_EMBEDDING_FUNCTION_ENV, "").lower() in ("1", "true", "yes"):
+        from chromadb.utils.embedding_functions import (  # noqa: PLC0415
+            DefaultEmbeddingFunction,
+        )
+
+        return DefaultEmbeddingFunction()  # type: ignore[return-value]
+    return DeterministicFakeEmbeddingFunction()
+
+
+def content_hash(text: str) -> str:
+    """Stable content hash used in StoryMemoryChunkMetadata.content_hash."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/src/afterworlds/pipeline/retrieval/query_builder.py
+++ b/src/afterworlds/pipeline/retrieval/query_builder.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 from afterworlds.models.enums import StoryMode
 from afterworlds.models.retrieval import RetrievalQueryRequest
 from afterworlds.models.turn import Turn
-from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
+from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility
 
 #: Default number of eligible recent turns folded into the query text.
 DEFAULT_TAIL_WINDOW = 3
@@ -69,8 +69,14 @@ class RetrievalQueryBuilder:
             session: Session = self._session_factory()  # type: ignore[operator]
             try:
                 for turn in tail_turns:
-                    decision = gather_turn_eligibility_for_turn(
-                        session, turn, story_mode
+                    # Reload the full committed turn rather than trusting
+                    # this projection's mode_metadata: production recent-turn
+                    # providers (e.g. SQLiteRecentTurnsProvider) may return a
+                    # lean Turn projection that omits mode_metadata, which
+                    # would otherwise make an eligible EXTRACTOR_ELIGIBLE
+                    # Writing turn look like missing metadata (Codex #119).
+                    decision = gather_turn_eligibility(
+                        session, turn.turn_id, story_mode
                     )
                     if decision.eligible:
                         eligible_texts.append(turn.assistant_output)

--- a/src/afterworlds/pipeline/retrieval/query_builder.py
+++ b/src/afterworlds/pipeline/retrieval/query_builder.py
@@ -2,10 +2,12 @@
 
 Orchestration-owned and deterministic, mirroring CRD Issue 15's
 ``RuleSliceRequest`` precedent: composes query text from the current
-Sojourner input plus an optional bounded recent-turn tail. The Context
-Builder gains no inference logic — this request is built before context
-assembly and threaded through ``ContextBuilderService.assemble()`` /
-``build_stable_prefix()`` unchanged (D8's protocol-shape-unchanged rule).
+Sojourner input, the already-classified intent, plus an optional bounded
+recent-turn tail. The Context Builder gains no inference logic — this
+request is built before context assembly and threaded through
+``ContextBuilderService.assemble()`` / ``build_stable_prefix()`` unchanged
+(D8's protocol-shape-unchanged rule); it forwards ``query_text`` verbatim
+to ``RetrievalMemoryProvider.retrieve()``, it never composes or inspects it.
 
 Query-context discipline (the direct trap from Issue #117's original
 wording): ``RecentTurnReader``'s ``exclude_ooc=True`` alone is NOT
@@ -24,6 +26,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import StoryMode
+from afterworlds.models.intent_classification import IntentClassificationResult
 from afterworlds.models.retrieval import RetrievalQueryRequest
 from afterworlds.models.turn import Turn
 from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility
@@ -52,7 +55,11 @@ class RetrievalQueryBuilder:
         self._tail_window = tail_window
 
     def build_query_request(
-        self, story_id: UUID, current_input: str, story_mode: StoryMode
+        self,
+        story_id: UUID,
+        current_input: str,
+        story_mode: StoryMode,
+        classified_intent: IntentClassificationResult,
     ) -> RetrievalQueryRequest:
         """Return the composed :class:`RetrievalQueryRequest` for this turn.
 
@@ -60,6 +67,15 @@ class RetrievalQueryBuilder:
         ``RecentTurnsProvider`` order) only when the D6/D8 eligibility
         predicate accepts them; ineligible tail turns contribute no text at
         all, not a redacted placeholder.
+
+        ``query_text`` is composed, in order: eligible tail texts, the
+        current Sojourner input, then a small deterministic
+        ``intent_type=<value>`` fragment (ADR-018 D8 requires the classified
+        intent to inform query composition, not just current input). This
+        is a fixed textual fragment, not a ``model_dump()`` of the full
+        ``IntentClassificationResult`` — dumping the whole typed result
+        would make query text depend on Pydantic field order/defaults
+        rather than a stable, deliberately-chosen fragment.
         """
         tail_turns = self._recent_turns_provider.get_recent_turns(
             story_id, limit=self._tail_window, exclude_ooc=True
@@ -83,9 +99,6 @@ class RetrievalQueryBuilder:
             finally:
                 session.close()
 
-        query_text = (
-            "\n\n".join([*eligible_texts, current_input])
-            if eligible_texts
-            else current_input
-        )
+        intent_fragment = f"intent_type={classified_intent.intent_type.value}"
+        query_text = "\n\n".join([*eligible_texts, current_input, intent_fragment])
         return RetrievalQueryRequest(story_id=story_id, query_text=query_text)

--- a/src/afterworlds/pipeline/retrieval/query_builder.py
+++ b/src/afterworlds/pipeline/retrieval/query_builder.py
@@ -1,0 +1,85 @@
+"""RetrievalQueryBuilder — CRD Issue 18 / ADR-018 D8.
+
+Orchestration-owned and deterministic, mirroring CRD Issue 15's
+``RuleSliceRequest`` precedent: composes query text from the current
+Sojourner input plus an optional bounded recent-turn tail. The Context
+Builder gains no inference logic — this request is built before context
+assembly and threaded through ``ContextBuilderService.assemble()`` /
+``build_stable_prefix()`` unchanged (D8's protocol-shape-unchanged rule).
+
+Query-context discipline (the direct trap from Issue #117's original
+wording): ``RecentTurnReader``'s ``exclude_ooc=True`` alone is NOT
+sufficient — it excludes only ``IntentType.OOC``, not e.g. a Writing turn
+whose committed per-turn metadata is ``NON_CANON_SUPPORT``. This builder
+reuses ``exclude_ooc=True`` for ordering/window mechanics and then applies
+the full D6/D8 eligibility predicate on top before any tail turn's text
+enters the composed query.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import StoryMode
+from afterworlds.models.retrieval import RetrievalQueryRequest
+from afterworlds.models.turn import Turn
+from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
+
+#: Default number of eligible recent turns folded into the query text.
+DEFAULT_TAIL_WINDOW = 3
+
+
+class _RecentTurnsProviderLike(Protocol):
+    def get_recent_turns(
+        self, story_id: UUID, limit: int, *, exclude_ooc: bool = True
+    ) -> list[Turn]: ...
+
+
+class RetrievalQueryBuilder:
+    """Composes the deterministic retrieval query for one pipeline turn."""
+
+    def __init__(
+        self,
+        recent_turns_provider: _RecentTurnsProviderLike,
+        session_factory: object,
+        tail_window: int = DEFAULT_TAIL_WINDOW,
+    ) -> None:
+        self._recent_turns_provider = recent_turns_provider
+        self._session_factory = session_factory
+        self._tail_window = tail_window
+
+    def build_query_request(
+        self, story_id: UUID, current_input: str, story_mode: StoryMode
+    ) -> RetrievalQueryRequest:
+        """Return the composed :class:`RetrievalQueryRequest` for this turn.
+
+        Recent-turn tail texts are prepended (oldest-first, matching
+        ``RecentTurnsProvider`` order) only when the D6/D8 eligibility
+        predicate accepts them; ineligible tail turns contribute no text at
+        all, not a redacted placeholder.
+        """
+        tail_turns = self._recent_turns_provider.get_recent_turns(
+            story_id, limit=self._tail_window, exclude_ooc=True
+        )
+        eligible_texts: list[str] = []
+        if tail_turns:
+            session: Session = self._session_factory()  # type: ignore[operator]
+            try:
+                for turn in tail_turns:
+                    decision = gather_turn_eligibility_for_turn(
+                        session, turn, story_mode
+                    )
+                    if decision.eligible:
+                        eligible_texts.append(turn.assistant_output)
+            finally:
+                session.close()
+
+        query_text = (
+            "\n\n".join([*eligible_texts, current_input])
+            if eligible_texts
+            else current_input
+        )
+        return RetrievalQueryRequest(story_id=story_id, query_text=query_text)

--- a/src/afterworlds/pipeline/retrieval/rules_corpus_service.py
+++ b/src/afterworlds/pipeline/retrieval/rules_corpus_service.py
@@ -1,0 +1,138 @@
+"""RulesCorpusService — CRD Issue 18 / ADR-018 D10/D11.
+
+Finalizes the rules-corpus Chroma schema and reindexes the CRD Issue 5b
+interim collection (``rp_chunks_interim_{package_id_hex}``,
+``ingestion/vector_writer.py``) into the finalized per-Rules-Package
+``rules_corpus_{package_id_hex}`` collection, rebuilt from the SQLite
+``rp_chunks`` ground truth — never from the interim Chroma collection
+itself (Central Invariant: Chroma is a rebuildable SQLite-derived
+projection).
+
+The diagnostic query exposed here is internal/admin-only in v1 (D10): no
+Context Builder, RPG adjudication loop, Writer, Planner, pass service, or
+runtime mechanical decision may consume it. Runtime rule inclusion remains
+exclusively ``get_active_rule_slice`` (CLAUDE.md invariant 8).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import suppress
+from uuid import UUID
+
+from chromadb.api import ClientAPI
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import SourceLocatorTypeEnum
+from afterworlds.models.retrieval import (
+    RulesCorpusChunkMetadata,
+    build_rules_corpus_chunk_id,
+    rules_corpus_collection_name,
+)
+from afterworlds.persistence.orm.rules_package import RuleChunkORM
+from afterworlds.pipeline.retrieval.collections import get_rules_corpus_collection
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import RetrievalEmbeddingFunction
+
+
+class RulesCorpusService:
+    """Reindex/diagnostic-query path for the finalized rules_corpus collections."""
+
+    def __init__(
+        self,
+        client: ClientAPI,
+        config: RetrievalMemoryConfig,
+        embedding_function: RetrievalEmbeddingFunction | None = None,
+    ) -> None:
+        self._client = client
+        self._config = config
+        self._embedding_function = embedding_function
+
+    def reindex_from_sql(self, session: Session, rules_package_id: UUID) -> int:
+        """Rebuild the finalized rules_corpus collection from SQL ground truth.
+
+        Wipes the collection first (surplus removal) then re-upserts every
+        enabled ``RuleChunk`` row for *rules_package_id*. This absorbs the
+        CRD Issue 5b interim collection without mutating any 5a source
+        record. Returns the number of chunks written.
+        """
+        collection_name = rules_corpus_collection_name(rules_package_id)
+        with suppress(Exception):  # collection may not exist yet
+            self._client.delete_collection(collection_name)
+        collection = get_rules_corpus_collection(
+            self._client, collection_name, self._config, self._embedding_function
+        )
+
+        rows = (
+            session.execute(
+                select(RuleChunkORM)
+                .where(RuleChunkORM.rules_package_id == str(rules_package_id))
+                .where(RuleChunkORM.is_enabled.is_(True))
+            )
+            .scalars()
+            .all()
+        )
+        if not rows:
+            return 0
+
+        ids: list[str] = []
+        documents: list[str] = []
+        metadatas: list[Mapping[str, str | int | float | bool | None]] = []
+        # Chunk index is per (source_locator_type, source_locator_value) pair
+        # so the deterministic ID matches the CRD Issue 5a chunk identity
+        # (ADR-018 D11) even when a locator produced multiple chunks.
+        locator_seen: dict[tuple[str, str], int] = {}
+        for row in rows:
+            locator_key = (row.source_locator_type, row.source_locator_value)
+            index = locator_seen.get(locator_key, 0)
+            locator_seen[locator_key] = index + 1
+            locator_type = SourceLocatorTypeEnum(row.source_locator_type)
+            metadata = RulesCorpusChunkMetadata(
+                rules_package_id=rules_package_id,
+                subsystem=row.subsystem,
+                source_document=row.source_document,
+                source_locator_type=locator_type,
+                source_locator_value=row.source_locator_value,
+                embedding_model_id=self._config.embedding_model_id,
+            )
+            ids.append(
+                build_rules_corpus_chunk_id(
+                    rules_package_id,
+                    locator_type,
+                    row.source_locator_value,
+                    index,
+                )
+            )
+            documents.append(row.content)
+            metadatas.append(metadata.model_dump(mode="json"))
+
+        collection.upsert(
+            documents=documents,
+            metadatas=metadatas,  # type: ignore[arg-type]
+            ids=ids,
+        )
+        return len(rows)
+
+    def diagnostic_query(
+        self, rules_package_id: UUID, query_text: str, n_results: int = 5
+    ) -> list[str]:
+        """Internal/admin-only semantic lookup. Never consumed by a runtime pass.
+
+        Returns raw matched documents with no threshold filtering — this is
+        a discovery/diagnostic surface, not a retrieval-eligibility path.
+        """
+        collection_name = rules_corpus_collection_name(rules_package_id)
+        collection = get_rules_corpus_collection(
+            self._client, collection_name, self._config, self._embedding_function
+        )
+        count = collection.count()
+        if count == 0:
+            return []
+        results = collection.query(
+            query_texts=[query_text], n_results=min(n_results, count)
+        )
+        documents_lists = results.get("documents") or []
+        if not documents_lists or not documents_lists[0]:
+            return []
+        return [str(d) for d in documents_lists[0]]

--- a/src/afterworlds/pipeline/retrieval/rules_corpus_service.py
+++ b/src/afterworlds/pipeline/retrieval/rules_corpus_service.py
@@ -79,14 +79,7 @@ class RulesCorpusService:
         ids: list[str] = []
         documents: list[str] = []
         metadatas: list[Mapping[str, str | int | float | bool | None]] = []
-        # Chunk index is per (source_locator_type, source_locator_value) pair
-        # so the deterministic ID matches the CRD Issue 5a chunk identity
-        # (ADR-018 D11) even when a locator produced multiple chunks.
-        locator_seen: dict[tuple[str, str], int] = {}
         for row in rows:
-            locator_key = (row.source_locator_type, row.source_locator_value)
-            index = locator_seen.get(locator_key, 0)
-            locator_seen[locator_key] = index + 1
             locator_type = SourceLocatorTypeEnum(row.source_locator_type)
             metadata = RulesCorpusChunkMetadata(
                 rules_package_id=rules_package_id,
@@ -96,13 +89,12 @@ class RulesCorpusService:
                 source_locator_value=row.source_locator_value,
                 embedding_model_id=self._config.embedding_model_id,
             )
+            # ID derives from RuleChunkORM.chunk_id -- the row's own durable
+            # primary key -- not a per-run occurrence index (Codex review,
+            # PR #119 round 4): stable regardless of SQL row-iteration order
+            # or how many chunks share the same source locator.
             ids.append(
-                build_rules_corpus_chunk_id(
-                    rules_package_id,
-                    locator_type,
-                    row.source_locator_value,
-                    index,
-                )
+                build_rules_corpus_chunk_id(rules_package_id, UUID(row.chunk_id))
             )
             documents.append(row.content)
             metadatas.append(metadata.model_dump(mode="json"))

--- a/src/afterworlds/pipeline/retrieval/rules_corpus_service.py
+++ b/src/afterworlds/pipeline/retrieval/rules_corpus_service.py
@@ -17,7 +17,6 @@ exclusively ``get_active_rule_slice`` (CLAUDE.md invariant 8).
 from __future__ import annotations
 
 from collections.abc import Mapping
-from contextlib import suppress
 from uuid import UUID
 
 from chromadb.api import ClientAPI
@@ -31,7 +30,10 @@ from afterworlds.models.retrieval import (
     rules_corpus_collection_name,
 )
 from afterworlds.persistence.orm.rules_package import RuleChunkORM
-from afterworlds.pipeline.retrieval.collections import get_rules_corpus_collection
+from afterworlds.pipeline.retrieval.collections import (
+    delete_collection_ignoring_absence,
+    get_rules_corpus_collection,
+)
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import RetrievalEmbeddingFunction
 
@@ -56,10 +58,17 @@ class RulesCorpusService:
         enabled ``RuleChunk`` row for *rules_package_id*. This absorbs the
         CRD Issue 5b interim collection without mutating any 5a source
         record. Returns the number of chunks written.
+
+        Raises:
+            Whatever ``delete_collection_ignoring_absence`` propagates (any
+                operational Chroma failure besides a genuinely absent
+                collection) — rebuild must never proceed past a wipe that
+                may not have actually happened (Codex review, PR #119 round
+                7), since stale disabled/deleted chunks would then remain
+                silently retrievable through the diagnostic query.
         """
         collection_name = rules_corpus_collection_name(rules_package_id)
-        with suppress(Exception):  # collection may not exist yet
-            self._client.delete_collection(collection_name)
+        delete_collection_ignoring_absence(self._client, collection_name)
         collection = get_rules_corpus_collection(
             self._client, collection_name, self._config, self._embedding_function
         )

--- a/src/afterworlds/pipeline/retrieval/scoring.py
+++ b/src/afterworlds/pipeline/retrieval/scoring.py
@@ -1,0 +1,28 @@
+"""Distance-to-similarity normalization — CRD Issue 18 / ADR-018 D5.
+
+Chroma returns a raw, metric-specific distance. Comparison against the
+configured threshold must never operate on that raw distance directly —
+everything is normalized into one internal ``normalized_similarity`` value
+first. Cutoff is inclusive: retained when ``normalized_similarity >=
+minimum_similarity_threshold``.
+"""
+
+from __future__ import annotations
+
+_SUPPORTED_METRICS = ("cosine",)
+
+
+def normalize_similarity(distance: float, metric: str) -> float:
+    """Convert a raw Chroma distance into a [0, 1] normalized similarity.
+
+    Only "cosine" is supported in v1 (the only metric
+    ``pipeline/retrieval/config.py`` configures for the story_memory
+    collection). Cosine distance in Chroma is ``1 - cosine_similarity``;
+    clamped to [0, 1] since embeddings are not guaranteed unit-normalized.
+    """
+    if metric not in _SUPPORTED_METRICS:
+        raise ValueError(
+            f"Unsupported distance metric {metric!r}; only {_SUPPORTED_METRICS} "
+            "are normalized in v1"
+        )
+    return max(0.0, min(1.0, 1.0 - distance))

--- a/src/afterworlds/pipeline/retrieval/write_service.py
+++ b/src/afterworlds/pipeline/retrieval/write_service.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from contextlib import suppress
 from uuid import UUID
 
 from chromadb.api import ClientAPI
@@ -28,6 +27,7 @@ from afterworlds.models.retrieval import (
 )
 from afterworlds.pipeline.retrieval.chunking import chunk_turn_prose
 from afterworlds.pipeline.retrieval.collections import (
+    delete_collection_ignoring_absence,
     get_existing_story_memory_collection_for_delete,
     get_story_memory_collection,
 )
@@ -168,6 +168,14 @@ class RetrievalMemoryWriteService:
         return len(result.get("ids") or [])
 
     def wipe_collection(self) -> None:
-        """Delete and recreate the entire story_memory collection (full reindex)."""
-        with suppress(Exception):  # collection may not exist yet
-            self._client.delete_collection(STORY_MEMORY_COLLECTION_NAME)
+        """Delete the entire story_memory collection (full reindex, operator-driven).
+
+        Only "collection genuinely absent" is treated as a no-op; any other
+        operational Chroma failure propagates rather than being swallowed —
+        an operator who believes this wipe succeeded and proceeds to
+        backfill every story must not silently write on top of a collection
+        that was never actually cleared (Codex review, PR #119 round 7).
+        Recreated lazily on next :func:`get_story_memory_collection` call,
+        not here.
+        """
+        delete_collection_ignoring_absence(self._client, STORY_MEMORY_COLLECTION_NAME)

--- a/src/afterworlds/pipeline/retrieval/write_service.py
+++ b/src/afterworlds/pipeline/retrieval/write_service.py
@@ -27,7 +27,10 @@ from afterworlds.models.retrieval import (
     build_story_memory_chunk_id,
 )
 from afterworlds.pipeline.retrieval.chunking import chunk_turn_prose
-from afterworlds.pipeline.retrieval.collections import get_story_memory_collection
+from afterworlds.pipeline.retrieval.collections import (
+    get_existing_story_memory_collection_for_delete,
+    get_story_memory_collection,
+)
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import (
     RetrievalEmbeddingFunction,
@@ -120,12 +123,30 @@ class RetrievalMemoryWriteService:
             collection.delete(ids=ids)
 
     def delete_turn(self, story_id: UUID, turn_id: UUID) -> None:
-        """Delete all chunks for *turn_id* (turn deletion)."""
-        self._delete_turn_chunks(self._collection(), story_id, turn_id)
+        """Delete all chunks for *turn_id* (turn deletion).
+
+        Uses the delete-only collection handle (Codex review, PR #119):
+        deletion is metadata-filtered and never invokes the embedding
+        function, so an operator must be able to scrub a mismatched/legacy
+        collection's chunks even while it fails the strict
+        ``embedding_model_id`` guard on every other path. A missing
+        collection means nothing to delete — a no-op, never created here.
+        """
+        collection = get_existing_story_memory_collection_for_delete(self._client)
+        if collection is None:
+            return
+        self._delete_turn_chunks(collection, story_id, turn_id)
 
     def delete_story(self, story_id: UUID) -> int:
-        """Delete all chunks for *story_id*; returns remaining count (must be 0)."""
-        collection = self._collection()
+        """Delete all chunks for *story_id*; returns remaining count (must be 0).
+
+        Uses the delete-only collection handle for the same reason as
+        :meth:`delete_turn`. A missing collection means zero chunks exist
+        for any story — return 0 without creating one.
+        """
+        collection = get_existing_story_memory_collection_for_delete(self._client)
+        if collection is None:
+            return 0
         existing = collection.get(where={"story_id": str(story_id)})
         ids = existing.get("ids") or []
         if ids:

--- a/src/afterworlds/pipeline/retrieval/write_service.py
+++ b/src/afterworlds/pipeline/retrieval/write_service.py
@@ -1,0 +1,152 @@
+"""RetrievalMemoryWriteService — CRD Issue 18 / ADR-018 D3/D7/D11.
+
+Writes story-memory chunks to the shared ``story_memory`` Chroma collection.
+Called only after the ingestion gate (``pipeline/orchestrator/service.py``)
+has confirmed a committed, delivery-cleared, D6-eligible narrative turn —
+this service does not itself re-check eligibility.
+
+Write-failure semantics (D7): a Chroma write failure here is logged and
+swallowed by the caller (the ingestion gate) — delivery is never blocked,
+reversed, or errored by a retrieval-write failure. This service raises on
+failure; the ingestion gate is responsible for catching and swallowing.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from contextlib import suppress
+from uuid import UUID
+
+from chromadb.api import ClientAPI
+from chromadb.api.models.Collection import Collection
+
+from afterworlds.models.retrieval import (
+    STORY_MEMORY_COLLECTION_NAME,
+    StoryMemoryChunkMetadata,
+    build_story_memory_chunk_id,
+)
+from afterworlds.pipeline.retrieval.chunking import chunk_turn_prose
+from afterworlds.pipeline.retrieval.collections import get_story_memory_collection
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import (
+    RetrievalEmbeddingFunction,
+    content_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RetrievalMemoryWriteService:
+    """Write/delete path for the shared story_memory Chroma collection."""
+
+    def __init__(
+        self,
+        client: ClientAPI,
+        config: RetrievalMemoryConfig,
+        embedding_function: RetrievalEmbeddingFunction | None = None,
+    ) -> None:
+        self._client = client
+        self._config = config
+        self._embedding_function = embedding_function
+
+    def _collection(self) -> Collection:
+        return get_story_memory_collection(
+            self._client, self._config, self._embedding_function
+        )
+
+    def ingest_turn(
+        self,
+        story_id: UUID,
+        turn_id: UUID,
+        node_id: UUID | None,
+        mode: str,
+        delivered_output: str,
+        created_at: str,
+    ) -> None:
+        """Chunk and upsert one delivered turn's prose.
+
+        Delete-before-write (ADR-018 D11): existing chunks for this
+        ``turn_id`` are deleted first, then the current chunk set is
+        written. Required even when the new chunk count is unchanged —
+        mandatory when it shrinks, since a deterministic-ID upsert alone
+        cannot remove chunks whose index no longer exists in the new set.
+        """
+        collection = self._collection()
+        self._delete_turn_chunks(collection, story_id, turn_id)
+
+        chunks = chunk_turn_prose(delivered_output, self._config.chunk_char_ceiling)
+        if not chunks or not delivered_output:
+            return
+
+        ids: list[str] = []
+        documents: list[str] = []
+        metadatas: list[Mapping[str, str | int | float | bool | None]] = []
+        for index, chunk_text in enumerate(chunks):
+            metadata = StoryMemoryChunkMetadata(
+                story_id=story_id,
+                node_id=node_id,
+                turn_id=turn_id,
+                mode=mode,
+                chunk_index=index,
+                chunk_count=len(chunks),
+                created_at=created_at,
+                content_hash=content_hash(chunk_text),
+                embedding_model_id=self._config.embedding_model_id,
+            )
+            ids.append(build_story_memory_chunk_id(story_id, turn_id, index))
+            documents.append(chunk_text)
+            metadatas.append(metadata.model_dump(mode="json"))
+
+        collection.upsert(
+            documents=documents,
+            metadatas=metadatas,  # type: ignore[arg-type]
+            ids=ids,
+        )
+
+    def _delete_turn_chunks(
+        self, collection: Collection, story_id: UUID, turn_id: UUID
+    ) -> None:
+        existing = collection.get(
+            where={
+                "$and": [
+                    {"story_id": str(story_id)},
+                    {"turn_id": str(turn_id)},
+                ]
+            }
+        )
+        ids = existing.get("ids") or []
+        if ids:
+            collection.delete(ids=ids)
+
+    def delete_turn(self, story_id: UUID, turn_id: UUID) -> None:
+        """Delete all chunks for *turn_id* (turn deletion)."""
+        self._delete_turn_chunks(self._collection(), story_id, turn_id)
+
+    def delete_story(self, story_id: UUID) -> int:
+        """Delete all chunks for *story_id*; returns remaining count (must be 0)."""
+        collection = self._collection()
+        existing = collection.get(where={"story_id": str(story_id)})
+        ids = existing.get("ids") or []
+        if ids:
+            collection.delete(ids=ids)
+        remaining = collection.get(where={"story_id": str(story_id)})
+        remaining_count = len(remaining.get("ids") or [])
+        if remaining_count != 0:
+            logger.error(
+                "story-delete post-condition violated: %d chunks remain for"
+                " story_id=%s",
+                remaining_count,
+                story_id,
+            )
+        return remaining_count
+
+    def count_for_story(self, story_id: UUID) -> int:
+        """Return the number of chunks currently indexed for *story_id*."""
+        result = self._collection().get(where={"story_id": str(story_id)})
+        return len(result.get("ids") or [])
+
+    def wipe_collection(self) -> None:
+        """Delete and recreate the entire story_memory collection (full reindex)."""
+        with suppress(Exception):  # collection may not exist yet
+            self._client.delete_collection(STORY_MEMORY_COLLECTION_NAME)

--- a/src/afterworlds/services/context_builder.py
+++ b/src/afterworlds/services/context_builder.py
@@ -373,7 +373,10 @@ class ContextBuilderService:
         Raises:
             UnknownModeError: if no prompt file exists for the given mode.
             ValueError: if a qualifying RPG rule_slice_request is provided but
-                rules_package_service was not injected.
+                rules_package_service was not injected, or if
+                retrieval_query_request.story_id does not match story_id
+                (ADR-018 D1 mandatory story_id gate — never query another
+                story's Retrieval Memory).
         """
         # 1. Load mode contract.
         system_prompt = load_mode_contract(mode)
@@ -410,8 +413,16 @@ class ContextBuilderService:
         # rendering, same cache-key neutrality).
         retrieval_memory = RetrievalMemoryPayload()
         if retrieval_query_request is not None:
+            if retrieval_query_request.story_id != story_id:
+                raise ValueError(
+                    f"retrieval_query_request.story_id "
+                    f"({retrieval_query_request.story_id}) does not match the "
+                    f"active story_id ({story_id}) being assembled; refusing to "
+                    "query another story's Retrieval Memory (ADR-018 D1 mandatory "
+                    "story_id gate)."
+                )
             retrieval_memory = self._retrieval_memory.retrieve(
-                retrieval_query_request.story_id, retrieval_query_request.query_text
+                story_id, retrieval_query_request.query_text
             )
 
         return StablePrefix(
@@ -497,7 +508,9 @@ class ContextBuilderService:
         Raises:
             UnknownModeError: if no prompt file exists for the given mode.
             ValueError: if a qualifying RPG rule_slice_request is provided but
-                rules_package_service was not injected.
+                rules_package_service was not injected, or if
+                retrieval_query_request.story_id does not match story_id
+                (ADR-018 D1 mandatory story_id gate).
         """
         stable_prefix = self.build_stable_prefix(
             story_id,

--- a/src/afterworlds/services/context_builder.py
+++ b/src/afterworlds/services/context_builder.py
@@ -14,13 +14,14 @@ Key constraints from the issue spec:
     (IN_CHARACTER_ACTION | DIALOGUE | LORE_QUESTION) + request → retrieve;
     all other cases → omit.
   - RecentTurnsProvider and RetrievalMemoryProvider are Protocol seams.
-    Neither is hard-coded to a concrete implementation.  ChromaDB integration
-    lands in Issue 18.
-  - StablePrefix.retrieval_memory is a reserved typed placeholder.  Issue 8
-    preserves the injectable seam and typed contract but does NOT materialize
-    query-dependent retrieval results inside the cacheable stable block.  Real
-    retrieval placement is deferred to Issue 18 (ADR-0010 Decision 4).
-  - NullRetrievalMemoryProvider is the default until Issue 18.
+    Neither is hard-coded to a concrete implementation.
+  - StablePrefix.retrieval_memory is populated only when the caller supplies
+    a ``retrieval_query_request`` (CRD Issue 18 / ADR-018 D8); the Context
+    Builder performs no query composition or eligibility inference itself.
+    It sits inside the existing cacheable stable block, under the existing
+    breakpoint (ADR-018 D9 resolves ADR-0010 Decision 4).
+  - NullRetrievalMemoryProvider is the default when no real provider is
+    injected (e.g. tests, or ChromaDB not configured).
   - No pipeline calls, no Writer invocation, no Story Bible writes.
 """
 
@@ -49,6 +50,7 @@ from afterworlds.models.enums import (
     normalize_legacy_intent_type,
 )
 from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.retrieval import RetrievalQueryRequest
 from afterworlds.models.rolling_summary import RollingSummary
 from afterworlds.models.rules_package import ActiveRuleSlice, RuleSliceRequest
 from afterworlds.models.story_bible import StoryBibleContext
@@ -334,6 +336,7 @@ class ContextBuilderService:
         mode: StoryMode,
         intent_classification: IntentClassificationResult,
         rule_slice_request: RuleSliceRequest | None = None,
+        retrieval_query_request: RetrievalQueryRequest | None = None,
     ) -> StablePrefix:
         """Assemble the stable prefix for one pipeline turn.
 
@@ -342,9 +345,13 @@ class ContextBuilderService:
           2. story_bible_context — ratified Story Bible canon
           3. rolling_summary_text — compressed narrative history (if present)
           4. rules_package_slice — RPG rule slice (mode×intent policy gate)
-          5. retrieval_memory — reserved typed placeholder; always empty in
-             Issue 8.  Query-dependent retrieval must not enter the cacheable
-             stable block (ADR-0010 Decision 4).  Issue 18 owns placement.
+          5. retrieval_memory — vector retrieval payload (CRD Issue 18 /
+             ADR-018). Populated only when ``retrieval_query_request`` is
+             supplied; empty otherwise. Retrieval memory sits inside the
+             existing StablePrefix envelope, under the existing cache
+             breakpoint (ADR-018 D9) — shared, unmodified, by every
+             provider-backed pass that renders this StablePrefix, not
+             Writer-only.
 
         Args:
             story_id: UUID of the story this turn belongs to.
@@ -354,6 +361,11 @@ class ContextBuilderService:
                 Used for mode×intent rule slice gate.
             rule_slice_request: optional parameter bundle for RPG rule slice.
                 Only honoured when mode is RPG and intent qualifies.
+            retrieval_query_request: optional orchestrator-constructed
+                request (``RetrievalQueryBuilder``, ADR-018 D8). The Context
+                Builder performs no query composition or eligibility
+                inference itself — it only forwards ``story_id``/
+                ``query_text`` to the injected ``RetrievalMemoryProvider``.
 
         Returns:
             Frozen StablePrefix ready to share across all pipeline passes.
@@ -392,16 +404,22 @@ class ContextBuilderService:
                 include_non_published=rule_slice_request.include_non_published,
             )
 
-        # 5. Retrieval memory — reserved placeholder; not materialized in Issue 8.
-        # Query-dependent retrieval must not enter the cacheable stable block
-        # (ADR-0010 Decision 4).  self._retrieval_memory seam is injected for
-        # Issue 18 to wire without changing the constructor signature.
+        # 5. Retrieval memory (CRD Issue 18 / ADR-018 D8). Empty when no
+        # request is supplied (mirrors the pre-Issue-18 placeholder
+        # behavior exactly — same empty typed payload, same omitted
+        # rendering, same cache-key neutrality).
+        retrieval_memory = RetrievalMemoryPayload()
+        if retrieval_query_request is not None:
+            retrieval_memory = self._retrieval_memory.retrieve(
+                retrieval_query_request.story_id, retrieval_query_request.query_text
+            )
+
         return StablePrefix(
             system_prompt=system_prompt,
             story_bible_context=bible_context,
             rolling_summary_text=rolling_summary_text,
             rules_package_slice=rules_package_slice,
-            retrieval_memory=RetrievalMemoryPayload(),
+            retrieval_memory=retrieval_memory,
         )
 
     def build_volatile_suffix(
@@ -455,6 +473,7 @@ class ContextBuilderService:
         current_input: str,
         classified_intent: IntentClassificationResult,
         rule_slice_request: RuleSliceRequest | None = None,
+        retrieval_query_request: RetrievalQueryRequest | None = None,
     ) -> AssembledContext:
         """Assemble the full context payload for one pipeline turn.
 
@@ -468,6 +487,8 @@ class ContextBuilderService:
             current_input: raw player input string for this turn.
             classified_intent: typed result from IntentClassifierService.
             rule_slice_request: optional parameter bundle for RPG rule slice.
+            retrieval_query_request: optional orchestrator-constructed
+                retrieval query request (ADR-018 D8).
 
         Returns:
             AssembledContext with stable prefix, volatile suffix, and an empty
@@ -479,7 +500,11 @@ class ContextBuilderService:
                 rules_package_service was not injected.
         """
         stable_prefix = self.build_stable_prefix(
-            story_id, mode, classified_intent, rule_slice_request
+            story_id,
+            mode,
+            classified_intent,
+            rule_slice_request,
+            retrieval_query_request,
         )
         volatile_suffix = self.build_volatile_suffix(
             story_id, current_input, classified_intent

--- a/tests/models/test_retrieval.py
+++ b/tests/models/test_retrieval.py
@@ -66,20 +66,40 @@ class TestStoryMemoryChunkId:
 
 
 class TestRulesCorpusChunkId:
+    """CRD Issue 18 / ADR-018 D11, Codex review round 4: rules-corpus chunk
+    IDs derive from RuleChunkORM.chunk_id -- the row's own durable primary
+    key -- not a per-run occurrence index over (locator_type, locator_value)
+    pairs, which depended on SQL row-iteration order."""
+
     def test_deterministic(self) -> None:
         package_id = uuid4()
-        args = (package_id, SourceLocatorTypeEnum.PAGE, "p. 72", 0)
-        assert build_rules_corpus_chunk_id(*args) == build_rules_corpus_chunk_id(*args)
+        chunk_id = uuid4()
+        assert build_rules_corpus_chunk_id(
+            package_id, chunk_id
+        ) == build_rules_corpus_chunk_id(package_id, chunk_id)
 
-    def test_distinct_per_locator_value(self) -> None:
+    def test_distinct_per_chunk_id(self) -> None:
+        """Two chunks that happen to share a source locator still get
+        distinct, stable IDs -- keyed on chunk_id, not locator occurrence."""
         package_id = uuid4()
-        a = build_rules_corpus_chunk_id(
-            package_id, SourceLocatorTypeEnum.PAGE, "p. 72", 0
-        )
-        b = build_rules_corpus_chunk_id(
-            package_id, SourceLocatorTypeEnum.PAGE, "p. 73", 0
-        )
+        a = build_rules_corpus_chunk_id(package_id, uuid4())
+        b = build_rules_corpus_chunk_id(package_id, uuid4())
         assert a != b
+
+    def test_distinct_per_package(self) -> None:
+        chunk_id = uuid4()
+        assert build_rules_corpus_chunk_id(
+            uuid4(), chunk_id
+        ) != build_rules_corpus_chunk_id(uuid4(), chunk_id)
+
+    def test_not_a_random_uuid_relative_to_chunk_identity(self) -> None:
+        """ADR-018 D11: the ID must be derived from the durable chunk_id,
+        not a freshly generated random UUID unrelated to it."""
+        package_id = uuid4()
+        chunk_id = uuid4()
+        result = build_rules_corpus_chunk_id(package_id, chunk_id)
+        assert str(package_id) in result
+        assert str(chunk_id) in result
 
     def test_collection_name_derives_from_package_id(self) -> None:
         package_id = uuid4()

--- a/tests/models/test_retrieval.py
+++ b/tests/models/test_retrieval.py
@@ -1,0 +1,139 @@
+"""Unit tests for Retrieval Memory DTOs and the deterministic ID scheme.
+
+CRD Issue 18 / ADR-018 D2/D11.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from afterworlds.models.enums import (
+    RetrievalChunkKind,
+    RetrievalSourceType,
+    SourceLocatorTypeEnum,
+)
+from afterworlds.models.retrieval import (
+    RulesCorpusChunkMetadata,
+    StoryMemoryChunkMetadata,
+    build_rules_corpus_chunk_id,
+    build_story_memory_chunk_id,
+    build_story_memory_chunk_id_prefix,
+    rules_corpus_collection_name,
+)
+
+
+class TestStoryMemoryChunkId:
+    def test_deterministic_same_inputs(self) -> None:
+        story_id = uuid4()
+        turn_id = uuid4()
+        assert build_story_memory_chunk_id(
+            story_id, turn_id, 0
+        ) == build_story_memory_chunk_id(story_id, turn_id, 0)
+
+    def test_distinct_per_index(self) -> None:
+        story_id = uuid4()
+        turn_id = uuid4()
+        assert build_story_memory_chunk_id(
+            story_id, turn_id, 0
+        ) != build_story_memory_chunk_id(story_id, turn_id, 1)
+
+    def test_distinct_per_turn(self) -> None:
+        story_id = uuid4()
+        assert build_story_memory_chunk_id(
+            story_id, uuid4(), 0
+        ) != build_story_memory_chunk_id(story_id, uuid4(), 0)
+
+    def test_not_a_random_uuid(self) -> None:
+        """ADR-018 D11: random UUIDs are prohibited as dedupe keys."""
+        story_id = uuid4()
+        turn_id = uuid4()
+        chunk_id = build_story_memory_chunk_id(story_id, turn_id, 0)
+        assert str(story_id) in chunk_id
+        assert str(turn_id) in chunk_id
+
+    def test_prefix_is_shared_across_indices(self) -> None:
+        story_id = uuid4()
+        turn_id = uuid4()
+        prefix = build_story_memory_chunk_id_prefix(story_id, turn_id)
+        assert build_story_memory_chunk_id(story_id, turn_id, 0).startswith(prefix)
+        assert build_story_memory_chunk_id(story_id, turn_id, 5).startswith(prefix)
+
+    def test_prefix_distinct_across_turns(self) -> None:
+        story_id = uuid4()
+        assert build_story_memory_chunk_id_prefix(
+            story_id, uuid4()
+        ) != build_story_memory_chunk_id_prefix(story_id, uuid4())
+
+
+class TestRulesCorpusChunkId:
+    def test_deterministic(self) -> None:
+        package_id = uuid4()
+        args = (package_id, SourceLocatorTypeEnum.PAGE, "p. 72", 0)
+        assert build_rules_corpus_chunk_id(*args) == build_rules_corpus_chunk_id(*args)
+
+    def test_distinct_per_locator_value(self) -> None:
+        package_id = uuid4()
+        a = build_rules_corpus_chunk_id(
+            package_id, SourceLocatorTypeEnum.PAGE, "p. 72", 0
+        )
+        b = build_rules_corpus_chunk_id(
+            package_id, SourceLocatorTypeEnum.PAGE, "p. 73", 0
+        )
+        assert a != b
+
+    def test_collection_name_derives_from_package_id(self) -> None:
+        package_id = uuid4()
+        name = rules_corpus_collection_name(package_id)
+        assert package_id.hex in name
+        assert name == rules_corpus_collection_name(package_id)
+
+
+class TestStoryMemoryChunkMetadata:
+    def test_defaults(self) -> None:
+        metadata = StoryMemoryChunkMetadata(
+            story_id=uuid4(),
+            node_id=uuid4(),
+            turn_id=uuid4(),
+            mode="rpg",
+            chunk_index=0,
+            chunk_count=1,
+            created_at="2026-01-01T00:00:00+00:00",
+            content_hash="abc",
+            embedding_model_id="test-model",
+        )
+        assert metadata.source_type is RetrievalSourceType.DELIVERED_TURN_PROSE
+        assert metadata.chunk_kind is RetrievalChunkKind.SCENE_PROSE
+        assert metadata.schema_version == 1
+
+    def test_source_type_and_chunk_kind_are_distinct_fields(self) -> None:
+        """ADR-018 D2 (Codex round-3 correction): must not be collapsed."""
+        metadata = StoryMemoryChunkMetadata(
+            story_id=uuid4(),
+            node_id=None,
+            turn_id=uuid4(),
+            mode="writing",
+            chunk_index=0,
+            chunk_count=1,
+            created_at="2026-01-01T00:00:00+00:00",
+            content_hash="abc",
+            embedding_model_id="test-model",
+        )
+        dumped = metadata.model_dump(mode="json")
+        assert "source_type" in dumped
+        assert "chunk_kind" in dumped
+        assert dumped["source_type"] != dumped["chunk_kind"]
+
+
+class TestRulesCorpusChunkMetadata:
+    def test_round_trip(self) -> None:
+        metadata = RulesCorpusChunkMetadata(
+            rules_package_id=uuid4(),
+            subsystem="combat",
+            source_document="srd_5e.json",
+            source_locator_type=SourceLocatorTypeEnum.PAGE,
+            source_locator_value="p. 72",
+            embedding_model_id="test-model",
+        )
+        dumped = metadata.model_dump(mode="json")
+        restored = RulesCorpusChunkMetadata.model_validate(dumped)
+        assert restored == metadata

--- a/tests/persistence/conftest.py
+++ b/tests/persistence/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.retrieval  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401
 

--- a/tests/persistence/test_retrieval_markers_db.py
+++ b/tests/persistence/test_retrieval_markers_db.py
@@ -12,22 +12,66 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from afterworlds.models.enums import IntentType, RpgTurnRetrievalCategory, StoryMode
+from afterworlds.models.character_sheet import RpgCharacterSheetBase
+from afterworlds.models.enums import (
+    IntentType,
+    RollVisibility,
+    RpgTurnRetrievalCategory,
+    StoryMode,
+)
 from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.character_sheet import create_rpg_base_sheet
 from afterworlds.persistence.crud.node import create_turn
 from afterworlds.persistence.crud.retrieval import (
     create_rpg_turn_retrieval_marker,
     get_era_boundary_timestamp,
     get_rpg_turn_retrieval_marker,
+    has_pending_roll_request_originating_from_turn,
     is_post_boundary,
 )
 from afterworlds.persistence.crud.story import create_story
 from afterworlds.persistence.database import create_session_factory
 from afterworlds.persistence.orm.retrieval import RetrievalMarkerEraBoundaryORM
+from afterworlds.persistence.orm.rpg import PendingRollRequestORM
 from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
 from tests.persistence.conftest import make_story
 
 _NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _seed_pending_roll_request(
+    session, story_id, originating_turn_id  # type: ignore[no-untyped-def]
+) -> None:
+    """Persist a minimal PendingRollRequest row whose originating_turn_id is
+    *originating_turn_id* — exercises the FK to rpg_character_sheet_bases
+    that the announce path (orchestrator) also writes against."""
+    sheet = RpgCharacterSheetBase(
+        story_id=story_id,
+        rules_package_id="dnd5e-v1",
+        character_name="Test Character",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    create_rpg_base_sheet(session, sheet)
+    session.add(
+        PendingRollRequestORM(
+            request_id=str(uuid4()),
+            story_id=str(story_id),
+            session_id=str(uuid4()),
+            character_id=str(sheet.sheet_id),
+            originating_turn_id=str(originating_turn_id),
+            check_label="Stealth Check",
+            player_facing_instruction="Roll a Stealth Check and report the total!",
+            expected_value_shape="d20",
+            visibility=RollVisibility.PLAYER.value,
+            source_proposal_ref="roll_0",
+            status="pending",
+            created_at=_NOW.isoformat(),
+            schema_version=1,
+            roll_expression="1d20+5",
+        )
+    )
+    session.commit()
 
 
 @pytest.fixture()
@@ -127,6 +171,21 @@ class TestEraBoundary:
         assert get_era_boundary_timestamp(session) == "2026-01-01T00:00:00+00:00"
 
 
+class TestHasPendingRollRequestOriginatingFromTurn:
+    def test_returns_true_when_row_exists(self, session) -> None:  # type: ignore[no-untyped-def]
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn()
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+        _seed_pending_roll_request(session, story.story_id, turn.turn_id)
+
+        assert has_pending_roll_request_originating_from_turn(session, turn.turn_id)
+
+    def test_returns_false_when_no_row_exists(self, session) -> None:  # type: ignore[no-untyped-def]
+        assert not has_pending_roll_request_originating_from_turn(session, uuid4())
+
+
 class TestGatherEligibilityDbIntegrated:
     def test_post_boundary_markerless_rpg_turn_is_data_integrity_error(
         self, session
@@ -162,6 +221,56 @@ class TestGatherEligibilityDbIntegrated:
 
         decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
         assert decision.eligible is True
+        assert decision.data_integrity_error is False
+
+    def test_pre_boundary_markerless_rpg_turn_with_pending_roll_is_excluded(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex #119 P1: a legacy pre-marker roll-request turn predates the
+        marker sidecar entirely (no marker row) but must still be excluded
+        via PendingRollRequest.originating_turn_id — ADR-018 D6's
+        era-boundary table, "Before persisted boundary, roll-request" row."""
+        session.add(
+            RetrievalMarkerEraBoundaryORM(
+                id=1, boundary_timestamp="2030-01-01T00:00:00+00:00"
+            )
+        )
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn(timestamp=_NOW)  # 2026, before the 2030 boundary
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+        _seed_pending_roll_request(session, story.story_id, turn.turn_id)
+
+        decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
+        assert decision.eligible is False
+        assert decision.data_integrity_error is False
+
+    def test_post_boundary_roll_request_marker_and_pending_roll_agree_is_excluded(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Coverage-invariant consistency (ADR-018 D6): for a post-boundary
+        turn, a ROLL_REQUEST marker and a PendingRollRequest row must never
+        disagree, and PendingRollRequest is what the predicate actually
+        checks — proven here against a real DB row, not just the pure
+        predicate's has_pending_roll_request=True flag."""
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn()
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn.turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ROLL_REQUEST,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+        _seed_pending_roll_request(session, story.story_id, turn.turn_id)
+
+        decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
+        assert decision.eligible is False
         assert decision.data_integrity_error is False
 
     def test_rpg_turn_with_ordinary_narrative_marker_is_eligible(

--- a/tests/persistence/test_retrieval_markers_db.py
+++ b/tests/persistence/test_retrieval_markers_db.py
@@ -1,0 +1,185 @@
+"""DB-level tests for the Retrieval Memory RPG turn-marker sidecar.
+
+CRD Issue 18 / ADR-018 D6. Covers the marker table, the era-boundary
+singleton, and the full DB-integrated eligibility gather path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from afterworlds.models.enums import IntentType, RpgTurnRetrievalCategory, StoryMode
+from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.node import create_turn
+from afterworlds.persistence.crud.retrieval import (
+    create_rpg_turn_retrieval_marker,
+    get_era_boundary_timestamp,
+    get_rpg_turn_retrieval_marker,
+    is_post_boundary,
+)
+from afterworlds.persistence.crud.story import create_story
+from afterworlds.persistence.database import create_session_factory
+from afterworlds.persistence.orm.retrieval import RetrievalMarkerEraBoundaryORM
+from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
+from tests.persistence.conftest import make_story
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture()
+def session_factory(engine):  # type: ignore[no-untyped-def]
+    return create_session_factory(engine)
+
+
+def _make_turn(**kwargs: object) -> Turn:
+    defaults: dict[str, object] = {
+        "user_input": "swing my sword",
+        "assistant_output": "The blade connects with a satisfying thud.",
+        "timestamp": _NOW,
+        "intent_classification": IntentType.IN_CHARACTER_ACTION,
+        "node_id": None,
+    }
+    defaults.update(kwargs)
+    return Turn(**defaults)  # type: ignore[arg-type]
+
+
+class TestMarkerRoundTrip:
+    def test_create_and_read(self, session) -> None:  # type: ignore[no-untyped-def]
+        story = make_story()
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn()
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn.turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+
+        result = get_rpg_turn_retrieval_marker(session, turn.turn_id)
+        assert result is RpgTurnRetrievalCategory.ORDINARY_NARRATIVE
+
+    def test_missing_marker_returns_none(self, session) -> None:  # type: ignore[no-untyped-def]
+        assert get_rpg_turn_retrieval_marker(session, uuid4()) is None
+
+    def test_duplicate_marker_raises(self, session) -> None:  # type: ignore[no-untyped-def]
+        story = make_story()
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn()
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn.turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+
+        with pytest.raises(IntegrityError):
+            create_rpg_turn_retrieval_marker(
+                session,
+                turn_id=turn.turn_id,
+                story_id=story.story_id,
+                category=RpgTurnRetrievalCategory.ROLL_REQUEST,
+                created_at=_NOW.isoformat(),
+            )
+
+
+class TestEraBoundary:
+    def test_no_boundary_row_returns_none(self, session) -> None:  # type: ignore[no-untyped-def]
+        assert get_era_boundary_timestamp(session) is None
+
+    def test_none_boundary_means_every_turn_is_post_boundary(self) -> None:
+        assert is_post_boundary("2020-01-01T00:00:00+00:00", None) is True
+
+    def test_timestamp_after_boundary_is_post_boundary(self) -> None:
+        boundary = "2026-01-01T00:00:00+00:00"
+        assert is_post_boundary("2026-06-01T00:00:00+00:00", boundary) is True
+
+    def test_timestamp_at_boundary_is_not_post_boundary(self) -> None:
+        boundary = "2026-01-01T00:00:00+00:00"
+        assert is_post_boundary(boundary, boundary) is False
+
+    def test_timestamp_before_boundary_is_not_post_boundary(self) -> None:
+        boundary = "2026-06-01T00:00:00+00:00"
+        assert is_post_boundary("2026-01-01T00:00:00+00:00", boundary) is False
+
+    def test_get_era_boundary_reads_persisted_row(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        session.add(
+            RetrievalMarkerEraBoundaryORM(
+                id=1, boundary_timestamp="2026-01-01T00:00:00+00:00"
+            )
+        )
+        session.commit()
+        assert get_era_boundary_timestamp(session) == "2026-01-01T00:00:00+00:00"
+
+
+class TestGatherEligibilityDbIntegrated:
+    def test_post_boundary_markerless_rpg_turn_is_data_integrity_error(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        session.add(
+            RetrievalMarkerEraBoundaryORM(
+                id=1, boundary_timestamp="2020-01-01T00:00:00+00:00"
+            )
+        )
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn(timestamp=_NOW)  # 2026, after the 2020 boundary
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+
+        decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
+        assert decision.eligible is False
+        assert decision.data_integrity_error is True
+
+    def test_pre_boundary_markerless_rpg_turn_is_eligible(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        session.add(
+            RetrievalMarkerEraBoundaryORM(
+                id=1, boundary_timestamp="2030-01-01T00:00:00+00:00"
+            )
+        )
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn(timestamp=_NOW)  # 2026, before the 2030 boundary
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+
+        decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
+        assert decision.eligible is True
+        assert decision.data_integrity_error is False
+
+    def test_rpg_turn_with_ordinary_narrative_marker_is_eligible(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn()
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn.turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+
+        decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
+        assert decision.eligible is True

--- a/tests/persistence/test_retrieval_markers_db.py
+++ b/tests/persistence/test_retrieval_markers_db.py
@@ -26,15 +26,42 @@ from afterworlds.persistence.crud.retrieval import (
     create_rpg_turn_retrieval_marker,
     get_era_boundary_timestamp,
     get_rpg_turn_retrieval_marker,
+    get_turn_for_eligibility,
     has_pending_roll_request_originating_from_turn,
     is_post_boundary,
 )
 from afterworlds.persistence.crud.story import create_story
 from afterworlds.persistence.database import create_session_factory
+from afterworlds.persistence.orm.node import TurnORM
 from afterworlds.persistence.orm.retrieval import RetrievalMarkerEraBoundaryORM
 from afterworlds.persistence.orm.rpg import PendingRollRequestORM
-from afterworlds.pipeline.retrieval.eligibility import gather_turn_eligibility_for_turn
+from afterworlds.pipeline.retrieval.eligibility import (
+    gather_turn_eligibility,
+    gather_turn_eligibility_for_turn,
+)
 from tests.persistence.conftest import make_story
+
+
+def _insert_malformed_mode_metadata_turn(
+    session, turn_id, malformed_metadata  # type: ignore[no-untyped-def]
+) -> None:
+    """Insert a Turn row whose mode_metadata JSON fails ModeMetadata
+    validation -- bypasses create_turn() (which validates via the Turn
+    pydantic model before persisting) to simulate a corrupted/schema-drifted
+    committed row."""
+    session.add(
+        TurnORM(
+            turn_id=str(turn_id),
+            node_id=None,
+            user_input="prior input",
+            assistant_output="Some delivered prose.",
+            timestamp=_NOW.isoformat(),
+            intent_classification=IntentType.DIALOGUE.value,
+            mode_metadata=malformed_metadata,
+        )
+    )
+    session.commit()
+
 
 _NOW = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -292,3 +319,71 @@ class TestGatherEligibilityDbIntegrated:
 
         decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
         assert decision.eligible is True
+
+
+class TestMalformedModeMetadataDoesNotAbort:
+    """Codex review (PR #119): a Writing turn with malformed persisted
+    mode_metadata must resolve to eligible=False, not raise -- and this must
+    not affect RPG eligibility, which never reads mode_metadata at all."""
+
+    def test_malformed_writing_metadata_returns_ineligible_not_raise(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        story = make_story(mode=StoryMode.WRITING)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn_id = uuid4()
+        # persona_registry_version expects int | None -- a string fails
+        # WritingNodeMetadata validation.
+        _insert_malformed_mode_metadata_turn(
+            session,
+            turn_id,
+            {"mode": "writing", "persona_registry_version": "not-a-number"},
+        )
+
+        decision = gather_turn_eligibility(session, turn_id, StoryMode.WRITING)
+
+        assert decision.eligible is False
+        assert decision.data_integrity_error is False
+
+    def test_get_turn_for_eligibility_does_not_raise_on_malformed_metadata(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        story = make_story(mode=StoryMode.WRITING)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn_id = uuid4()
+        _insert_malformed_mode_metadata_turn(
+            session, turn_id, {"mode": "writing", "persona_registry_version": "bad"}
+        )
+
+        turn = get_turn_for_eligibility(session, turn_id)
+
+        assert turn is not None
+        assert turn.mode_metadata is None
+        assert turn.assistant_output == "Some delivered prose."
+
+    def test_malformed_rpg_mode_metadata_does_not_affect_rpg_eligibility(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """RPG eligibility never reads mode_metadata (it reads the marker
+        table + era boundary + PendingRollRequest) -- a malformed
+        mode_metadata row on an RPG turn must not change the outcome an
+        ORDINARY_NARRATIVE marker would otherwise produce."""
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn_id = uuid4()
+        _insert_malformed_mode_metadata_turn(
+            session, turn_id, {"mode": "rpg", "dice_results": "not-a-list-of-int"}
+        )
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+
+        decision = gather_turn_eligibility(session, turn_id, StoryMode.RPG)
+
+        assert decision.eligible is True
+        assert decision.data_integrity_error is False

--- a/tests/persistence/test_retrieval_markers_db.py
+++ b/tests/persistence/test_retrieval_markers_db.py
@@ -361,6 +361,61 @@ class TestMalformedModeMetadataDoesNotAbort:
         assert turn.mode_metadata is None
         assert turn.assistant_output == "Some delivered prose."
 
+    @pytest.mark.parametrize(
+        "non_object_metadata",
+        [
+            pytest.param([], id="empty-list"),
+            pytest.param("junk", id="bare-string"),
+            pytest.param(123, id="bare-int"),
+        ],
+    )
+    def test_non_object_mode_metadata_does_not_raise_attribute_error(
+        self, session, non_object_metadata: object
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119) round 3: malformed SQLite JSON is not
+        guaranteed to be an object. ``.get("mode")`` on a list/string/int
+        raises AttributeError, not ValueError -- get_turn_for_eligibility
+        must catch that too, not just pydantic's ValidationError."""
+        story = make_story(mode=StoryMode.WRITING)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn_id = uuid4()
+        _insert_malformed_mode_metadata_turn(session, turn_id, non_object_metadata)
+
+        turn = get_turn_for_eligibility(session, turn_id)
+        assert turn is not None
+        assert turn.mode_metadata is None
+
+        decision = gather_turn_eligibility(session, turn_id, StoryMode.WRITING)
+        assert decision.eligible is False
+        assert decision.data_integrity_error is False
+
+    def test_non_object_rpg_mode_metadata_does_not_affect_rpg_eligibility(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Same non-object-JSON shape as above, but for RPG: since RPG
+        eligibility never reads mode_metadata, a non-object value there must
+        be just as inert as a malformed-but-dict-shaped one."""
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn_id = uuid4()
+        _insert_malformed_mode_metadata_turn(session, turn_id, [])
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+
+        turn = get_turn_for_eligibility(session, turn_id)
+        assert turn is not None
+        assert turn.mode_metadata is None
+
+        decision = gather_turn_eligibility(session, turn_id, StoryMode.RPG)
+        assert decision.eligible is True
+        assert decision.data_integrity_error is False
+
     def test_malformed_rpg_mode_metadata_does_not_affect_rpg_eligibility(
         self, session
     ) -> None:  # type: ignore[no-untyped-def]
@@ -387,3 +442,31 @@ class TestMalformedModeMetadataDoesNotAbort:
 
         assert decision.eligible is True
         assert decision.data_integrity_error is False
+
+    def test_malformed_intent_classification_result_still_raises(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """get_turn_for_eligibility's tolerance is scoped to mode_metadata
+        only (ADR-018's Writing-ineligibility rule). A malformed
+        intent_classification_result is unrelated data corruption and must
+        still raise, exactly like a database error -- it must not be
+        silently reclassified as an eligibility outcome."""
+        story = make_story(mode=StoryMode.WRITING)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn_id = uuid4()
+        session.add(
+            TurnORM(
+                turn_id=str(turn_id),
+                node_id=None,
+                user_input="prior input",
+                assistant_output="Some delivered prose.",
+                timestamp=_NOW.isoformat(),
+                intent_classification=IntentType.DIALOGUE.value,
+                # Missing required fields (confidence, raw_input, ambiguous).
+                intent_classification_result={"intent_type": "dialogue"},
+            )
+        )
+        session.commit()
+
+        with pytest.raises(Exception, match="validation error"):
+            get_turn_for_eligibility(session, turn_id)

--- a/tests/persistence/test_retrieval_markers_db.py
+++ b/tests/persistence/test_retrieval_markers_db.py
@@ -300,6 +300,32 @@ class TestGatherEligibilityDbIntegrated:
         assert decision.eligible is False
         assert decision.data_integrity_error is False
 
+    def test_post_boundary_pending_roll_with_mismatched_marker_is_data_integrity_error(
+        self, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119) round 6: a post-boundary PendingRollRequest
+        row whose marker is not ROLL_REQUEST (here: ORDINARY_NARRATIVE) is a
+        coverage-invariant violation (ADR-018 D6) and must be surfaced as a
+        data-integrity error, not silently treated as plain ineligible."""
+        story = make_story(mode=StoryMode.RPG)
+        create_story(session, story)  # type: ignore[arg-type]
+        turn = _make_turn()
+        create_turn(session, turn)  # type: ignore[arg-type]
+        session.commit()
+        create_rpg_turn_retrieval_marker(
+            session,
+            turn_id=turn.turn_id,
+            story_id=story.story_id,
+            category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            created_at=_NOW.isoformat(),
+        )
+        session.commit()
+        _seed_pending_roll_request(session, story.story_id, turn.turn_id)
+
+        decision = gather_turn_eligibility_for_turn(session, turn, StoryMode.RPG)
+        assert decision.eligible is False
+        assert decision.data_integrity_error is True
+
     def test_rpg_turn_with_ordinary_narrative_marker_is_eligible(
         self, session
     ) -> None:  # type: ignore[no-untyped-def]

--- a/tests/pipeline/orchestrator/conftest.py
+++ b/tests/pipeline/orchestrator/conftest.py
@@ -20,6 +20,7 @@ import pytest
 # Ensure all ORM models populate Base.metadata.
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.retrieval  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401
@@ -225,6 +226,7 @@ class FakeContextBuilder:
         current_input: str,
         classified_intent: IntentClassificationResult,
         rule_slice_request: Any = None,
+        retrieval_query_request: Any = None,
     ) -> AssembledContext:
         self.calls.append((story_id, mode, current_input))
         if story_id not in self.contexts:

--- a/tests/pipeline/orchestrator/test_retrieval_memory.py
+++ b/tests/pipeline/orchestrator/test_retrieval_memory.py
@@ -181,11 +181,31 @@ class _FakeRetrievalWriteService:
         )
 
 
+class _SpyRetrievalQueryBuilder:
+    """Records the args OrchestratorService passes to build_query_request."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def build_query_request(
+        self,
+        story_id: UUID,
+        current_input: str,
+        story_mode: StoryMode,
+        classified_intent: object,
+    ) -> object:
+        from afterworlds.models.retrieval import RetrievalQueryRequest
+
+        self.calls.append((story_id, current_input, story_mode, classified_intent))
+        return RetrievalQueryRequest(story_id=story_id, query_text=current_input)
+
+
 def _make_branching_orch_with_retrieval(
     session_factory: object,
     retrieval_write_service: _FakeRetrievalWriteService,
     *,
     safety_output: SafetyResult | None = None,
+    retrieval_query_builder: object | None = None,
 ) -> OrchestratorService:
     from afterworlds.models.enums import InteractionStyle, PacingStage
     from afterworlds.models.session import BranchingPlayStatus, BranchingSessionState
@@ -214,6 +234,7 @@ def _make_branching_orch_with_retrieval(
         mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
         branching_session_resolver=_branching_resolver,
         retrieval_write_service=retrieval_write_service,
+        retrieval_query_builder=retrieval_query_builder,  # type: ignore[arg-type]
     )
 
 
@@ -271,6 +292,38 @@ class TestIngestionGateBranching:
         assert result.disposition is PipelineDisposition.BLOCKED_OUTPUT_SAFETY
         assert result.turn_id is None
         assert fake_retrieval.calls == []
+
+
+class TestOrchestratorPassesClassifiedIntentToQueryBuilder:
+    """Codex review (PR #119) round 4: the orchestrator must thread the
+    real, already-computed IntentClassificationResult into
+    RetrievalQueryBuilder.build_query_request -- not omit it, and not
+    synthesize a separate one."""
+
+    def test_real_classified_intent_is_passed(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        spy_query_builder = _SpyRetrievalQueryBuilder()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            fake_retrieval,
+            retrieval_query_builder=spy_query_builder,
+        )
+
+        orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert len(spy_query_builder.calls) == 1
+        called_story_id, called_input, called_mode, called_intent = (
+            spy_query_builder.calls[0]
+        )
+        assert called_story_id == story_id
+        assert called_input == "I open the door."
+        assert called_mode is StoryMode.BRANCHING
+        assert called_intent.intent_type is IntentType.IN_CHARACTER_ACTION
 
 
 def _make_pending_roll_request_for_sheet(

--- a/tests/pipeline/orchestrator/test_retrieval_memory.py
+++ b/tests/pipeline/orchestrator/test_retrieval_memory.py
@@ -1,0 +1,341 @@
+"""Orchestrator-level integration tests for Retrieval Memory ingestion.
+
+CRD Issue 18 / ADR-018. Covers the ingestion gate (§6/D6/D7), the mandatory
+RPG turn-retrieval-marker write (D6, typed PIPELINE_ERROR on failure), and
+the Writing durable setup-turn guard (D6).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from afterworlds.entitlement.enums import RuntimeAccessPath
+from afterworlds.models.enums import (
+    IntentType,
+    RpgTurnRetrievalCategory,
+    StoryMode,
+    WritingCanonEligibility,
+    WritingWorkProductKind,
+)
+from afterworlds.persistence.crud.node import get_turn
+from afterworlds.persistence.crud.retrieval import get_rpg_turn_retrieval_marker
+from afterworlds.pipeline.orchestrator.models import (
+    CapabilityProfileAwareSafetyPolicy,
+    PipelineDisposition,
+)
+from afterworlds.pipeline.orchestrator.service import OrchestratorService
+from afterworlds.pipeline.provider._routing import (
+    EligibleModelRoute,
+    TurnProviderBinding,
+)
+from afterworlds.pipeline.safety.models import (
+    SafetyCategory,
+    SafetyConcern,
+    SafetyReport,
+    SafetyResult,
+    SafetyTarget,
+)
+from afterworlds.pipeline.writing.models import WritingTurnRequest
+from tests.pipeline.orchestrator.conftest import (
+    FakeContextBuilder,
+    FakeContradictionService,
+    FakeExtractorService,
+    FakeIntentClassifier,
+    FakePlannerService,
+    FakeSafetyService,
+    FakeWriterService,
+    fixed_mode_resolver,
+    make_intent,
+)
+from tests.pipeline.orchestrator.test_service import (
+    _make_orchestrator_with_adjudication,
+    _seed_writing_story_setup_wss,
+)
+
+_SOJOURNER = uuid4()
+
+
+class _FakeProviderAdapter:
+    provider_name = "fake-anthropic"
+
+
+def _make_fake_resolver() -> object:
+    from afterworlds.pipeline.provider._routing import SafetyWhitelistStatus
+
+    route = EligibleModelRoute(
+        provider_name="fake-anthropic",
+        model_identifier="fake-anthropic:claude-test",
+        whitelist_status=SafetyWhitelistStatus.NOT_WHITELISTED,
+        supports_required_capabilities=False,
+    )
+    binding = TurnProviderBinding(
+        adapter=_FakeProviderAdapter(),
+        primary_writer_route=route,
+        eligible_writer_routes=(route,),
+        access_path=RuntimeAccessPath.HOSTED,
+    )
+
+    class _Resolver:
+        def resolve_for_turn(self, access_path: object, sojourner_id: object) -> object:
+            return binding
+
+    return _Resolver()
+
+
+def _block_safety(target: SafetyTarget) -> SafetyResult:
+    return SafetyResult(
+        report=SafetyReport(
+            concerns=[
+                SafetyConcern(
+                    category=SafetyCategory.OTHER,
+                    description="synthetic",
+                    evidence_summary="test",
+                )
+            ]
+        ),
+        target=target,
+    )
+
+
+class _FakeRetrievalWriteService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    def ingest_turn(
+        self,
+        story_id: UUID,
+        turn_id: UUID,
+        node_id: UUID | None,
+        mode: str,
+        delivered_output: str,
+        created_at: str,
+    ) -> None:
+        self.calls.append(
+            (story_id, turn_id, node_id, mode, delivered_output, created_at)
+        )
+
+
+def _make_branching_orch_with_retrieval(
+    session_factory: object,
+    retrieval_write_service: _FakeRetrievalWriteService,
+    *,
+    safety_output: SafetyResult | None = None,
+) -> OrchestratorService:
+    from afterworlds.models.enums import InteractionStyle, PacingStage
+    from afterworlds.models.session import BranchingPlayStatus, BranchingSessionState
+
+    def _branching_resolver(story_id: UUID) -> BranchingSessionState:
+        return BranchingSessionState(
+            story_id=story_id,
+            pacing_stage=PacingStage.ESCALATION,
+            interaction_style=InteractionStyle.FREEFORM_ONLY,
+            play_status=BranchingPlayStatus.IN_PLAY,
+        )
+
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(
+            make_intent(IntentType.IN_CHARACTER_ACTION)
+        ),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(output_verdict=safety_output),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.BRANCHING),
+        branching_session_resolver=_branching_resolver,
+        retrieval_write_service=retrieval_write_service,
+    )
+
+
+class TestIngestionGateBranching:
+    def test_delivered_turn_is_ingested_exactly_once(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(session_factory, fake_retrieval)
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert len(fake_retrieval.calls) == 1
+        called_story_id, called_turn_id, *_ = fake_retrieval.calls[0]
+        assert called_story_id == story_id
+        assert called_turn_id == result.turn_id
+
+    def test_blocked_input_safety_never_ingests(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(session_factory, fake_retrieval)
+        # Force input safety block via the FakeSafetyService input_verdict.
+        orch._safety_service.input_verdict = _block_safety(  # type: ignore[attr-defined]
+            SafetyTarget.INPUT
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "harmful?", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.BLOCKED_INPUT_SAFETY
+        assert fake_retrieval.calls == []
+
+    def test_blocked_output_safety_rolls_back_and_never_ingests(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            fake_retrieval,
+            safety_output=_block_safety(SafetyTarget.OUTPUT),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.BLOCKED_OUTPUT_SAFETY
+        assert result.turn_id is None
+        assert fake_retrieval.calls == []
+
+
+class TestRpgTurnRetrievalMarker:
+    def test_ordinary_narrative_turn_gets_marker_and_is_ingested(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_orchestrator_with_adjudication(session_factory)
+        orch._retrieval_write_service = fake_retrieval  # type: ignore[attr-defined]
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.turn_id is not None
+        with session_factory() as read_session:  # type: ignore[operator]
+            category = get_rpg_turn_retrieval_marker(read_session, result.turn_id)
+        assert category is RpgTurnRetrievalCategory.ORDINARY_NARRATIVE
+        assert len(fake_retrieval.calls) == 1
+
+    def test_setup_turn_gets_setup_confirmation_marker_and_is_not_ingested(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_orchestrator_with_adjudication(
+            session_factory, play_status_setup=True
+        )
+        orch._retrieval_write_service = fake_retrieval  # type: ignore[attr-defined]
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I roll up my character.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.turn_id is not None
+        with session_factory() as read_session:  # type: ignore[operator]
+            category = get_rpg_turn_retrieval_marker(read_session, result.turn_id)
+        assert category is RpgTurnRetrievalCategory.SETUP_CONFIRMATION
+        assert fake_retrieval.calls == []
+
+    def test_marker_write_failure_is_mandatory_pipeline_error(
+        self, session_factory, seeded_story, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """ADR-018 D6: the marker write is mandatory, not best-effort — unlike
+        the Writing metadata block, a failure here must map to typed
+        PIPELINE_ERROR and roll back, never commit markerless."""
+        story_id, node_id = seeded_story
+        orch = _make_orchestrator_with_adjudication(session_factory)
+
+        def _raise(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("synthetic marker write failure")
+
+        monkeypatch.setattr(
+            "afterworlds.persistence.crud.retrieval.create_rpg_turn_retrieval_marker",
+            _raise,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert result.turn_id is None
+        assert result.delivered_output is None
+
+
+class TestWritingSetupTurnGuard:
+    def test_setup_turn_request_override_is_forced_non_canon(
+        self, session_factory, session
+    ) -> None:  # type: ignore[no-untyped-def]
+        """ADR-018 D6: a request carrying a prose-like work_product_kind +
+        EXTRACTOR_ELIGIBLE taken during SETUP must be persisted as
+        SETUP_CONFIRMATION/NON_CANON_SUPPORT regardless of the request."""
+        story_id, node_id = _seed_writing_story_setup_wss(session)
+        fake_retrieval = _FakeRetrievalWriteService()
+
+        from afterworlds.models.session import WritingSessionState
+
+        def _resolver(sid: UUID) -> WritingSessionState:
+            return WritingSessionState(story_id=sid)  # SETUP, no persona
+
+        from tests.pipeline.orchestrator.test_service import _make_writing_gate_orch
+
+        orch = _make_writing_gate_orch(session_factory, writing_resolver=_resolver)
+        orch._retrieval_write_service = fake_retrieval  # type: ignore[attr-defined]
+
+        writing_turn_request = WritingTurnRequest(
+            work_product_kind=WritingWorkProductKind.DRAFT_PROSE,
+            canon_eligibility_override=WritingCanonEligibility.EXTRACTOR_ELIGIBLE,
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "Continue the draft.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+            writing_turn_request=writing_turn_request,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.turn_id is not None
+        with session_factory() as read_session:  # type: ignore[operator]
+            turn = get_turn(read_session, result.turn_id)
+        assert turn is not None
+        assert turn.mode_metadata is not None
+        assert (
+            turn.mode_metadata.work_product_kind  # type: ignore[union-attr]
+            == WritingWorkProductKind.SETUP_CONFIRMATION.value
+        )
+        assert (
+            turn.mode_metadata.canon_eligibility  # type: ignore[union-attr]
+            == WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        # Ineligible per the durable guard: never ingested despite the
+        # request having asked for EXTRACTOR_ELIGIBLE.
+        assert fake_retrieval.calls == []

--- a/tests/pipeline/orchestrator/test_retrieval_memory.py
+++ b/tests/pipeline/orchestrator/test_retrieval_memory.py
@@ -101,6 +101,68 @@ def _block_safety(target: SafetyTarget) -> SafetyResult:
     )
 
 
+def _make_rpg_orch_without_adjudication(
+    session_factory: object,
+    retrieval_write_service: _FakeRetrievalWriteService | None = None,
+    *,
+    play_status_setup: bool = False,
+) -> OrchestratorService:
+    """RPG orchestrator with a session/sheet resolver wired but NO RPG
+    adjudication service -- the exact shape Codex #119 P2 flagged: a story
+    can have Retrieval Memory enabled before adjudication is wired, and the
+    mandatory turn-retrieval-marker classification must still resolve
+    rpg_play_status correctly rather than defaulting to ORDINARY_NARRATIVE."""
+    from afterworlds.models.enums import DiceHandling, RpgPlayStatus
+    from afterworlds.models.session import RpgSessionState
+
+    session_state, sheet = _make_rpg_session_and_sheet()
+    if play_status_setup:
+        session_state = RpgSessionState(
+            story_id=session_state.story_id,
+            character_sheet_id=session_state.character_sheet_id,
+            dice_handling=DiceHandling.AI_ROLLS,
+            play_status=RpgPlayStatus.SETUP,
+        )
+
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(make_intent()),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.RPG),
+        rpg_session_sheet_resolver=lambda _sid: (session_state, sheet),  # type: ignore[arg-type]
+        # rpg_adjudication_service intentionally absent.
+        retrieval_write_service=retrieval_write_service,
+    )
+
+
+def _make_rpg_orch_with_neither_adjudication_nor_resolver(
+    session_factory: object,
+) -> OrchestratorService:
+    """RPG mode active, but nothing can resolve rpg_play_status at all --
+    the marker-classification fail-closed case (Codex #119 P2)."""
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(make_intent()),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.RPG),
+        # Neither rpg_adjudication_service nor rpg_session_sheet_resolver wired.
+    )
+
+
 class _FakeRetrievalWriteService:
     def __init__(self) -> None:
         self.calls: list[tuple[object, ...]] = []
@@ -437,6 +499,104 @@ class TestRpgTurnRetrievalMarker:
         assert result.disposition is PipelineDisposition.PIPELINE_ERROR
         assert result.turn_id is None
         assert result.delivered_output is None
+
+    def test_setup_confirmation_marker_without_adjudication_wired(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119) P2: rpg_play_status must resolve from the
+        session/sheet resolver directly, independent of RPG adjudication
+        wiring -- a story can have Retrieval Memory enabled before
+        adjudication is wired. A SETUP turn must still get
+        SETUP_CONFIRMATION, not fall through to ORDINARY_NARRATIVE."""
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_rpg_orch_without_adjudication(
+            session_factory, fake_retrieval, play_status_setup=True
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I roll up my character.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.turn_id is not None
+        with session_factory() as read_session:  # type: ignore[operator]
+            category = get_rpg_turn_retrieval_marker(read_session, result.turn_id)
+        assert category is RpgTurnRetrievalCategory.SETUP_CONFIRMATION
+        assert fake_retrieval.calls == []
+
+    def test_ordinary_narrative_marker_without_adjudication_wired(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Same independence proof as above, for the IN_PLAY/non-SETUP case:
+        rpg_play_status resolves to IN_PLAY without adjudication wired, and
+        the turn is marked ORDINARY_NARRATIVE (and ingested) exactly as it
+        would be with adjudication wired."""
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_rpg_orch_without_adjudication(session_factory, fake_retrieval)
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.turn_id is not None
+        with session_factory() as read_session:  # type: ignore[operator]
+            category = get_rpg_turn_retrieval_marker(read_session, result.turn_id)
+        assert category is RpgTurnRetrievalCategory.ORDINARY_NARRATIVE
+        assert len(fake_retrieval.calls) == 1
+
+    def test_unresolvable_play_status_fails_closed_not_ordinary_narrative(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119) P2: when RPG mode is active but nothing
+        can resolve rpg_play_status at all (no adjudication service, no
+        session/sheet resolver), marker classification must fail closed --
+        a typed PIPELINE_ERROR and rollback, never a silently-written
+        ORDINARY_NARRATIVE marker for an unclassified turn."""
+        story_id, node_id = seeded_story
+        orch = _make_rpg_orch_with_neither_adjudication_nor_resolver(session_factory)
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert result.turn_id is None
+        assert result.delivered_output is None
+        with session_factory() as read_session:  # type: ignore[operator]
+            # No marker row at all -- never a fallback ORDINARY_NARRATIVE.
+            from sqlalchemy import select
+
+            from afterworlds.persistence.orm.node import NodeORM, TurnORM
+            from afterworlds.persistence.orm.story import ArcORM, ChapterORM
+
+            existing_turn_ids = (
+                read_session.execute(
+                    select(TurnORM.turn_id)
+                    .join(NodeORM, TurnORM.node_id == NodeORM.node_id)
+                    .join(ChapterORM, NodeORM.chapter_id == ChapterORM.chapter_id)
+                    .join(ArcORM, ChapterORM.arc_id == ArcORM.arc_id)
+                    .where(ArcORM.story_id == str(story_id))
+                )
+                .scalars()
+                .all()
+            )
+        # Rolled back: no Turn row was committed for this failed attempt.
+        assert existing_turn_ids == []
 
 
 class TestWritingSetupTurnGuard:

--- a/tests/pipeline/orchestrator/test_retrieval_memory.py
+++ b/tests/pipeline/orchestrator/test_retrieval_memory.py
@@ -326,6 +326,147 @@ class TestOrchestratorPassesClassifiedIntentToQueryBuilder:
         assert called_intent.intent_type is IntentType.IN_CHARACTER_ACTION
 
 
+class _RaisingRetrievalQueryBuilder:
+    """Simulates a configured RetrievalQueryBuilder whose query construction
+    fails (Codex review, PR #119 round 8) -- a pre-context read/construction
+    failure, distinct from the post-commit ingestion write path."""
+
+    def build_query_request(
+        self,
+        story_id: UUID,
+        current_input: str,
+        story_mode: StoryMode,
+        classified_intent: object,
+    ) -> object:
+        raise RuntimeError("chroma unreachable")
+
+
+class TestRetrievalQueryConstructionFailureFailsClosed:
+    """Codex review (PR #119) round 8: a configured RetrievalQueryBuilder
+    that raises must fail the turn with a typed PIPELINE_ERROR, not silently
+    proceed with retrieval_query_request=None (ADR-018 D7's best-effort
+    swallow applies only to the post-commit ingestion/write path, not to
+    this pre-context query-construction step)."""
+
+    def test_query_build_failure_returns_pipeline_error(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            fake_retrieval,
+            retrieval_query_builder=_RaisingRetrievalQueryBuilder(),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert result.pipeline_error_summary is not None
+        assert "retrieval query construction failed" in result.pipeline_error_summary
+
+    def test_writer_not_called_after_query_build_failure(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            fake_retrieval,
+            retrieval_query_builder=_RaisingRetrievalQueryBuilder(),
+        )
+
+        orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert orch._writer_service.calls == []  # type: ignore[attr-defined]
+
+    def test_context_builder_not_called_after_query_build_failure(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Not merely 'not called with retrieval_query_request=None' --
+        _build_context() must never run at all once query construction has
+        already failed for this turn."""
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            fake_retrieval,
+            retrieval_query_builder=_RaisingRetrievalQueryBuilder(),
+        )
+
+        orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert orch._context_builder.calls == []  # type: ignore[attr-defined]
+
+    def test_no_configured_query_builder_still_delivers_normally(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """The Null-builder case (no retrieval query builder wired at all)
+        remains a valid no-retrieval turn -- distinct from a configured
+        builder that raises."""
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory, fake_retrieval, retrieval_query_builder=None
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+
+    def test_query_builder_returning_empty_request_still_delivers_normally(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """A configured builder that succeeds (even with an effectively empty
+        retrieval query) is not an error -- only a raised exception is."""
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            fake_retrieval,
+            retrieval_query_builder=_SpyRetrievalQueryBuilder(),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+
+    def test_post_commit_ingestion_failure_remains_swallowed(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Sibling contrast: a post-commit retrieval-ingestion failure (D7)
+        must still be best-effort and swallowed -- unaffected by this
+        round's read-path fix, which only tightens pre-context query
+        construction."""
+
+        class _RaisingRetrievalWriteService:
+            def ingest_turn(self, *args: object, **kwargs: object) -> None:
+                raise RuntimeError("chroma write failed")
+
+        story_id, node_id = seeded_story
+        orch = _make_branching_orch_with_retrieval(
+            session_factory,
+            _RaisingRetrievalWriteService(),  # type: ignore[arg-type]
+            retrieval_query_builder=_SpyRetrievalQueryBuilder(),
+        )
+
+        result = orch.orchestrate_turn(
+            story_id, node_id, "I open the door.", _SOJOURNER, RuntimeAccessPath.HOSTED
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+
+
 def _make_pending_roll_request_for_sheet(
     story_id: UUID, sheet_id: UUID, originating_turn_id: UUID
 ) -> object:

--- a/tests/pipeline/orchestrator/test_retrieval_memory.py
+++ b/tests/pipeline/orchestrator/test_retrieval_memory.py
@@ -50,7 +50,9 @@ from tests.pipeline.orchestrator.conftest import (
     make_intent,
 )
 from tests.pipeline.orchestrator.test_service import (
+    _FakePendingRollService,
     _make_orchestrator_with_adjudication,
+    _make_rpg_session_and_sheet,
     _seed_writing_story_setup_wss,
 )
 
@@ -209,6 +211,126 @@ class TestIngestionGateBranching:
         assert fake_retrieval.calls == []
 
 
+def _make_pending_roll_request_for_sheet(
+    story_id: UUID, sheet_id: UUID, originating_turn_id: UUID
+) -> object:
+    """Build a PendingRollRequest whose story_id/character_id satisfy the
+    pending_roll_requests table's FKs to stories/rpg_character_sheet_bases —
+    the announce path writes this row directly via ``session.add``, unlike
+    the mark_consumed path which goes through the injected service."""
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    from afterworlds.models.enums import RollVisibility
+    from afterworlds.models.rpg import PendingRollRequest
+
+    return PendingRollRequest(
+        request_id=uuid4(),
+        story_id=story_id,
+        session_id=uuid4(),
+        character_id=sheet_id,
+        check_label="Stealth Check",
+        player_facing_instruction="Roll a Stealth Check and report the total!",
+        expected_value_shape="d20",
+        visibility=RollVisibility.PLAYER,
+        source_proposal_ref="roll_0",
+        originating_turn_id=originating_turn_id,
+        created_at=datetime.now(tz=UTC),
+        roll_expression="1d20+5",
+    )
+
+
+class _AdjServiceAnnouncingPending:
+    """Fake adjudication service that always announces a new pending roll
+    for a specific, already-persisted (story_id, sheet_id) pair."""
+
+    def __init__(self, story_id: UUID, sheet_id: UUID) -> None:
+        self._story_id = story_id
+        self._sheet_id = sheet_id
+
+    def is_adjudicable(self, sheet: object) -> bool:
+        return True
+
+    def adjudicate(self, *args: object, **kwargs: object) -> object:
+        from uuid import uuid4
+
+        from afterworlds.pipeline.rpg.models import AdjudicationPassResult
+
+        return AdjudicationPassResult(
+            proposals=(),
+            writer_views=(),
+            pending_roll_request=_make_pending_roll_request_for_sheet(
+                self._story_id, self._sheet_id, uuid4()
+            ),
+        )
+
+
+def _seed_character_sheet(session_factory: object, story_id: UUID) -> object:
+    """Persist a real RpgCharacterSheetBase + Dnd5eCharacterSheet row pair
+    for *story_id* and return the (session_state, sheet) pair to hand to the
+    orchestrator. The announce path's FK to rpg_character_sheet_bases has
+    never been exercised by an existing fixture — every prior test either
+    reads an existing DB-less fake pending or never reaches the INSERT."""
+    from afterworlds.models.enums import DiceHandling, RpgPlayStatus
+    from afterworlds.models.session import RpgSessionState
+    from afterworlds.persistence.crud.character_sheet import (
+        create_dnd5e_sheet,
+        create_rpg_base_sheet,
+    )
+
+    _, sheet = _make_rpg_session_and_sheet()
+    sheet = sheet.model_copy(update={"story_id": story_id})  # type: ignore[attr-defined]
+    session = session_factory()  # type: ignore[operator]
+    try:
+        create_rpg_base_sheet(session, sheet)  # type: ignore[arg-type]
+        create_dnd5e_sheet(session, sheet)  # type: ignore[arg-type]
+        session.commit()
+    finally:
+        session.close()
+
+    session_state = RpgSessionState(
+        story_id=story_id,
+        character_sheet_id=sheet.sheet_id,  # type: ignore[attr-defined]
+        dice_handling=DiceHandling.AI_ROLLS,
+        play_status=RpgPlayStatus.IN_PLAY,
+    )
+    return session_state, sheet
+
+
+def _make_rpg_orch_announcing_pending_with_svc(
+    session_factory: object,
+    story_id: UUID,
+    retrieval_write_service: _FakeRetrievalWriteService,
+) -> OrchestratorService:
+    """RPG orchestrator: adjudication announces a pending roll and the
+    lifecycle service IS wired — the turn completes DELIVERED, unlike the
+    no-service-wired guard case covered by TestRpgPendingRollServiceGuard."""
+    from afterworlds.pipeline.rpg.dice import SystemRandomDiceService
+
+    session_state, sheet = _seed_character_sheet(session_factory, story_id)
+
+    return OrchestratorService(
+        intent_classifier=FakeIntentClassifier(make_intent()),
+        context_builder=FakeContextBuilder(),
+        safety_service=FakeSafetyService(),
+        planner_service=FakePlannerService(),
+        writer_service=FakeWriterService(),
+        extractor_service=FakeExtractorService(),
+        contradiction_service=FakeContradictionService(),
+        session_factory=session_factory,  # type: ignore[arg-type]
+        safety_policy=CapabilityProfileAwareSafetyPolicy(),
+        provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        mode_resolver=fixed_mode_resolver(StoryMode.RPG),
+        rpg_adjudication_service=_AdjServiceAnnouncingPending(  # type: ignore[arg-type]
+            story_id, sheet.sheet_id  # type: ignore[attr-defined]
+        ),
+        rpg_session_sheet_resolver=lambda _sid: (session_state, sheet),  # type: ignore[arg-type]
+        rpg_dice_service=SystemRandomDiceService(seed=42),  # type: ignore[arg-type]
+        rpg_pending_roll_service=_FakePendingRollService(pending=None),  # type: ignore[arg-type]
+        retrieval_write_service=retrieval_write_service,
+    )
+
+
 class TestRpgTurnRetrievalMarker:
     def test_ordinary_narrative_turn_gets_marker_and_is_ingested(
         self, session_factory, seeded_story
@@ -256,6 +378,35 @@ class TestRpgTurnRetrievalMarker:
         with session_factory() as read_session:  # type: ignore[operator]
             category = get_rpg_turn_retrieval_marker(read_session, result.turn_id)
         assert category is RpgTurnRetrievalCategory.SETUP_CONFIRMATION
+        assert fake_retrieval.calls == []
+
+    def test_pending_roll_announced_gets_roll_request_marker_and_is_not_ingested(
+        self, session_factory, seeded_story
+    ) -> None:  # type: ignore[no-untyped-def]
+        """ADR-018 D6: a turn on which adjudication announces a new pending
+        roll must be marked ROLL_REQUEST (not ORDINARY_NARRATIVE) and must
+        never enter Retrieval Memory — the marker⟺PendingRollRequest
+        correspondence the ADR requires, exercised end-to-end rather than
+        only at the pure-predicate level (see test_eligibility.py)."""
+        story_id, node_id = seeded_story
+        fake_retrieval = _FakeRetrievalWriteService()
+        orch = _make_rpg_orch_announcing_pending_with_svc(
+            session_factory, story_id, fake_retrieval
+        )
+
+        result = orch.orchestrate_turn(
+            story_id,
+            node_id,
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+
+        assert result.disposition is PipelineDisposition.DELIVERED
+        assert result.turn_id is not None
+        with session_factory() as read_session:  # type: ignore[operator]
+            category = get_rpg_turn_retrieval_marker(read_session, result.turn_id)
+        assert category is RpgTurnRetrievalCategory.ROLL_REQUEST
         assert fake_retrieval.calls == []
 
     def test_marker_write_failure_is_mandatory_pipeline_error(

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -5788,10 +5788,16 @@ class _SpyContextBuilder:
         current_input: object,
         classified_intent: object,
         rule_slice_request: object = None,
+        retrieval_query_request: object = None,
     ) -> object:
         self.rule_slice_requests.append(rule_slice_request)
         return self._inner.assemble(  # type: ignore[arg-type]
-            story_id, mode, current_input, classified_intent, rule_slice_request
+            story_id,
+            mode,
+            current_input,
+            classified_intent,
+            rule_slice_request,
+            retrieval_query_request,
         )
 
 

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -4613,6 +4613,15 @@ def _make_orchestrator_with_pending(
         make_intent,
     )
 
+    # RPG turns that reach _narrative_persist need rpg_play_status resolved
+    # (ADR-018 D6 turn-retrieval-marker classification, Codex #119 P2) even
+    # when RPG adjudication itself is not wired for this fixture -- an
+    # IN_PLAY session/sheet resolver here keeps this CRD Issue 15
+    # pending-roll-intercept fixture realistic rather than relying on the
+    # since-removed "unresolved play_status defaults to ORDINARY_NARRATIVE"
+    # behavior.
+    session_state, sheet = _make_rpg_session_and_sheet()
+
     return OrchestratorService(
         intent_classifier=FakeIntentClassifier(make_intent(intent_type)),
         context_builder=FakeContextBuilder(),
@@ -4624,6 +4633,7 @@ def _make_orchestrator_with_pending(
         session_factory=session_factory,  # type: ignore[arg-type]
         safety_policy=CapabilityProfileAwareSafetyPolicy(),
         provider_resolver=_make_fake_resolver(),  # type: ignore[arg-type]
+        rpg_session_sheet_resolver=lambda _sid: (session_state, sheet),  # type: ignore[arg-type]
         mode_resolver=mode_resolver or fixed_mode_resolver(StoryMode.RPG),
         rpg_pending_roll_service=pending_roll_svc,  # type: ignore[arg-type]
     )

--- a/tests/pipeline/retrieval/conftest.py
+++ b/tests/pipeline/retrieval/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for pipeline/retrieval tests."""
+
+from __future__ import annotations
+
+import pytest
+
+# Import all ORM models to ensure they register with Base.metadata
+import afterworlds.persistence.orm.character_sheet  # noqa: F401
+import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.retrieval  # noqa: F401
+import afterworlds.persistence.orm.rules_package  # noqa: F401
+import afterworlds.persistence.orm.session_state  # noqa: F401
+import afterworlds.persistence.orm.state  # noqa: F401
+import afterworlds.persistence.orm.story  # noqa: F401
+import afterworlds.persistence.orm.story_bible  # noqa: F401
+from afterworlds.persistence.database import create_engine
+from afterworlds.persistence.orm.base import Base
+
+
+@pytest.fixture()
+def engine():  # type: ignore[no-untyped-def]
+    """In-memory SQLite engine with all tables created."""
+    eng = create_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    yield eng
+    Base.metadata.drop_all(eng)
+    eng.dispose()

--- a/tests/pipeline/retrieval/test_backfill.py
+++ b/tests/pipeline/retrieval/test_backfill.py
@@ -13,14 +13,28 @@ from uuid import uuid4
 
 import pytest
 
-from afterworlds.models.enums import IntentType, StoryMode, WritingCanonEligibility
+from afterworlds.models.character_sheet import RpgCharacterSheetBase
+from afterworlds.models.enums import (
+    IntentType,
+    RollVisibility,
+    RpgTurnRetrievalCategory,
+    StoryMode,
+    WritingCanonEligibility,
+)
 from afterworlds.models.node import WritingNodeMetadata
 from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.character_sheet import create_rpg_base_sheet
 from afterworlds.persistence.crud.node import create_node, create_turn
+from afterworlds.persistence.crud.retrieval import create_rpg_turn_retrieval_marker
 from afterworlds.persistence.crud.story import create_arc, create_chapter, create_story
 from afterworlds.persistence.database import create_session_factory
 from afterworlds.persistence.orm.node import TurnORM
-from afterworlds.pipeline.retrieval.backfill import backfill_story, reindex_story
+from afterworlds.persistence.orm.rpg import PendingRollRequestORM
+from afterworlds.pipeline.retrieval.backfill import (
+    RetrievalReindexWipeIncompleteError,
+    backfill_story,
+    reindex_story,
+)
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.collections import (
     RetrievalCollectionReindexRequiredError,
@@ -139,6 +153,78 @@ def _seed_writing_story_with_malformed_and_valid_turn(session):  # type: ignore[
     return story.story_id, valid_turn.turn_id, malformed_turn_id
 
 
+def _seed_rpg_story_with_marker_mismatch_turn(session):  # type: ignore[no-untyped-def]
+    """One RPG turn with a PendingRollRequest row but an ORDINARY_NARRATIVE
+    marker -- a coverage-invariant violation (ADR-018 D6) that backfill must
+    report as a data-integrity error, not silently ingest or skip."""
+    from afterworlds.models.node import (
+        BranchingNodeMetadata,
+        Node,
+        NodeMetadata,
+        StateDelta,
+    )
+
+    story = make_story(mode=StoryMode.RPG)
+    create_story(session, story)  # type: ignore[arg-type]
+    arc = make_arc(str(story.story_id))
+    create_arc(session, arc)  # type: ignore[arg-type]
+    chapter = make_chapter(str(arc.arc_id))
+    create_chapter(session, chapter)  # type: ignore[arg-type]
+    node = Node(
+        chapter_id=chapter.chapter_id,
+        content="",
+        state_delta=StateDelta(),
+        branching_logic=[],
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        metadata=NodeMetadata(timestamp=_NOW),
+        mode_metadata=BranchingNodeMetadata(),
+    )
+    create_node(session, node)  # type: ignore[arg-type]
+    turn = Turn(
+        user_input="swing my sword",
+        assistant_output="The blade connects.",
+        timestamp=_NOW,
+        intent_classification=IntentType.IN_CHARACTER_ACTION,
+        node_id=node.node_id,
+    )
+    create_turn(session, turn)  # type: ignore[arg-type]
+    create_rpg_turn_retrieval_marker(
+        session,
+        turn_id=turn.turn_id,
+        story_id=story.story_id,
+        category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+        created_at=_NOW.isoformat(),
+    )
+    sheet = RpgCharacterSheetBase(
+        story_id=story.story_id,
+        rules_package_id="dnd5e-v1",
+        character_name="Test Character",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    create_rpg_base_sheet(session, sheet)
+    session.add(
+        PendingRollRequestORM(
+            request_id=str(uuid4()),
+            story_id=str(story.story_id),
+            session_id=str(uuid4()),
+            character_id=str(sheet.sheet_id),
+            originating_turn_id=str(turn.turn_id),
+            check_label="Stealth Check",
+            player_facing_instruction="Roll a Stealth Check and report the total!",
+            expected_value_shape="d20",
+            visibility=RollVisibility.PLAYER.value,
+            source_proposal_ref="roll_0",
+            status="pending",
+            created_at=_NOW.isoformat(),
+            schema_version=1,
+            roll_expression="1d20+5",
+        )
+    )
+    session.commit()
+    return story.story_id, turn.turn_id
+
+
 class TestBackfillStory:
     def test_backfill_ingests_eligible_turns(
         self, session_factory, tmp_path: Path
@@ -205,6 +291,28 @@ class TestBackfillStory:
         assert report.data_integrity_errors == ()
         assert write_service.count_for_story(story_id) == 1
 
+    def test_rpg_marker_pending_roll_mismatch_is_reported_as_data_integrity_error(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119) round 6: backfill must report the turn ID
+        of a post-boundary marker/PendingRollRequest mismatch as a
+        data-integrity error, not ingest it and not silently skip it."""
+        session = session_factory()
+        story_id, turn_id = _seed_rpg_story_with_marker_mismatch_turn(session)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+
+        report = backfill_story(session, write_service, story_id, StoryMode.RPG)
+
+        assert report.turns_scanned == 1
+        assert report.turns_ingested == 0
+        assert report.data_integrity_errors == (turn_id,)
+        assert write_service.count_for_story(story_id) == 0
+
 
 class TestReindexStory:
     def test_reindex_wipes_then_rebuilds(
@@ -230,6 +338,52 @@ class TestReindexStory:
 
         assert report.turns_ingested == 2
         assert write_service.count_for_story(story_id) == 2
+
+
+class TestReindexAbortsOnIncompleteWipe:
+    """Codex review (PR #119) round 6: reindex_story() must never rebuild on
+    top of an incomplete delete_story() wipe -- that would leave stale
+    chunks alongside the freshly rebuilt set."""
+
+    def test_reindex_aborts_and_skips_backfill_when_delete_leaves_chunks(
+        self, session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, _turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 2)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+        monkeypatch.setattr(write_service, "delete_story", lambda story_id: 3)
+
+        backfill_calls = []
+        monkeypatch.setattr(
+            "afterworlds.pipeline.retrieval.backfill.backfill_story",
+            lambda *a, **k: backfill_calls.append((a, k)),
+        )
+
+        with pytest.raises(RetrievalReindexWipeIncompleteError):
+            reindex_story(session, write_service, story_id, StoryMode.BRANCHING)
+
+        assert backfill_calls == []
+
+    def test_reindex_rebuilds_when_delete_returns_zero(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, _turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 2)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+
+        report = reindex_story(session, write_service, story_id, StoryMode.BRANCHING)
+
+        assert report.turns_ingested == 2
 
 
 class TestEmbeddingModelMismatchSurfacesThroughBackfill:

--- a/tests/pipeline/retrieval/test_backfill.py
+++ b/tests/pipeline/retrieval/test_backfill.py
@@ -21,6 +21,7 @@ from afterworlds.persistence.database import create_session_factory
 from afterworlds.pipeline.retrieval.backfill import backfill_story, reindex_story
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
 from tests.persistence.conftest import make_arc, make_chapter, make_story
 
@@ -80,7 +81,9 @@ class TestBackfillStory:
 
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        write_service = RetrievalMemoryWriteService(client, config)
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
 
         report = backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
 
@@ -98,7 +101,9 @@ class TestBackfillStory:
 
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        write_service = RetrievalMemoryWriteService(client, config)
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
 
         backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
         count_after_first = write_service.count_for_story(story_id)
@@ -118,7 +123,9 @@ class TestReindexStory:
 
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        write_service = RetrievalMemoryWriteService(client, config)
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
         backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
 
         # Simulate stray drift: an extra chunk not backed by SQL ground truth.

--- a/tests/pipeline/retrieval/test_backfill.py
+++ b/tests/pipeline/retrieval/test_backfill.py
@@ -13,11 +13,13 @@ from uuid import uuid4
 
 import pytest
 
-from afterworlds.models.enums import IntentType, StoryMode
+from afterworlds.models.enums import IntentType, StoryMode, WritingCanonEligibility
+from afterworlds.models.node import WritingNodeMetadata
 from afterworlds.models.turn import Turn
 from afterworlds.persistence.crud.node import create_node, create_turn
 from afterworlds.persistence.crud.story import create_arc, create_chapter, create_story
 from afterworlds.persistence.database import create_session_factory
+from afterworlds.persistence.orm.node import TurnORM
 from afterworlds.pipeline.retrieval.backfill import backfill_story, reindex_story
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
@@ -72,6 +74,68 @@ def _seed_story_with_turns(session, mode: StoryMode, count: int):  # type: ignor
     return story.story_id, turn_ids
 
 
+def _seed_writing_story_with_malformed_and_valid_turn(session):  # type: ignore[no-untyped-def]
+    """One valid EXTRACTOR_ELIGIBLE turn + one turn with malformed
+    persisted mode_metadata (inserted directly, bypassing the Turn pydantic
+    model's validation, to simulate a corrupted/schema-drifted row).
+
+    Both turns are attached to a real Node -- _all_turn_ids_for_story joins
+    Turn -> Node -> Chapter -> Arc -> Story, so a null node_id would make
+    the turn invisible to backfill regardless of this test's intent.
+    """
+    from afterworlds.models.node import (
+        BranchingNodeMetadata,
+        Node,
+        NodeMetadata,
+        StateDelta,
+    )
+
+    story = make_story(mode=StoryMode.WRITING)
+    create_story(session, story)  # type: ignore[arg-type]
+    arc = make_arc(str(story.story_id))
+    create_arc(session, arc)  # type: ignore[arg-type]
+    chapter = make_chapter(str(arc.arc_id))
+    create_chapter(session, chapter)  # type: ignore[arg-type]
+    node = Node(
+        chapter_id=chapter.chapter_id,
+        content="",
+        state_delta=StateDelta(),
+        branching_logic=[],
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        metadata=NodeMetadata(timestamp=_NOW),
+        mode_metadata=BranchingNodeMetadata(),
+    )
+    create_node(session, node)  # type: ignore[arg-type]
+
+    valid_metadata = WritingNodeMetadata(
+        canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+    )
+    valid_turn = Turn(
+        user_input="prior input",
+        assistant_output="Kestrel drew her blade in the moonlight.",
+        timestamp=_NOW,
+        intent_classification=IntentType.DIALOGUE,
+        node_id=node.node_id,
+        mode_metadata=valid_metadata,
+    )
+    create_turn(session, valid_turn)  # type: ignore[arg-type]
+
+    malformed_turn_id = uuid4()
+    session.add(
+        TurnORM(
+            turn_id=str(malformed_turn_id),
+            node_id=str(node.node_id),
+            user_input="prior input",
+            assistant_output="This turn has corrupted metadata.",
+            timestamp=_NOW.isoformat(),
+            intent_classification=IntentType.DIALOGUE.value,
+            mode_metadata={"mode": "writing", "persona_registry_version": "bad"},
+        )
+    )
+    session.commit()
+    return story.story_id, valid_turn.turn_id, malformed_turn_id
+
+
 class TestBackfillStory:
     def test_backfill_ingests_eligible_turns(
         self, session_factory, tmp_path: Path
@@ -112,6 +176,31 @@ class TestBackfillStory:
         count_after_second = write_service.count_for_story(story_id)
 
         assert count_after_first == count_after_second == 2
+
+    def test_malformed_writing_metadata_is_skipped_not_aborting(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119): a single Writing turn with malformed
+        persisted mode_metadata must not abort the whole story's backfill --
+        the valid EXTRACTOR_ELIGIBLE turn must still be ingested."""
+        session = session_factory()
+        story_id, valid_turn_id, malformed_turn_id = (
+            _seed_writing_story_with_malformed_and_valid_turn(session)
+        )
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+
+        report = backfill_story(session, write_service, story_id, StoryMode.WRITING)
+
+        assert report.turns_scanned == 2
+        assert report.turns_ingested == 1
+        assert report.turns_skipped_ineligible == 1
+        assert report.data_integrity_errors == ()
+        assert write_service.count_for_story(story_id) == 1
 
 
 class TestReindexStory:

--- a/tests/pipeline/retrieval/test_backfill.py
+++ b/tests/pipeline/retrieval/test_backfill.py
@@ -1,0 +1,133 @@
+"""Tests for backfill/reindex — CRD Issue 18 / ADR-018 D7.
+
+Recovery for a Chroma write failure is a re-run: these are the idempotent
+manual backfill/reindex operations. Both consult the single shared
+eligibility predicate, so live ingestion and offline backfill never disagree.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.models.enums import IntentType, StoryMode
+from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.node import create_node, create_turn
+from afterworlds.persistence.crud.story import create_arc, create_chapter, create_story
+from afterworlds.persistence.database import create_session_factory
+from afterworlds.pipeline.retrieval.backfill import backfill_story, reindex_story
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
+from tests.persistence.conftest import make_arc, make_chapter, make_story
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture()
+def session_factory(engine):  # type: ignore[no-untyped-def]
+    return create_session_factory(engine)
+
+
+def _seed_story_with_turns(session, mode: StoryMode, count: int):  # type: ignore[no-untyped-def]
+    story = make_story(mode=mode)
+    create_story(session, story)  # type: ignore[arg-type]
+    arc = make_arc(str(story.story_id))
+    create_arc(session, arc)  # type: ignore[arg-type]
+    chapter = make_chapter(str(arc.arc_id))
+    create_chapter(session, chapter)  # type: ignore[arg-type]
+    from afterworlds.models.node import (
+        BranchingNodeMetadata,
+        Node,
+        NodeMetadata,
+        StateDelta,
+    )
+
+    node = Node(
+        chapter_id=chapter.chapter_id,
+        content="",
+        state_delta=StateDelta(),
+        branching_logic=[],
+        intent_type=IntentType.IN_CHARACTER_ACTION,
+        metadata=NodeMetadata(timestamp=_NOW),
+        mode_metadata=BranchingNodeMetadata(),
+    )
+    create_node(session, node)  # type: ignore[arg-type]
+    turn_ids = []
+    for i in range(count):
+        turn = Turn(
+            user_input=f"input {i}",
+            assistant_output=f"Delivered prose number {i}.",
+            timestamp=_NOW,
+            intent_classification=IntentType.IN_CHARACTER_ACTION,
+            node_id=node.node_id,
+        )
+        create_turn(session, turn)  # type: ignore[arg-type]
+        turn_ids.append(turn.turn_id)
+    session.commit()
+    return story.story_id, turn_ids
+
+
+class TestBackfillStory:
+    def test_backfill_ingests_eligible_turns(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 3)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(client, config)
+
+        report = backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
+
+        assert report.turns_scanned == 3
+        assert report.turns_ingested == 3
+        assert report.turns_skipped_ineligible == 0
+        assert report.data_integrity_errors == ()
+        assert write_service.count_for_story(story_id) == 3
+
+    def test_backfill_is_idempotent(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, _turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 2)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(client, config)
+
+        backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
+        count_after_first = write_service.count_for_story(story_id)
+
+        backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
+        count_after_second = write_service.count_for_story(story_id)
+
+        assert count_after_first == count_after_second == 2
+
+
+class TestReindexStory:
+    def test_reindex_wipes_then_rebuilds(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 2)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(client, config)
+        backfill_story(session, write_service, story_id, StoryMode.BRANCHING)
+
+        # Simulate stray drift: an extra chunk not backed by SQL ground truth.
+        write_service.ingest_turn(
+            story_id, uuid4(), None, "branching", "Orphaned drift chunk.", "t-drift"
+        )
+        assert write_service.count_for_story(story_id) == 3
+
+        report = reindex_story(session, write_service, story_id, StoryMode.BRANCHING)
+
+        assert report.turns_ingested == 2
+        assert write_service.count_for_story(story_id) == 2

--- a/tests/pipeline/retrieval/test_backfill.py
+++ b/tests/pipeline/retrieval/test_backfill.py
@@ -22,6 +22,9 @@ from afterworlds.persistence.database import create_session_factory
 from afterworlds.persistence.orm.node import TurnORM
 from afterworlds.pipeline.retrieval.backfill import backfill_story, reindex_story
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.collections import (
+    RetrievalCollectionReindexRequiredError,
+)
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
@@ -227,3 +230,31 @@ class TestReindexStory:
 
         assert report.turns_ingested == 2
         assert write_service.count_for_story(story_id) == 2
+
+
+class TestEmbeddingModelMismatchSurfacesThroughBackfill:
+    """Codex review (PR #119) round 3: backfill/reindex must surface the
+    typed reindex-required error clearly rather than continuing to upsert
+    into a collection whose recorded embedding model differs from config."""
+
+    def test_backfill_raises_on_embedding_model_mismatch(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, _turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 2)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        # Create the shared collection under model-a first.
+        RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        ).ingest_turn(uuid4(), uuid4(), None, "branching", "Unrelated seed.", "t0")
+
+        mismatched_write_service = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError):
+            backfill_story(
+                session, mismatched_write_service, story_id, StoryMode.BRANCHING
+            )

--- a/tests/pipeline/retrieval/test_backfill.py
+++ b/tests/pipeline/retrieval/test_backfill.py
@@ -258,3 +258,43 @@ class TestEmbeddingModelMismatchSurfacesThroughBackfill:
             backfill_story(
                 session, mismatched_write_service, story_id, StoryMode.BRANCHING
             )
+
+    def test_reindex_story_deletes_stale_entries_then_fails_clearly_on_mismatch(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119) round 5: story_memory is shared across all
+        stories (ADR-018 D1), so a single story's reindex_story() cannot
+        repair a collection-level embedding-model mismatch on its own. It
+        may safely delete this story's stale entries (metadata-only, never
+        gated by the model guard) but must fail with the same clear typed
+        error rather than silently upserting into the still-incompatible
+        collection -- never "pretend" the story-level reindex fixed it."""
+        session = session_factory()
+        story_id, _turn_ids = _seed_story_with_turns(session, StoryMode.BRANCHING, 2)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        # Create the shared collection under model-a, ingest this story's
+        # own (now-stale) chunks under that model too.
+        write_service_a = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        )
+        for turn_id in _turn_ids:
+            write_service_a.ingest_turn(
+                story_id, turn_id, None, "branching", "Stale prose.", "t"
+            )
+        assert write_service_a.count_for_story(story_id) == 2
+
+        mismatched_write_service = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError, match="shared"):
+            reindex_story(
+                session, mismatched_write_service, story_id, StoryMode.BRANCHING
+            )
+
+        # The delete-only phase ran safely (metadata delete never gated by
+        # the model guard) -- this story's stale entries are gone even
+        # though the collection-level mismatch blocked the rebuild.
+        assert write_service_a.count_for_story(story_id) == 0

--- a/tests/pipeline/retrieval/test_chroma_provider.py
+++ b/tests/pipeline/retrieval/test_chroma_provider.py
@@ -1,0 +1,123 @@
+"""Integration tests for ChromaRetrievalMemoryProvider.
+
+CRD Issue 18 / ADR-018 D1 (mandatory story_id query gate / cross-story
+leakage) and D5 (inclusive threshold boundary).
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from uuid import uuid4
+
+from afterworlds.pipeline.retrieval.chroma_provider import ChromaRetrievalMemoryProvider
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
+
+
+class _ControllableEmbeddingFunction:
+    """Maps known text strings to exact 2D unit vectors for precise cosine control."""
+
+    def __init__(self, vectors: dict[str, tuple[float, float]]) -> None:
+        self._vectors = vectors
+
+    def __call__(self, input: list[str]) -> list[list[float]]:
+        return [list(self._vectors[text]) for text in input]
+
+    def embed_query(self, input: list[str]) -> list[list[float]]:
+        return self(input)
+
+    def name(self) -> str:
+        return "controllable-test-embedding"
+
+    def is_legacy(self) -> bool:
+        return True
+
+
+def _unit_vector_at_similarity(similarity: float) -> tuple[float, float]:
+    """Return a unit vector whose cosine similarity to (1, 0) is *similarity*."""
+    return (similarity, math.sqrt(max(0.0, 1.0 - similarity**2)))
+
+
+class TestMandatoryStoryIdFilter:
+    def test_cross_story_leakage_never_occurs(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig(minimum_similarity_threshold=0.0, top_k=10)
+        write_service = RetrievalMemoryWriteService(client, config)
+        provider = ChromaRetrievalMemoryProvider(client, config)
+
+        story_a, story_b = uuid4(), uuid4()
+        # Identical/overlapping content across both stories.
+        write_service.ingest_turn(
+            story_a, uuid4(), None, "rpg", "The dragon roars overhead.", "t1"
+        )
+        write_service.ingest_turn(
+            story_b, uuid4(), None, "rpg", "The dragon roars overhead.", "t2"
+        )
+
+        result_a = provider.retrieve(story_a, "The dragon roars overhead.")
+        result_b = provider.retrieve(story_b, "The dragon roars overhead.")
+
+        assert len(result_a.passages) == 1
+        assert len(result_b.passages) == 1
+        # Every read path is gated by story_id; a query for A never surfaces
+        # B's chunk and vice versa, even with byte-identical content.
+        assert result_a.passages[0] == "The dragon roars overhead."
+        assert result_b.passages[0] == "The dragon roars overhead."
+
+    def test_query_for_story_with_no_chunks_is_empty(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        write_service = RetrievalMemoryWriteService(client, config)
+        provider = ChromaRetrievalMemoryProvider(client, config)
+
+        story_a, story_b = uuid4(), uuid4()
+        write_service.ingest_turn(story_a, uuid4(), None, "rpg", "Some prose.", "t1")
+
+        result = provider.retrieve(story_b, "Some prose.")
+        assert result.passages == ()
+
+    def test_empty_query_returns_empty_payload(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        provider = ChromaRetrievalMemoryProvider(client, config)
+        result = provider.retrieve(uuid4(), "")
+        assert result.passages == ()
+
+
+class TestThresholdBoundary:
+    def test_below_threshold_excluded_and_at_threshold_included(
+        self, tmp_path: Path
+    ) -> None:
+        """D5: must assert both the below-threshold exclusion AND the
+        exact-boundary inclusion — "above survives" alone is insufficient."""
+        threshold = 0.6
+        query_text = "query"
+        at_threshold_text = "at_threshold_chunk"
+        below_threshold_text = "below_threshold_chunk"
+
+        vectors = {
+            query_text: (1.0, 0.0),
+            at_threshold_text: _unit_vector_at_similarity(threshold),
+            below_threshold_text: _unit_vector_at_similarity(threshold - 0.2),
+        }
+        ef = _ControllableEmbeddingFunction(vectors)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig(minimum_similarity_threshold=threshold, top_k=10)
+        write_service = RetrievalMemoryWriteService(client, config, ef)
+        provider = ChromaRetrievalMemoryProvider(client, config, ef)
+
+        story_id = uuid4()
+        write_service.ingest_turn(
+            story_id, uuid4(), None, "rpg", at_threshold_text, "t1"
+        )
+        write_service.ingest_turn(
+            story_id, uuid4(), None, "rpg", below_threshold_text, "t2"
+        )
+
+        result = provider.retrieve(story_id, query_text)
+
+        assert at_threshold_text in result.passages
+        assert below_threshold_text not in result.passages

--- a/tests/pipeline/retrieval/test_chroma_provider.py
+++ b/tests/pipeline/retrieval/test_chroma_provider.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from afterworlds.pipeline.retrieval.chroma_provider import ChromaRetrievalMemoryProvider
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
 
 
@@ -44,8 +45,9 @@ class TestMandatoryStoryIdFilter:
     def test_cross_story_leakage_never_occurs(self, tmp_path: Path) -> None:
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig(minimum_similarity_threshold=0.0, top_k=10)
-        write_service = RetrievalMemoryWriteService(client, config)
-        provider = ChromaRetrievalMemoryProvider(client, config)
+        ef = DeterministicFakeEmbeddingFunction()
+        write_service = RetrievalMemoryWriteService(client, config, ef)
+        provider = ChromaRetrievalMemoryProvider(client, config, ef)
 
         story_a, story_b = uuid4(), uuid4()
         # Identical/overlapping content across both stories.
@@ -69,8 +71,9 @@ class TestMandatoryStoryIdFilter:
     def test_query_for_story_with_no_chunks_is_empty(self, tmp_path: Path) -> None:
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        write_service = RetrievalMemoryWriteService(client, config)
-        provider = ChromaRetrievalMemoryProvider(client, config)
+        ef = DeterministicFakeEmbeddingFunction()
+        write_service = RetrievalMemoryWriteService(client, config, ef)
+        provider = ChromaRetrievalMemoryProvider(client, config, ef)
 
         story_a, story_b = uuid4(), uuid4()
         write_service.ingest_turn(story_a, uuid4(), None, "rpg", "Some prose.", "t1")
@@ -81,7 +84,9 @@ class TestMandatoryStoryIdFilter:
     def test_empty_query_returns_empty_payload(self, tmp_path: Path) -> None:
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        provider = ChromaRetrievalMemoryProvider(client, config)
+        provider = ChromaRetrievalMemoryProvider(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
         result = provider.retrieve(uuid4(), "")
         assert result.passages == ()
 

--- a/tests/pipeline/retrieval/test_chunking.py
+++ b/tests/pipeline/retrieval/test_chunking.py
@@ -1,0 +1,38 @@
+"""Unit tests for the ADR-018 D3 chunking policy."""
+
+from __future__ import annotations
+
+from afterworlds.pipeline.retrieval.chunking import chunk_turn_prose
+
+
+class TestChunkTurnProse:
+    def test_short_text_single_chunk(self) -> None:
+        text = "A short beat of prose."
+        assert chunk_turn_prose(text, ceiling=4000) == [text]
+
+    def test_exactly_at_ceiling_single_chunk(self) -> None:
+        text = "x" * 100
+        assert chunk_turn_prose(text, ceiling=100) == [text]
+
+    def test_splits_on_paragraph_boundary_above_ceiling(self) -> None:
+        para_a = "a" * 60
+        para_b = "b" * 60
+        text = f"{para_a}\n\n{para_b}"
+        chunks = chunk_turn_prose(text, ceiling=60)
+        assert len(chunks) == 2
+        assert chunks[0] == para_a
+        assert chunks[1] == para_b
+
+    def test_groups_small_paragraphs_under_ceiling(self) -> None:
+        paragraphs = ["short one.", "short two.", "short three."]
+        text = "\n\n".join(paragraphs)
+        chunks = chunk_turn_prose(text, ceiling=1000)
+        assert chunks == [text]
+
+    def test_oversized_single_paragraph_kept_whole(self) -> None:
+        huge_paragraph = "x" * 500
+        chunks = chunk_turn_prose(huge_paragraph, ceiling=100)
+        assert chunks == [huge_paragraph]
+
+    def test_empty_text(self) -> None:
+        assert chunk_turn_prose("", ceiling=4000) == [""]

--- a/tests/pipeline/retrieval/test_collections.py
+++ b/tests/pipeline/retrieval/test_collections.py
@@ -17,6 +17,7 @@ import pytest
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.collections import (
     RetrievalCollectionReindexRequiredError,
+    delete_collection_ignoring_absence,
     get_existing_story_memory_collection_for_delete,
     get_rules_corpus_collection,
     get_story_memory_collection,
@@ -115,6 +116,37 @@ class TestGetExistingStoryMemoryCollectionForDelete:
 
         with pytest.raises(RuntimeError, match="store locked"):
             get_existing_story_memory_collection_for_delete(client)
+
+
+class TestDeleteCollectionIgnoringAbsence:
+    """Codex review (PR #119) round 7: the shared wipe-then-rebuild helper
+    used by both story-memory and rules-corpus reindex paths."""
+
+    def test_absent_collection_is_a_noop(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        delete_collection_ignoring_absence(client, "story_memory")  # must not raise
+
+    def test_existing_collection_is_deleted(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        get_story_memory_collection(client, RetrievalMemoryConfig(), ef)
+
+        delete_collection_ignoring_absence(client, "story_memory")
+
+        assert client.list_collections() == []
+
+    def test_operational_error_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(client, "delete_collection", _boom)
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            delete_collection_ignoring_absence(client, "story_memory")
 
 
 class TestRulesCorpusCollectionEmbeddingModelGuard:

--- a/tests/pipeline/retrieval/test_collections.py
+++ b/tests/pipeline/retrieval/test_collections.py
@@ -17,6 +17,7 @@ import pytest
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.collections import (
     RetrievalCollectionReindexRequiredError,
+    get_existing_story_memory_collection_for_delete,
     get_rules_corpus_collection,
     get_story_memory_collection,
 )
@@ -80,6 +81,40 @@ class TestStoryMemoryCollectionEmbeddingModelGuard:
             get_story_memory_collection(
                 client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
             )
+
+
+class TestGetExistingStoryMemoryCollectionForDelete:
+    """Codex review (PR #119) round 6: the delete-only accessor must treat
+    only a genuinely-absent collection as "nothing to delete" -- an
+    operational error (locked store, permission failure, etc.) must
+    propagate rather than being silently reported as missing."""
+
+    def test_absent_collection_returns_none(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        assert get_existing_story_memory_collection_for_delete(client) is None
+
+    def test_existing_collection_is_returned(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        get_story_memory_collection(client, RetrievalMemoryConfig(), ef)
+
+        collection = get_existing_story_memory_collection_for_delete(client)
+
+        assert collection is not None
+        assert collection.name == "story_memory"
+
+    def test_operational_error_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(client, "get_collection", _boom)
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            get_existing_story_memory_collection_for_delete(client)
 
 
 class TestRulesCorpusCollectionEmbeddingModelGuard:

--- a/tests/pipeline/retrieval/test_collections.py
+++ b/tests/pipeline/retrieval/test_collections.py
@@ -1,0 +1,132 @@
+"""Tests for the Chroma collection-access helpers — CRD Issue 18 / ADR-018 D4.
+
+Codex review (PR #119) round 3: an existing persistent collection's
+recorded embedding_model_id must be checked against config before reuse —
+mixed-model collections are a defect (D4), and the collection-level
+metadata dict is silently ignored by Chroma on an already-created
+collection, so this check must be explicit, not inferred from the
+``metadata=`` kwarg alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.collections import (
+    RetrievalCollectionReindexRequiredError,
+    get_rules_corpus_collection,
+    get_story_memory_collection,
+)
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
+
+
+class TestStoryMemoryCollectionEmbeddingModelGuard:
+    def test_new_collection_stores_embedding_model_id(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig(embedding_model_id="model-a")
+
+        collection = get_story_memory_collection(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+
+        assert collection.metadata is not None
+        assert collection.metadata.get("embedding_model_id") == "model-a"
+
+    def test_matching_existing_collection_reuses_cleanly(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig(embedding_model_id="model-a")
+        ef = DeterministicFakeEmbeddingFunction()
+
+        first = get_story_memory_collection(client, config, ef)
+        second = get_story_memory_collection(client, config, ef)
+
+        assert first.name == second.name
+        assert second.metadata.get("embedding_model_id") == "model-a"
+
+    def test_mismatched_existing_collection_raises(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        get_story_memory_collection(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError, match="reindex"):
+            get_story_memory_collection(
+                client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+            )
+
+    def test_legacy_collection_missing_embedding_model_id_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """A collection created before this guard existed has no
+        embedding_model_id key at all -- ADR-018 does not permit silently
+        assuming that shape is compatible with the configured model."""
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        # Simulate a pre-guard collection: only hnsw:space, no
+        # embedding_model_id, created directly against the raw client
+        # (bypassing get_story_memory_collection entirely).
+        client.get_or_create_collection(
+            name="story_memory",
+            metadata={"hnsw:space": "cosine"},
+            embedding_function=ef,  # type: ignore[arg-type]
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError, match="reindex"):
+            get_story_memory_collection(
+                client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+            )
+
+
+class TestRulesCorpusCollectionEmbeddingModelGuard:
+    def test_new_collection_stores_embedding_model_id(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig(embedding_model_id="model-a")
+
+        collection = get_rules_corpus_collection(
+            client, "rules_corpus_test", config, DeterministicFakeEmbeddingFunction()
+        )
+
+        assert collection.metadata is not None
+        assert collection.metadata.get("embedding_model_id") == "model-a"
+
+    def test_mismatched_existing_collection_raises(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        get_rules_corpus_collection(
+            client,
+            "rules_corpus_test",
+            RetrievalMemoryConfig(embedding_model_id="model-a"),
+            ef,
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError, match="reindex"):
+            get_rules_corpus_collection(
+                client,
+                "rules_corpus_test",
+                RetrievalMemoryConfig(embedding_model_id="model-b"),
+                ef,
+            )
+
+    def test_legacy_collection_missing_embedding_model_id_raises(
+        self, tmp_path: Path
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        client.get_or_create_collection(
+            name="rules_corpus_test",
+            metadata={"hnsw:space": "cosine"},
+            embedding_function=ef,  # type: ignore[arg-type]
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError, match="reindex"):
+            get_rules_corpus_collection(
+                client,
+                "rules_corpus_test",
+                RetrievalMemoryConfig(embedding_model_id="model-a"),
+                ef,
+            )

--- a/tests/pipeline/retrieval/test_eligibility.py
+++ b/tests/pipeline/retrieval/test_eligibility.py
@@ -106,6 +106,64 @@ class TestRpgEligibility:
         assert decision.eligible is True  # type: ignore[attr-defined]
         assert decision.data_integrity_error is False  # type: ignore[attr-defined]
 
+    def test_pre_boundary_markerless_with_pending_roll_is_excluded(self) -> None:
+        """Codex #119 P1: a legacy pre-marker roll-request turn has no
+        marker row (predates the sidecar entirely), so the markerless
+        pre-boundary fallback above would otherwise wrongly treat it as
+        eligible ORDINARY_NARRATIVE. PendingRollRequest.originating_turn_id
+        is the only signal that can exclude it (ADR-018 D6 era-boundary
+        table, "Before persisted boundary, roll-request" row)."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=None,
+            is_post_boundary=False,
+            has_pending_roll_request=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is False  # type: ignore[attr-defined]
+
+    def test_pre_boundary_markerless_without_pending_roll_remains_eligible(
+        self,
+    ) -> None:
+        """Same shape as above but with no PendingRollRequest row: must
+        remain eligible — the pending-roll check must not over-exclude
+        ordinary legacy turns that never announced a roll."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=None,
+            is_post_boundary=False,
+            has_pending_roll_request=False,
+        )
+        assert decision.eligible is True  # type: ignore[attr-defined]
+
+    def test_post_boundary_markerless_remains_data_integrity_error(self) -> None:
+        """A post-boundary markerless turn is a data-integrity error
+        regardless of has_pending_roll_request — the coverage invariant
+        (ADR-018 D6) means every post-boundary narrative-path turn must have
+        a marker row; a missing one is a bug to surface, not to paper over
+        by falling through to the pending-roll or legacy-eligible paths."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=None,
+            is_post_boundary=True,
+            has_pending_roll_request=False,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is True  # type: ignore[attr-defined]
+
+    def test_pending_roll_request_governs_regardless_of_marker_category(self) -> None:
+        """ADR-018 D6: PendingRollRequest.originating_turn_id governs the
+        exclusion decision regardless of marker category — verified here
+        against an ORDINARY_NARRATIVE marker, which would otherwise be
+        eligible."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            is_post_boundary=True,
+            has_pending_roll_request=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+
 
 class TestBranchingEligibility:
     def test_branching_default_eligible(self) -> None:

--- a/tests/pipeline/retrieval/test_eligibility.py
+++ b/tests/pipeline/retrieval/test_eligibility.py
@@ -151,11 +151,13 @@ class TestRpgEligibility:
         assert decision.eligible is False  # type: ignore[attr-defined]
         assert decision.data_integrity_error is True  # type: ignore[attr-defined]
 
-    def test_pending_roll_request_governs_regardless_of_marker_category(self) -> None:
-        """ADR-018 D6: PendingRollRequest.originating_turn_id governs the
-        exclusion decision regardless of marker category — verified here
-        against an ORDINARY_NARRATIVE marker, which would otherwise be
-        eligible."""
+    def test_post_boundary_pending_roll_ordinary_narrative_marker_is_defect(
+        self,
+    ) -> None:
+        """Codex review (PR #119) round 6: post-boundary, the two signals
+        must agree (ADR-018 D6 coverage invariant) — PendingRollRequest
+        present but an ORDINARY_NARRATIVE marker is a mismatch and must be
+        flagged, not silently treated as plain ineligible."""
         decision = _decide(
             story_mode=StoryMode.RPG,
             rpg_marker_category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
@@ -163,6 +165,59 @@ class TestRpgEligibility:
             has_pending_roll_request=True,
         )
         assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is True  # type: ignore[attr-defined]
+
+    def test_post_boundary_pending_roll_setup_confirmation_marker_is_defect(
+        self,
+    ) -> None:
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.SETUP_CONFIRMATION,
+            is_post_boundary=True,
+            has_pending_roll_request=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is True  # type: ignore[attr-defined]
+
+    def test_post_boundary_pending_roll_with_missing_marker_is_data_integrity_error(
+        self,
+    ) -> None:
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=None,
+            is_post_boundary=True,
+            has_pending_roll_request=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is True  # type: ignore[attr-defined]
+
+    def test_post_boundary_pending_roll_with_roll_request_marker_is_normal_ineligible(
+        self,
+    ) -> None:
+        """The agreeing shape (both signals present) is the expected,
+        non-defect case — ineligible, but not a data-integrity error."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.ROLL_REQUEST,
+            is_post_boundary=True,
+            has_pending_roll_request=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is False  # type: ignore[attr-defined]
+
+    def test_post_boundary_roll_request_marker_without_pending_roll_is_defect(
+        self,
+    ) -> None:
+        """The inverse mismatch: a ROLL_REQUEST marker with no matching
+        PendingRollRequest row also violates the coverage invariant."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.ROLL_REQUEST,
+            is_post_boundary=True,
+            has_pending_roll_request=False,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is True  # type: ignore[attr-defined]
 
 
 class TestBranchingEligibility:

--- a/tests/pipeline/retrieval/test_eligibility.py
+++ b/tests/pipeline/retrieval/test_eligibility.py
@@ -1,0 +1,115 @@
+"""Unit tests for the shared retrieval-eligibility predicate.
+
+CRD Issue 18 / ADR-018 D6/D8. These exercise ``decide_turn_eligibility``
+directly (pure function, no I/O) — the DB-integration path
+(``gather_turn_eligibility`` / ``gather_turn_eligibility_for_turn``) is
+covered in ``tests/persistence/test_retrieval_markers_db.py``.
+"""
+
+from __future__ import annotations
+
+from afterworlds.models.enums import (
+    IntentType,
+    RpgTurnRetrievalCategory,
+    StoryMode,
+    WritingCanonEligibility,
+)
+from afterworlds.models.node import WritingNodeMetadata
+from afterworlds.pipeline.retrieval.eligibility import decide_turn_eligibility
+
+
+def _decide(**overrides: object) -> object:
+    defaults: dict[str, object] = {
+        "story_mode": StoryMode.WRITING,
+        "intent_classification": IntentType.DIALOGUE,
+        "mode_metadata": None,
+        "rpg_marker_category": None,
+        "is_post_boundary": True,
+    }
+    defaults.update(overrides)
+    return decide_turn_eligibility(**defaults)  # type: ignore[arg-type]
+
+
+class TestOocExclusion:
+    def test_ooc_always_excluded_regardless_of_mode(self) -> None:
+        for mode in StoryMode:
+            decision = _decide(story_mode=mode, intent_classification=IntentType.OOC)
+            assert decision.eligible is False  # type: ignore[attr-defined]
+
+
+class TestWritingEligibility:
+    def test_extractor_eligible_is_eligible(self) -> None:
+        metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        decision = _decide(story_mode=StoryMode.WRITING, mode_metadata=metadata)
+        assert decision.eligible is True  # type: ignore[attr-defined]
+
+    def test_non_canon_support_is_ineligible(self) -> None:
+        metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        decision = _decide(story_mode=StoryMode.WRITING, mode_metadata=metadata)
+        assert decision.eligible is False  # type: ignore[attr-defined]
+
+    def test_missing_metadata_is_ineligible(self) -> None:
+        """Best-effort write failure must be treated as ineligible, never eligible."""
+        decision = _decide(story_mode=StoryMode.WRITING, mode_metadata=None)
+        assert decision.eligible is False  # type: ignore[attr-defined]
+
+    def test_malformed_metadata_is_ineligible(self) -> None:
+        decision = _decide(story_mode=StoryMode.WRITING, mode_metadata="not-metadata")
+        assert decision.eligible is False  # type: ignore[attr-defined]
+
+
+class TestRpgEligibility:
+    def test_ordinary_narrative_marker_eligible(self) -> None:
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.ORDINARY_NARRATIVE,
+            is_post_boundary=True,
+        )
+        assert decision.eligible is True  # type: ignore[attr-defined]
+
+    def test_roll_request_marker_ineligible(self) -> None:
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.ROLL_REQUEST,
+            is_post_boundary=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+
+    def test_setup_confirmation_marker_ineligible(self) -> None:
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=RpgTurnRetrievalCategory.SETUP_CONFIRMATION,
+            is_post_boundary=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+
+    def test_post_boundary_markerless_is_data_integrity_error(self) -> None:
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=None,
+            is_post_boundary=True,
+        )
+        assert decision.eligible is False  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is True  # type: ignore[attr-defined]
+
+    def test_pre_boundary_markerless_is_eligible_ordinary_narrative(self) -> None:
+        """Legacy turns predating the marker era are treated as ORDINARY_NARRATIVE."""
+        decision = _decide(
+            story_mode=StoryMode.RPG,
+            rpg_marker_category=None,
+            is_post_boundary=False,
+        )
+        assert decision.eligible is True  # type: ignore[attr-defined]
+        assert decision.data_integrity_error is False  # type: ignore[attr-defined]
+
+
+class TestBranchingEligibility:
+    def test_branching_default_eligible(self) -> None:
+        """Branching setup confirmations remain eligible as ordinary narrative
+        (CRD Issue 16) — no special sidecar exclusion for Branching."""
+        decision = _decide(story_mode=StoryMode.BRANCHING)
+        assert decision.eligible is True  # type: ignore[attr-defined]

--- a/tests/pipeline/retrieval/test_embedding.py
+++ b/tests/pipeline/retrieval/test_embedding.py
@@ -1,0 +1,144 @@
+"""Tests for the embedding function seam — CRD Issue 18 / ADR-018 D4.
+
+Codex review (PR #119): the real local ONNX MiniLM embedding function must
+be the production default; the deterministic fake must only ever be used
+via explicit caller injection, never selected implicitly on omission.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from afterworlds.pipeline.retrieval import collections as collections_module
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import (
+    DeterministicFakeEmbeddingFunction,
+    RetrievalEmbeddingUnavailableError,
+    resolve_default_embedding_function,
+)
+
+
+class _StubRealEmbeddingFunction:
+    """Stands in for chromadb's real DefaultEmbeddingFunction in tests, so
+    resolution can be proven without a network call / model download.
+
+    Fully duck-types ``RetrievalEmbeddingFunction`` so chromadb's own
+    collection-creation validation accepts it like any real function.
+    """
+
+    def __call__(self, input: list[str]) -> list[list[float]]:
+        return [[0.0, 1.0] for _ in input]
+
+    def embed_query(self, input: list[str]) -> list[list[float]]:
+        return self(input)
+
+    def name(self) -> str:
+        return "stub-real-embedding-function"
+
+    def is_legacy(self) -> bool:
+        return True
+
+
+class TestResolveDefaultEmbeddingFunction:
+    def test_omitted_embedding_function_resolves_to_real_not_fake(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Omitting an embedding function must resolve to the real ADR-018
+        D4 default, never the deterministic fake."""
+        monkeypatch.setattr(
+            "chromadb.utils.embedding_functions.DefaultEmbeddingFunction",
+            _StubRealEmbeddingFunction,
+        )
+
+        ef = resolve_default_embedding_function()
+
+        assert isinstance(ef, _StubRealEmbeddingFunction)
+        assert not isinstance(ef, DeterministicFakeEmbeddingFunction)
+
+    def test_real_embedding_unavailable_raises_typed_error_not_fake_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the real embedding function cannot initialize, resolution must
+        fail loudly with a typed error — never silently fall back to the
+        deterministic fake in production/default code."""
+
+        def _raise(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("synthetic ONNX model load failure")
+
+        monkeypatch.setattr(
+            "chromadb.utils.embedding_functions.DefaultEmbeddingFunction", _raise
+        )
+
+        with pytest.raises(RetrievalEmbeddingUnavailableError):
+            resolve_default_embedding_function()
+
+    def test_explicit_fake_injection_still_runs_fully_offline(self) -> None:
+        """Tests/offline fixtures must still be able to opt into the fake by
+        constructing it explicitly — no network, no model download."""
+        fake = DeterministicFakeEmbeddingFunction()
+
+        vectors = fake(["some prose"])
+
+        assert len(vectors) == 1
+        assert len(vectors[0]) > 0
+        # Deterministic: identical input always yields identical output.
+        assert fake(["some prose"]) == vectors
+
+
+class TestCollectionHelpersNeverSilentlyFake:
+    """Sibling audit: no shared collection helper may substitute the fake
+    when the caller omits an embedding function — every fake usage must be
+    an explicit injection at the call site, not an implicit default here."""
+
+    def test_story_memory_collection_uses_resolved_default_when_omitted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[object] = []
+        real_resolve = resolve_default_embedding_function
+
+        def _spy_resolve() -> object:
+            calls.append(object())
+            monkeypatch.setattr(
+                "chromadb.utils.embedding_functions.DefaultEmbeddingFunction",
+                _StubRealEmbeddingFunction,
+            )
+            return real_resolve()
+
+        monkeypatch.setattr(
+            collections_module, "resolve_default_embedding_function", _spy_resolve
+        )
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+
+        collections_module.get_story_memory_collection(client, config)
+
+        assert len(calls) == 1
+
+    def test_rules_corpus_collection_uses_resolved_default_when_omitted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[object] = []
+        real_resolve = resolve_default_embedding_function
+
+        def _spy_resolve() -> object:
+            calls.append(object())
+            monkeypatch.setattr(
+                "chromadb.utils.embedding_functions.DefaultEmbeddingFunction",
+                _StubRealEmbeddingFunction,
+            )
+            return real_resolve()
+
+        monkeypatch.setattr(
+            collections_module, "resolve_default_embedding_function", _spy_resolve
+        )
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+
+        collections_module.get_rules_corpus_collection(
+            client, "rules_corpus_test", config
+        )
+
+        assert len(calls) == 1

--- a/tests/pipeline/retrieval/test_query_builder.py
+++ b/tests/pipeline/retrieval/test_query_builder.py
@@ -198,6 +198,26 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         )
         create_turn(session, turn)  # type: ignore[arg-type]
 
+    def _persist_malformed_writing_turn(
+        self, session: Session, node_id: object, assistant_output: str
+    ) -> None:
+        """Insert a Turn row whose mode_metadata JSON fails ModeMetadata
+        validation -- bypasses create_turn()'s pydantic validation to
+        simulate a corrupted/schema-drifted committed row (Codex #119 P2)."""
+        from afterworlds.persistence.orm.node import TurnORM
+
+        session.add(
+            TurnORM(
+                turn_id=str(uuid4()),
+                node_id=str(node_id),
+                user_input="prior input",
+                assistant_output=assistant_output,
+                timestamp=_NOW.isoformat(),
+                intent_classification=IntentType.DIALOGUE.value,
+                mode_metadata={"mode": "writing", "persona_registry_version": "bad"},
+            )
+        )
+
     def test_extractor_eligible_prose_turn_appears_in_query_tail(
         self, session_factory
     ) -> None:  # type: ignore[no-untyped-def]
@@ -322,3 +342,37 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         assert "Kestrel drew her blade" in request.query_text
         assert "brainstorm" not in request.query_text
         assert "sequel" not in request.query_text
+
+    def test_malformed_writing_metadata_turn_is_skipped_not_aborting(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Codex review (PR #119): a malformed-metadata Writing turn in the
+        tail window must not abort query composition -- it is simply
+        excluded, and the query still builds from the other eligible tail
+        turn plus current input."""
+        session = session_factory()
+        story_id, node_id = self._seed_writing_story(session)
+        extractor_eligible_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        self._persist_malformed_writing_turn(
+            session, node_id, "This turn has corrupted metadata."
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Kestrel drew her blade in the moonlight.",
+            extractor_eligible_metadata,
+        )
+        session.commit()
+
+        provider = SQLiteRecentTurnsProvider(session)
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+        )
+
+        assert "Kestrel drew her blade" in request.query_text
+        assert "corrupted metadata" not in request.query_text
+        assert "What happens next?" in request.query_text

--- a/tests/pipeline/retrieval/test_query_builder.py
+++ b/tests/pipeline/retrieval/test_query_builder.py
@@ -4,6 +4,12 @@ The critical obligation: a test must fail if ``exclude_ooc=True`` alone is
 treated as sufficient for the retrieval-query tail. A fixture with a
 non-OOC, D6-ineligible support turn in the recent window must prove that
 turn's text is absent from the composed query.
+
+Turns are persisted (not just held in-memory) because the query builder
+reloads full committed turn state before deciding Writing eligibility
+(Codex #119 P2: a production recent-turn provider may return a lean Turn
+projection without ``mode_metadata``, which must not be mistaken for a
+missing/malformed-metadata turn).
 """
 
 from __future__ import annotations
@@ -12,12 +18,23 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import IntentType, StoryMode, WritingCanonEligibility
-from afterworlds.models.node import WritingNodeMetadata
+from afterworlds.models.node import (
+    BranchingNodeMetadata,
+    Node,
+    NodeMetadata,
+    StateDelta,
+    WritingNodeMetadata,
+)
 from afterworlds.models.turn import Turn
+from afterworlds.persistence.crud.node import create_node, create_turn
+from afterworlds.persistence.crud.story import create_arc, create_chapter, create_story
 from afterworlds.persistence.database import create_session_factory
 from afterworlds.pipeline.retrieval.query_builder import RetrievalQueryBuilder
+from afterworlds.services.context_builder import SQLiteRecentTurnsProvider
+from tests.persistence.conftest import make_arc, make_chapter, make_story
 
 _NOW = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -37,14 +54,19 @@ class _FakeRecentTurnsProvider:
         return turns[-limit:]
 
 
-def _make_turn(assistant_output: str, mode_metadata: object = None) -> Turn:
-    return Turn(
+def _persist_turn(
+    session: Session, assistant_output: str, mode_metadata: object = None
+) -> Turn:
+    """Persist a committed Turn (node_id omitted — nullable, no FK needed
+    for these tests) so eligibility reload sees real SQLite state."""
+    turn = Turn(
         user_input="prior input",
         assistant_output=assistant_output,
         timestamp=_NOW,
         intent_classification=IntentType.DIALOGUE,
         mode_metadata=mode_metadata,  # type: ignore[arg-type]
     )
+    return create_turn(session, turn)  # type: ignore[arg-type]
 
 
 @pytest.fixture()
@@ -54,18 +76,24 @@ def session_factory(engine):  # type: ignore[no-untyped-def]
 
 class TestQueryTailEligibilityFiltering:
     def test_exclude_ooc_alone_is_not_sufficient(self, session_factory) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
         non_canon_metadata = WritingNodeMetadata(
             canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
         )
         extractor_eligible_metadata = WritingNodeMetadata(
             canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
         )
-        support_turn = _make_turn(
-            "Let's brainstorm some names for the antagonist.", non_canon_metadata
+        support_turn = _persist_turn(
+            session,
+            "Let's brainstorm some names for the antagonist.",
+            non_canon_metadata,
         )
-        canon_turn = _make_turn(
-            "Kestrel drew her blade in the moonlight.", extractor_eligible_metadata
+        canon_turn = _persist_turn(
+            session,
+            "Kestrel drew her blade in the moonlight.",
+            extractor_eligible_metadata,
         )
+        session.commit()
         provider = _FakeRecentTurnsProvider([support_turn, canon_turn])
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
@@ -80,10 +108,12 @@ class TestQueryTailEligibilityFiltering:
     def test_no_eligible_tail_turns_falls_back_to_current_input_only(
         self, session_factory
     ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
         non_canon_metadata = WritingNodeMetadata(
             canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
         )
-        support_turn = _make_turn("config chatter", non_canon_metadata)
+        support_turn = _persist_turn(session, "config chatter", non_canon_metadata)
+        session.commit()
         provider = _FakeRecentTurnsProvider([support_turn])
         builder = RetrievalQueryBuilder(provider, session_factory)
 
@@ -100,7 +130,7 @@ class TestQueryTailEligibilityFiltering:
         builder = RetrievalQueryBuilder(provider, session_factory)
 
         request = builder.build_query_request(
-            uuid4(), "current input", StoryMode.WRITING
+            uuid4(), "current input", StoryMode.BRANCHING
         )
 
         assert request.query_text == "current input"
@@ -108,7 +138,9 @@ class TestQueryTailEligibilityFiltering:
     def test_branching_tail_turns_are_eligible_by_default(
         self, session_factory
     ) -> None:  # type: ignore[no-untyped-def]
-        turn = _make_turn("The party chooses the left path.")
+        session = session_factory()
+        turn = _persist_turn(session, "The party chooses the left path.")
+        session.commit()
         provider = _FakeRecentTurnsProvider([turn])
         builder = RetrievalQueryBuilder(provider, session_factory)
 
@@ -117,3 +149,176 @@ class TestQueryTailEligibilityFiltering:
         )
 
         assert "The party chooses the left path." in request.query_text
+
+
+class TestQueryTailWithProductionRecentTurnsProvider:
+    """Codex #119 P2: the fake provider above always carries in-memory
+    mode_metadata, which masked a bug that only shows up with a real
+    projection. ``SQLiteRecentTurnsProvider`` returns a lean ``Turn`` with no
+    ``mode_metadata`` set (see ``_orm_turn_to_model``); the query builder
+    must reload full committed state before deciding Writing eligibility
+    rather than trusting that projection."""
+
+    def _seed_writing_story(
+        self, session: Session
+    ) -> tuple[object, object]:  # -> (story_id, node_id)
+        story = make_story(mode=StoryMode.WRITING)
+        create_story(session, story)  # type: ignore[arg-type]
+        arc = make_arc(str(story.story_id))
+        create_arc(session, arc)  # type: ignore[arg-type]
+        chapter = make_chapter(str(arc.arc_id))
+        create_chapter(session, chapter)  # type: ignore[arg-type]
+        node = Node(
+            chapter_id=chapter.chapter_id,
+            content="",
+            state_delta=StateDelta(),
+            branching_logic=[],
+            intent_type=IntentType.IN_CHARACTER_ACTION,
+            metadata=NodeMetadata(timestamp=_NOW),
+            mode_metadata=BranchingNodeMetadata(),
+        )
+        create_node(session, node)  # type: ignore[arg-type]
+        return story.story_id, node.node_id
+
+    def _persist_writing_turn(
+        self,
+        session: Session,
+        node_id: object,
+        assistant_output: str,
+        mode_metadata: object,
+        intent: IntentType = IntentType.DIALOGUE,
+    ) -> None:
+        turn = Turn(
+            user_input="prior input",
+            assistant_output=assistant_output,
+            timestamp=_NOW,
+            intent_classification=intent,
+            node_id=node_id,  # type: ignore[arg-type]
+            mode_metadata=mode_metadata,  # type: ignore[arg-type]
+        )
+        create_turn(session, turn)  # type: ignore[arg-type]
+
+    def test_extractor_eligible_prose_turn_appears_in_query_tail(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, node_id = self._seed_writing_story(session)
+        extractor_eligible_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Kestrel drew her blade in the moonlight.",
+            extractor_eligible_metadata,
+        )
+        session.commit()
+
+        provider = SQLiteRecentTurnsProvider(session)
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+        )
+
+        assert "Kestrel drew her blade" in request.query_text
+
+    def test_non_canon_support_turn_does_not_appear_in_query_tail(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, node_id = self._seed_writing_story(session)
+        non_canon_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Let's brainstorm some antagonist names.",
+            non_canon_metadata,
+        )
+        session.commit()
+
+        provider = SQLiteRecentTurnsProvider(session)
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+        )
+
+        assert "brainstorm" not in request.query_text
+        assert request.query_text == "What happens next?"
+
+    def test_ooc_turn_does_not_leak_into_query_tail(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        story_id, node_id = self._seed_writing_story(session)
+        extractor_eligible_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Is this story going to have a sequel?",
+            extractor_eligible_metadata,
+            intent=IntentType.OOC,
+        )
+        session.commit()
+
+        provider = SQLiteRecentTurnsProvider(session)
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+        )
+
+        assert "sequel" not in request.query_text
+        assert request.query_text == "What happens next?"
+
+    def test_mixed_tail_only_extractor_eligible_survives(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Regression proof for the exact Codex #119 defect: with the real
+        SQLite-backed provider, an EXTRACTOR_ELIGIBLE turn must survive
+        alongside an excluded NON_CANON_SUPPORT turn and an excluded OOC
+        turn in the same tail window."""
+        session = session_factory()
+        story_id, node_id = self._seed_writing_story(session)
+        extractor_eligible_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        non_canon_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Let's brainstorm some antagonist names.",
+            non_canon_metadata,
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Is this story going to have a sequel?",
+            extractor_eligible_metadata,
+            intent=IntentType.OOC,
+        )
+        self._persist_writing_turn(
+            session,
+            node_id,
+            "Kestrel drew her blade in the moonlight.",
+            extractor_eligible_metadata,
+        )
+        session.commit()
+
+        provider = SQLiteRecentTurnsProvider(session)
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+        )
+
+        assert "Kestrel drew her blade" in request.query_text
+        assert "brainstorm" not in request.query_text
+        assert "sequel" not in request.query_text

--- a/tests/pipeline/retrieval/test_query_builder.py
+++ b/tests/pipeline/retrieval/test_query_builder.py
@@ -1,0 +1,119 @@
+"""Tests for RetrievalQueryBuilder — CRD Issue 18 / ADR-018 D8.
+
+The critical obligation: a test must fail if ``exclude_ooc=True`` alone is
+treated as sufficient for the retrieval-query tail. A fixture with a
+non-OOC, D6-ineligible support turn in the recent window must prove that
+turn's text is absent from the composed query.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.models.enums import IntentType, StoryMode, WritingCanonEligibility
+from afterworlds.models.node import WritingNodeMetadata
+from afterworlds.models.turn import Turn
+from afterworlds.persistence.database import create_session_factory
+from afterworlds.pipeline.retrieval.query_builder import RetrievalQueryBuilder
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+class _FakeRecentTurnsProvider:
+    """Mimics RecentTurnsProvider: already excludes OOC via exclude_ooc=True."""
+
+    def __init__(self, turns: list[Turn]) -> None:
+        self._turns = turns
+
+    def get_recent_turns(
+        self, story_id: object, limit: int, *, exclude_ooc: bool = True
+    ) -> list[Turn]:
+        turns = self._turns
+        if exclude_ooc:
+            turns = [t for t in turns if t.intent_classification is not IntentType.OOC]
+        return turns[-limit:]
+
+
+def _make_turn(assistant_output: str, mode_metadata: object = None) -> Turn:
+    return Turn(
+        user_input="prior input",
+        assistant_output=assistant_output,
+        timestamp=_NOW,
+        intent_classification=IntentType.DIALOGUE,
+        mode_metadata=mode_metadata,  # type: ignore[arg-type]
+    )
+
+
+@pytest.fixture()
+def session_factory(engine):  # type: ignore[no-untyped-def]
+    return create_session_factory(engine)
+
+
+class TestQueryTailEligibilityFiltering:
+    def test_exclude_ooc_alone_is_not_sufficient(self, session_factory) -> None:  # type: ignore[no-untyped-def]
+        non_canon_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        extractor_eligible_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        support_turn = _make_turn(
+            "Let's brainstorm some names for the antagonist.", non_canon_metadata
+        )
+        canon_turn = _make_turn(
+            "Kestrel drew her blade in the moonlight.", extractor_eligible_metadata
+        )
+        provider = _FakeRecentTurnsProvider([support_turn, canon_turn])
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            uuid4(), "What happens next?", StoryMode.WRITING
+        )
+
+        assert "brainstorm" not in request.query_text
+        assert "Kestrel drew her blade" in request.query_text
+        assert "What happens next?" in request.query_text
+
+    def test_no_eligible_tail_turns_falls_back_to_current_input_only(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        non_canon_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        support_turn = _make_turn("config chatter", non_canon_metadata)
+        provider = _FakeRecentTurnsProvider([support_turn])
+        builder = RetrievalQueryBuilder(provider, session_factory)
+
+        request = builder.build_query_request(
+            uuid4(), "current input", StoryMode.WRITING
+        )
+
+        assert request.query_text == "current input"
+
+    def test_empty_tail_uses_current_input_only(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        provider = _FakeRecentTurnsProvider([])
+        builder = RetrievalQueryBuilder(provider, session_factory)
+
+        request = builder.build_query_request(
+            uuid4(), "current input", StoryMode.WRITING
+        )
+
+        assert request.query_text == "current input"
+
+    def test_branching_tail_turns_are_eligible_by_default(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        turn = _make_turn("The party chooses the left path.")
+        provider = _FakeRecentTurnsProvider([turn])
+        builder = RetrievalQueryBuilder(provider, session_factory)
+
+        request = builder.build_query_request(
+            uuid4(), "current input", StoryMode.BRANCHING
+        )
+
+        assert "The party chooses the left path." in request.query_text

--- a/tests/pipeline/retrieval/test_query_builder.py
+++ b/tests/pipeline/retrieval/test_query_builder.py
@@ -21,6 +21,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import IntentType, StoryMode, WritingCanonEligibility
+from afterworlds.models.intent_classification import IntentClassificationResult
 from afterworlds.models.node import (
     BranchingNodeMetadata,
     Node,
@@ -37,6 +38,19 @@ from afterworlds.services.context_builder import SQLiteRecentTurnsProvider
 from tests.persistence.conftest import make_arc, make_chapter, make_story
 
 _NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _make_classified_intent(
+    intent: IntentType = IntentType.IN_CHARACTER_ACTION,
+    raw_input: str = "test input",
+) -> IntentClassificationResult:
+    return IntentClassificationResult(
+        intent_type=intent,
+        confidence=0.95,
+        raw_input=raw_input,
+        ambiguous=False,
+        secondary_intent=None,
+    )
 
 
 class _FakeRecentTurnsProvider:
@@ -98,7 +112,7 @@ class TestQueryTailEligibilityFiltering:
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
         request = builder.build_query_request(
-            uuid4(), "What happens next?", StoryMode.WRITING
+            uuid4(), "What happens next?", StoryMode.WRITING, _make_classified_intent()
         )
 
         assert "brainstorm" not in request.query_text
@@ -118,10 +132,10 @@ class TestQueryTailEligibilityFiltering:
         builder = RetrievalQueryBuilder(provider, session_factory)
 
         request = builder.build_query_request(
-            uuid4(), "current input", StoryMode.WRITING
+            uuid4(), "current input", StoryMode.WRITING, _make_classified_intent()
         )
 
-        assert request.query_text == "current input"
+        assert request.query_text == "current input\n\nintent_type=in_character_action"
 
     def test_empty_tail_uses_current_input_only(
         self, session_factory
@@ -130,10 +144,10 @@ class TestQueryTailEligibilityFiltering:
         builder = RetrievalQueryBuilder(provider, session_factory)
 
         request = builder.build_query_request(
-            uuid4(), "current input", StoryMode.BRANCHING
+            uuid4(), "current input", StoryMode.BRANCHING, _make_classified_intent()
         )
 
-        assert request.query_text == "current input"
+        assert request.query_text == "current input\n\nintent_type=in_character_action"
 
     def test_branching_tail_turns_are_eligible_by_default(
         self, session_factory
@@ -145,7 +159,7 @@ class TestQueryTailEligibilityFiltering:
         builder = RetrievalQueryBuilder(provider, session_factory)
 
         request = builder.build_query_request(
-            uuid4(), "current input", StoryMode.BRANCHING
+            uuid4(), "current input", StoryMode.BRANCHING, _make_classified_intent()
         )
 
         assert "The party chooses the left path." in request.query_text
@@ -238,7 +252,10 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
         request = builder.build_query_request(
-            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+            story_id,  # type: ignore[arg-type]
+            "What happens next?",
+            StoryMode.WRITING,
+            _make_classified_intent(),
         )
 
         assert "Kestrel drew her blade" in request.query_text
@@ -263,11 +280,17 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
         request = builder.build_query_request(
-            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+            story_id,  # type: ignore[arg-type]
+            "What happens next?",
+            StoryMode.WRITING,
+            _make_classified_intent(),
         )
 
         assert "brainstorm" not in request.query_text
-        assert request.query_text == "What happens next?"
+        assert (
+            request.query_text
+            == "What happens next?\n\nintent_type=in_character_action"
+        )
 
     def test_ooc_turn_does_not_leak_into_query_tail(
         self, session_factory
@@ -290,11 +313,17 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
         request = builder.build_query_request(
-            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+            story_id,  # type: ignore[arg-type]
+            "What happens next?",
+            StoryMode.WRITING,
+            _make_classified_intent(),
         )
 
         assert "sequel" not in request.query_text
-        assert request.query_text == "What happens next?"
+        assert (
+            request.query_text
+            == "What happens next?\n\nintent_type=in_character_action"
+        )
 
     def test_mixed_tail_only_extractor_eligible_survives(
         self, session_factory
@@ -336,7 +365,10 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
         request = builder.build_query_request(
-            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+            story_id,  # type: ignore[arg-type]
+            "What happens next?",
+            StoryMode.WRITING,
+            _make_classified_intent(),
         )
 
         assert "Kestrel drew her blade" in request.query_text
@@ -370,9 +402,88 @@ class TestQueryTailWithProductionRecentTurnsProvider:
         builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
 
         request = builder.build_query_request(
-            story_id, "What happens next?", StoryMode.WRITING  # type: ignore[arg-type]
+            story_id,  # type: ignore[arg-type]
+            "What happens next?",
+            StoryMode.WRITING,
+            _make_classified_intent(),
         )
 
         assert "Kestrel drew her blade" in request.query_text
         assert "corrupted metadata" not in request.query_text
         assert "What happens next?" in request.query_text
+
+
+class TestClassifiedIntentInQueryText:
+    """Codex review (PR #119) round 4: ADR-018 D8 requires query text to be
+    composed from current input AND classified intent, not current input
+    alone. RetrievalQueryBuilder previously never received/used intent at
+    all."""
+
+    def test_build_query_request_includes_classified_intent(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        provider = _FakeRecentTurnsProvider([])
+        builder = RetrievalQueryBuilder(provider, session_factory)
+
+        request = builder.build_query_request(
+            uuid4(),
+            "current input",
+            StoryMode.BRANCHING,
+            _make_classified_intent(intent=IntentType.DIALOGUE),
+        )
+
+        assert "intent_type=dialogue" in request.query_text
+
+    def test_different_intents_produce_distinguishable_query_text(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        provider = _FakeRecentTurnsProvider([])
+        builder = RetrievalQueryBuilder(provider, session_factory)
+
+        request_a = builder.build_query_request(
+            uuid4(),
+            "current input",
+            StoryMode.BRANCHING,
+            _make_classified_intent(intent=IntentType.DIALOGUE),
+        )
+        request_b = builder.build_query_request(
+            uuid4(),
+            "current input",
+            StoryMode.BRANCHING,
+            _make_classified_intent(intent=IntentType.IN_CHARACTER_ACTION),
+        )
+
+        assert request_a.query_text != request_b.query_text
+        assert "intent_type=dialogue" in request_a.query_text
+        assert "intent_type=in_character_action" in request_b.query_text
+
+    def test_tail_eligibility_behavior_unaffected_by_intent_fragment(
+        self, session_factory
+    ) -> None:  # type: ignore[no-untyped-def]
+        """The intent fragment is additive -- D6/D8 tail-eligibility
+        filtering (eligible tail included, OOC/support tail excluded) must
+        keep working exactly as before."""
+        session = session_factory()
+        non_canon_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.NON_CANON_SUPPORT.value
+        )
+        extractor_eligible_metadata = WritingNodeMetadata(
+            canon_eligibility=WritingCanonEligibility.EXTRACTOR_ELIGIBLE.value
+        )
+        support_turn = _persist_turn(
+            session, "Let's brainstorm names.", non_canon_metadata
+        )
+        canon_turn = _persist_turn(
+            session, "Kestrel drew her blade.", extractor_eligible_metadata
+        )
+        session.commit()
+        provider = _FakeRecentTurnsProvider([support_turn, canon_turn])
+        builder = RetrievalQueryBuilder(provider, session_factory, tail_window=3)
+
+        request = builder.build_query_request(
+            uuid4(), "What happens next?", StoryMode.WRITING, _make_classified_intent()
+        )
+
+        assert "brainstorm" not in request.query_text
+        assert "Kestrel drew her blade" in request.query_text
+        assert "intent_type=in_character_action" in request.query_text

--- a/tests/pipeline/retrieval/test_rules_corpus_service.py
+++ b/tests/pipeline/retrieval/test_rules_corpus_service.py
@@ -24,6 +24,7 @@ from afterworlds.persistence.orm.rules_package import (
 )
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.rules_corpus_service import RulesCorpusService
 
 _NOW = datetime(2026, 1, 1, tzinfo=UTC).isoformat()
@@ -93,7 +94,9 @@ class TestReindexFromSql:
 
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        service = RulesCorpusService(client, config)
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
 
         written = service.reindex_from_sql(session, package_id)
 
@@ -128,7 +131,9 @@ class TestReindexFromSql:
 
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        service = RulesCorpusService(client, config)
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
 
         written = service.reindex_from_sql(session, package_id)
         assert written == 1
@@ -140,7 +145,9 @@ class TestReindexFromSql:
 
         client = build_isolated_test_chroma_client(str(tmp_path))
         config = RetrievalMemoryConfig()
-        service = RulesCorpusService(client, config)
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
         service.reindex_from_sql(session, package_id)
 
         # Simulate a chunk being removed from SQL ground truth, then reindex.

--- a/tests/pipeline/retrieval/test_rules_corpus_service.py
+++ b/tests/pipeline/retrieval/test_rules_corpus_service.py
@@ -1,0 +1,213 @@
+"""Tests for RulesCorpusService — CRD Issue 18 / ADR-018 D10/D11.
+
+Covers reindex-from-SQL-ground-truth and the diagnostic-only contract: no
+runtime pass may consume this service (verified structurally by absence of
+any import from a pass service, not just by a passing test — see the
+docstring on ``test_no_pass_service_imports_rules_corpus_service``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, select
+
+from afterworlds.models.enums import SourceLocatorTypeEnum
+from afterworlds.persistence.database import create_session_factory
+from afterworlds.persistence.orm.rules_package import (
+    RuleChunkORM,
+    RuleSourceORM,
+    RulesPackageORM,
+)
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.rules_corpus_service import RulesCorpusService
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+
+
+@pytest.fixture()
+def session_factory(engine):  # type: ignore[no-untyped-def]
+    return create_session_factory(engine)
+
+
+def _seed_package_with_chunks(session, package_id, chunk_contents):  # type: ignore[no-untyped-def]
+    # Flushed in separate steps (package, then source, then chunks): SQLAlchemy's
+    # unit-of-work dependency sort does not reliably order this schema's
+    # multi-FK chain (rp_chunks -> rp_packages AND rp_chunks -> rp_sources
+    # composite) within a single flush spanning all three new parent/child
+    # rows — confirmed via raw-SQL insert working fine in the same order.
+    session.add(
+        RulesPackageORM(
+            rules_package_id=str(package_id),
+            name="Test SRD",
+            system="dnd5e",
+            version="1.0",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    session.flush()
+    source_id = str(uuid4())
+    session.add(
+        RuleSourceORM(
+            source_id=source_id,
+            rules_package_id=str(package_id),
+            name="Test Source",
+            category="core",
+            precedence_rank=1,
+            created_at=_NOW,
+        )
+    )
+    session.flush()
+    for i, content in enumerate(chunk_contents):
+        session.add(
+            RuleChunkORM(
+                chunk_id=str(uuid4()),
+                rules_package_id=str(package_id),
+                source_id=source_id,
+                subsystem="combat",
+                content=content,
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value=f"p. {i}",
+                is_enabled=True,
+                created_at=_NOW,
+            )
+        )
+    session.commit()
+
+
+class TestReindexFromSql:
+    def test_reindex_writes_all_enabled_chunks(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(
+            session, package_id, ["Fireball deals damage.", "Shield blocks."]
+        )
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(client, config)
+
+        written = service.reindex_from_sql(session, package_id)
+
+        assert written == 2
+        results = service.diagnostic_query(
+            package_id, "Fireball deals damage.", n_results=1
+        )
+        assert results == ["Fireball deals damage."]
+
+    def test_disabled_chunks_excluded(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["Enabled chunk."])
+        # Add a disabled chunk directly.
+        session.add(
+            RuleChunkORM(
+                chunk_id=str(uuid4()),
+                rules_package_id=str(package_id),
+                source_id=session.execute(select(RuleSourceORM.source_id)).scalar_one(),
+                subsystem="combat",
+                content="Disabled chunk.",
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value="p. 99",
+                is_enabled=False,
+                created_at=_NOW,
+            )
+        )
+        session.commit()
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(client, config)
+
+        written = service.reindex_from_sql(session, package_id)
+        assert written == 1
+
+    def test_reindex_wipes_prior_state(self, session_factory, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["First version."])
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(client, config)
+        service.reindex_from_sql(session, package_id)
+
+        # Simulate a chunk being removed from SQL ground truth, then reindex.
+        session.execute(
+            delete(RuleChunkORM).where(RuleChunkORM.rules_package_id == str(package_id))
+        )
+        session.commit()
+        existing_source_id = session.execute(
+            select(RuleSourceORM.source_id).where(
+                RuleSourceORM.rules_package_id == str(package_id)
+            )
+        ).scalar_one()
+        session.add(
+            RuleChunkORM(
+                chunk_id=str(uuid4()),
+                rules_package_id=str(package_id),
+                source_id=existing_source_id,
+                subsystem="combat",
+                content="Only surviving chunk.",
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value="p. 0",
+                is_enabled=True,
+                created_at=_NOW,
+            )
+        )
+        session.commit()
+
+        written = service.reindex_from_sql(session, package_id)
+        assert written == 1
+        results = service.diagnostic_query(package_id, "surviving", n_results=10)
+        assert results == ["Only surviving chunk."]
+
+
+def test_no_pass_service_imports_rules_corpus_service() -> None:
+    """D10: no Context Builder / adjudication / Writer / Planner / pass
+    service may import RulesCorpusService — semantic rules retrieval stays
+    internal/admin-diagnostic only in v1."""
+    import ast
+    from pathlib import Path as _Path
+
+    src_root = _Path(__file__).resolve().parents[3] / "src" / "afterworlds"
+    forbidden_dirs = {
+        src_root / "services" / "context_builder.py",
+        src_root / "pipeline" / "rpg",
+        src_root / "pipeline" / "writer",
+        src_root / "pipeline" / "planner",
+        src_root / "pipeline" / "extractor",
+        src_root / "pipeline" / "contradiction",
+        src_root / "pipeline" / "safety",
+        src_root / "pipeline" / "branching",
+        src_root / "pipeline" / "writing",
+    }
+    offending: list[str] = []
+    for path in forbidden_dirs:
+        candidates = [path] if path.is_file() else list(path.rglob("*.py"))
+        for file_path in candidates:
+            tree = ast.parse(file_path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.ImportFrom)
+                    and node.module
+                    and "rules_corpus_service" in node.module
+                ):
+                    offending.append(str(file_path))
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if "rules_corpus_service" in alias.name:
+                            offending.append(str(file_path))
+    assert offending == []

--- a/tests/pipeline/retrieval/test_rules_corpus_service.py
+++ b/tests/pipeline/retrieval/test_rules_corpus_service.py
@@ -16,6 +16,7 @@ import pytest
 from sqlalchemy import delete, select
 
 from afterworlds.models.enums import SourceLocatorTypeEnum
+from afterworlds.models.retrieval import rules_corpus_collection_name
 from afterworlds.persistence.database import create_session_factory
 from afterworlds.persistence.orm.rules_package import (
     RuleChunkORM,
@@ -23,11 +24,60 @@ from afterworlds.persistence.orm.rules_package import (
     RulesPackageORM,
 )
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.collections import get_rules_corpus_collection
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.rules_corpus_service import RulesCorpusService
 
 _NOW = datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+
+
+def _seed_package_with_explicit_chunks(
+    session, package_id, chunk_specs  # type: ignore[no-untyped-def]
+):
+    """Like _seed_package_with_chunks but with full control over chunk_id
+    and source_locator_value per chunk. chunk_specs is a list of
+    (chunk_id, content, locator_value) tuples, inserted in list order."""
+    session.add(
+        RulesPackageORM(
+            rules_package_id=str(package_id),
+            name="Test SRD",
+            system="dnd5e",
+            version="1.0",
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    session.flush()
+    source_id = str(uuid4())
+    session.add(
+        RuleSourceORM(
+            source_id=source_id,
+            rules_package_id=str(package_id),
+            name="Test Source",
+            category="core",
+            precedence_rank=1,
+            created_at=_NOW,
+        )
+    )
+    session.flush()
+    for chunk_id, content, locator_value in chunk_specs:
+        session.add(
+            RuleChunkORM(
+                chunk_id=str(chunk_id),
+                rules_package_id=str(package_id),
+                source_id=source_id,
+                subsystem="combat",
+                content=content,
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value=locator_value,
+                is_enabled=True,
+                created_at=_NOW,
+            )
+        )
+    session.commit()
+    return source_id
 
 
 @pytest.fixture()
@@ -180,6 +230,202 @@ class TestReindexFromSql:
         assert written == 1
         results = service.diagnostic_query(package_id, "surviving", n_results=10)
         assert results == ["Only surviving chunk."]
+
+
+class TestRulesCorpusIdStability:
+    """Codex review (PR #119) round 4: rules-corpus Chroma IDs must derive
+    from RuleChunkORM.chunk_id (durable SQL identity), not a per-run
+    occurrence index over (locator_type, locator_value) -- that ordinal
+    depended on SQL row-iteration order, so it could reassign different
+    Chroma IDs to the same SQL ground truth across reindex runs."""
+
+    def _stored_ids(self, client, package_id, config, ef):  # type: ignore[no-untyped-def]
+        collection_name = rules_corpus_collection_name(package_id)
+        collection = get_rules_corpus_collection(client, collection_name, config, ef)
+        return set(collection.get()["ids"])
+
+    def test_same_locator_different_chunk_ids_produce_distinct_stable_ids(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        chunk_id_a, chunk_id_b = uuid4(), uuid4()
+        # Both chunks share the same source locator -- the exact shape the
+        # old per-locator ordinal existed to handle, but must not collide on.
+        _seed_package_with_explicit_chunks(
+            session,
+            package_id,
+            [
+                (chunk_id_a, "First half of the page.", "p. 72"),
+                (chunk_id_b, "Second half of the page.", "p. 72"),
+            ],
+        )
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        ef = DeterministicFakeEmbeddingFunction()
+        service = RulesCorpusService(client, config, ef)
+        written = service.reindex_from_sql(session, package_id)
+
+        assert written == 2
+        ids = self._stored_ids(client, package_id, config, ef)
+        assert len(ids) == 2
+        assert f"rules:{package_id}:chunk:{chunk_id_a}" in ids
+        assert f"rules:{package_id}:chunk:{chunk_id_b}" in ids
+
+    def test_reindex_in_reversed_insertion_order_produces_same_id_set(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        ef = DeterministicFakeEmbeddingFunction()
+        chunk_id_a, chunk_id_b = uuid4(), uuid4()
+
+        session_forward = session_factory()
+        package_id = uuid4()
+        _seed_package_with_explicit_chunks(
+            session_forward,
+            package_id,
+            [
+                (chunk_id_a, "Content A.", "p. 1"),
+                (chunk_id_b, "Content B.", "p. 1"),
+            ],
+        )
+        service = RulesCorpusService(client, config, ef)
+        service.reindex_from_sql(session_forward, package_id)
+        ids_forward = self._stored_ids(client, package_id, config, ef)
+
+        # Delete and re-insert the same two chunk_ids/content in reversed
+        # order -- genuinely changes on-disk row order, not just a relabel.
+        session_forward.execute(
+            delete(RuleChunkORM).where(RuleChunkORM.rules_package_id == str(package_id))
+        )
+        session_forward.commit()
+        existing_source_id = session_forward.execute(
+            select(RuleSourceORM.source_id).where(
+                RuleSourceORM.rules_package_id == str(package_id)
+            )
+        ).scalar_one()
+        session_forward.add(
+            RuleChunkORM(
+                chunk_id=str(chunk_id_b),
+                rules_package_id=str(package_id),
+                source_id=existing_source_id,
+                subsystem="combat",
+                content="Content B.",
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value="p. 1",
+                is_enabled=True,
+                created_at=_NOW,
+            )
+        )
+        session_forward.add(
+            RuleChunkORM(
+                chunk_id=str(chunk_id_a),
+                rules_package_id=str(package_id),
+                source_id=existing_source_id,
+                subsystem="combat",
+                content="Content A.",
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value="p. 1",
+                is_enabled=True,
+                created_at=_NOW,
+            )
+        )
+        session_forward.commit()
+
+        service.reindex_from_sql(session_forward, package_id)
+        ids_reversed = self._stored_ids(client, package_id, config, ef)
+
+        assert ids_forward == ids_reversed
+
+    def test_adding_sibling_locator_row_does_not_change_existing_ids(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        chunk_id_a, chunk_id_b = uuid4(), uuid4()
+        _seed_package_with_explicit_chunks(
+            session,
+            package_id,
+            [
+                (chunk_id_a, "First half.", "p. 5"),
+                (chunk_id_b, "Second half.", "p. 5"),
+            ],
+        )
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        ef = DeterministicFakeEmbeddingFunction()
+        service = RulesCorpusService(client, config, ef)
+        service.reindex_from_sql(session, package_id)
+        id_a_before = f"rules:{package_id}:chunk:{chunk_id_a}"
+        ids_before = self._stored_ids(client, package_id, config, ef)
+        assert id_a_before in ids_before
+
+        # Add a third chunk sharing the same locator, reindex again.
+        chunk_id_c = uuid4()
+        source_id = session.execute(select(RuleSourceORM.source_id)).scalar_one()
+        session.add(
+            RuleChunkORM(
+                chunk_id=str(chunk_id_c),
+                rules_package_id=str(package_id),
+                source_id=source_id,
+                subsystem="combat",
+                content="Third chunk, same locator.",
+                source_document="srd.json",
+                source_locator_type=SourceLocatorTypeEnum.PAGE.value,
+                source_locator_value="p. 5",
+                is_enabled=True,
+                created_at=_NOW,
+            )
+        )
+        session.commit()
+        service.reindex_from_sql(session, package_id)
+        ids_after_add = self._stored_ids(client, package_id, config, ef)
+
+        assert id_a_before in ids_after_add
+        assert len(ids_after_add) == 3
+
+        # Remove the added chunk, reindex again -- id_a must still be stable.
+        session.execute(
+            delete(RuleChunkORM).where(RuleChunkORM.chunk_id == str(chunk_id_c))
+        )
+        session.commit()
+        service.reindex_from_sql(session, package_id)
+        ids_after_remove = self._stored_ids(client, package_id, config, ef)
+
+        assert id_a_before in ids_after_remove
+        assert len(ids_after_remove) == 2
+
+    def test_reindex_uses_shared_id_builder_not_local_formula(
+        self, session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["Some content."])
+
+        calls: list[tuple[object, object]] = []
+        import afterworlds.pipeline.retrieval.rules_corpus_service as rcs_module
+
+        original = rcs_module.build_rules_corpus_chunk_id
+
+        def _spy(pkg_id, chunk_id):  # type: ignore[no-untyped-def]
+            calls.append((pkg_id, chunk_id))
+            return original(pkg_id, chunk_id)
+
+        monkeypatch.setattr(rcs_module, "build_rules_corpus_chunk_id", _spy)
+
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+        service.reindex_from_sql(session, package_id)
+
+        assert len(calls) == 1
+        assert calls[0][0] == package_id
 
 
 def test_no_pass_service_imports_rules_corpus_service() -> None:

--- a/tests/pipeline/retrieval/test_rules_corpus_service.py
+++ b/tests/pipeline/retrieval/test_rules_corpus_service.py
@@ -232,6 +232,112 @@ class TestReindexFromSql:
         assert results == ["Only surviving chunk."]
 
 
+class TestReindexPropagatesWipeFailure:
+    """Codex review (PR #119) round 7: reindex_from_sql() must ignore only a
+    genuinely absent collection when wiping -- an operational Chroma
+    failure (locked/corrupt store, permission error) must propagate and
+    must abort before get_rules_corpus_collection()/upsert() ever runs, so
+    stale disabled/deleted chunks can never remain silently retrievable
+    after a supposed rebuild."""
+
+    def test_operational_delete_failure_propagates(
+        self, session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["Some content."])
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+        service.reindex_from_sql(session, package_id)  # creates the collection
+
+        def _boom(name: str) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(client, "delete_collection", _boom)
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            service.reindex_from_sql(session, package_id)
+
+    def test_operational_delete_failure_skips_get_collection_and_upsert(
+        self, session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["Some content."])
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+
+        def _boom(name: str) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(client, "delete_collection", _boom)
+
+        import afterworlds.pipeline.retrieval.rules_corpus_service as rcs_module
+
+        get_collection_calls: list[object] = []
+        monkeypatch.setattr(
+            rcs_module,
+            "get_rules_corpus_collection",
+            lambda *a, **k: get_collection_calls.append(1),
+        )
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            service.reindex_from_sql(session, package_id)
+
+        assert get_collection_calls == []
+
+    def test_stale_chunks_remain_visible_not_silently_hidden_after_failed_wipe(
+        self, session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["Stale content."])
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+        service.reindex_from_sql(session, package_id)
+
+        def _boom(name: str) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(client, "delete_collection", _boom)
+        with pytest.raises(RuntimeError, match="store locked"):
+            service.reindex_from_sql(session, package_id)
+
+        # The old collection is untouched -- the failure is loud (an
+        # exception), not a silently-empty or silently-stale "success".
+        results = service.diagnostic_query(package_id, "Stale content.", n_results=1)
+        assert results == ["Stale content."]
+
+    def test_absent_collection_is_ignored_and_reindex_rebuilds_normally(
+        self, session_factory, tmp_path: Path
+    ) -> None:  # type: ignore[no-untyped-def]
+        """The expected no-op case: no prior collection exists at all."""
+        session = session_factory()
+        package_id = uuid4()
+        _seed_package_with_chunks(session, package_id, ["Fresh content."])
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        config = RetrievalMemoryConfig()
+        service = RulesCorpusService(
+            client, config, DeterministicFakeEmbeddingFunction()
+        )
+
+        written = service.reindex_from_sql(session, package_id)
+
+        assert written == 1
+        assert service.diagnostic_query(package_id, "Fresh content.", n_results=1) == [
+            "Fresh content."
+        ]
+
+
 class TestRulesCorpusIdStability:
     """Codex review (PR #119) round 4: rules-corpus Chroma IDs must derive
     from RuleChunkORM.chunk_id (durable SQL identity), not a per-run

--- a/tests/pipeline/retrieval/test_scoring.py
+++ b/tests/pipeline/retrieval/test_scoring.py
@@ -1,0 +1,22 @@
+"""Unit tests for ADR-018 D5 distance-to-similarity normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from afterworlds.pipeline.retrieval.scoring import normalize_similarity
+
+
+class TestNormalizeSimilarity:
+    def test_zero_distance_is_full_similarity(self) -> None:
+        assert normalize_similarity(0.0, "cosine") == 1.0
+
+    def test_max_distance_clamped_to_zero(self) -> None:
+        assert normalize_similarity(2.0, "cosine") == 0.0
+
+    def test_mid_distance(self) -> None:
+        assert normalize_similarity(0.4, "cosine") == pytest.approx(0.6)
+
+    def test_unsupported_metric_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported distance metric"):
+            normalize_similarity(0.1, "euclidean")

--- a/tests/pipeline/retrieval/test_write_service.py
+++ b/tests/pipeline/retrieval/test_write_service.py
@@ -305,3 +305,32 @@ class TestDeleteBypassesEmbeddingModelGuard:
 
         with pytest.raises(RuntimeError, match="store locked"):
             service.delete_story(uuid4())
+
+
+class TestWipeCollectionPropagatesOperationalFailure:
+    """Codex review (PR #119) round 7: wipe_collection() must ignore only a
+    genuinely absent collection -- an operational Chroma failure must
+    propagate rather than leave an operator believing the wipe succeeded."""
+
+    def test_absent_collection_is_a_noop(self, tmp_path: Path) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        service = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(), DeterministicFakeEmbeddingFunction()
+        )
+        service.wipe_collection()  # must not raise
+
+    def test_operational_error_propagates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        service = RetrievalMemoryWriteService(client, RetrievalMemoryConfig(), ef)
+        service.ingest_turn(uuid4(), uuid4(), None, "rpg", "Some prose.", "t1")
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(client, "delete_collection", _boom)
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            service.wipe_collection()

--- a/tests/pipeline/retrieval/test_write_service.py
+++ b/tests/pipeline/retrieval/test_write_service.py
@@ -137,3 +137,148 @@ class TestEmbeddingModelMismatchSurfaces:
 
         with pytest.raises(RetrievalCollectionReindexRequiredError):
             service_b.ingest_turn(uuid4(), uuid4(), None, "rpg", "More prose.", "t2")
+
+
+class TestDeleteBypassesEmbeddingModelGuard:
+    """Codex review (PR #119) round 5: delete_turn()/delete_story() are
+    metadata-filtered operations that never invoke the embedding function,
+    so they must still work against a collection whose recorded
+    embedding_model_id no longer matches config -- an operator must be able
+    to scrub stale/mismatched chunks ahead of a full reindex. Normal
+    ingest/query paths must stay strict (proved above)."""
+
+    def test_delete_story_removes_chunks_from_mismatched_collection(
+        self, tmp_path: Path
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        story_id = uuid4()
+        service_a = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        )
+        service_a.ingest_turn(story_id, uuid4(), None, "rpg", "Stale prose.", "t1")
+
+        service_b = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+        )
+
+        remaining = service_b.delete_story(story_id)
+
+        assert remaining == 0
+
+    def test_delete_turn_removes_chunks_from_mismatched_collection(
+        self, tmp_path: Path
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        story_id, turn_id = uuid4(), uuid4()
+        service_a = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        )
+        service_a.ingest_turn(story_id, turn_id, None, "rpg", "Stale prose.", "t1")
+
+        service_b = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+        )
+        # Must not raise despite the mismatch.
+        service_b.delete_turn(story_id, turn_id)
+
+        # Verify via the delete-only accessor directly (avoids re-raising
+        # the guard through a strict collection fetch).
+        from afterworlds.pipeline.retrieval.collections import (
+            get_existing_story_memory_collection_for_delete,
+        )
+
+        collection = get_existing_story_memory_collection_for_delete(client)
+        assert collection is not None
+        result = collection.get(where={"story_id": str(story_id)})
+        assert result["ids"] == []
+
+    def test_delete_works_on_legacy_collection_missing_embedding_model_id(
+        self, tmp_path: Path
+    ) -> None:
+        """A collection created before the embedding-model guard existed has
+        no embedding_model_id key at all -- delete must still work."""
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        story_id = uuid4()
+        # Simulate a legacy pre-guard collection directly against the raw
+        # client, bypassing get_story_memory_collection entirely.
+        legacy_collection = client.get_or_create_collection(
+            name="story_memory",
+            metadata={"hnsw:space": "cosine"},
+            embedding_function=ef,  # type: ignore[arg-type]
+        )
+        legacy_collection.upsert(
+            documents=["Legacy prose."],
+            metadatas=[{"story_id": str(story_id)}],
+            ids=["legacy-chunk-1"],
+        )
+
+        service = RetrievalMemoryWriteService(client, RetrievalMemoryConfig(), ef)
+        remaining = service.delete_story(story_id)
+
+        assert remaining == 0
+
+    def test_delete_on_missing_collection_is_noop_and_creates_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        service = RetrievalMemoryWriteService(client, RetrievalMemoryConfig(), ef)
+
+        remaining = service.delete_story(uuid4())
+        service.delete_turn(uuid4(), uuid4())
+
+        assert remaining == 0
+        assert client.list_collections() == []
+
+    def test_delete_story_never_calls_upsert(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        story_id = uuid4()
+        service_a = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        )
+        service_a.ingest_turn(story_id, uuid4(), None, "rpg", "Stale prose.", "t1")
+
+        from afterworlds.pipeline.retrieval.collections import (
+            get_existing_story_memory_collection_for_delete as real_getter,
+        )
+
+        class _UpsertSpyCollectionWrapper:
+            def __init__(self, wrapped: object) -> None:
+                self._wrapped = wrapped
+                self.upsert_called = False
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(self._wrapped, name)
+
+            def upsert(self, *args: object, **kwargs: object) -> None:
+                self.upsert_called = True
+                raise AssertionError("delete-only path must never call upsert()")
+
+        spy_holder: dict[str, _UpsertSpyCollectionWrapper] = {}
+
+        def _spy_getter(client_arg: object):  # type: ignore[no-untyped-def]
+            real = real_getter(client_arg)
+            if real is None:
+                return None
+            wrapper = _UpsertSpyCollectionWrapper(real)
+            spy_holder["wrapper"] = wrapper
+            return wrapper
+
+        monkeypatch.setattr(
+            "afterworlds.pipeline.retrieval.write_service."
+            "get_existing_story_memory_collection_for_delete",
+            _spy_getter,
+        )
+
+        service_b = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+        )
+        service_b.delete_story(story_id)
+
+        assert spy_holder["wrapper"].upsert_called is False

--- a/tests/pipeline/retrieval/test_write_service.py
+++ b/tests/pipeline/retrieval/test_write_service.py
@@ -1,0 +1,108 @@
+"""Integration tests for RetrievalMemoryWriteService against an isolated Chroma client.
+
+CRD Issue 18 / ADR-018 D3/D7/D11.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
+
+
+def _make_service(
+    tmp_path: Path, chunk_char_ceiling: int = 4000
+) -> RetrievalMemoryWriteService:
+    client = build_isolated_test_chroma_client(str(tmp_path))
+    config = RetrievalMemoryConfig(chunk_char_ceiling=chunk_char_ceiling)
+    return RetrievalMemoryWriteService(client, config)
+
+
+class TestIngestIdempotence:
+    def test_reingesting_same_turn_is_byte_identical(self, tmp_path: Path) -> None:
+        service = _make_service(tmp_path)
+        story_id, turn_id = uuid4(), uuid4()
+        service.ingest_turn(story_id, turn_id, None, "rpg", "Some prose.", "t1")
+        count_after_first = service.count_for_story(story_id)
+
+        service.ingest_turn(story_id, turn_id, None, "rpg", "Some prose.", "t1")
+        count_after_second = service.count_for_story(story_id)
+
+        assert count_after_first == count_after_second == 1
+
+    def test_atomic_metadata_provenance(self, tmp_path: Path) -> None:
+        """Every chunk's content_hash must describe its own document."""
+        service = _make_service(tmp_path)
+        story_id, turn_id = uuid4(), uuid4()
+        service.ingest_turn(story_id, turn_id, None, "rpg", "Consistent prose.", "t1")
+        collection = service._collection()  # noqa: SLF001 — test introspection
+        result = collection.get(where={"story_id": str(story_id)})
+        from afterworlds.pipeline.retrieval.embedding import content_hash
+
+        for doc, meta in zip(result["documents"], result["metadatas"], strict=True):
+            assert meta["content_hash"] == content_hash(doc)
+
+
+class TestDeleteBeforeWrite:
+    def test_shrinking_chunk_set_removes_stale_high_index_chunks(
+        self, tmp_path: Path
+    ) -> None:
+        """ADR-018 D11: a shrunk re-ingestion must not leave stray old chunks."""
+        service = _make_service(tmp_path, chunk_char_ceiling=20)
+        story_id, turn_id = uuid4(), uuid4()
+
+        long_text = "\n\n".join(["paragraph one is long enough"] * 5)
+        service.ingest_turn(story_id, turn_id, None, "rpg", long_text, "t1")
+        count_before = service.count_for_story(story_id)
+        assert count_before > 1  # sanity: multiple chunks produced
+
+        short_text = "short."
+        service.ingest_turn(story_id, turn_id, None, "rpg", short_text, "t2")
+        count_after = service.count_for_story(story_id)
+        assert count_after == 1
+
+    def test_unchanged_chunk_count_still_deletes_before_write(
+        self, tmp_path: Path
+    ) -> None:
+        """Required even when new chunk count is unchanged (ADR-018 D11)."""
+        service = _make_service(tmp_path)
+        story_id, turn_id = uuid4(), uuid4()
+        service.ingest_turn(story_id, turn_id, None, "rpg", "Version one.", "t1")
+        service.ingest_turn(story_id, turn_id, None, "rpg", "Version two.", "t2")
+        assert service.count_for_story(story_id) == 1
+        collection = service._collection()  # noqa: SLF001
+        result = collection.get(where={"story_id": str(story_id)})
+        assert result["documents"] == ["Version two."]
+
+
+class TestDeletion:
+    def test_delete_turn_removes_only_that_turns_chunks(self, tmp_path: Path) -> None:
+        service = _make_service(tmp_path)
+        story_id = uuid4()
+        turn_a, turn_b = uuid4(), uuid4()
+        service.ingest_turn(story_id, turn_a, None, "rpg", "Turn A prose.", "t1")
+        service.ingest_turn(story_id, turn_b, None, "rpg", "Turn B prose.", "t2")
+
+        service.delete_turn(story_id, turn_a)
+
+        collection = service._collection()  # noqa: SLF001
+        result = collection.get(where={"story_id": str(story_id)})
+        assert result["documents"] == ["Turn B prose."]
+
+    def test_delete_story_removes_all_and_reports_zero_remaining(
+        self, tmp_path: Path
+    ) -> None:
+        service = _make_service(tmp_path)
+        story_a, story_b = uuid4(), uuid4()
+        service.ingest_turn(story_a, uuid4(), None, "rpg", "Story A prose.", "t1")
+        service.ingest_turn(story_a, uuid4(), None, "rpg", "More A prose.", "t2")
+        service.ingest_turn(story_b, uuid4(), None, "rpg", "Story B prose.", "t3")
+
+        remaining = service.delete_story(story_a)
+
+        assert remaining == 0
+        assert service.count_for_story(story_a) == 0
+        assert service.count_for_story(story_b) == 1

--- a/tests/pipeline/retrieval/test_write_service.py
+++ b/tests/pipeline/retrieval/test_write_service.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.collections import (
+    RetrievalCollectionReindexRequiredError,
+)
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
@@ -109,3 +114,26 @@ class TestDeletion:
         assert remaining == 0
         assert service.count_for_story(story_a) == 0
         assert service.count_for_story(story_b) == 1
+
+
+class TestEmbeddingModelMismatchSurfaces:
+    """Codex review (PR #119) round 3: the write service must surface the
+    typed reindex-required error clearly rather than continuing to upsert
+    into a collection whose recorded embedding model differs from config."""
+
+    def test_ingest_turn_raises_on_embedding_model_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        service_a = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-a"), ef
+        )
+        service_a.ingest_turn(uuid4(), uuid4(), None, "rpg", "Some prose.", "t1")
+
+        service_b = RetrievalMemoryWriteService(
+            client, RetrievalMemoryConfig(embedding_model_id="model-b"), ef
+        )
+
+        with pytest.raises(RetrievalCollectionReindexRequiredError):
+            service_b.ingest_turn(uuid4(), uuid4(), None, "rpg", "More prose.", "t2")

--- a/tests/pipeline/retrieval/test_write_service.py
+++ b/tests/pipeline/retrieval/test_write_service.py
@@ -282,3 +282,26 @@ class TestDeleteBypassesEmbeddingModelGuard:
         service_b.delete_story(story_id)
 
         assert spy_holder["wrapper"].upsert_called is False
+
+    def test_delete_story_propagates_operational_error_not_remaining_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex review (PR #119) round 6: an operational failure opening the
+        collection (locked store, permission error, etc.) must propagate --
+        delete_story() must never report remaining=0 in that case, since
+        that would look like a successful (empty) delete."""
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        service = RetrievalMemoryWriteService(client, RetrievalMemoryConfig(), ef)
+
+        def _boom(client_arg: object) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(
+            "afterworlds.pipeline.retrieval.write_service."
+            "get_existing_story_memory_collection_for_delete",
+            _boom,
+        )
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            service.delete_story(uuid4())

--- a/tests/pipeline/retrieval/test_write_service.py
+++ b/tests/pipeline/retrieval/test_write_service.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
 
 
@@ -18,7 +19,9 @@ def _make_service(
 ) -> RetrievalMemoryWriteService:
     client = build_isolated_test_chroma_client(str(tmp_path))
     config = RetrievalMemoryConfig(chunk_char_ceiling=chunk_char_ceiling)
-    return RetrievalMemoryWriteService(client, config)
+    return RetrievalMemoryWriteService(
+        client, config, DeterministicFakeEmbeddingFunction()
+    )
 
 
 class TestIngestIdempotence:

--- a/tests/pipeline/test_stable_prefix_renderer_retrieval.py
+++ b/tests/pipeline/test_stable_prefix_renderer_retrieval.py
@@ -1,0 +1,64 @@
+"""D9 cache-interaction test — CRD Issue 18 / ADR-018.
+
+The CRD Issue 12c structural-identity guarantee must hold even with a
+populated Retrieval Memory block: retrieval sits inside the existing
+StablePrefix envelope, under the existing single cache breakpoint, not as a
+second cached block or a volatile suffix.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from afterworlds.models.context import RetrievalMemoryPayload
+from afterworlds.pipeline._stable_prefix_renderer import render_stable_prefix_blocks
+from tests.pipeline.orchestrator.conftest import make_stable_prefix
+
+
+class TestRetrievalMemoryCacheBreakpoint:
+    def test_empty_retrieval_produces_no_extra_block(self) -> None:
+        prefix = make_stable_prefix(uuid4())
+        blocks = render_stable_prefix_blocks(prefix)
+        assert sum(1 for b in blocks if b.has_cache_breakpoint) == 1
+
+    def test_populated_retrieval_is_the_terminal_cache_breakpoint_block(self) -> None:
+        prefix = make_stable_prefix(uuid4())
+        populated = prefix.model_copy(
+            update={
+                "retrieval_memory": RetrievalMemoryPayload(
+                    passages=("A relevant past scene.",)
+                )
+            }
+        )
+        blocks = render_stable_prefix_blocks(populated)
+
+        # Exactly one cache breakpoint, still — never a second cached block.
+        breakpoint_blocks = [b for b in blocks if b.has_cache_breakpoint]
+        assert len(breakpoint_blocks) == 1
+        # The breakpoint is on the LAST block, and it carries the retrieval text.
+        assert blocks[-1].has_cache_breakpoint is True
+        assert "A relevant past scene." in blocks[-1].text
+
+    def test_populated_retrieval_does_not_change_preceding_blocks(self) -> None:
+        """Byte-identical structural rendering for every block before retrieval."""
+        prefix = make_stable_prefix(uuid4())
+        empty_blocks = render_stable_prefix_blocks(prefix)
+
+        populated = prefix.model_copy(
+            update={
+                "retrieval_memory": RetrievalMemoryPayload(
+                    passages=("A relevant past scene.",)
+                )
+            }
+        )
+        populated_blocks = render_stable_prefix_blocks(populated)
+
+        # One new block is added (retrieval); every earlier block is untouched
+        # except that the previously-terminal block loses its breakpoint flag
+        # (the new retrieval block inherits it instead).
+        assert len(populated_blocks) == len(empty_blocks) + 1
+        for empty_block, populated_block in zip(
+            empty_blocks, populated_blocks[:-1], strict=True
+        ):
+            assert empty_block.text == populated_block.text
+            assert populated_block.has_cache_breakpoint is False

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -10,6 +10,7 @@ import pytest
 # Import all ORM models to ensure Base.metadata is fully populated
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.retrieval  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401

--- a/tests/services/test_context_builder.py
+++ b/tests/services/test_context_builder.py
@@ -989,6 +989,86 @@ def test_retrieval_query_request_populates_stable_prefix() -> None:
     assert "RETRIEVAL_WIRE_THROUGH_SENTINEL" in prefix.render()
 
 
+def test_retrieval_query_request_matching_story_id_retrieves_normally() -> None:
+    """Baseline for the mismatch-guard tests below: a request whose
+    story_id equals the active story_id must retrieve exactly as before."""
+    retrieval = _SentinelRetrievalMemoryProvider()
+    service = ContextBuilderService(
+        story_bible_service=_FixedStoryBibleService(_minimal_bible()),
+        rolling_summary_service=_FixedRollingSummaryService(),
+        recent_turns_provider=_CountingRecentTurnsProvider(),
+        retrieval_memory=retrieval,
+    )
+    request = RetrievalQueryRequest(story_id=_STORY_ID, query_text="a past scene")
+
+    prefix = service.build_stable_prefix(
+        story_id=_STORY_ID,
+        mode=StoryMode.RPG,
+        intent_classification=_make_classified_intent(),
+        retrieval_query_request=request,
+    )
+
+    assert retrieval.call_count == 1
+    assert prefix.retrieval_memory.passages == retrieval.last_payload.passages
+
+
+def test_mismatched_retrieval_query_request_story_id_raises_before_querying() -> None:
+    """Codex review (PR #119): a RetrievalQueryRequest.story_id that does
+    not match the active story_id being assembled must never reach the
+    provider -- ADR-018 D1's mandatory story_id gate must not be
+    bypassable via a caller bug that constructs a mismatched request."""
+    other_story_id = uuid4()
+    retrieval = _SentinelRetrievalMemoryProvider()
+    service = ContextBuilderService(
+        story_bible_service=_FixedStoryBibleService(_minimal_bible()),
+        rolling_summary_service=_FixedRollingSummaryService(),
+        recent_turns_provider=_CountingRecentTurnsProvider(),
+        retrieval_memory=retrieval,
+    )
+    mismatched_request = RetrievalQueryRequest(
+        story_id=other_story_id, query_text="a past scene"
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        service.build_stable_prefix(
+            story_id=_STORY_ID,
+            mode=StoryMode.RPG,
+            intent_classification=_make_classified_intent(),
+            retrieval_query_request=mismatched_request,
+        )
+
+    assert retrieval.call_count == 0
+
+
+def test_mismatched_retrieval_query_request_cannot_leak_cross_story_chunks() -> None:
+    """No cross-story chunks can enter StablePrefix.retrieval_memory through
+    a malformed request: the raise happens before StablePrefix construction,
+    so no StablePrefix carrying another story's data is ever returned."""
+    other_story_id = uuid4()
+
+    class _AlwaysReturnsForeignStoryChunks:
+        def retrieve(self, story_id: UUID, query: str) -> RetrievalMemoryPayload:
+            return RetrievalMemoryPayload(passages=("FOREIGN_STORY_CHUNK",))
+
+    service = ContextBuilderService(
+        story_bible_service=_FixedStoryBibleService(_minimal_bible()),
+        rolling_summary_service=_FixedRollingSummaryService(),
+        recent_turns_provider=_CountingRecentTurnsProvider(),
+        retrieval_memory=_AlwaysReturnsForeignStoryChunks(),
+    )
+    mismatched_request = RetrievalQueryRequest(
+        story_id=other_story_id, query_text="a past scene"
+    )
+
+    with pytest.raises(ValueError):
+        service.build_stable_prefix(
+            story_id=_STORY_ID,
+            mode=StoryMode.RPG,
+            intent_classification=_make_classified_intent(),
+            retrieval_query_request=mismatched_request,
+        )
+
+
 # ===========================================================================
 # Rule slice — inside StablePrefix (Issue 8 contract; ADR-0010 revised)
 # ===========================================================================

--- a/tests/services/test_context_builder.py
+++ b/tests/services/test_context_builder.py
@@ -423,9 +423,16 @@ def test_build_stable_prefix_called_once_per_turn() -> None:
         mode: StoryMode,
         intent_classification: IntentClassificationResult,
         rule_slice_request: RuleSliceRequest | None = None,
+        retrieval_query_request: object = None,
     ) -> StablePrefix:
         call_count[0] += 1
-        return original_build(story_id, mode, intent_classification, rule_slice_request)  # type: ignore[arg-type]
+        return original_build(  # type: ignore[arg-type]
+            story_id,
+            mode,
+            intent_classification,
+            rule_slice_request,
+            retrieval_query_request,
+        )
 
     service.build_stable_prefix = counting_build  # type: ignore[method-assign]
 

--- a/tests/services/test_context_builder.py
+++ b/tests/services/test_context_builder.py
@@ -47,6 +47,7 @@ from afterworlds.models.enums import (
     StoryMode,
 )
 from afterworlds.models.intent_classification import IntentClassificationResult
+from afterworlds.models.retrieval import RetrievalQueryRequest
 from afterworlds.models.rolling_summary import RollingSummary
 from afterworlds.models.rules_package import ActiveRuleSlice, RuleSliceRequest
 from afterworlds.models.story import Story
@@ -149,6 +150,24 @@ class _CountingRetrievalMemoryProvider:
         self.call_count += 1
         self.last_query = query
         return RetrievalMemoryPayload()
+
+
+class _SentinelRetrievalMemoryProvider:
+    """Stub that always returns a fixed non-empty payload."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.last_story_id: UUID | None = None
+        self.last_query: str | None = None
+        self.last_payload = RetrievalMemoryPayload(
+            passages=("RETRIEVAL_WIRE_THROUGH_SENTINEL",)
+        )
+
+    def retrieve(self, story_id: UUID, query: str) -> RetrievalMemoryPayload:
+        self.call_count += 1
+        self.last_story_id = story_id
+        self.last_query = query
+        return self.last_payload
 
 
 # ---------------------------------------------------------------------------
@@ -935,6 +954,39 @@ def test_stable_prefix_retrieval_memory_always_empty_regardless_of_provider() ->
     )
     assert assembled.stable_prefix.retrieval_memory.passages == ()
     assert "SHOULD_NOT_APPEAR" not in assembled.stable_prefix.render()
+
+
+def test_retrieval_query_request_populates_stable_prefix() -> None:
+    """CRD Issue 18 / ADR-018 D8/D9 read-path wire-through.
+
+    When the orchestrator supplies a ``retrieval_query_request``,
+    ``build_stable_prefix`` must call the injected provider with the
+    request's ``story_id``/``query_text`` and surface its result on
+    ``StablePrefix.retrieval_memory`` — the one seam Issue 18 actually
+    added to this service, distinct from the Issue 8 always-empty default
+    exercised above.
+    """
+    retrieval = _SentinelRetrievalMemoryProvider()
+    service = ContextBuilderService(
+        story_bible_service=_FixedStoryBibleService(_minimal_bible()),
+        rolling_summary_service=_FixedRollingSummaryService(),
+        recent_turns_provider=_CountingRecentTurnsProvider(),
+        retrieval_memory=retrieval,
+    )
+    request = RetrievalQueryRequest(story_id=_STORY_ID, query_text="a past scene")
+
+    prefix = service.build_stable_prefix(
+        story_id=_STORY_ID,
+        mode=StoryMode.RPG,
+        intent_classification=_make_classified_intent(),
+        retrieval_query_request=request,
+    )
+
+    assert retrieval.call_count == 1
+    assert retrieval.last_story_id == _STORY_ID
+    assert retrieval.last_query == "a past scene"
+    assert prefix.retrieval_memory.passages == retrieval.last_payload.passages
+    assert "RETRIEVAL_WIRE_THROUGH_SENTINEL" in prefix.render()
 
 
 # ===========================================================================

--- a/tests/test_retrieval_backfill_script.py
+++ b/tests/test_retrieval_backfill_script.py
@@ -1,0 +1,129 @@
+"""Tests for scripts/retrieval_backfill.py — CRD Issue 18 / ADR-018 D4/D7.
+
+Codex review (PR #119): the manual recovery CLI must derive its
+RetrievalMemoryConfig from the same environment the running application
+reads, not dataclass defaults -- otherwise reindex/backfill/delete run
+through this script can recreate the exact embedding-model mismatch they
+were meant to fix.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.collections import get_story_memory_collection
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
+from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "retrieval_backfill.py"
+
+
+def _load_script():  # type: ignore[no-untyped-def]
+    """Import scripts/retrieval_backfill.py as a module (scripts/ is not a
+    package). Cached in sys.modules so repeated calls don't re-exec it."""
+    module_name = "retrieval_backfill_script_under_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBuildEffectiveConfig:
+    def test_honors_env_embedding_model_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        script = _load_script()
+        monkeypatch.setenv("AFTERWORLDS_RETRIEVAL_EMBEDDING_MODEL_ID", "env-model-x")
+
+        config = script.build_effective_config(None)
+
+        assert config.embedding_model_id == "env-model-x"
+
+    def test_honors_env_chunk_ceiling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        script = _load_script()
+        monkeypatch.setenv("AFTERWORLDS_RETRIEVAL_CHUNK_CHAR_CEILING", "1234")
+
+        config = script.build_effective_config(None)
+
+        assert config.chunk_char_ceiling == 1234
+
+    def test_chroma_path_overrides_only_persist_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        script = _load_script()
+        monkeypatch.setenv("AFTERWORLDS_RETRIEVAL_EMBEDDING_MODEL_ID", "env-model-y")
+        monkeypatch.setenv("AFTERWORLDS_RETRIEVAL_CHUNK_CHAR_CEILING", "999")
+
+        config = script.build_effective_config("/explicit/override/path")
+
+        assert config.persist_directory == "/explicit/override/path"
+        assert config.embedding_model_id == "env-model-y"
+        assert config.chunk_char_ceiling == 999
+
+    def test_none_chroma_path_uses_env_persist_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        script = _load_script()
+        monkeypatch.setenv(
+            "AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY", "/env/derived/path"
+        )
+
+        config = script.build_effective_config(None)
+
+        assert config.persist_directory == "/env/derived/path"
+
+    def test_parse_args_chroma_path_defaults_to_none(self) -> None:
+        script = _load_script()
+        old_argv = sys.argv
+        try:
+            sys.argv = ["retrieval_backfill.py", "--story-id", str(uuid4())]
+            args = script.parse_args()
+        finally:
+            sys.argv = old_argv
+
+        assert args.chroma_path is None
+
+
+class TestEnvConfiguredReindexMatchesAppConfig:
+    """Integration proof tying fix #1 (delete-only bypass) and fix #2
+    (env-derived CLI config) together: after a recovery script reindex
+    using env-derived config, the application's own env-derived config must
+    see a compatible (not mismatched) collection."""
+
+    def test_app_config_after_recovery_reindex_sees_compatible_collection(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch  # type: ignore[no-untyped-def]
+    ) -> None:
+        monkeypatch.setenv(
+            "AFTERWORLDS_RETRIEVAL_EMBEDDING_MODEL_ID", "shared-env-model"
+        )
+        monkeypatch.setenv("AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY", str(tmp_path))
+
+        # "Recovery script" side: builds config the same way the CLI does.
+        recovery_config = RetrievalMemoryConfig.from_env()
+        client = build_isolated_test_chroma_client(str(tmp_path))
+        ef = DeterministicFakeEmbeddingFunction()
+        recovery_write_service = RetrievalMemoryWriteService(
+            client, recovery_config, ef
+        )
+        recovery_write_service.ingest_turn(
+            uuid4(), uuid4(), None, "rpg", "Recovered prose.", "t1"
+        )
+
+        # "Application" side: builds its own config independently from the
+        # same environment and must see a compatible collection, not a
+        # RetrievalCollectionReindexRequiredError.
+        app_config = RetrievalMemoryConfig.from_env()
+        app_collection = get_story_memory_collection(client, app_config, ef)
+
+        assert app_collection.metadata.get("embedding_model_id") == "shared-env-model"

--- a/tests/test_retrieval_backfill_script.py
+++ b/tests/test_retrieval_backfill_script.py
@@ -16,11 +16,23 @@ from uuid import uuid4
 
 import pytest
 
+import afterworlds.persistence.orm.character_sheet  # noqa: F401
+import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.retrieval  # noqa: F401
+import afterworlds.persistence.orm.rules_package  # noqa: F401
+import afterworlds.persistence.orm.session_state  # noqa: F401
+import afterworlds.persistence.orm.state  # noqa: F401
+import afterworlds.persistence.orm.story  # noqa: F401
+import afterworlds.persistence.orm.story_bible  # noqa: F401
+from afterworlds.persistence.crud.story import create_story
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.collections import get_story_memory_collection
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
 from afterworlds.pipeline.retrieval.write_service import RetrievalMemoryWriteService
+from tests.persistence.conftest import make_story
 
 _SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "retrieval_backfill.py"
 
@@ -127,3 +139,95 @@ class TestEnvConfiguredReindexMatchesAppConfig:
         app_collection = get_story_memory_collection(client, app_config, ef)
 
         assert app_collection.metadata.get("embedding_model_id") == "shared-env-model"
+
+
+def _seed_story_db(tmp_path: Path) -> tuple[str, object]:
+    """Create a file-backed SQLite DB with one story, for driving the
+    script's main() end-to-end (a separate engine connection, like the CLI
+    creates, needs a real file rather than an in-memory ``sqlite://`` URL)."""
+    db_url = f"sqlite:///{tmp_path / 'test.db'}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+    session = create_session_factory(engine)()
+    story = make_story()
+    create_story(session, story)  # type: ignore[arg-type]
+    session.commit()
+    session.close()
+    return db_url, story.story_id
+
+
+class TestCliExitCodes:
+    """Codex review (PR #119) round 6: operational failures during delete/
+    reindex must exit nonzero and must not print a success-looking report."""
+
+    def test_delete_mode_raises_on_operational_open_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        script = _load_script()
+        db_url, story_id = _seed_story_db(tmp_path)
+        monkeypatch.setenv(
+            "AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY", str(tmp_path / "chroma")
+        )
+
+        def _boom(self: object, story_id: object) -> None:
+            raise RuntimeError("store locked")
+
+        monkeypatch.setattr(RetrievalMemoryWriteService, "delete_story", _boom)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "retrieval_backfill.py",
+                "--story-id",
+                str(story_id),
+                "--mode",
+                "delete",
+                "--db-url",
+                db_url,
+            ],
+        )
+
+        with pytest.raises(RuntimeError, match="store locked"):
+            script.main()
+
+        assert "deleted story chunks" not in capsys.readouterr().out
+
+    def test_reindex_mode_exits_nonzero_on_incomplete_wipe(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        script = _load_script()
+        db_url, story_id = _seed_story_db(tmp_path)
+        monkeypatch.setenv(
+            "AFTERWORLDS_RETRIEVAL_PERSIST_DIRECTORY", str(tmp_path / "chroma")
+        )
+        monkeypatch.setattr(
+            RetrievalMemoryWriteService, "delete_story", lambda self, story_id: 3
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "retrieval_backfill.py",
+                "--story-id",
+                str(story_id),
+                "--mode",
+                "reindex",
+                "--db-url",
+                db_url,
+            ],
+        )
+
+        from afterworlds.pipeline.retrieval.backfill import (
+            RetrievalReindexWipeIncompleteError,
+        )
+
+        with pytest.raises(RetrievalReindexWipeIncompleteError):
+            script.main()
+
+        assert "scanned=" not in capsys.readouterr().out


### PR DESCRIPTION
## Summary

CRD Issue 18 Phase 2 — implements ADR-018 (Retrieval Memory) as merged (#118), per the owner's Phase 1 acceptance comment. ChromaDB becomes a rebuildable, SQLite-derived projection: a shared `story_memory` collection with mandatory `story_id` filtering, a finalized per-Rules-Package `rules_corpus` collection absorbing the CRD Issue 5b interim path, an ingestion gate that fires only after commit-success on a delivery-cleared D6-eligible turn, a mandatory RPG turn-retrieval marker (typed `PIPELINE_ERROR` on failure), a durable Writing setup-turn guard, and a `RetrievalQueryBuilder` that applies full D6/D8 eligibility to the query tail (not `exclude_ooc=True` alone).

- Schema/DTOs/ID scheme: `models/retrieval.py`, new enums in `models/enums.py` (`RetrievalSourceType`, `RetrievalChunkKind`, `RpgTurnRetrievalCategory`)
- Config/embedding/chunking/scoring/client seams: `pipeline/retrieval/{config,embedding,chunking,scoring,client,collections}.py`
- `rpg_turn_retrieval_markers` + persisted marker-era-boundary: migration `0015`, `persistence/orm/retrieval.py`, `persistence/crud/retrieval.py`
- Write/query/reindex services: `RetrievalMemoryWriteService`, `ChromaRetrievalMemoryProvider`, `RetrievalQueryBuilder`, `RulesCorpusService`, `backfill.py` + `scripts/retrieval_backfill.py`
- Shared eligibility predicate: `pipeline/retrieval/eligibility.py` (one predicate for ingestion gate, query tail, backfill, reindex)
- Orchestrator wiring: ingestion gate in `_run_narrative`, mandatory RPG marker write in `_narrative_persist`, Writing durable setup-turn guard fix, `retrieval_query_request` threaded through `ContextBuilderService`
- CVE-2026-45829 pip-audit ignore re-justified with a concrete safe-deployment-path rationale (not silently preserved)

## Acceptance criteria coverage (owner acceptance comment, PR #118)

| Non-negotiable | Status |
|---|---|
| Real commit-success + delivery-cleared ingestion gate (existing `post_transaction_fn` unmodified is disqualified) | Done — new gate in `_run_narrative`, gated on the post-`_finalize_transaction` `OrchestrationResult` |
| Marker write inside the outer transaction, typed `PIPELINE_ERROR` on failure | Done — `_narrative_persist`, RPG-mode-gated, mandatory (not best-effort like the Writing block) |
| Writing eligibility from committed `WritingNodeMetadata` only, durable setup-turn guard | Done — SETUP forces `SETUP_CONFIRMATION`/`NON_CANON_SUPPORT` on the persisted record regardless of request |
| All-pass `StablePrefix` visibility | Done by construction — `retrieval_memory` is a field on the single shared `StablePrefix`; all 7 `render_stable_prefix_blocks` callsites consume it uniformly, no pass-specific branching introduced |
| D6-eligibility filtering on the retrieval-query tail | Done — `RetrievalQueryBuilder` applies `gather_turn_eligibility_for_turn` on top of `exclude_ooc=True`; test proves `exclude_ooc` alone is insufficient |
| Mandatory `story_id` gate + leakage tests | Done — `ChromaRetrievalMemoryProvider.retrieve()`; cross-story leakage test with overlapping content |
| Normalized inclusive threshold semantics | Done — `scoring.normalize_similarity`, `>=` comparison; below/at-threshold boundary test |
| Delete-before-write for turn-level chunk replacement | Done — `RetrievalMemoryWriteService.ingest_turn`; shrink test proves stale high-index chunks are removed |
| chromadb CVE-2026-45829 pip-audit ignore resolved | Owner-accepted (see Architecture Notes) — no patched release exists upstream; ignore is temporary, tracked in #120 |

## Test coverage summary

2172 tests passed (10 skipped, pre-existing/unrelated), 90.97% aggregate coverage. New/modified test files:

- `tests/models/test_retrieval.py` — ID determinism, DTO round-trips
- `tests/pipeline/retrieval/test_{chunking,scoring,eligibility,write_service,chroma_provider,query_builder,rules_corpus_service,backfill}.py`
- `tests/persistence/test_retrieval_markers_db.py` — marker/era-boundary DB integration
- `tests/pipeline/orchestrator/test_retrieval_memory.py` — ingestion-gate deny-list proof, mandatory marker-write-failure → `PIPELINE_ERROR`, Writing setup-turn guard end-to-end
- `tests/pipeline/test_stable_prefix_renderer_retrieval.py` — D9 cache-breakpoint structural identity with a populated retrieval block
- Companion fixture fixes: `FakeContextBuilder`, `_SpyContextBuilder`, and a `counting_build` test double all needed the new optional `retrieval_query_request` parameter on `assemble()` — caught by running the full existing suite, not just new tests
- `test_retrieval_query_request_populates_stable_prefix` (`tests/services/test_context_builder.py`) — the actual `build_stable_prefix(retrieval_query_request=...)` → `provider.retrieve()` → populated `StablePrefix.retrieval_memory` wire-through, distinct from the Issue 8 always-empty-by-default tests already in that file
- `test_pending_roll_announced_gets_roll_request_marker_and_is_not_ingested` (`tests/pipeline/orchestrator/test_retrieval_memory.py`) — end-to-end ROLL_REQUEST marker + non-ingestion proof; required seeding a real `RpgCharacterSheetBaseORM` row since the announce path's `session.add(PendingRollRequestORM(...))` had never been exercised against its FK to `rpg_character_sheet_bases` in any existing fixture

Binding ADR-018 obligations covered: D1 (leakage/mandatory story_id gate), D5 (inclusive threshold, both boundary cases), D6 (OOC/Writing/RPG/Branching eligibility, post/pre-boundary data-integrity-error split, mandatory marker semantics), D8 (query-tail eligibility beyond `exclude_ooc`), D9 (populated-retrieval structural identity), D11 (delete-before-write on shrink), plus the sibling-audit checkpoint that ingestion/query-tail/backfill/reindex share one eligibility predicate (`gather_turn_eligibility` / `gather_turn_eligibility_for_turn`).

## Architecture Notes

**No drift from design principles** for the accepted ADR-018 invariants, gates, and coverage rules. Module layout, helper naming, and factoring below are Phase 2 implementation choices per the Two-Phase Gate Record's review-closure standard — not owner decisions, and open to non-blocking naming/factoring feedback. (Codex-review remediation chronology across eight review rounds has been moved to a local working note, `.claude/review-notes/pr-119-issue-18-remediation-log.md`, to keep this section limited to current, durable facts.)

**Open sibling-audit item, owner decision needed**: `ingestion/vector_writer.py::delete_collection()` (CRD Issue 5b's interim ingestion path, called from `ingestion_service.py::_repopulate_vector_index()`) still broadly suppresses `delete_collection()` failures before its own upsert — the same defect family just fixed below in the ADR-018 retrieval-memory module's wipe-then-rebuild paths. Left unpatched: it is CRD Issue 5b's own subsystem, not part of the module this PR owns, and the round-5 note already flagged `vector_writer.py` as a candidate for retirement now that `RulesCorpusService` supersedes it. Fixing it here would be an undecided scope expansion; flagged for an explicit owner call (retire 5b's interim path vs. patch it in place).

**Ingestion gate mechanism** (advisor-consulted): implemented as an explicit post-return check in `_run_narrative` — `_maybe_ingest_retrieval_memory(result, story_id, story_mode)` is called after `_run_with_transaction` returns, gated on `result.disposition is DELIVERED and result.turn_id is not None`. Does **not** reuse `post_transaction_fn` (dedicated to provider-adapter proxy buffering/flush, unconditional, no result access). Ingestion opens its own short-lived read session after the outer transaction's session is closed, matching the backfill/reindex read pattern. This same gate now feeds the shared eligibility predicate through a tolerant read (`get_turn_for_eligibility`) so a single turn with malformed persisted metadata cannot abort ingestion.

**Marker-era boundary mechanism** (advisor-consulted, schema-verified): `turns.turn_id` is a UUID primary key with no integer sequence/rowid alias; `turns.timestamp` is a `String(64)` ISO-8601 UTC datetime, relied upon for lexicographic sort correctness elsewhere. The boundary is a singleton row (`retrieval_marker_era_boundary`) storing `MAX(turns.timestamp)` captured once, in migration `0015`'s data step; post-boundary is `timestamp > boundary` (strict), forward-only, never retroactive.

**RPG turn-retrieval marker classification** resolves `rpg_play_status` directly from the session/sheet resolver whenever RPG mode is active, independent of whether RPG adjudication is wired. When `rpg_play_status` cannot be resolved at all, marker classification fails closed with a typed `PIPELINE_ERROR` and rollback rather than defaulting to `ORDINARY_NARRATIVE`. RPG legacy-turn (pre-boundary) eligibility checks only `PendingRollRequest.originating_turn_id`, since a pre-boundary roll-request turn predates the marker sidecar entirely. Post-boundary, the marker row and `PendingRollRequest` presence must agree (ADR-018 D6 coverage invariant) — any disagreement (missing marker, wrong marker category, or a `ROLL_REQUEST` marker with no matching `PendingRollRequest` row) is surfaced as a data-integrity error, never silently resolved to an ordinary eligibility outcome. Retrieval-domain code never reads current `RpgSessionState.play_status` — only the turn-time durable marker.

**Malformed persisted Writing `mode_metadata`** (including non-object JSON: a list, bare string, or number) is treated as retrieval-ineligible, not a fatal error. `persistence/crud/retrieval.py::get_turn_for_eligibility()` is a retrieval-domain-local tolerant read (catches `(ValueError, AttributeError)` around `mode_metadata` deserialization only) feeding `gather_turn_eligibility()`, `backfill_story()`, and the orchestrator's ingestion gate. The general-purpose `get_turn()` is untouched for every other caller (Writer, Extractor, etc.) — those must keep seeing a raised deserialization error as a real data-integrity failure. `intent_classification_result` corruption is deliberately outside this tolerance and still raises.

**Cross-story retrieval guard**: `ContextBuilderService.build_stable_prefix()`/`assemble()` reject a `RetrievalQueryRequest` whose `story_id` does not match the active `story_id` being assembled, with a typed `ValueError` raised before `RetrievalMemoryProvider.retrieve()` is ever called — ADR-018 D1's mandatory `story_id` gate cannot be bypassed by a caller bug constructing a mismatched request. This is the single public retrieval query gate; every read path goes through it.

**Collection-level embedding-model guard**: `get_story_memory_collection()`/`get_rules_corpus_collection()` record `embedding_model_id` in Chroma collection metadata at creation and check it against `config.embedding_model_id` on every call — Chroma silently ignores the `metadata=` kwarg once a collection exists, so this check is explicit rather than assumed. A mismatch (including a legacy collection with no `embedding_model_id` key) raises `RetrievalCollectionReindexRequiredError` rather than mixing incompatible vector spaces (ADR-018 D4). This guard applies to normal semantic read/write/upsert paths only. Metadata-only delete (`RetrievalMemoryWriteService.delete_turn()`/`delete_story()`) opens the collection through a separate bypass (`get_existing_story_memory_collection_for_delete()`) that catches only `chromadb.errors.NotFoundError` — never embedding-model compatibility, and never any other operational error (a locked/corrupt store, permission failure) — and never creates a collection. Deletion by metadata filter never invokes the embedding function, so an operator must still be able to scrub a mismatched or legacy collection's chunks ahead of a full reindex; a genuine operational failure still propagates rather than being reported as a successful no-op. The helper never auto-wipes or auto-reindexes; every other write/query/backfill/reindex path still surfaces the typed error by routing through the strict choke point.

**Story reindex wipe post-condition**: `reindex_story()` checks `delete_story()`'s returned remaining-chunk count before rebuilding — a nonzero remaining count raises a typed `RetrievalReindexWipeIncompleteError` and `backfill_story()` is never called, so a partial wipe can never leave stale chunks alongside a freshly rebuilt set. This is distinct from a data-integrity error (a per-turn marker/SQLite defect reported in `BackfillReport.data_integrity_errors`): it is an operational failure of the delete phase itself, and the two remain independently distinguishable in the CLI's output/exit code.

**Chroma wipe-then-rebuild failure propagation**: every `delete_collection()`-based wipe-then-rebuild path (`RulesCorpusService.reindex_from_sql()`, `RetrievalMemoryWriteService.wipe_collection()`) routes through the shared `delete_collection_ignoring_absence()` helper, which ignores only `chromadb.errors.NotFoundError` (a genuinely absent collection) and propagates every other operational failure (locked/corrupt store, permission error) before any subsequent `get_*_collection()`/`upsert()` call — preserving the Central Invariant that Chroma is a rebuildable SQLite-derived projection: a rebuild must never silently proceed on top of a wipe that didn't actually happen.

**Retrieval recovery CLI** (`scripts/retrieval_backfill.py`) builds its `RetrievalMemoryConfig` from `RetrievalMemoryConfig.from_env()` — the same environment-derived config the running application uses — and applies `--chroma-path` only as an explicit `persist_directory` override when the flag is passed. Both new typed errors above propagate uncaught out of `main()`, so an operational delete failure or an incomplete-wipe reindex exits nonzero without printing a success-looking report.

**Retrieval query construction** (`RetrievalQueryBuilder.build_query_request()`) composes `query_text` from, in order: the eligible recent-turn tail (full D6/D8 eligibility, not `exclude_ooc=True` alone, reloading full committed turn state rather than trusting a lean provider projection), the current Sojourner input, and a deterministic `intent_type=<value>` fragment from the already-classified intent (ADR-018 D8) — a fixed textual fragment, not a `model_dump()` of the full typed result, so query text doesn't depend on Pydantic field order/defaults. `RetrievalQueryRequest`'s envelope is unchanged; intent is folded into `query_text`, not a new field. Context Builder remains pass-through only — it never infers or composes retrieval-query contents.

**Retrieval query construction/read failure semantics**: a configured `RetrievalQueryBuilder` (or the Context Builder's underlying `RetrievalMemoryProvider.retrieve()` read) that raises before context assembly is a context-construction failure and returns a typed `PIPELINE_ERROR` — `_build_context()`/the Writer are never reached for that turn. This is distinct from ADR-018 D7's best-effort swallow, which applies only to the post-commit Chroma ingestion/write path (`_maybe_ingest_retrieval_memory()`) and never to this pre-context read. No retrieval query builder configured at all, and a configured builder returning an empty/normal result, both remain valid no-retrieval-memory turns — only a raised exception from a configured builder/read fails the turn.

**Rules-corpus vector IDs** derive from `RuleChunkORM.chunk_id` — the row's own durable primary key, assigned once at CRD Issue 5a ingestion — via the single shared `build_rules_corpus_chunk_id(package_id, chunk_id)` builder, stable regardless of SQL row-iteration order or how many chunks share a source locator. Story-memory's chunk-ID builder is a separate, unaffected function.

**Production embedding default**: `resolve_default_embedding_function()` returns the real local ONNX MiniLM default unconditionally (ADR-018 D4) and raises a typed `RetrievalEmbeddingUnavailableError` if it can't initialize, rather than falling back to a fake. `DeterministicFakeEmbeddingFunction` is explicit test-injection only — no call site defaults to it implicitly.

**chromadb CVE-2026-45829 / PYSEC-2026-311 resolution** (owner decision: [PR #119 comment](https://github.com/AfterworldsAI/afterworlds/pull/119#issuecomment-4891471947)): no patched release exists upstream for any chromadb version 1.0.0–1.5.9 (pre-auth code-injection in chromadb's HTTP server component via `trust_remote_code=True`). ChromaDB remains mandatory for Issue 18 / v1 Retrieval Memory — a first-class memory layer required on every access path (CLAUDE.md invariant 2, BYOK-parity). The CVE is mitigated by local embedded-only Chroma client construction, not by optional dependency scoping: `pipeline/retrieval/client.py::build_chroma_client` is the single choke point constructing Chroma clients — always embedded (`PersistentClient`/`EphemeralClient`), Chroma HTTP/server client use is not introduced — and no Afterworlds embedding-function path ever sets `trust_remote_code=True`. The CI `--ignore-vuln CVE-2026-45829` is temporarily approved under this rationale. Follow-up tracking: [#120](https://github.com/AfterworldsAI/afterworlds/issues/120) — remove the ignore once a patched release exists or if Chroma HTTP/server deployment is ever introduced.

**5b interim-collection absorption**: `RulesCorpusService.reindex_from_sql` rebuilds the finalized `rules_corpus_{package_id_hex}` collection from `rp_chunks` SQL ground truth (never from the interim Chroma collection itself). `ingestion/vector_writer.py` (the 5b interim path) is left in place, unmodified, in this PR — worth a sibling-audit note if the owner wants it retired now rather than deferred.

**RetrievalQueryBuilder module placement**: lives in `pipeline/retrieval/` matching the per-concern subpackage convention already used for `pipeline/{writer,planner,rpg,...}`.

## Test plan

- [x] `black --check src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean (149 source files)
- [x] `pytest` — 2172 passed, 10 skipped, 90.97% coverage (≥80% gate)
- [x] `pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829` — verified against the actual CI run on this branch: `No known vulnerabilities found, 1 ignored`. (A local run against a stale venv shows unrelated findings — a local-environment artifact, not real CI drift; a fresh install matching CI's exact invocation reproduces CI's clean result.)
- [x] `alembic upgrade head` / `alembic downgrade base` round-trip (existing `test_alembic.py` suite, extended coverage via migration 0015)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
