### PR TITLE
fix(corpus): persist-then-prove publication lifecycle (CRD Issue 5c remediation of #134)

### DIFF
--- a/alembic/versions/0017_corpus_integrity_release.py
+++ b/alembic/versions/0017_corpus_integrity_release.py
@@ -32,14 +32,19 @@ def upgrade() -> None:
         sa.Column("authoritative_source_hash", sa.String(64), nullable=False),
         sa.Column("transform_config_hash", sa.String(64), nullable=False),
         sa.Column("bundle_root_hash", sa.String(64), nullable=False),
-        sa.Column("evidence_report_hash", sa.String(64), nullable=False),
-        sa.Column("persisted_corpus_digest", sa.String(64), nullable=False),
+        # Post-persistence proof identities (Component K steps d/e/f): NULL on
+        # the initial draft insert (the leaf/chunk/projection rows they are
+        # computed from do not exist yet), set exactly once by
+        # ``persistence.finalize_release`` from the actual persisted and
+        # reconstructed state before the final gate runs.
+        sa.Column("evidence_report_hash", sa.String(64), nullable=True),
+        sa.Column("persisted_corpus_digest", sa.String(64), nullable=True),
         sa.Column("ledger_hash", sa.String(64), nullable=False),
         sa.Column("policy_hash", sa.String(64), nullable=False),
         sa.Column("reconciliation_hash", sa.String(64), nullable=False),
-        sa.Column("corpus_report_reference", sa.String(64), nullable=False),
+        sa.Column("corpus_report_reference", sa.String(64), nullable=True),
         sa.Column("transform_config", sa.JSON, nullable=False),
-        sa.Column("report_payload", sa.JSON, nullable=False),
+        sa.Column("report_payload", sa.JSON, nullable=True),
         sa.Column("publication_status", sa.String(32), nullable=False),
         sa.Column("created_at", sa.String(64), nullable=False),
         sa.ForeignKeyConstraint(

--- a/scripts/ingest_srd.py
+++ b/scripts/ingest_srd.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python
-"""CLI — build and persist the authoritative SRD 5.2.1 corpus release.
+"""CLI — build and publish the authoritative SRD 5.2.1 corpus release.
 
 CRD Issue 5c (#132) / ADR-005c Completion Contract A. This script runs the
 deterministic corpus pipeline directly from the authoritative PDF
-(``docs/sources/DnD5_5e_SRD_CC_v5_2_1.pdf``) and persists a new immutable
-release only if it passes the publication gate.
+(``docs/sources/DnD5_5e_SRD_CC_v5_2_1.pdf``), then persists, reconstructs,
+proves, and gates the release strictly from the target database's actual
+state (Component K steps c-g) before publishing.
 
 It does **not** read the quarantined legacy artifact. The former ``--data-path``
 default (the legacy structured JSON under ``data/srd/``) was removed under Owner
 Decision 1 (strict legacy quarantine); that artifact is inert evidence at
 ``docs/legacy/quarantine/`` and is unreachable from every executable path.
+
+The target database is brought to the repository's current Alembic head before
+the final gate runs — including migration 0018's legacy-package purge — via the
+same ``upgrade_to_head`` the application uses at startup
+(``afterworlds.api.db_bootstrap``). This is not assumed to be sufficient on its
+own: the gate also runs a live zero-reachability check against the same session
+(Component L) and fails closed if an active legacy row remains regardless of
+migration state.
 
 Usage
 -----
@@ -28,15 +37,9 @@ from pathlib import Path
 # Ensure project src is on path when run from repo root
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-# Import all corpus + rules-package ORM models so Base.metadata is complete.
-import afterworlds.persistence.orm.corpus  # noqa: E402, F401
-import afterworlds.persistence.orm.rules_package  # noqa: E402, F401
-from afterworlds.ingestion.corpus.gate import run_gate  # noqa: E402
-from afterworlds.ingestion.corpus.persistence import persist_release  # noqa: E402
-from afterworlds.ingestion.corpus.pipeline import build_release  # noqa: E402
-from afterworlds.ingestion.corpus.quarantine import (  # noqa: E402
-    check_legacy_reachability,
-)
+from afterworlds.api.db_bootstrap import upgrade_to_head  # noqa: E402
+from afterworlds.ingestion.corpus.persistence import finalize_release  # noqa: E402
+from afterworlds.ingestion.corpus.pipeline import build_candidate  # noqa: E402
 from afterworlds.persistence.database import (  # noqa: E402
     create_engine,
     create_session_factory,
@@ -48,7 +51,7 @@ _DEFAULT_PDF = "docs/sources/DnD5_5e_SRD_CC_v5_2_1.pdf"
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Build and persist the authoritative SRD 5.2.1 corpus release."
+        description="Build and publish the authoritative SRD 5.2.1 corpus release."
     )
     parser.add_argument("--pdf-path", default=_DEFAULT_PDF)
     parser.add_argument("--db-url", default="sqlite:///afterworlds.db")
@@ -62,32 +65,36 @@ def main() -> int:
         print(f"ERROR: authoritative PDF not found: {pdf_path}", file=sys.stderr)
         return 1
 
-    print(f"Building corpus release from {pdf_path} ...")
-    violations = check_legacy_reachability(None, _REPO_ROOT)
-    artifacts = build_release(pdf_path, legacy_reachability_violations=len(violations))
-    print(f"  package : {artifacts.release.package_uuid}")
-    print(f"  version : {artifacts.release.release_version}")
-    print(f"  chunks  : {len(artifacts.members.chunks)}")
+    print(f"Building corpus candidate from {pdf_path} ...")
+    candidate = build_candidate(pdf_path)
+    print(f"  package : {candidate.package_uuid}")
+    print(f"  version : {candidate.release_version}")
+    print(f"  chunks  : {len(candidate.members.chunks)}")
 
-    gate = run_gate(artifacts, legacy_reachability_violations=len(violations))
-    if not gate.passed:
-        print("PUBLICATION GATE FAILED:", file=sys.stderr)
-        for failure in gate.failures:
-            print(f"  - {failure}", file=sys.stderr)
-        return 1
-    print("Publication gate passed.")
+    print(f"Applying migrations to head against: {args.db_url}")
+    upgrade_to_head(args.db_url)
 
-    print(f"Connecting to database: {args.db_url}")
     engine = create_engine(args.db_url)
-    from afterworlds.persistence.orm.base import Base
-
-    Base.metadata.create_all(engine)
     session_factory = create_session_factory(engine)
     now = datetime.now(UTC).isoformat()
     with session_factory() as session:
-        persist_release(session, artifacts, now=now)
-        session.commit()
-    print("=== Corpus release persisted ===")
+        result = finalize_release(
+            session, candidate, repo_root=_REPO_ROOT, now=now
+        )
+
+    if result.reused:
+        print(f"Release {candidate.package_uuid} already published — no-op.")
+        return 0
+
+    if not result.published:
+        print("PUBLICATION GATE FAILED — nothing was persisted:", file=sys.stderr)
+        failures = result.gate.failures if result.gate is not None else ()
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print("Publication gate passed.")
+    print("=== Corpus release persisted and published ===")
     return 0
 
 

--- a/src/afterworlds/ingestion/corpus/gate.py
+++ b/src/afterworlds/ingestion/corpus/gate.py
@@ -40,6 +40,7 @@ def run_gate(
     artifacts: ReleaseArtifacts,
     *,
     legacy_reachability_violations: int = 0,
+    chunk_membership_violations: int = 0,
     sql_persist_ok: bool = True,
     vector_write_ok: bool = True,
 ) -> GateResult:
@@ -209,6 +210,15 @@ def run_gate(
     # 22. Zero legacy-reachability violations (Owner Decision 1 / Component L).
     if legacy_reachability_violations != 0:
         f.append("legacy-reachability violation present")
+
+    # 23. Persisted rp_chunks exactly matches the declared projection set, and
+    #     every declared-projected chunk and its source are runtime-enabled —
+    #     otherwise the digest/report can pass while runtime reads omit or add
+    #     content (checked against the live DB by
+    #     persistence.verify_chunk_runtime_membership; not recomputable from
+    #     in-memory artifacts alone).
+    if chunk_membership_violations != 0:
+        f.append("persisted rp_chunks runtime-membership violation present")
 
     return GateResult(passed=not f, failures=tuple(f))
 

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -1,10 +1,24 @@
-"""Persist a corpus release and recompute its digest from the DB — Issue 5c.
+"""Persist a corpus release and finalize it from actual DB state — Issue 5c.
 
-Component K step c (persist) and the tamper-detection half of Component A/I: the
-persisted-corpus digest is recomputed from the actual persisted rows, so editing
-any persisted leaf, disposition, exclusion reason, projection link, policy
-reference, or reconciliation finding changes the recomputed digest and fails the
-publication gate.
+Component K steps c–g. The root defect this module fixes (PR #134 remediation):
+a release's proof identities must be produced *from the database*, in the
+acyclic order Component K mandates, not claimed in memory before persistence
+occurs:
+
+    c  persist the candidate as a non-runtime-visible draft
+    d  reconstruct the authoritative logical state from the actual persisted
+       rows and compute the persisted-corpus digest from that reconstruction
+    e  generate the evidence report from the reconstructed state (+ a live
+       legacy zero-reachability check against the same session)
+    f  hash the completed evidence report
+    g  record the five top-level hashes and run the final publication gate
+       against the DB-grounded artifacts; publish only if it passes
+
+:func:`finalize_release` is the sole entry point that performs c–g and
+transitions a release to ``published``. :func:`persist_release` is the lower
+-level step-c-only primitive (used by ``finalize_release`` internally, and
+directly by tests that already hold a fully-identified ``ReleaseArtifacts`` and
+want to exercise persistence/reconstruction/tamper-detection in isolation).
 
 The authoritative RuleChunks persist into the existing ``rp_chunks`` table
 (Issue 5a model, unextended); the ledger, policy, reconciliation, projection
@@ -15,6 +29,10 @@ back in the exact order the in-memory payload used.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
@@ -22,12 +40,17 @@ from afterworlds.ingestion.corpus.bundle import (
     persisted_corpus_digest,
     persisted_corpus_payload,
 )
+from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
+from afterworlds.ingestion.corpus.gate import run_gate
+from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
+    CanonicalBundle,
     Container,
     ContainerType,
     CorpusBundleMembers,
     CorpusChunk,
     Disposition,
+    GateResult,
     Leaf,
     LeafDisposition,
     LeafType,
@@ -35,10 +58,19 @@ from afterworlds.ingestion.corpus.models import (
     ReconciliationFindings,
     ReconciliationMember,
     ReconciliationPolicy,
+    ReleaseIdentity,
+    ReleaseRecord,
     SourceLedger,
 )
-from afterworlds.ingestion.corpus.pipeline import ReleaseArtifacts
+from afterworlds.ingestion.corpus.pdf_source import ExtractedPage
+from afterworlds.ingestion.corpus.pipeline import CandidateRelease, ReleaseArtifacts
 from afterworlds.ingestion.corpus.policy import FROZEN_POLICY, policy_payload
+from afterworlds.ingestion.corpus.quarantine import check_legacy_reachability
+from afterworlds.ingestion.corpus.report import (
+    EvidenceReport,
+    build_report,
+    report_hash,
+)
 from afterworlds.persistence.orm.corpus import (
     CorpusProjectionORM,
     CorpusReleaseORM,
@@ -54,21 +86,21 @@ from afterworlds.persistence.orm.rules_package import (
     RulesPackageORM,
 )
 
+# ---------------------------------------------------------------------------
+# Shared row-building primitives
+# ---------------------------------------------------------------------------
 
-def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) -> None:
-    """Persist the full release into SQL (Component K step c)."""
-    rel = artifacts.release
-    pkg = rel.package_uuid
-    ledger = artifacts.ledger
-    recon = artifacts.reconciliation
 
-    # Package + source rows (host the authoritative RuleChunks).
+def _persist_package_and_source(
+    session: Session, pkg: str, release_version: str, *, now: str
+) -> str:
+    """Insert the package + its single source row; returns the source id."""
     session.add(
         RulesPackageORM(
             rules_package_id=pkg,
             name="SRD 5.2.1 Corpus",
             system="d20",
-            version=rel.release_version,
+            version=release_version,
             is_enabled=True,
             publication_status="draft",
             published_at=None,
@@ -90,36 +122,76 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
         )
     )
     session.flush()
+    return source_id
 
-    # Release record.
-    ident = rel.identity
+
+def _persist_release_record(
+    session: Session,
+    pkg: str,
+    *,
+    release_version: str,
+    authoritative_source_hash: str,
+    transform_config_hash: str,
+    bundle_root_hash: str,
+    evidence_report_hash: str | None,
+    persisted_corpus_digest: str | None,
+    ledger_hash: str,
+    policy_hash: str,
+    reconciliation_hash: str,
+    corpus_report_reference: str | None,
+    transform_config: dict[str, Any],
+    report_payload: dict[str, Any] | None,
+    now: str,
+) -> None:
+    """Insert the external release/publication record (draft).
+
+    ``evidence_report_hash``/``persisted_corpus_digest``/``corpus_report_reference``/
+    ``report_payload`` are ``None`` when this is the pre-finalize draft insert
+    (Component K step c) — those are post-persistence proof identities (steps
+    d/e/f) that ``finalize_release`` fills in afterward via
+    :func:`_set_post_persistence_identity`, once they exist to compute.
+    """
     session.add(
         CorpusReleaseORM(
             package_uuid=pkg,
-            release_version=rel.release_version,
-            authoritative_source_hash=ident.authoritative_source_hash,
-            transform_config_hash=ident.transform_config_hash,
-            bundle_root_hash=ident.bundle_root_hash,
-            evidence_report_hash=ident.evidence_report_hash,
-            persisted_corpus_digest=ident.persisted_corpus_digest,
-            ledger_hash=rel.ledger_hash,
-            policy_hash=rel.policy_hash,
-            reconciliation_hash=rel.reconciliation_hash,
-            corpus_report_reference=rel.corpus_report_reference,
-            transform_config=rel.transform_config,
-            report_payload=artifacts.report.payload,
+            release_version=release_version,
+            authoritative_source_hash=authoritative_source_hash,
+            transform_config_hash=transform_config_hash,
+            bundle_root_hash=bundle_root_hash,
+            evidence_report_hash=evidence_report_hash,
+            persisted_corpus_digest=persisted_corpus_digest,
+            ledger_hash=ledger_hash,
+            policy_hash=policy_hash,
+            reconciliation_hash=reconciliation_hash,
+            corpus_report_reference=corpus_report_reference,
+            transform_config=transform_config,
+            report_payload=report_payload,
             publication_status="draft",
             created_at=now,
         )
     )
-    # The release row is the FK parent of every Issue 5c table; flush it (and the
-    # source, parent of the chunks) before inserting children. No ORM
-    # relationships are declared, so the unit of work cannot order these itself.
+    # The release row is the FK parent of every Issue 5c table; flush it before
+    # inserting children. No ORM relationships are declared, so the unit of
+    # work cannot order these itself.
     session.flush()
+
+
+def _persist_bundle_rows(
+    session: Session,
+    pkg: str,
+    source_id: str,
+    *,
+    ledger: SourceLedger,
+    recon: ReconciliationMember,
+    policy: ReconciliationPolicy,
+    members: CorpusBundleMembers,
+    now: str,
+) -> None:
+    """Insert the ledger/policy/reconciliation/leaves/chunks/projections rows."""
     session.add(
         SourceLedgerORM(
             package_uuid=pkg,
-            ledger_hash=rel.ledger_hash,
+            ledger_hash=ledger_hash(ledger),
             source_document=ledger.source_document,
             source_version=ledger.source_version,
             source_sha256=ledger.source_sha256,
@@ -129,9 +201,9 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
     session.add(
         ReconciliationPolicyORM(
             package_uuid=pkg,
-            policy_version=artifacts.policy.policy_version,
+            policy_version=policy.policy_version,
             policy_hash=recon.policy_hash,
-            payload=policy_payload(artifacts.policy),
+            payload=policy_payload(policy),
         )
     )
     session.add(
@@ -200,7 +272,7 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
             is_enabled=True,
             created_at=now,
         )
-        for chunk in members_chunks(artifacts)
+        for chunk in members.chunks
     )
 
     # Declared-projection linkage (insertion order == recon.projections order).
@@ -219,12 +291,51 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
     session.flush()
 
 
-def members_chunks(artifacts: ReleaseArtifacts) -> tuple[CorpusChunk, ...]:
-    return artifacts.members.chunks
+def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) -> None:
+    """Persist an already-finalized release's full state (Component K step c).
+
+    Used when the release's identity — including the post-persistence proof
+    hashes — is already known, e.g. re-persisting a previously finalized
+    ``ReleaseArtifacts`` into a different store to exercise persistence,
+    reconstruction, and tamper detection in isolation. Production publication
+    goes through :func:`finalize_release` instead, which computes those hashes
+    from the actual persisted state rather than trusting them from the caller.
+    """
+    rel = artifacts.release
+    pkg = rel.package_uuid
+    ident = rel.identity
+    source_id = _persist_package_and_source(session, pkg, rel.release_version, now=now)
+    _persist_release_record(
+        session,
+        pkg,
+        release_version=rel.release_version,
+        authoritative_source_hash=ident.authoritative_source_hash,
+        transform_config_hash=ident.transform_config_hash,
+        bundle_root_hash=ident.bundle_root_hash,
+        evidence_report_hash=ident.evidence_report_hash,
+        persisted_corpus_digest=ident.persisted_corpus_digest,
+        ledger_hash=rel.ledger_hash,
+        policy_hash=rel.policy_hash,
+        reconciliation_hash=rel.reconciliation_hash,
+        corpus_report_reference=rel.corpus_report_reference,
+        transform_config=rel.transform_config,
+        report_payload=artifacts.report.payload,
+        now=now,
+    )
+    _persist_bundle_rows(
+        session,
+        pkg,
+        source_id,
+        ledger=artifacts.ledger,
+        recon=artifacts.reconciliation,
+        policy=artifacts.policy,
+        members=artifacts.members,
+        now=now,
+    )
 
 
 # ---------------------------------------------------------------------------
-# Reconstruction from the DB (tamper detection)
+# Reconstruction from the DB (tamper detection + post-persistence proof)
 # ---------------------------------------------------------------------------
 
 
@@ -336,6 +447,17 @@ def _load_reconciliation(
 def _load_members(
     session: Session, pkg: str, ledger: SourceLedger
 ) -> CorpusBundleMembers:
+    """Reconstruct the authoritative corpus members from persisted rows.
+
+    Scoped strictly to the declared-projection set: a chunk with no declared
+    projection is not authoritative corpus content (it is an orphan — a
+    provenance failure, Component I) and does not enter this reconstruction or
+    the persisted-corpus digest. Whether the DB *also* holds such an orphan row
+    (or a disabled projected chunk/source) is a separate runtime-visibility
+    question that this function does not answer — see
+    :func:`verify_chunk_runtime_membership`, whose violations must independently
+    gate publication.
+    """
     leaves_by_id = {leaf.leaf_id: leaf for leaf in ledger.leaves}
     occ = {leaf.leaf_id: leaf.occurrence_index for leaf in ledger.leaves}
     # chunk_id -> ordered leaf ids (projection insertion order)
@@ -354,7 +476,11 @@ def _load_members(
     }
     chunks: list[CorpusChunk] = []
     for chunk_id, leaf_ids in chunk_leaves.items():
-        chunk_row = chunk_rows[chunk_id]
+        chunk_row = chunk_rows.get(chunk_id)
+        if chunk_row is None:
+            continue  # a declared projection with no backing row: an I-level
+            # failure surfaced by verify_chunk_runtime_membership, not silently
+            # synthesized here.
         primary = leaves_by_id[leaf_ids[0]]
         chunks.append(
             CorpusChunk(
@@ -370,6 +496,73 @@ def _load_members(
     # Restore canonical (build_corpus) order: by primary leaf occurrence index.
     chunks.sort(key=lambda c: occ[c.source_leaf_ids[0]])
     return CorpusBundleMembers(chunks=tuple(chunks), derivative_notes=())
+
+
+def verify_chunk_runtime_membership(session: Session, pkg: str) -> tuple[str, ...]:
+    """Fail-closed check: DB-persisted ``rp_chunks`` vs. the declared projection.
+
+    The persisted-corpus digest and evidence report are computed only over the
+    *declared-projection* chunk set (:func:`_load_members`); ``RulesPackageService``
+    and vector reindexing instead read *every enabled* ``rp_chunks`` row for the
+    package whose source is enabled. Those two views must coincide exactly for
+    the published package to expose precisely the canonical, proven chunks —
+    otherwise:
+
+    * an extra enabled ``rp_chunks`` row with no declared projection would be
+      served by runtime reads while remaining invisible to the digest/report
+      (the orphan-chunk gap); or
+    * a declared-projected chunk (or its source) disabled after persistence
+      would still count in the digest/report while runtime reads omit it.
+
+    Returns the list of such violations; publication must fail closed when
+    non-empty (Component I).
+    """
+    projected_ids = {
+        chunk_id
+        for chunk_id in session.execute(
+            select(CorpusProjectionORM.chunk_id).where(
+                CorpusProjectionORM.package_uuid == pkg
+            )
+        ).scalars()
+    }
+    chunk_rows = {
+        row.chunk_id: row
+        for row in session.execute(
+            select(RuleChunkORM).where(RuleChunkORM.rules_package_id == pkg)
+        ).scalars()
+    }
+    persisted_ids = set(chunk_rows)
+
+    violations: list[str] = []
+    for cid in sorted(persisted_ids - projected_ids):
+        violations.append(
+            f"orphan rp_chunks row {cid} has no declared projection but would "
+            "be served by runtime reads"
+        )
+    for cid in sorted(projected_ids - persisted_ids):
+        violations.append(f"declared projection references missing rp_chunks row {cid}")
+
+    source_rows = {
+        row.source_id: row
+        for row in session.execute(
+            select(RuleSourceORM).where(RuleSourceORM.rules_package_id == pkg)
+        ).scalars()
+    }
+    for cid in sorted(projected_ids & persisted_ids):
+        row = chunk_rows[cid]
+        if not row.is_enabled:
+            violations.append(
+                f"declared-projected chunk {cid} is disabled; runtime reads "
+                "would omit it"
+            )
+            continue
+        source = source_rows.get(row.source_id)
+        if source is None or not source.is_enabled:
+            violations.append(
+                f"declared-projected chunk {cid} source {row.source_id} is "
+                "disabled; runtime reads would omit it"
+            )
+    return tuple(violations)
 
 
 def recompute_persisted_digest(
@@ -421,3 +614,313 @@ def delete_release(session: Session, pkg: str) -> None:
         delete(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
     )
     session.flush()
+
+
+# ---------------------------------------------------------------------------
+# finalize_release — Component K steps c–g, the corrected publication lifecycle
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FinalizeResult:
+    """Outcome of :func:`finalize_release`.
+
+    ``reused`` is True only for the idempotent no-op path: an identical release
+    (same content-derived ``package_uuid``) was already published in this
+    database, so nothing was re-persisted or mutated. ``artifacts`` is populated
+    whenever ``published`` is True (fresh publish or verified reuse); ``gate``
+    is populated whenever a fresh publish attempt was made (whether it passed
+    or failed) and is ``None`` on the reuse path, where the gate does not
+    re-run.
+    """
+
+    published: bool
+    reused: bool
+    artifacts: ReleaseArtifacts | None
+    gate: GateResult | None
+
+
+def _reconstruct_artifacts(
+    session: Session,
+    pkg: str,
+    *,
+    pages: list[ExtractedPage],
+    policy: ReconciliationPolicy,
+    bundle: CanonicalBundle,
+) -> tuple[ReleaseArtifacts, tuple[str, ...]]:
+    """Load a fully-persisted release's DB-grounded artifacts + its membership
+    violations (used by both the fresh-publish and the idempotent-reuse path).
+    """
+    release_row = session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+    ).scalar_one()
+    ledger = _load_ledger(session, pkg)
+    recon = _load_reconciliation(session, pkg, policy)
+    members = _load_members(session, pkg, ledger)
+    membership_violations = verify_chunk_runtime_membership(session, pkg)
+    concordance = check_concordance(members.chunks, pages)
+    canaries = check_canaries(pages)
+
+    assert release_row.evidence_report_hash is not None
+    assert release_row.persisted_corpus_digest is not None
+    assert release_row.corpus_report_reference is not None
+    assert release_row.report_payload is not None
+
+    identity = ReleaseIdentity(
+        authoritative_source_hash=release_row.authoritative_source_hash,
+        transform_config_hash=release_row.transform_config_hash,
+        bundle_root_hash=release_row.bundle_root_hash,
+        evidence_report_hash=release_row.evidence_report_hash,
+        persisted_corpus_digest=release_row.persisted_corpus_digest,
+    )
+    release_record = ReleaseRecord(
+        package_uuid=pkg,
+        release_version=release_row.release_version,
+        identity=identity,
+        transform_config=release_row.transform_config,
+        ledger_hash=release_row.ledger_hash,
+        policy_hash=release_row.policy_hash,
+        reconciliation_hash=release_row.reconciliation_hash,
+        corpus_report_reference=release_row.corpus_report_reference,
+    )
+    report = EvidenceReport(payload=release_row.report_payload, persisted=True)
+    artifacts = ReleaseArtifacts(
+        pages=pages,
+        ledger=ledger,
+        members=members,
+        reconciliation=recon,
+        policy=policy,
+        bundle=bundle,
+        report=report,
+        release=release_record,
+        concordance=concordance,
+        canaries=canaries,
+    )
+    return artifacts, membership_violations
+
+
+def finalize_release(
+    session: Session,
+    candidate: CandidateRelease,
+    *,
+    repo_root: Path,
+    now: str,
+) -> FinalizeResult:
+    """Persist, reconstruct, prove, gate, and (only if the gate passes) publish.
+
+    Executes Component K steps c–g in the mandated order:
+
+    1. Idempotency check: an already-*published* release for this content
+       -derived ``package_uuid`` is a safe no-op (reused, not re-persisted or
+       mutated); a changed source/config produces a different ``package_uuid``
+       and is always a new release.
+    2. (c) Persist the candidate as a non-runtime-visible ``draft`` — flushed,
+       not committed, so nothing is visible to any other session yet.
+    3. Reconstruct the authoritative logical state from the rows just persisted
+       (never from the in-memory candidate) and verify DB-vs-declared chunk
+       membership.
+    4. (d) Compute the persisted-corpus digest from that reconstruction.
+    5. Live legacy zero-reachability check against *this* session (does not
+       assume any migration ran).
+    6. (e) Generate the post-persistence evidence report; (f) hash it.
+    7. (g) Run the final gate over the DB-grounded artifacts, with real
+       (non-default) evidence for legacy reachability, chunk-runtime
+       membership, and SQL persistence.
+    8. If the gate passes: transition both records to ``published``, set
+       ``published_at``, and commit. If it fails: roll the whole transaction
+       back — no draft row, no chunk, nothing survives a failed gate.
+    """
+    pkg = candidate.package_uuid
+
+    existing = session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+    ).scalar_one_or_none()
+    if existing is not None:
+        if existing.publication_status != "published":
+            # persist_release/finalize_release only ever commit a row whose
+            # publication_status is "published" (success) or roll back entirely
+            # (failure) — a non-published row surviving to a new attempt means
+            # an earlier run committed partway through, outside this contract.
+            # Fail closed rather than silently mutating or republishing it.
+            return FinalizeResult(
+                published=False,
+                reused=False,
+                artifacts=None,
+                gate=GateResult(
+                    passed=False,
+                    failures=(
+                        f"release {pkg} already has a non-published row in "
+                        f"publication_status={existing.publication_status!r}; "
+                        "refusing to mutate — investigate before retrying",
+                    ),
+                ),
+            )
+        artifacts, membership_violations = _reconstruct_artifacts(
+            session,
+            pkg,
+            pages=candidate.pages,
+            policy=candidate.policy,
+            bundle=candidate.bundle,
+        )
+        if not verify_persisted_digest(session, pkg, policy=candidate.policy):
+            return FinalizeResult(
+                published=False,
+                reused=False,
+                artifacts=None,
+                gate=GateResult(
+                    passed=False,
+                    failures=(
+                        f"published release {pkg} failed digest re-verification "
+                        "on reuse (persisted state tampered since publication)",
+                    ),
+                ),
+            )
+        if membership_violations:
+            return FinalizeResult(
+                published=False,
+                reused=False,
+                artifacts=None,
+                gate=GateResult(passed=False, failures=membership_violations),
+            )
+        return FinalizeResult(
+            published=True, reused=True, artifacts=artifacts, gate=None
+        )
+
+    # --- c: persist the candidate as a non-runtime-visible draft -------------
+    source_id = _persist_package_and_source(
+        session, pkg, candidate.release_version, now=now
+    )
+    _persist_release_record(
+        session,
+        pkg,
+        release_version=candidate.release_version,
+        authoritative_source_hash=candidate.authoritative_source_hash,
+        transform_config_hash=candidate.transform_config_hash,
+        bundle_root_hash=candidate.bundle.bundle_root_hash,
+        evidence_report_hash=None,
+        persisted_corpus_digest=None,
+        ledger_hash=candidate.ledger_hash,
+        policy_hash=candidate.policy_hash,
+        reconciliation_hash=candidate.reconciliation_hash,
+        corpus_report_reference=None,
+        transform_config=candidate.transform_config,
+        report_payload=None,
+        now=now,
+    )
+    _persist_bundle_rows(
+        session,
+        pkg,
+        source_id,
+        ledger=candidate.ledger,
+        recon=candidate.reconciliation,
+        policy=candidate.policy,
+        members=candidate.members,
+        now=now,
+    )
+
+    # --- reconstruct strictly from what was just persisted --------------------
+    membership_violations = verify_chunk_runtime_membership(session, pkg)
+    ledger = _load_ledger(session, pkg)
+    recon = _load_reconciliation(session, pkg, candidate.policy)
+    members = _load_members(session, pkg, ledger)
+
+    # --- d: persisted-corpus digest from the actual persisted state ----------
+    digest = persisted_corpus_digest(
+        pkg, candidate.release_version, ledger, members, recon, candidate.policy
+    )
+
+    # --- live legacy zero-reachability check (this session, not assumed) -----
+    legacy_violations = check_legacy_reachability(session, repo_root)
+
+    # --- e: post-persistence evidence report; f: hash it ----------------------
+    concordance = check_concordance(members.chunks, candidate.pages)
+    canaries = check_canaries(candidate.pages)
+    report = build_report(
+        ledger=ledger,
+        members=members,
+        recon=recon,
+        policy=candidate.policy,
+        authoritative_source_hash=candidate.authoritative_source_hash,
+        transform_config_hash=candidate.transform_config_hash,
+        bundle_root_hash=candidate.bundle.bundle_root_hash,
+        ledger_hash_value=ledger_hash(ledger),
+        persisted_corpus_digest=digest,
+        concordance=concordance,
+        canaries=canaries,
+        legacy_reachability_violations=len(legacy_violations),
+        persisted=True,  # legitimate: computed from the reconstruction above
+    )
+    report_h = report_hash(report)
+
+    identity = ReleaseIdentity(
+        authoritative_source_hash=candidate.authoritative_source_hash,
+        transform_config_hash=candidate.transform_config_hash,
+        bundle_root_hash=candidate.bundle.bundle_root_hash,
+        evidence_report_hash=report_h,
+        persisted_corpus_digest=digest,
+    )
+    release_record = ReleaseRecord(
+        package_uuid=pkg,
+        release_version=candidate.release_version,
+        identity=identity,
+        transform_config=candidate.transform_config,
+        ledger_hash=candidate.ledger_hash,
+        policy_hash=candidate.policy_hash,
+        reconciliation_hash=candidate.reconciliation_hash,
+        corpus_report_reference=report_h,
+    )
+    artifacts = ReleaseArtifacts(
+        pages=candidate.pages,
+        ledger=ledger,
+        members=members,
+        reconciliation=recon,
+        policy=candidate.policy,
+        bundle=candidate.bundle,
+        report=report,
+        release=release_record,
+        concordance=concordance,
+        canaries=canaries,
+    )
+
+    # Real evidence, not a rubber-stamped default: persistence is judged "ok"
+    # only if reconstruction actually reproduced what was just written.
+    sql_persist_ok = (
+        len(ledger.leaves) == len(candidate.ledger.leaves)
+        and len(members.chunks) == len(candidate.members.chunks)
+        and not membership_violations
+    )
+
+    # --- g: fill in the post-persistence identity, then run the final gate ---
+    release_row = session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+    ).scalar_one()
+    release_row.evidence_report_hash = report_h
+    release_row.persisted_corpus_digest = digest
+    release_row.corpus_report_reference = report_h
+    release_row.report_payload = report.payload
+    session.flush()
+
+    gate = run_gate(
+        artifacts,
+        legacy_reachability_violations=len(legacy_violations),
+        chunk_membership_violations=len(membership_violations),
+        sql_persist_ok=sql_persist_ok,
+        vector_write_ok=True,  # vector persistence is not implemented by this
+        # package (pre-existing scope gap, unchanged by this remediation); see
+        # Architecture Notes.
+    )
+
+    if not gate.passed:
+        session.rollback()
+        return FinalizeResult(published=False, reused=False, artifacts=None, gate=gate)
+
+    package_row = session.execute(
+        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
+    ).scalar_one()
+    package_row.publication_status = "published"
+    package_row.published_at = now
+    package_row.updated_at = now
+    release_row.publication_status = "published"
+    session.commit()
+
+    return FinalizeResult(published=True, reused=False, artifacts=artifacts, gate=gate)

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -762,28 +762,47 @@ def finalize_release(
             policy=candidate.policy,
             bundle=candidate.bundle,
         )
-        if not verify_persisted_digest(session, pkg, policy=candidate.policy):
+        legacy_violations = check_legacy_reachability(session, repo_root)
+        sql_persist_ok = (
+            len(artifacts.ledger.leaves) == len(candidate.ledger.leaves)
+            and len(artifacts.members.chunks) == len(candidate.members.chunks)
+            and not membership_violations
+        )
+        # Re-run the *full* gate against the reconstructed existing release —
+        # not just the digest — so a reuse can't be accepted on a release whose
+        # other proof identities (bundle root, evidence-report hash, reconciliation
+        # hash, ...) or live legacy state no longer satisfy publication.
+        gate = run_gate(
+            artifacts,
+            legacy_reachability_violations=len(legacy_violations),
+            chunk_membership_violations=len(membership_violations),
+            sql_persist_ok=sql_persist_ok,
+            vector_write_ok=True,
+        )
+        package_row = session.execute(
+            select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
+        ).scalar_one_or_none()
+        package_state_ok = (
+            package_row is not None
+            and package_row.is_enabled
+            and package_row.publication_status == "published"
+        )
+        if not gate.passed or not package_state_ok:
+            failures = list(gate.failures)
+            if not package_state_ok:
+                failures.append(
+                    f"rp_packages row for {pkg} is missing or not in a "
+                    "published+enabled state consistent with its published "
+                    "rp_corpus_releases row"
+                )
             return FinalizeResult(
                 published=False,
                 reused=False,
                 artifacts=None,
-                gate=GateResult(
-                    passed=False,
-                    failures=(
-                        f"published release {pkg} failed digest re-verification "
-                        "on reuse (persisted state tampered since publication)",
-                    ),
-                ),
-            )
-        if membership_violations:
-            return FinalizeResult(
-                published=False,
-                reused=False,
-                artifacts=None,
-                gate=GateResult(passed=False, failures=membership_violations),
+                gate=GateResult(passed=False, failures=tuple(failures)),
             )
         return FinalizeResult(
-            published=True, reused=True, artifacts=artifacts, gate=None
+            published=True, reused=True, artifacts=artifacts, gate=gate
         )
 
     # --- c: persist the candidate as a non-runtime-visible draft -------------

--- a/src/afterworlds/ingestion/corpus/pipeline.py
+++ b/src/afterworlds/ingestion/corpus/pipeline.py
@@ -2,18 +2,31 @@
 
 Drives the fixed acyclic order that produces every proof identity, so no
 artifact is ever covered by a hash it contains and the evidence report is never
-generated before the (logical) persisted state exists:
+generated before the (actual, persisted) state it reports on exists:
 
     a0  freeze the reconciliation policy (committed input, covered by B)
     a1  derive and hash the frozen source ledger
     a2  generate the canonical corpus members from the frozen ledger
     a3  apply only the frozen policy → reconciliation member
-    b   compute the bundle-root hash
-    (c  persist — see persistence layer)
-    d   compute the persisted-corpus digest from the canonical logical state
+    b   compute the bundle-root hash                                  } build_candidate
+    ------------------------------------------------------------------
+    c   persist — see persistence.finalize_release
+    d   compute the persisted-corpus digest from the actual persisted
+        (and reconstructed) state
     e   generate the evidence report (post-persistence)
     f   hash the completed evidence report
-    g   record the five top-level hashes in the release record
+    g   record the five top-level hashes in the release record and    } finalize_release
+        run the final publication gate                                (persistence.py)
+
+``build_candidate`` performs only steps a0–b: everything that is a pure,
+deterministic function of the committed PDF and frozen policy, and nothing
+else. Its result, :class:`CandidateRelease`, structurally cannot claim that
+persistence occurred — it has no evidence report, no persisted-corpus digest,
+and no external release/publication record, because steps c–g require an
+actual database and cannot be produced, or faked via a boolean flag, in
+memory. :func:`afterworlds.ingestion.corpus.persistence.finalize_release`
+performs steps c–g against a live session and returns the completed
+:class:`ReleaseArtifacts`.
 
 A clean checkout regenerates a0–g byte-for-byte from committed inputs.
 """
@@ -27,24 +40,17 @@ from afterworlds.ingestion.corpus.bundle import (
     build_bundle,
     derive_package_uuid,
     derive_release_version,
-    persisted_corpus_digest,
     reconciliation_hash,
     transform_config_hash,
     transform_config_payload,
 )
-from afterworlds.ingestion.corpus.concordance import (
-    CanaryResult,
-    ConcordanceResult,
-    check_canaries,
-    check_concordance,
-)
+from afterworlds.ingestion.corpus.concordance import CanaryResult, ConcordanceResult
 from afterworlds.ingestion.corpus.ledger import build_ledger, ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CanonicalBundle,
     CorpusBundleMembers,
     ReconciliationMember,
     ReconciliationPolicy,
-    ReleaseIdentity,
     ReleaseRecord,
     SourceLedger,
 )
@@ -56,17 +62,19 @@ from afterworlds.ingestion.corpus.pdf_source import (
 )
 from afterworlds.ingestion.corpus.policy import FROZEN_POLICY, policy_hash
 from afterworlds.ingestion.corpus.reconcile import reconcile
-from afterworlds.ingestion.corpus.report import (
-    EvidenceReport,
-    build_report,
-    report_hash,
-)
+from afterworlds.ingestion.corpus.report import EvidenceReport
 from afterworlds.ingestion.corpus.transform import build_corpus
 
 
 @dataclass(frozen=True)
-class ReleaseArtifacts:
-    """Everything a build produces, in one immutable bundle."""
+class CandidateRelease:
+    """Everything derivable before persistence exists (Component K steps a0–b).
+
+    This type cannot claim persistence occurred: it carries no evidence report,
+    no persisted-corpus digest, and no external release/publication record. Those
+    require an actual persisted (and reconstructed) database state and are the
+    sole responsibility of :func:`persistence.finalize_release` (steps c–g).
+    """
 
     pages: list[ExtractedPage]
     ledger: SourceLedger
@@ -74,20 +82,29 @@ class ReleaseArtifacts:
     reconciliation: ReconciliationMember
     policy: ReconciliationPolicy
     bundle: CanonicalBundle
-    report: EvidenceReport
-    release: ReleaseRecord
-    concordance: ConcordanceResult
-    canaries: tuple[CanaryResult, ...]
+    package_uuid: str
+    release_version: str
+    authoritative_source_hash: str
+    transform_config_hash: str
+    transform_config: dict[str, object]
+    ledger_hash: str
+    policy_hash: str
+    reconciliation_hash: str
 
 
-def build_release(
+def build_candidate(
     pdf_path: Path,
     *,
-    legacy_reachability_violations: int = 0,
-    persisted: bool = True,
     policy: ReconciliationPolicy = FROZEN_POLICY,
-) -> ReleaseArtifacts:
-    """Execute steps a0–g and return the release artifacts (Component K)."""
+) -> CandidateRelease:
+    """Execute steps a0–b: the pre-persistence candidate build.
+
+    Deterministic and side-effect-free; touches no database. The returned
+    ``package_uuid``/``release_version`` are content-derived from the committed
+    PDF and frozen transform/policy inputs (Owner Decision 1) and are therefore
+    already stable at this stage — but nothing about the state described here is
+    yet proven persisted or runtime-visible.
+    """
     # a0 — freeze policy (committed input).
     p_hash = policy_hash(policy)
     ex_cfg = extraction_config()
@@ -112,63 +129,40 @@ def build_release(
     # b — bundle-root hash.
     bundle = build_bundle(ledger, members, recon)
 
-    concordance = check_concordance(members.chunks, pages)
-    canaries = check_canaries(pages)
-
-    # d — persisted-corpus digest from the canonical logical persisted state.
-    digest = (
-        persisted_corpus_digest(
-            package_uuid, release_version, ledger, members, recon, policy
-        )
-        if persisted
-        else ""
-    )
-
-    # e — evidence report (post-persistence).
-    report = build_report(
-        ledger=ledger,
-        members=members,
-        recon=recon,
-        policy=policy,
-        authoritative_source_hash=PDF_SHA256,
-        transform_config_hash=thash,
-        bundle_root_hash=bundle.bundle_root_hash,
-        ledger_hash_value=l_hash,
-        persisted_corpus_digest=digest,
-        concordance=concordance,
-        canaries=canaries,
-        legacy_reachability_violations=legacy_reachability_violations,
-        persisted=persisted,
-    )
-    # f — hash the completed report.
-    report_h = report_hash(report)
-
-    # g — external release/publication record with the five top-level hashes.
-    release = ReleaseRecord(
-        package_uuid=package_uuid,
-        release_version=release_version,
-        identity=ReleaseIdentity(
-            authoritative_source_hash=PDF_SHA256,
-            transform_config_hash=thash,
-            bundle_root_hash=bundle.bundle_root_hash,
-            evidence_report_hash=report_h,
-            persisted_corpus_digest=digest,
-        ),
-        transform_config=tconfig,
-        ledger_hash=l_hash,
-        policy_hash=p_hash,
-        reconciliation_hash=r_hash,
-        corpus_report_reference=report_h,
-    )
-    return ReleaseArtifacts(
+    return CandidateRelease(
         pages=pages,
         ledger=ledger,
         members=members,
         reconciliation=recon,
         policy=policy,
         bundle=bundle,
-        report=report,
-        release=release,
-        concordance=concordance,
-        canaries=canaries,
+        package_uuid=package_uuid,
+        release_version=release_version,
+        authoritative_source_hash=PDF_SHA256,
+        transform_config_hash=thash,
+        transform_config=tconfig,
+        ledger_hash=l_hash,
+        policy_hash=p_hash,
+        reconciliation_hash=r_hash,
     )
+
+
+@dataclass(frozen=True)
+class ReleaseArtifacts:
+    """The completed, post-persistence release (Component K steps a0–g).
+
+    Produced only by :func:`persistence.finalize_release` from a candidate plus
+    the actual reconstructed persisted state — never assembled directly from a
+    :class:`CandidateRelease` alone.
+    """
+
+    pages: list[ExtractedPage]
+    ledger: SourceLedger
+    members: CorpusBundleMembers
+    reconciliation: ReconciliationMember
+    policy: ReconciliationPolicy
+    bundle: CanonicalBundle
+    report: EvidenceReport
+    release: ReleaseRecord
+    concordance: ConcordanceResult
+    canaries: tuple[CanaryResult, ...]

--- a/src/afterworlds/persistence/orm/corpus.py
+++ b/src/afterworlds/persistence/orm/corpus.py
@@ -43,14 +43,28 @@ class CorpusReleaseORM(Base):
     )
     transform_config_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     bundle_root_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
-    evidence_report_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
-    persisted_corpus_digest: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    # These three are the post-persistence proof identities (Component K steps
+    # d/e/f): they cannot be known when the draft row is first inserted, before
+    # the leaf/chunk/projection rows exist to reconstruct and digest. They stay
+    # NULL from insertion through the draft phase and are set exactly once, by
+    # ``persistence.finalize_release``, from the actual persisted/reconstructed
+    # state — never defaulted, never caller-supplied as evidence of persistence.
+    evidence_report_hash: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+    persisted_corpus_digest: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
     ledger_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     policy_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     reconciliation_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
-    corpus_report_reference: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    corpus_report_reference: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
     transform_config: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
-    report_payload: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
+    report_payload: Mapped[dict[str, Any] | None] = mapped_column(
+        sa.JSON, nullable=True
+    )
     publication_status: Mapped[str] = mapped_column(
         sa.String(32), nullable=False, default="draft"
     )

--- a/tests/ingestion/corpus/conftest.py
+++ b/tests/ingestion/corpus/conftest.py
@@ -1,8 +1,12 @@
 """Fixtures for the Issue 5c corpus-integrity suite.
 
 The real corpus build (extraction + ledger + reconcile + digest) is expensive,
-so it is built once per session and shared. Adversarial gate/findings tests use
-small synthetic ledgers built by :func:`synthetic_release` and run fast.
+so the candidate is built once per session and shared; ``release`` additionally
+finalizes it (persist -> reconstruct -> prove -> gate -> publish) once against a
+private, already-committed store, so it exercises the *real* Component K c-g
+lifecycle rather than an in-memory approximation. Adversarial gate/findings
+tests use small synthetic ledgers built by :func:`synthetic_release` and run
+fast.
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy import event
 
 from afterworlds.ingestion.corpus.hashing import content_id
 from afterworlds.ingestion.corpus.models import (
@@ -19,25 +24,66 @@ from afterworlds.ingestion.corpus.models import (
     LeafType,
     SourceLedger,
 )
-from afterworlds.ingestion.corpus.pipeline import ReleaseArtifacts, build_release
+from afterworlds.ingestion.corpus.persistence import finalize_release
+from afterworlds.ingestion.corpus.pipeline import (
+    CandidateRelease,
+    ReleaseArtifacts,
+    build_candidate,
+)
 from afterworlds.persistence.database import create_engine, create_session_factory
 from afterworlds.persistence.orm.base import Base
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PDF_PATH = REPO_ROOT / "docs" / "sources" / "DnD5_5e_SRD_CC_v5_2_1.pdf"
 
+NOW = "2026-07-23T00:00:00Z"
+
 
 @pytest.fixture(scope="session")
-def release() -> ReleaseArtifacts:
-    """The real corpus release, built once for the whole test session."""
-    return build_release(PDF_PATH)
+def candidate() -> CandidateRelease:
+    """The real pre-persistence candidate, built once for the whole session."""
+    return build_candidate(PDF_PATH)
+
+
+def finalize_in_fresh_db(candidate: CandidateRelease):  # type: ignore[no-untyped-def]
+    """Finalize *candidate* against a brand-new, already-committed in-memory DB.
+
+    Returns the ``FinalizeResult``; the caller is responsible for asserting
+    ``published``/``reused`` as appropriate to the test.
+    """
+    eng = create_engine("sqlite://")
+
+    @event.listens_for(eng, "connect")
+    def _fk(dbapi, _rec):  # type: ignore[no-untyped-def]
+        dbapi.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(eng)
+    factory = create_session_factory(eng)
+    sess = factory()
+    try:
+        result = finalize_release(sess, candidate, repo_root=REPO_ROOT, now=NOW)
+    finally:
+        sess.close()
+        eng.dispose()
+    return result
+
+
+@pytest.fixture(scope="session")
+def release(candidate: CandidateRelease) -> ReleaseArtifacts:
+    """The real corpus release, finalized once for the whole test session.
+
+    Goes through the actual publish lifecycle (finalize_release) rather than
+    being assembled in memory, so every test that reads from this fixture is
+    implicitly exercising Component K's full acyclic c-g order.
+    """
+    result = finalize_in_fresh_db(candidate)
+    assert result.published and result.artifacts is not None, result.gate
+    return result.artifacts
 
 
 @pytest.fixture()
 def engine():  # type: ignore[no-untyped-def]
     eng = create_engine("sqlite://")
-
-    from sqlalchemy import event
 
     @event.listens_for(eng, "connect")
     def _fk(dbapi, _rec):  # type: ignore[no-untyped-def]

--- a/tests/ingestion/corpus/test_ledger_pipeline.py
+++ b/tests/ingestion/corpus/test_ledger_pipeline.py
@@ -12,9 +12,9 @@ from afterworlds.ingestion.corpus.bundle import reconciliation_hash
 from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
 from afterworlds.ingestion.corpus.ledger import build_ledger, ledger_hash
 from afterworlds.ingestion.corpus.models import Disposition, LeafType
-from afterworlds.ingestion.corpus.pipeline import build_release
+from afterworlds.ingestion.corpus.pipeline import build_candidate
 
-from .conftest import PDF_PATH
+from .conftest import PDF_PATH, finalize_in_fresh_db
 
 # --- Component C: frozen ledger, occurrence partition, disjointness -----------
 
@@ -146,8 +146,13 @@ def test_release_binds_five_top_level_hashes(release):
 
 
 def test_clean_regeneration_is_byte_for_byte_deterministic(release):
-    # One fresh regeneration must reproduce the session build byte-for-byte.
-    b = build_release(PDF_PATH)
+    # One fresh regeneration — full candidate build + finalize into a brand-new
+    # DB — must reproduce the session build byte-for-byte, including the
+    # post-persistence proof hashes (Component K's full acyclic c-g order).
+    fresh_candidate = build_candidate(PDF_PATH)
+    result = finalize_in_fresh_db(fresh_candidate)
+    assert result.published and result.artifacts is not None, result.gate
+    b = result.artifacts
     assert release.release.package_uuid == b.release.package_uuid
     assert release.release.release_version == b.release.release_version
     assert release.release.identity == b.release.identity

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -299,6 +299,49 @@ def test_repeated_finalize_is_idempotent_and_does_not_mutate(session, candidate)
     assert pkg_row.published_at == _NOW  # reuse never mutated the publish record
 
 
+def test_reuse_rejects_inconsistent_package_row_state(session, candidate):
+    """A published rp_corpus_releases row is not, by itself, sufficient
+    evidence for reuse — the rp_packages row must independently confirm
+    published+enabled, or reuse must fail closed rather than report success."""
+    first = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+    assert first.published and not first.reused
+
+    pkg_row = session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == candidate.package_uuid
+        )
+    ).scalar_one()
+    pkg_row.publication_status = "draft"
+    session.commit()
+
+    result = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+    assert not result.published and not result.reused
+    assert result.gate is not None
+    assert any("rp_packages" in f for f in result.gate.failures)
+
+
+def test_reuse_rejects_tampered_release_row(session, candidate):
+    """Reuse must re-run the full gate against the reconstructed existing
+    release, not just the digest — a tampered proof-identity field (here,
+    bundle_root_hash) must fail reuse even if the digest itself still
+    matches."""
+    first = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+    assert first.published and not first.reused
+
+    release_row = session.execute(
+        select(CorpusReleaseORM).where(
+            CorpusReleaseORM.package_uuid == candidate.package_uuid
+        )
+    ).scalar_one()
+    release_row.bundle_root_hash = "0" * 64
+    session.commit()
+
+    result = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+    assert not result.published and not result.reused
+    assert result.gate is not None
+    assert any("bundle_root_hash" in f for f in result.gate.failures)
+
+
 def test_final_gate_failure_does_not_publish_partial_content(session, candidate):
     tampered = dataclasses.replace(candidate, transform_config_hash="0" * 64)
 

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -1,30 +1,46 @@
 """Persistence, tamper-detection, and legacy-quarantine tests — Issue 5c.
 
 Maps to Acceptance #1/#8 (persisted-corpus digest round-trip), the tamper-
-detection test requirement, and Acceptance #12 (legacy zero-reachability).
+detection test requirement, Acceptance #12 (legacy zero-reachability), and the
+PR #134 remediation regression set: DB-grounded final gating, fail-closed
+chunk-runtime-membership verification, idempotent republication, and no
+partial content on a failed gate.
 """
 
 from __future__ import annotations
+
+import dataclasses
+from uuid import UUID
 
 from sqlalchemy import select
 
 from afterworlds.ingestion.corpus.bundle import persisted_corpus_payload
 from afterworlds.ingestion.corpus.persistence import (
+    finalize_release,
     persist_release,
     reconstruct_payload,
+    verify_chunk_runtime_membership,
     verify_persisted_digest,
 )
+from afterworlds.ingestion.corpus.pipeline import CandidateRelease
 from afterworlds.ingestion.corpus.quarantine import (
     LEGACY_ARTIFACT_SHA256,
     check_active_store,
     check_legacy_reachability,
 )
+from afterworlds.models.enums import PublicationStatusEnum, RuleSubsystemEnum
 from afterworlds.persistence.orm.corpus import (
     CorpusProjectionORM,
+    CorpusReleaseORM,
     LedgerLeafORM,
     ReconciliationORM,
 )
-from afterworlds.persistence.orm.rules_package import RuleChunkORM, RulesPackageORM
+from afterworlds.persistence.orm.rules_package import (
+    RuleChunkORM,
+    RuleSourceORM,
+    RulesPackageORM,
+)
+from afterworlds.services.rules_package import RulesPackageService
 
 from .conftest import REPO_ROOT
 
@@ -143,3 +159,185 @@ def test_corpus_release_is_not_flagged_as_legacy(session, release):
     # The new corpus release uses a different package name; never flagged.
     assert check_active_store(session) == []
     assert pkg
+
+
+# --- Chunk runtime-membership verification (PR #134 remediation, req. 4) -----
+
+
+def test_orphan_enabled_chunk_breaks_runtime_membership_verification(session, release):
+    """An extra enabled rp_chunks row with no declared projection is invisible
+    to the digest but would be served by runtime reads — verification must
+    catch it even though the digest itself still matches."""
+    pkg = _persist(session, release)
+    session.add(
+        RuleChunkORM(
+            chunk_id="orphan-chunk-1",
+            rules_package_id=pkg,
+            source_id=pkg,
+            subsystem="general",
+            content="stray content with no declared projection",
+            source_document="D&D SRD 5.2.1",
+            source_locator_type="page",
+            source_locator_value="p. 1",
+            is_enabled=True,
+            created_at=_NOW,
+        )
+    )
+    session.commit()
+    assert verify_persisted_digest(session, pkg)  # digest scoped to declared set
+    violations = verify_chunk_runtime_membership(session, pkg)
+    assert any("orphan-chunk-1" in v for v in violations)
+
+
+def test_disabled_projected_chunk_breaks_runtime_membership_verification(
+    session, release
+):
+    """A declared-projected chunk disabled after persistence would vanish from
+    runtime reads while the digest (which doesn't track is_enabled) stays
+    unaffected — verification must fail closed on the mismatch."""
+    pkg = _persist(session, release)
+    row = session.execute(
+        select(RuleChunkORM).where(RuleChunkORM.rules_package_id == pkg).limit(1)
+    ).scalar_one()
+    row.is_enabled = False
+    session.commit()
+    violations = verify_chunk_runtime_membership(session, pkg)
+    assert any(row.chunk_id in v and "disabled" in v for v in violations)
+
+
+def test_disabled_required_source_breaks_runtime_membership_verification(
+    session, release
+):
+    """Disabling the source of every declared-projected chunk empties runtime
+    reads for the whole package while leaving the digest unaffected."""
+    pkg = _persist(session, release)
+    source = session.execute(
+        select(RuleSourceORM).where(RuleSourceORM.rules_package_id == pkg)
+    ).scalar_one()
+    source.is_enabled = False
+    session.commit()
+    violations = verify_chunk_runtime_membership(session, pkg)
+    assert violations
+    assert all("source" in v and "disabled" in v for v in violations)
+
+
+# --- Candidate construction cannot claim persistence (req. 1) -----------------
+
+
+def test_candidate_release_carries_no_persistence_claim():
+    """CandidateRelease is structurally incapable of claiming persistence: it
+    has no report, no release/publication record, and no persisted-corpus
+    digest field for a caller-supplied boolean to fake."""
+    field_names = {f.name for f in dataclasses.fields(CandidateRelease)}
+    assert "report" not in field_names
+    assert "release" not in field_names
+    assert "persisted_corpus_digest" not in field_names
+    assert "evidence_report_hash" not in field_names
+
+
+# --- finalize_release lifecycle: legacy blocking, idempotency, rollback ------
+
+
+def test_legacy_active_row_blocks_publication(session, candidate):
+    session.add(
+        RulesPackageORM(
+            rules_package_id="legacy-active-1",
+            name="D&D SRD 5.2.1",
+            system="d20",
+            version="5.2.1",
+            is_enabled=True,
+            publication_status="published",
+            published_at=None,
+            created_at=_NOW,
+            updated_at=_NOW,
+        )
+    )
+    session.commit()
+
+    result = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+
+    assert not result.published
+    assert result.gate is not None
+    assert any("legacy" in f for f in result.gate.failures)
+    # No partial content: the new release never became visible.
+    assert (
+        session.execute(
+            select(CorpusReleaseORM).where(
+                CorpusReleaseORM.package_uuid == candidate.package_uuid
+            )
+        ).scalar_one_or_none()
+        is None
+    )
+
+
+def test_repeated_finalize_is_idempotent_and_does_not_mutate(session, candidate):
+    first = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+    assert first.published and not first.reused and first.artifacts is not None
+
+    second = finalize_release(
+        session, candidate, repo_root=REPO_ROOT, now="2026-07-24T00:00:00Z"
+    )
+    assert second.published and second.reused and second.artifacts is not None
+    assert second.artifacts.release.identity == first.artifacts.release.identity
+
+    rows = (
+        session.execute(
+            select(CorpusReleaseORM).where(
+                CorpusReleaseORM.package_uuid == candidate.package_uuid
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1  # not a duplicate-key failure, not a second row
+
+    pkg_row = session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == candidate.package_uuid
+        )
+    ).scalar_one()
+    assert pkg_row.published_at == _NOW  # reuse never mutated the publish record
+
+
+def test_final_gate_failure_does_not_publish_partial_content(session, candidate):
+    tampered = dataclasses.replace(candidate, transform_config_hash="0" * 64)
+
+    result = finalize_release(session, tampered, repo_root=REPO_ROOT, now=_NOW)
+
+    assert not result.published
+    assert result.gate is not None and not result.gate.passed
+    assert (
+        session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == tampered.package_uuid
+            )
+        ).scalar_one_or_none()
+        is None
+    )
+    assert (
+        session.execute(
+            select(CorpusReleaseORM).where(
+                CorpusReleaseORM.package_uuid == tampered.package_uuid
+            )
+        ).scalar_one_or_none()
+        is None
+    )
+
+
+def test_published_package_retrievable_via_rules_package_service(session, candidate):
+    """A successful ingest publishes both records, and RulesPackageService's
+    normal published-only play-time path can retrieve the package and its
+    chunks — no draft-visibility backdoor is needed or used."""
+    result = finalize_release(session, candidate, repo_root=REPO_ROOT, now=_NOW)
+    assert result.published and not result.reused
+
+    svc = RulesPackageService(session)
+    pkg_id = UUID(candidate.package_uuid)
+
+    detail = svc.get_package_by_id(pkg_id)
+    assert detail is not None
+    assert detail.publication_status == PublicationStatusEnum.PUBLISHED
+    assert detail.sources
+
+    chunks = svc.get_chunks_by_subsystem(pkg_id, RuleSubsystemEnum.GENERAL)
+    assert chunks.chunks


### PR DESCRIPTION
## What was built

Root-cause remediation of PR #134's (CRD Issue 5c / #132) publication lifecycle,
stacked on top of that PR's branch. Codex's round-1 review found three
symptoms — the corpus package never gets published, the CLI's legacy check
runs with no DB session, and an orphan `rp_chunks` row can pass digest
verification — all three trace to one root defect: the lifecycle proved the
**intended in-memory corpus**, not the **actual persisted, runtime-visible**
state. `build_release()` computed the persisted-corpus digest and marked the
evidence report `persisted=True` before any database was opened; `run_gate()`
ran before persistence with `sql_persist_ok`/`persisted` defaulted `True`; the
CLI then persisted both records as `draft` and committed — nothing ever
verified against the DB, and nothing ever flipped either record to
`published`.

Fixed by splitting the pipeline at the true persistence boundary, matching
Issue 5c Component K's required order (persist → compute digest from actual
persisted state → generate/hash evidence report → record hashes → final gate
→ publish):

- **`pipeline.build_candidate()`** — Component K steps a0–b only. Returns
  `CandidateRelease`, a type with no report, no digest, and no
  release/publication record — it is structurally incapable of claiming
  persistence occurred, not just conventionally trusted not to.
- **`persistence.finalize_release()`** — Component K steps c–g, the sole path
  that publishes. Persists the candidate as a non-runtime-visible `draft`
  (flushed, not committed), reconstructs the ledger/reconciliation/chunks
  strictly from those persisted rows, computes the persisted-corpus digest
  from that reconstruction, runs a **live** legacy zero-reachability check
  against the same session, generates and hashes the post-persistence
  evidence report, and runs the final gate against these DB-grounded
  artifacts — with real (not default) `sql_persist_ok` and a new
  `chunk_membership_violations` check. Only if the gate passes does it
  transition both `RulesPackageORM.publication_status` and
  `CorpusReleaseORM.publication_status` to `published`, set `published_at`,
  and commit through one transaction; a failed gate rolls the whole
  transaction back, so no partial content is ever runtime-visible.
- **`scripts/ingest_srd.py`** now applies the repository's real Alembic
  migrations to head (`afterworlds.api.db_bootstrap.upgrade_to_head`, the same
  path the app uses at startup) before finalizing, instead of assuming
  `Base.metadata.create_all()` executed migration 0018's legacy purge, and
  calls `finalize_release`.
- **`persistence.verify_chunk_runtime_membership()`** (new): the digest/report
  are scoped to the declared-projection chunk set, but
  `RulesPackageService`/vector reindexing read *all enabled* chunks for a
  package — so an orphan enabled `rp_chunks` row, a declared-projected chunk
  disabled after persistence, or a declared-projected chunk's source disabled
  after persistence now each independently fail the gate instead of silently
  diverging from what runtime actually serves.
- **Idempotency (with full re-verification)**: `finalize_release` treats an
  already-published release for the same content-derived `package_uuid` as a
  safe no-op — but only after re-running the **full** `run_gate()` against the
  reconstructed existing release (not just the digest) and independently
  confirming the `rp_packages` row is `published` **and** `is_enabled`. A
  tampered proof identity or an inconsistent package/release state fails reuse
  exactly like a fresh failed publish. Changed source/policy/config inputs
  still change the transform hash and therefore the `package_uuid`, always
  producing a new draft release.
- **Migration 0017 / `CorpusReleaseORM`**: `evidence_report_hash`,
  `persisted_corpus_digest`, `corpus_report_reference`, and `report_payload`
  are now nullable — they are genuinely unknown at the draft-insert instant
  (the rows they're computed from don't exist yet) and are set exactly once,
  from real reconstructed state, before the final gate runs. The migration is
  unmerged on PR #134; this is a direct edit, not a new migration. The
  five-hash publication requirement itself is unweakened: all five must be
  non-null and gate-verified before `published` is reachable.

`tests/ingestion/corpus/conftest.py`'s session-scoped `release` fixture now
goes through the real `finalize_release` lifecycle (persist into a fresh
in-memory SQLite DB, reconstruct, gate, publish) instead of an in-memory
build, so every existing test that reads from it is now implicitly exercising
the actual Component K c–g order, not an approximation of it.

## How this satisfies each acceptance criterion

Builds on PR #134's existing acceptance-matrix mapping (Components A–L
unchanged for rows 2–7, 10, 11). Rows this PR corrects or adds:

| # | Where implemented | Test |
|---|---|---|
| 1 | `bundle.persisted_corpus_digest` computed from **DB-reconstructed** state via `persistence.finalize_release` (steps c–d), not the in-memory candidate | `test_persist_round_trip_digest_matches`, `test_release_binds_five_top_level_hashes` (now exercised through the real lifecycle), `test_repeated_finalize_is_idempotent_and_does_not_mutate` |
| 8 | `report.build_report` (post-persistence, no self-hash) — now only ever invoked from `finalize_release` after reconstruction | `test_evidence_report_carries_proof_hashes_but_not_its_own`, `test_candidate_release_carries_no_persistence_claim` |
| 9 | `gate.run_gate` — DB-grounded: new `chunk_membership_violations` condition, real (non-default) `sql_persist_ok`, live legacy check; re-run in full on the reuse path | `tests/ingestion/corpus/test_gate.py::*`, `test_final_gate_failure_does_not_publish_partial_content`, `test_reuse_rejects_tampered_release_row`, `test_reuse_rejects_inconsistent_package_row_state` |
| 12 | `quarantine.check_legacy_reachability` run with the **live session** inside `finalize_release`; CLI applies real Alembic migrations (0018) instead of assuming `create_all()` ran them | `test_zero_legacy_reachability_in_repo`, `test_legacy_active_row_blocks_publication` |
| new | Publication actually flips both `RulesPackageORM` and `CorpusReleaseORM` to `published`, and the package is retrievable through `RulesPackageService`'s normal published-only path (no draft-visibility backdoor) | `test_published_package_retrievable_via_rules_package_service` |
| new | Persisted `rp_chunks` exactly matches the declared projection set, and runtime enablement (chunk + source) matches what the digest/report claim | `test_orphan_enabled_chunk_breaks_runtime_membership_verification`, `test_disabled_projected_chunk_breaks_runtime_membership_verification`, `test_disabled_required_source_breaks_runtime_membership_verification` |

## Test coverage summary

```
python -m pytest tests/ingestion/corpus/ -q     # 66 passed (56 original + 10 new)
python -m pytest tests/services/test_rules_package.py -q   # 77 passed
python -m pytest -q                              # full suite: 2407 passed, 10 skipped (pre-reuse-fix; +2 corpus tests since)
black --check src/ tests/                        # clean
ruff check src/ tests/ scripts/                  # clean
mypy src/                                        # clean (189 source files)
pip-audit                                        # 1 pre-existing chromadb advisory (PYSEC-2026-311), unrelated to this change; afterworlds itself not on PyPI (expected, unaudited)
```

Full-suite coverage: 92.35% (project-wide gate: 80%). `services/rules_package.py`
99%, `ingestion/corpus/persistence.py`/`gate.py`/`report.py`/`pipeline.py` all
covered by the corpus suite.

New regression tests (`tests/ingestion/corpus/test_persistence_quarantine.py`
unless noted):

- `test_legacy_active_row_blocks_publication` — an active legacy package row
  in the target DB fails the final gate and leaves no partial `rp_corpus_releases`
  row for the new release.
- `test_published_package_retrievable_via_rules_package_service` — a
  successful `finalize_release` publishes both records, and
  `RulesPackageService`'s normal published-only path retrieves the package and
  its chunks.
- `test_orphan_enabled_chunk_breaks_runtime_membership_verification` — an
  extra enabled `rp_chunks` row with no declared projection breaks
  `verify_chunk_runtime_membership` even though the digest still matches.
- `test_disabled_projected_chunk_breaks_runtime_membership_verification` /
  `test_disabled_required_source_breaks_runtime_membership_verification` — a
  disabled projected chunk or its disabled source is caught even though it
  would silently disappear from runtime reads while the digest stays green.
- `test_candidate_release_carries_no_persistence_claim` — `CandidateRelease`
  has no `report`/`release`/digest fields; it cannot claim persistence by
  construction.
- `test_repeated_finalize_is_idempotent_and_does_not_mutate` — re-ingesting
  the identical release is a verified no-op: exactly one `rp_corpus_releases`
  row, `published_at` unchanged.
- `test_reuse_rejects_tampered_release_row` /
  `test_reuse_rejects_inconsistent_package_row_state` — the reuse no-op path
  re-runs the full gate and the package-state check: a tampered
  `bundle_root_hash` on the release row, or a package row left `draft` while
  the release row says `published`, fails reuse rather than being accepted as
  a successful no-op.
- `test_final_gate_failure_does_not_publish_partial_content` — a tampered
  candidate (mismatched transform hash) fails the gate and leaves zero rows
  for that package in either `rp_packages` or `rp_corpus_releases`.
- `test_clean_regeneration_is_byte_for_byte_deterministic`
  (`test_ledger_pipeline.py`, strengthened) — a fresh `build_candidate` +
  `finalize_release` into a brand-new DB reproduces the session build's full
  five-hash identity byte-for-byte, not just the pre-persistence pieces.

## Architecture Notes

**No drift from design principles**, with one correction to PR #134's own
Architecture Notes: its claim that the publication gate "proves source-corpus
integrity against the PDF rather than 'the pipeline ran on nonempty input'"
was itself only proven against an in-memory build, not the actual
persisted/runtime-visible state — a recurrence of the same defect family
ADR-005c's Context items 1–7 describe, one layer down (the gate proved "the
build looks right in memory," not "the database is right"). This remediation
closes that gap at the root — the candidate/finalize split, the DB-grounded
gate (run on both the fresh-publish and the reuse path), and the fail-closed
chunk-runtime-membership check — rather than patching the Codex-flagged
symptoms individually.

**Known gap, unchanged by this remediation, surfaced not resolved:**
`gate.run_gate`'s `vector_write_ok` parameter remains a caller-supplied flag
(default `True`); this PR does not implement or verify vector/Chroma
persistence for the corpus release. That was out of scope before this
remediation (no vector-store code exists anywhere in
`ingestion/corpus/`) and remains out of scope now — flagged per CLAUDE.md's
Known Unknowns discipline rather than left silently unremarked.

**Sibling-audit note** (defect family, PR #134 Codex review + PR #135
follow-up):
- **Defect family:** publication/gate evidence proved from in-memory or
  caller-supplied state, or from a partial re-check, instead of the actual
  persisted/runtime-visible state.
- **Triggering comments:** all three PR #134 round-1 Codex threads
  (`persistence.py:73` publish-after-gate; `scripts/ingest_srd.py:66`
  legacy-check-with-None-session; `persistence.py:356` orphan-chunk digest
  gap) plus the PR #135 follow-up (`persistence.py:787` reuse path only
  checked the digest).
- **Searched sibling paths:** `pipeline.build_release` (root cause — replaced
  by `build_candidate`/`finalize_release`); `gate.run_gate`'s
  `sql_persist_ok`/`persisted` defaults (replaced with DB-grounded evidence);
  `gate.run_gate`'s `vector_write_ok` default (Known Unknown — no vector-store
  implementation exists in this package to ground it against; not silently
  "fixed"); `persistence._load_members` (orphan-chunk gap — paired with a new
  independent `verify_chunk_runtime_membership` rather than folding orphans
  into the digest); the `publication_status` transition on both ORMs (now set
  only by `finalize_release` after a passing gate, inside one transaction);
  **the reuse/no-op branch** (found in follow-up — now re-runs the full gate
  and an independent package-state check before accepting reuse, so it can't
  bless a tampered or inconsistent already-published release).
- **Disposition:** all threads `patched` at the root; `vector_write_ok`
  disposition: `Known Unknown`, unchanged — owner decision needed if/when
  vector-persistence proof becomes a publication requirement.

Does not touch Issue 5d/2b/15c scope, `RuleChunk`/Issue 5a models, PR #129, or
Issue 15b/19b — this PR only restructures the persistence/publication
orchestration inside Issue 5c's own `ingestion/corpus` package plus the two
unmerged Issue 5c migrations.

## Review-Loop / Boundary Check

- [x] This PR still fits the intended scope of the issue (CRD Issue 5c /
      Component K's persistence-and-publication lifecycle only).
- [x] Repeated review churn has **not** accumulated on the same file or
      function — the one follow-up (reuse-path re-verification) was a distinct
      condition in the same feature, addressed at the root.
- [x] The remaining work is still concrete defect-fixing, not an ownership or
      boundary dispute.

No boundary/scope issues to flag; `vector_write_ok` is called out above as a
pre-existing, unchanged Known Unknown rather than resolved or silently left
unremarked.

---

This PR targets `feature/issue-5c-srd-corpus-integrity` (PR #134's head
branch) rather than `main`, since it is a direct remediation of #134's review
feedback and should land there before #134 merges. Do not merge to `main`.
