### PR TITLE
Issue 14a follow-up: BYOK readiness seam for Issue 19 (#122)

### DIFF
--- a/docs/decisions/adr-014a-provider-routing-core.md
+++ b/docs/decisions/adr-014a-provider-routing-core.md
@@ -202,6 +202,47 @@ has explicitly deactivated it.
 
 ---
 
+## Decision 13: BYOK readiness seam formalized ahead of Issue 19 (GH #122)
+
+**Decision:** The Decision 12 runnability predicate (eligible credential
+metadata + retrievable key +, when OpenRouter is in the pool, a usable,
+non-dynamic-alias `ProviderRouteConfig` model id) is extracted into
+`_readiness.py` as `_compute_byok_runnable`, and exposed read-only via
+`ByokCredentialReadinessProvider.is_byok_runnable(sojourner_id) -> bool`.
+`ProviderResolver._resolve_byok` and `is_byok_runnable` both call the same
+`_collect_available_byok_keys` / `_fetch_openrouter_preferred_model` helpers,
+and the dynamic-alias check reuses `adapters/_openrouter.py::_is_dynamic_alias`
+(the same guard `OpenRouterAdapter.__init__` enforces) rather than
+re-implementing it — there is exactly one implementation of each check, not two.
+
+**Residual gap, documented not closed:** `is_byok_runnable` does not evaluate
+14b `OpenRouterCapabilityRegistry` admission (whitelist/capability rejection in
+`_resolve_openrouter_route`). No production `ProviderResolver` construction
+wires a `capability_registry` today, so this path is currently inert; if that
+changes, a registry-admitted-but-rejected model could report runnable=True and
+still fail at `resolve_for_turn`. Folding 14b capability policy into this 14a
+seam was rejected as scope creep (requirement: no provider-routing-policy
+changes); this is flagged for Issue 19 to re-check if/when 14b registries are
+wired into production.
+
+**Rationale:** Issue 19 Rev3 DoR-E requires access-path selection to compute
+*runnable* paths, not merely *licensed* ones. BYOK runnable = Issue 13's
+`byok_turn_available` AND this seam. Before this change, 14a exposed no public
+readiness read, so Issue 19 could select BYOK on entitlement/license state
+alone and then hit `resolve_for_turn` raising `ProviderConfigError` — an
+operational pipeline error where a typed `BYOK_CREDENTIALS_REQUIRED` preflight
+response belongs instead. This seam lets Issue 19 ask the readiness question up
+front without reaching into `_resolver.py` privates or re-deriving
+`ProviderResolver` policy.
+
+**Consequence:** `is_byok_runnable` returns a plain `bool` — no key material,
+provider secrets, or route internals cross the boundary. This is a seam
+formalization of existing Decision 12 behavior, not a new access-path policy;
+it changes no entitlement, routing, or fallback behavior. Issue 19's own
+preflight response type and wiring are out of scope here.
+
+---
+
 ## Architecture Notes
 
 No drift from the core design principles. The safety envelope (conditional
@@ -222,6 +263,13 @@ serialize prompt text from `system_blocks`/`rendered_blocks` or any key-containi
 field into `coarse_metadata_json` or any other column. Enforcement is by policy in
 the calling code, not by the router itself. This constraint is verified by
 `tests/pipeline/provider/test_refusal_log_writer.py::test_log_row_excludes_prompt_text_and_raw_excerpt`.
+
+**Decision 13: `ByokCredentialReadinessProvider` (`_readiness.py`) is a seam
+formalization, not a new access-path policy.** It is the pre-Issue-19 (GH #122)
+follow-up to Decision 12: the same runnability predicate, exposed read-only so
+Issue 19 DoR-E can compute a runnable BYOK path without reaching into
+`_resolver.py` privates or duplicating `ProviderResolver` policy. See Decision
+13 above for the full rationale.
 
 **Decision 10: `session_factory` is required for `ProviderResolver.resolve_for_turn`.**
 `_resolve_hosted` and `_resolve_byok` raise `ProviderConfigError` when

--- a/src/afterworlds/pipeline/provider/__init__.py
+++ b/src/afterworlds/pipeline/provider/__init__.py
@@ -20,6 +20,7 @@ from afterworlds.pipeline.provider._models import (
     ProviderToolDefinition,
 )
 from afterworlds.pipeline.provider._protocol import ProviderAdapter
+from afterworlds.pipeline.provider._readiness import ByokCredentialReadinessProvider
 from afterworlds.pipeline.provider._registry import (
     OpenRouterCapabilityRegistry,
     WhitelistConfig,
@@ -53,6 +54,7 @@ __all__ = [
     "AnthropicCapabilityProfile",
     "AnthropicDirectAdapter",
     "AnthropicNormalizationFactorProvider",
+    "ByokCredentialReadinessProvider",
     "CapabilityEvidenceSource",
     "CapabilityProfileAwareSafetyPolicy",
     "CredentialValidationError",

--- a/src/afterworlds/pipeline/provider/_readiness.py
+++ b/src/afterworlds/pipeline/provider/_readiness.py
@@ -1,0 +1,187 @@
+"""BYOK readiness seam — CRD Issue 14a follow-up (#122), pre-Issue-19 DoR-E.
+
+Issue 19 Rev3 DoR-E requires access-path selection to compute *runnable* paths,
+not merely *licensed* paths. BYOK runnable = Issue 13's ``byok_turn_available``
+AND this module reports usable BYOK credentials/route configuration for the
+Sojourner. This module is the single source of truth for the latter half of
+that predicate.
+
+``_compute_byok_runnable`` is the one implementation of BYOK runnability. Both
+``ProviderResolver._resolve_byok`` (which raises ``ProviderConfigError`` on
+failure) and ``ByokCredentialReadinessProvider.is_byok_runnable`` (which
+returns ``False`` on failure) call through the same helpers in this module —
+there is no second copy of the eligibility/retrievability/route-config logic.
+
+This is a seam formalization, not a new access-path policy: it exposes a
+read-only check, it does not change entitlement, provider routing, or
+fallback behavior.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from afterworlds.pipeline.provider.credentials._store import CredentialStore
+
+_BYOK_PROVIDER_NAMES: tuple[str, ...] = ("anthropic", "openrouter")
+
+
+def _is_credential_eligible(
+    session_factory: object, sojourner_id: UUID, provider_name: str
+) -> bool:
+    """Return True iff the credential row exists, is active, and is not INVALID/ERROR.
+
+    VALID and UNTESTED are eligible (permissive default for unchecked keys).
+    INVALID and ERROR are excluded to prevent routing to known-bad credentials.
+    Absent row or is_active=False both return False.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import Session
+
+    from afterworlds.pipeline.provider.credentials._metadata import (
+        ProviderCredentialMetadata,
+        ValidationStatus,
+    )
+
+    _factory = session_factory
+    assert callable(_factory)
+    session_obj = _factory()
+    assert isinstance(session_obj, Session)
+    with session_obj as session:
+        stmt = select(ProviderCredentialMetadata).where(
+            ProviderCredentialMetadata.sojourner_id == str(sojourner_id),
+            ProviderCredentialMetadata.provider_name == provider_name,
+            ProviderCredentialMetadata.is_active.is_(True),
+        )
+        row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return False
+    return row.validation_status not in (
+        ValidationStatus.INVALID,
+        ValidationStatus.ERROR,
+    )
+
+
+def _fetch_openrouter_preferred_model(
+    session_factory: object, sojourner_id: UUID
+) -> str | None:
+    """Return the active, non-blank OpenRouter ``preferred_model_identifier``.
+
+    Returns None (never raises) if no active route-config row exists or the
+    identifier is missing/blank — the caller decides whether that is a hard
+    failure (``_resolve_byok``) or a readiness ``False`` (readiness provider).
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import Session
+
+    from afterworlds.pipeline.provider._route_config import ProviderRouteConfigORM
+
+    _factory = session_factory
+    assert callable(_factory)
+    session_obj = _factory()
+    assert isinstance(session_obj, Session)
+    with session_obj as session:
+        stmt = select(ProviderRouteConfigORM).where(
+            ProviderRouteConfigORM.sojourner_id == str(sojourner_id),
+            ProviderRouteConfigORM.provider_name == "openrouter",
+            ProviderRouteConfigORM.is_active.is_(True),
+        )
+        row = session.execute(stmt).scalar_one_or_none()
+    if row is None:
+        return None
+    model = (row.preferred_model_identifier or "").strip()
+    return model or None
+
+
+def _collect_available_byok_keys(
+    credential_store: CredentialStore,
+    session_factory: object,
+    sojourner_id: UUID,
+) -> dict[str, str]:
+    """Return ``{provider_name: key}`` for providers with eligible metadata AND a
+    retrievable, non-empty key. Keys for ineligible providers are never fetched.
+    """
+    available: dict[str, str] = {}
+    for provider_name in _BYOK_PROVIDER_NAMES:
+        if _is_credential_eligible(session_factory, sojourner_id, provider_name):
+            key = credential_store.get(sojourner_id, provider_name)
+            if key:
+                available[provider_name] = key
+    return available
+
+
+def _compute_byok_runnable(
+    credential_store: CredentialStore,
+    session_factory: object,
+    sojourner_id: UUID,
+) -> bool:
+    """The single BYOK runnability predicate shared by resolver and readiness provider.
+
+    Runnable iff at least one provider has eligible metadata plus a retrievable
+    key, and — whenever OpenRouter is among the available providers, since
+    ``_resolve_byok`` always needs its model id (as sole provider or as
+    fallback) — a usable, non-dynamic-alias route-config model id exists for
+    it. ``_is_dynamic_alias`` is imported from ``adapters/_openrouter.py``
+    rather than re-implemented: that is the same check
+    ``OpenRouterAdapter.__init__`` enforces, so a Sojourner whose
+    ``preferred_model_identifier`` is a dynamic alias (rejected at adapter
+    construction) is correctly reported as not runnable.
+
+    Does not evaluate 14b ``OpenRouterCapabilityRegistry`` admission (whitelist/
+    capability). That registry is not wired into any production
+    ``ProviderResolver`` construction as of this seam; if/when it is, capability
+    rejection remains a resolve-time concern documented as a residual gap in
+    ADR-014a Decision 13, not one this predicate covers.
+    """
+    available = _collect_available_byok_keys(
+        credential_store, session_factory, sojourner_id
+    )
+    if not available:
+        return False
+    if "openrouter" not in available:
+        return True
+    model = _fetch_openrouter_preferred_model(session_factory, sojourner_id)
+    if model is None:
+        return False
+    from afterworlds.pipeline.provider.adapters._openrouter import _is_dynamic_alias
+
+    return not _is_dynamic_alias(model)
+
+
+class ByokCredentialReadinessProvider:
+    """Public, read-only BYOK runnability check owned by the provider-routing package.
+
+    Exposes exactly the predicate ``ProviderResolver._resolve_byok`` enforces
+    for credential eligibility, key retrievability, and (for OpenRouter)
+    route-config presence/validity — without raw key material, provider
+    secrets, or route internals. Issue 19 DoR-E uses this to compute a
+    runnable BYOK path instead of inspecting ``_resolver.py`` privates or
+    duplicating ``ProviderResolver`` policy.
+
+    Residual gap (see ADR-014a Decision 13): this does not evaluate a 14b
+    ``OpenRouterCapabilityRegistry``, which is not wired into production
+    ``ProviderResolver`` construction today. If that changes, a registry-admitted
+    model could still be reported runnable here yet be rejected at resolve time.
+    """
+
+    def __init__(
+        self, credential_store: CredentialStore, session_factory: object
+    ) -> None:
+        self._credential_store = credential_store
+        self._session_factory = session_factory
+
+    def is_byok_runnable(self, sojourner_id: UUID) -> bool:
+        """Return True iff BYOK has usable credentials and route config for
+        this Sojourner.
+
+        Never raises on missing/ineligible credentials or config — returns
+        False instead.
+        """
+        if self._session_factory is None:
+            return False
+        return _compute_byok_runnable(
+            self._credential_store, self._session_factory, sojourner_id
+        )
+
+
+__all__ = ["ByokCredentialReadinessProvider"]

--- a/src/afterworlds/pipeline/provider/_resolver.py
+++ b/src/afterworlds/pipeline/provider/_resolver.py
@@ -35,6 +35,10 @@ from uuid import UUID
 
 from afterworlds.entitlement.enums import RuntimeAccessPath
 from afterworlds.pipeline.provider._errors import ProviderConfigError
+from afterworlds.pipeline.provider._readiness import (
+    _collect_available_byok_keys,
+    _fetch_openrouter_preferred_model,
+)
 from afterworlds.pipeline.provider._registry import (
     OpenRouterCapabilityRegistry,
     make_anthropic_capability_profile,
@@ -208,42 +212,6 @@ def _build_refusal_log_fn(session_factory: object) -> RefusalLogProxy:
     return RefusalLogProxy(session_factory)
 
 
-def _is_credential_eligible(
-    session_factory: object, sojourner_id: UUID, provider_name: str
-) -> bool:
-    """Return True iff the credential row exists, is active, and is not INVALID/ERROR.
-
-    VALID and UNTESTED are eligible (permissive default for unchecked keys).
-    INVALID and ERROR are excluded to prevent routing to known-bad credentials.
-    Absent row or is_active=False both return False.
-    """
-    from sqlalchemy import select
-    from sqlalchemy.orm import Session
-
-    from afterworlds.pipeline.provider.credentials._metadata import (
-        ProviderCredentialMetadata,
-        ValidationStatus,
-    )
-
-    _factory = session_factory
-    assert callable(_factory)
-    session_obj = _factory()
-    assert isinstance(session_obj, Session)
-    with session_obj as session:
-        stmt = select(ProviderCredentialMetadata).where(
-            ProviderCredentialMetadata.sojourner_id == str(sojourner_id),
-            ProviderCredentialMetadata.provider_name == provider_name,
-            ProviderCredentialMetadata.is_active.is_(True),
-        )
-        row = session.execute(stmt).scalar_one_or_none()
-    if row is None:
-        return False
-    return row.validation_status not in (
-        ValidationStatus.INVALID,
-        ValidationStatus.ERROR,
-    )
-
-
 # ---------------------------------------------------------------------------
 # ProviderResolver
 # ---------------------------------------------------------------------------
@@ -372,8 +340,6 @@ class ProviderResolver:
     # -----------------------------------------------------------------------
 
     def _resolve_byok(self, sojourner_id: UUID) -> TurnProviderBinding:
-        from afterworlds.pipeline.provider._route_config import ProviderRouteConfigORM
-
         if self._session_factory is None:
             raise ProviderConfigError(
                 "ProviderResolver: session_factory is required for refusal logging"
@@ -382,12 +348,11 @@ class ProviderResolver:
 
         # Build available pool: requires both active credential metadata row
         # AND retrievable key.  Keys for inactive providers are not fetched.
-        available_keys: dict[str, str] = {}
-        for _pname in ("anthropic", "openrouter"):
-            if _is_credential_eligible(self._session_factory, sojourner_id, _pname):
-                _key = self._credential_store.get(sojourner_id, _pname)
-                if _key:
-                    available_keys[_pname] = _key
+        # Shared with `ByokCredentialReadinessProvider.is_byok_runnable` — see
+        # `_readiness.py`; do not reimplement this gathering logic here.
+        available_keys = _collect_available_byok_keys(
+            self._credential_store, self._session_factory, sojourner_id
+        )
 
         anthropic_key: str | None = available_keys.get("anthropic")
         openrouter_key: str | None = available_keys.get("openrouter")
@@ -423,32 +388,12 @@ class ProviderResolver:
             return adapter, route
 
         def _get_openrouter_model(sojourner_id: UUID) -> str:
-            if self._session_factory is None:
-                raise ProviderConfigError(
-                    "BYOK OpenRouter: session_factory required to read"
-                    " ProviderRouteConfig"
-                )
-            from sqlalchemy import select
-            from sqlalchemy.orm import Session
-
-            _factory = self._session_factory
-            assert callable(_factory)
-            session_obj = _factory()
-            assert isinstance(session_obj, Session)
-            with session_obj as session:
-                stmt = select(ProviderRouteConfigORM).where(
-                    ProviderRouteConfigORM.sojourner_id == str(sojourner_id),
-                    ProviderRouteConfigORM.provider_name == "openrouter",
-                    ProviderRouteConfigORM.is_active.is_(True),
-                )
-                row = session.execute(stmt).scalar_one_or_none()
-            if row is None:
-                raise ProviderConfigError(
-                    f"BYOK OpenRouter: no preferred_model_identifier configured "
-                    f"for Sojourner {sojourner_id} — fail closed"
-                )
-            model = (row.preferred_model_identifier or "").strip()
-            if not model:
+            # Shared with `ByokCredentialReadinessProvider.is_byok_runnable` —
+            # see `_readiness.py`; do not reimplement this lookup here.
+            model = _fetch_openrouter_preferred_model(
+                self._session_factory, sojourner_id
+            )
+            if model is None:
                 raise ProviderConfigError(
                     f"BYOK OpenRouter: no preferred_model_identifier configured "
                     f"for Sojourner {sojourner_id} — fail closed"

--- a/tests/pipeline/provider/test_byok_readiness.py
+++ b/tests/pipeline/provider/test_byok_readiness.py
@@ -1,0 +1,280 @@
+"""Tests for `ByokCredentialReadinessProvider` — CRD Issue 14a follow-up (#122).
+
+Formalizes the BYOK readiness seam ahead of Issue 19 DoR-E: `is_byok_runnable`
+must agree with `ProviderResolver._resolve_byok` (success vs. `ProviderConfigError`)
+for every case below, since both read through the same shared predicate in
+`_readiness.py`.
+
+Covers:
+  - no credential metadata → not runnable
+  - inactive/invalid/error credential metadata → not runnable
+  - eligible metadata but unretrievable/empty key material → not runnable
+  - eligible metadata + retrievable key + required route config → runnable
+  - missing required OpenRouter route config → not runnable
+  - agreement between `_resolve_byok` and `is_byok_runnable` for all of the above
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+from afterworlds.entitlement.enums import RuntimeAccessPath
+from afterworlds.persistence.database import create_session_factory
+from afterworlds.pipeline.provider._errors import ProviderConfigError
+from afterworlds.pipeline.provider._readiness import ByokCredentialReadinessProvider
+from afterworlds.pipeline.provider._resolver import ProviderResolver
+from afterworlds.pipeline.provider._route_config import ProviderRouteConfigORM
+from afterworlds.pipeline.provider.credentials._metadata import (
+    ProviderCredentialMetadata,
+    ValidationStatus,
+)
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _add_metadata(
+    sf: object,
+    sid: UUID,
+    provider: str,
+    *,
+    is_active: bool = True,
+    validation_status: str = ValidationStatus.UNTESTED,
+) -> None:
+    assert callable(sf)
+    sess = sf()
+    sess.add(
+        ProviderCredentialMetadata(
+            sojourner_id=str(sid),
+            provider_name=provider,
+            is_active=is_active,
+            validation_status=validation_status,
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    sess.commit()
+    sess.close()
+
+
+def _add_route_config(
+    sf: object, sid: UUID, *, preferred_model_identifier: str | None
+) -> None:
+    assert callable(sf)
+    sess = sf()
+    sess.add(
+        ProviderRouteConfigORM(
+            sojourner_id=str(sid),
+            provider_name="openrouter",
+            preferred_model_identifier=preferred_model_identifier,
+            is_active=True,
+        )
+    )
+    sess.commit()
+    sess.close()
+
+
+def _store(keys: dict[str, str | None]) -> MagicMock:
+    store = MagicMock()
+    store.get.side_effect = lambda _sid, provider: keys.get(provider)
+    return store
+
+
+def _agreement(store: MagicMock, sf: object, sid: UUID) -> tuple[bool, bool]:
+    """Return (is_byok_runnable(...), resolve_for_turn succeeded)."""
+    readiness = ByokCredentialReadinessProvider(
+        credential_store=store, session_factory=sf
+    )
+    runnable = readiness.is_byok_runnable(sid)
+    resolver = ProviderResolver(
+        credential_store=store, hosted_config=None, session_factory=sf
+    )
+    try:
+        resolver.resolve_for_turn(RuntimeAccessPath.BYOK, sid)
+        resolvable = True
+    except ProviderConfigError:
+        resolvable = False
+    return runnable, resolvable
+
+
+# ---------------------------------------------------------------------------
+# No credential metadata at all
+# ---------------------------------------------------------------------------
+
+
+def test_no_metadata_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    store = _store({"anthropic": "sk-ant-test", "openrouter": "sk-or-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+# ---------------------------------------------------------------------------
+# Inactive / invalid / error metadata
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_metadata_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic", is_active=False)
+    store = _store({"anthropic": "sk-ant-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+def test_invalid_status_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic", validation_status=ValidationStatus.INVALID)
+    store = _store({"anthropic": "sk-ant-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+def test_error_status_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic", validation_status=ValidationStatus.ERROR)
+    store = _store({"anthropic": "sk-ant-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+# ---------------------------------------------------------------------------
+# Eligible metadata but unretrievable / empty key material
+# ---------------------------------------------------------------------------
+
+
+def test_eligible_metadata_unretrievable_key_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    """Metadata is eligible (active, UNTESTED) but the keychain has no key."""
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic")
+    store = _store({"anthropic": None})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+def test_eligible_metadata_empty_key_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    """Metadata is eligible but the retrieved key is an empty string."""
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic")
+    store = _store({"anthropic": ""})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+# ---------------------------------------------------------------------------
+# Eligible metadata + retrievable key (+ route config where required) → runnable
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_only_eligible_and_retrievable_is_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    """Anthropic needs no route config — eligible metadata + key is enough."""
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic")
+    store = _store({"anthropic": "sk-ant-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is True
+    assert resolvable is True
+
+
+def test_openrouter_eligible_key_and_route_config_is_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "openrouter")
+    _add_route_config(sf, sid, preferred_model_identifier="anthropic/claude-haiku-4-5")
+    store = _store({"openrouter": "sk-or-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is True
+    assert resolvable is True
+
+
+# ---------------------------------------------------------------------------
+# Missing required BYOK route config (OpenRouter only, no/blank model id)
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_missing_route_config_row_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "openrouter")
+    store = _store({"openrouter": "sk-or-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+def test_openrouter_blank_route_config_model_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "openrouter")
+    _add_route_config(sf, sid, preferred_model_identifier="   ")
+    store = _store({"openrouter": "sk-or-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+def test_openrouter_dynamic_alias_route_config_not_runnable(engine) -> None:  # type: ignore[no-untyped-def]
+    """`preferred_model_identifier` set to a dynamic alias (e.g. "openrouter/auto")
+    is rejected at `OpenRouterAdapter` construction — the readiness predicate
+    must agree, not just check that a model id is present.
+    """
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "openrouter")
+    _add_route_config(sf, sid, preferred_model_identifier="openrouter/auto")
+    store = _store({"openrouter": "sk-or-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+def test_both_providers_but_openrouter_route_config_missing_not_runnable(
+    engine,  # type: ignore[no-untyped-def]
+) -> None:
+    """Anthropic alone would be runnable, but `_resolve_byok` always needs the
+    OpenRouter model id once OpenRouter is in the available pool (primary +
+    fallback) — the readiness predicate mirrors that exactly, not a "best
+    available provider" relaxation.
+    """
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic")
+    _add_metadata(sf, sid, "openrouter")
+    store = _store({"anthropic": "sk-ant-test", "openrouter": "sk-or-test"})
+    runnable, resolvable = _agreement(store, sf, sid)
+    assert runnable is False
+    assert resolvable is False
+
+
+# ---------------------------------------------------------------------------
+# Readiness method exposes no key material
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_result_is_a_plain_bool_not_leaking_key_material(
+    engine,  # type: ignore[no-untyped-def]
+) -> None:
+    sf = create_session_factory(engine)
+    sid = uuid4()
+    _add_metadata(sf, sid, "anthropic")
+    store = _store({"anthropic": "sk-ant-super-secret"})
+    readiness = ByokCredentialReadinessProvider(
+        credential_store=store, session_factory=sf
+    )
+    result = readiness.is_byok_runnable(sid)
+    assert result is True
+    assert "sk-ant" not in repr(result)


### PR DESCRIPTION
## What was built

Formalizes a public, read-only BYOK readiness seam owned by the provider-routing package (CRD Issue 14a), ahead of Issue 19 Rev3 DoR-E.

- Extracted the BYOK runnability predicate that `ProviderResolver._resolve_byok` enforces into shared helpers in a new `src/afterworlds/pipeline/provider/_readiness.py`: `_is_credential_eligible`, `_collect_available_byok_keys`, `_fetch_openrouter_preferred_model`, and `_compute_byok_runnable`.
- Exposed it via `ByokCredentialReadinessProvider.is_byok_runnable(sojourner_id: UUID) -> bool`, re-exported from `afterworlds.pipeline.provider`.
- `_resolve_byok` now calls the same shared helpers instead of inlining the logic — one implementation, not two.
- The predicate mirrors `_resolve_byok`'s exact gates: active/non-error credential metadata, a retrievable non-empty key, and (whenever OpenRouter is in the available pool) a usable, non-dynamic-alias `preferred_model_identifier`. The alias check reuses `adapters/_openrouter.py::_is_dynamic_alias` rather than duplicating it.
- Returns a plain `bool` — no key material, provider secrets, or route internals cross the boundary.

Closes the "no-seam" failure mode described in #122: previously Issue 19 could only learn BYOK was unusable by calling `resolve_for_turn` and catching `ProviderConfigError`, surfacing as an operational pipeline error instead of a typed `BYOK_CREDENTIALS_REQUIRED` preflight response.

## Acceptance criteria coverage

- [x] BYOK runnability predicate extracted into one shared implementation
- [x] Public read-only `ByokCredentialReadinessProvider.is_byok_runnable(sojourner_id) -> bool`
- [x] `_resolve_byok` and the public method use the same underlying helpers (no second copy)
- [x] No raw key material, provider secrets, or route internals exposed
- [x] Accounts for key retrievability, not just metadata presence
- [x] No changes to `_resolver.py` privates required by Issue 19 (this PR does not touch Issue 19)
- [x] No entitlement, provider-routing, or fallback-behavior changes

## Test coverage summary

`tests/pipeline/provider/test_byok_readiness.py` (13 new tests), all asserting agreement between `is_byok_runnable` and `resolve_for_turn`:
- no credential metadata → not runnable
- inactive / INVALID / ERROR credential metadata → not runnable
- eligible metadata but unretrievable (`None`) or empty-string key → not runnable
- eligible metadata + retrievable key, no route config needed (Anthropic) → runnable
- eligible metadata + retrievable key + valid route config (OpenRouter) → runnable
- missing / blank / dynamic-alias `preferred_model_identifier` → not runnable
- readiness result is a plain bool with no key material in `repr()`

Full suite: `pytest tests/pipeline/provider/ tests/entitlement/` — 360 passed. `black`, `ruff`, and `mypy --strict` clean on all touched files.

## Architecture Notes

This is a 14a seam formalization required by Issue 19 DoR-E, **not** a new access-path policy. No entitlement, provider-routing, or fallback behavior changed. Documented as ADR-014a Decision 13, including one honest residual gap: `is_byok_runnable` does not evaluate a 14b `OpenRouterCapabilityRegistry` (whitelist/capability admission), because no production `ProviderResolver` construction wires one in today. Folding that in was rejected as scope creep against this PR's constraint (no provider-routing-policy changes); flagged for Issue 19 to re-check if/when 14b registries are wired into production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)