### PR TITLE
docs: simplify Claude and Codex harness guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,22 +2,21 @@
 
 Read this file fully before reviewing an Afterworlds PR.
 
-## Role
+## Role and Authority
 
-Review as Codex/review agent, not as primary implementer. Your job is to find correctness, security, maintainability, test, scope, and architecture problems before merge. Prefer high-signal findings over nitpicks.
+Review as Codex/review agent, not as primary implementer. Find correctness, security, maintainability, test, scope, and architecture problems before merge. Prefer high-signal findings over nitpicks.
 
-The authoritative sources are:
+Apply authority in this order:
 
-1. Current PR diff and tests.
-2. The governing CRD issue spec.
-3. ADRs in `/docs/decisions/`.
-4. `/docs/architecture/construction_readiness.md`.
-5. `/docs/architecture/design.md`.
-6. `/docs/architecture/known_unknowns.md`.
-7. Prompt contracts in `/docs/prompts/`.
-8. `CLAUDE.md` and this file.
+1. The governing CRD issue and recorded Owner Decisions.
+2. Accepted ADRs in `/docs/decisions/`.
+3. `/docs/architecture/construction_readiness.md`.
+4. `/docs/architecture/design.md`.
+5. `/docs/architecture/known_unknowns.md`.
+6. Prompt contracts in `/docs/prompts/`.
+7. `CLAUDE.md` and this file.
 
-Do not review from memory when the issue, ADR, or changed code gives the answer.
+The PR diff, implementation, and tests are evidence of what was built and whether it works. They do not redefine what should have been built. Do not review from memory when governing authority or repository inspection gives the answer.
 
 ## Review Priorities
 
@@ -53,50 +52,22 @@ Flag violations explicitly.
 11. Operational state affecting money, access, user data, or auditability must be reconstructable from explicit event logs.
 12. Known Unknowns and scope boundaries must be surfaced, not silently resolved.
 
-## Context-Process Review
+## Reviewer Discretion
 
-For non-trivial PRs, verify that the implementation process did not create context-degradation risk.
+Use Graphify, subagents, advisor consultation, invariant cards, or other tools when they materially improve the review. None is mandatory unless the governing issue or an accepted ADR explicitly requires it.
 
-Look for PR evidence that Claude Code:
-
-* used a briefing subagent or equivalent summarized reconnaissance for broad docs/source/Graphify reading;
-* kept the main implementation context focused on issue spec, invariant card, plan, target files, failing tests, and current diff;
-* consulted advisor after briefing/planning when architecture, ownership, safety, entitlement, provider routing, RPG adjudication, migrations, or Known Unknowns were involved;
-* used phase commits or coherent phase boundaries for large issues;
-* ran local gates on the final branch head;
-* recorded unresolved process or boundary issues in Architecture Notes.
-
-Absence of this evidence is not automatically merge-blocking for small PRs. For large invariant-heavy issues, missing process evidence is review-relevant because it increases the chance of quiet spec drift. Ask for a short clarification before turning process opacity into a blocking finding.
-
-## Graphify Review Preflight
-
-Before reviewing a non-trivial PR, use Graphify when available.
-
-Graphify is a review aid only. It is not an architectural authority and never replaces source, tests, issue specs, ADRs, `AGENTS.md`, `CLAUDE.md`, or architecture docs.
-
-Required sequence:
-
-1. Read `AGENTS.md`, the PR description, and the diff first.
-2. Query Graphify before broad manual spelunking.
-3. Use narrow review-specific queries for changed-file impact, ownership seams, downstream callers, related tests, and likely sibling defects.
-4. Verify Graphify output against source, tests, issue specs, and docs before writing findings.
-5. If blocked by sandbox, request approval/escalation once. If still unavailable, stale, or failing, state that and continue normal review.
-
-```powershell
-cd D:\AI\Claude\afterworlds\src
-graphify query "Summarize changed-file impact, ownership seams, downstream callers, related tests, and architecture risks for this PR."
-```
+Tool choice, subagent use, advisor consultation, plan format, context-management method, and commit structure are not review findings unless explicitly required by governing authority or their absence caused a concrete correctness, scope, or verification defect. Review results and evidence, not ritual compliance.
 
 ## Review Method
 
-Use this order for substantive reviews:
+For substantive reviews:
 
 1. Identify the governing CRD issue and PR scope.
-2. Read Architecture Notes and compare them to the diff.
-3. Check new/changed migrations, schemas, DTOs, enums, and service interfaces.
-4. Check transaction and rollback behavior before style issues.
+2. Read Architecture Notes and compare them to the authority, diff, and tests.
+3. Inspect changed migrations, schemas, DTOs, enums, service interfaces, and affected production paths.
+4. Check transaction and rollback behavior before style.
 5. Check tests against acceptance criteria and likely failure modes.
-6. Audit sibling structures when one defect suggests a pattern.
+6. Audit sibling structures only when recurrence or evidence suggests a defect family.
 7. Classify each finding before commenting.
 
 Finding classes:
@@ -111,53 +82,38 @@ Do not inflate severity because a comment is interesting.
 
 ## Boundary-over-Patch Rule
 
-Distinguish concrete defects from boundary problems.
-
-Trigger this check when:
+Trigger a boundary check when:
 
 * the same PR receives repeated review/fix/re-review cycles;
 * the same file, function, query path, schema hotspot, or service hotspot is revised across multiple rounds;
 * feedback shifts from defects to semantics, ownership, architecture placement, or which issue owns behavior;
 * a proposed fix would move behavior into an issue that does not clearly own it;
-* the implementation appears to resolve a Known Unknown without owner approval.
+* implementation appears to resolve a Known Unknown without owner approval.
 
 When triggered:
 
 1. Stop treating the latest review comment as automatically the next patch.
-2. Classify remaining feedback as merge-blocking defect, scope boundary, Known Unknown, owner decision needed, or non-blocking improvement.
-3. Surface the boundary explicitly in PR comments or Architecture Notes.
-4. Use `[OWNER DECISION]:` for ownership/scope/policy questions.
-5. Defer implementation until the owner narrows scope, defers behavior, or defines the missing rule.
+2. Rebuild the defect-family and sibling map.
+3. Classify the residue as issue-scoped implementation, specification correction, scope leak, Known Unknown, Owner Decision, or non-blocking improvement.
+4. Surface the boundary in PR comments or Architecture Notes.
+5. Resume remediation only after boundary or owner residue is resolved or explicitly deferred.
 
-Repeated hotspot churn is a coordination signal, not just a coding task.
+Repeated hotspot churn is a coordination signal, not just another coding task.
 
 ## Recurring Defect Family Gate
 
 Codex comments are symptoms. First classify the defect family, then check sibling structures before handing fixes to Claude.
 
-A formal sibling audit is not required for every isolated comment. The gate applies only after recurrence:
+A formal sibling audit is not required for an isolated comment. Trigger the gate only when:
 
 * the same defect family appears in two or more review rounds;
 * the same hotspot file/function/service/DTO/validator/test seam is implicated again;
 * the same invariant is violated in multiple places;
 * a narrow fix is followed by a sibling defect that should have been checked with it.
 
-When the gate triggers, stop the narrow patch/re-review loop until Claude produces a short sibling-audit note and the owner accepts it or explicitly waives it.
+When triggered, stop the narrow patch/re-review loop and inspect representative parallel structures until the defect is confidently isolated or systemic. Record a lightweight note naming the defect family, trigger, structures sampled, regression coverage, and each disposition: `patched`, `already safe`, `out of scope`, `Known Unknown`, or `owner decision needed`.
 
-The note must identify:
-
-1. defect family;
-2. triggering review comments or rounds;
-3. sibling paths, functions, services, DTOs, validators, tests, prompts, or transaction seams searched;
-4. disposition for each sibling, using only `patched`, `already safe`, `out of scope`, `Known Unknown`, or `owner decision needed`.
-
-The audit should be lightweight: a PR comment, handoff note, or implementation note is enough. Do not turn the PR body into a remediation diary.
-
-This gate controls scope; it does not expand it. A sibling marked `out of scope`, `Known Unknown`, or `owner decision needed` must not be silently fixed as part of the current PR unless the owner explicitly authorizes that expansion.
-
-When recurrence is concrete and in scope, request one bundled sibling fix. When it shifts into semantics, ownership, architecture placement, or issue boundary, switch to `[OWNER DECISION]:`.
-
-Examples of recurring defect families include fail-open fallback paths, stale metadata authority, missing corrective notes, usage preservation gaps, parser/selection grammar inconsistencies, nondeterministic ordering, missing tie-breakers, rollback gaps, and inconsistent equivalent inputs.
+Stop once the defect family and in-scope remedy are established and more searching is unlikely to change either. This gate controls scope; it does not expand it. Do not silently fix `out of scope`, `Known Unknown`, or `owner decision needed` items.
 
 ## Comment Rules
 
@@ -167,22 +123,23 @@ Examples of recurring defect families include fail-open fallback paths, stale me
 * Avoid style-only comments unless they obscure correctness or maintainability.
 * Do not ask for broad refactors outside issue scope.
 * Do not suggest resolving Known Unknowns in code.
-* If the PR discovers a better architecture than the spec, require ADR/spec revision in the same PR or owner-approved follow-up before merge.
+* If a materially better architecture contradicts the accepted specification or ADR, require authority to be reconciled in the same PR or through an Owner Decision before implementation.
 
 ## Tests and CI
 
-Check that tests cover the issue’s required behavior, not merely the happy path.
+Check that tests cover the issue’s promised system, not merely isolated components or the happy path.
 
 Call out missing tests for:
 
 * acceptance criteria;
-* migration round trips and DB constraints;
-* transaction rollback / savepoint behavior;
+* production entry points and authoritative inputs;
+* migration round trips and database constraints;
+* transaction rollback and savepoint behavior;
 * typed parser failures and provider refusal paths;
-* cache-boundary/stable-prefix identity;
+* cache-boundary and stable-prefix identity;
 * entitlement settlement and event replay;
-* safety/contradiction blocking behavior;
-* RPG dice/adjudication invariants;
+* safety and contradiction blocking behavior;
+* RPG dice and adjudication invariants;
 * sibling defect classes revealed during review.
 
 Passing CI is required but not sufficient. A green build can still be wrong.
@@ -207,7 +164,7 @@ or explicitly describe:
 
 * what drift or unresolved boundary exists;
 * why it was necessary or unavoidable;
-* which issue/ADR/owner decision authorizes it;
+* which issue, ADR, or Owner Decision authorizes it;
 * what remains deferred or risky.
 
 If the diff and Architecture Notes disagree, review the disagreement, not just the code. That is usually where the skeleton is politely wearing a hat.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,19 @@
 
 Read this file fully at the start of every Claude Code session before taking action.
 
-## Project
+## Project and Authority
 
-Afterworlds is an interactive storytelling platform built on the Sojourn Story State Machine. Users are **Sojourners**. Modes are RPG, Branching, and Writing. Authoritative sources live in `/docs/architecture/`, `/docs/decisions/`, and `/docs/prompts/`. The CRD issue spec governs the current task. If implementation would deviate from these sources, flag it in Architecture Notes; do not resolve drift silently.
+Afterworlds is an interactive storytelling platform built on the Sojourn Story State Machine. Users are **Sojourners**. Modes are RPG, Branching, and Writing.
+
+Implement the governing CRD issue against repository reality. Apply authority in this order:
+
+1. The governing CRD issue and recorded Owner Decisions.
+2. Accepted ADRs in `/docs/decisions/`.
+3. Architecture and Known Unknowns in `/docs/architecture/`.
+4. Prompt contracts in `/docs/prompts/`.
+5. This file and other standing repository guidance.
+
+Source code and tests are evidence of the current implementation, not authority to redefine an accepted contract. If authorities conflict or implementation would deviate from them, surface the conflict in Architecture Notes; do not resolve drift silently.
 
 ## Stack and Local Gates
 
@@ -24,7 +34,7 @@ pytest -q
 pip-audit
 ```
 
-Run gates on the exact branch head before pushing. If blocked, say what could not run.
+Run applicable gates on the exact branch head before pushing. If blocked, say what could not run.
 
 ## Architecture Invariants
 
@@ -43,88 +53,48 @@ These are non-negotiable. Violations must be surfaced, not quietly patched.
 11. Operational state affecting money, access, user data, or auditability must be reconstructable from explicit event logs, not inferred from opaque state.
 12. Scope creep and Known Unknowns must be surfaced, not silently resolved.
 
-## Context Discipline
+## Engineering Discretion
 
-Claude Code context is a build resource. Do not waste it on raw archaeology.
+You own ordinary engineering choices, including investigation order, algorithms, internal organization, helper boundaries, tool use, test organization, and commit decomposition. Choose the lowest-complexity repository-native approach that satisfies the governing contract.
 
-* Use `/context` before large implementation phases. Note major context costs.
-* Do not dump broad docs, Graphify output, or large source sweeps into the main implementation thread when a subagent can summarize them.
-* Use subagents for reconnaissance: architecture-doc reading, source seam discovery, Graphify orientation, sibling-structure audits, and review triage.
-* Keep the main implementation context focused on the issue spec, invariant card, accepted plan, target files, failing tests, and current diff.
-* Consult `/advisor` after briefing and planning, not after raw doc ingestion. Advisor is for judgment forks; subagents are for context isolation.
-* Prefer manual `/compact` or `/clear` at phase boundaries. Do not wait for auto-compact to fire mid-edit.
-* For large issues, use fresh phases rather than one long invariant-heavy pass.
+Use Graphify, subagents, advisor consultation, invariant cards, context compaction, and phased delivery when they materially improve the work. They are not required unless the governing issue or an accepted ADR explicitly requires them. Read `AGENTS.md` when performing or responding to PR review; it is not mandatory startup reading for ordinary implementation.
 
-## Compact Instructions
+Issue- and ADR-specific requirements remain authoritative. This standing guidance does not retroactively remove procedures explicitly required by accepted work already in progress.
 
-When compacting, preserve these items exactly:
+Before handoff:
 
-1. CRD issue number, GitHub issue/PR number, branch, and implementation phase.
-2. In-scope and out-of-scope boundaries.
-3. Owner decisions, ADR decisions, and Known Unknowns touched by the work.
-4. Narrow issue-specific invariants; do not replace them with vague summaries.
-5. Exact service, DTO, enum, migration, prompt, and test names changed.
-6. Files changed and why each file changed.
-7. Test commands run and results.
-8. Current failing tests, reviewer comments, and unresolved boundary questions.
-9. Architecture Notes content that must appear in the PR.
-
-## Graphify Preflight
-
-Use Graphify before non-trivial implementation or review when available. It is an orientation aid only, not an authority and not a runtime dependency.
-
-1. Read governing instructions and the issue/PR first.
-2. Refresh or query the graph before broad file inspection.
-3. Use narrow, task-specific queries for files, services, models, tests, callers, and ownership seams.
-4. Verify Graphify output against source, tests, issue specs, ADRs, and docs.
-5. If blocked, request approval/escalation once. If still unavailable, state that and continue with normal source inspection.
-
-```powershell
-cd D:\AI\Claude\afterworlds\src
-graphify .
-graphify cluster-only D:\AI\Claude\afterworlds\src
-graphify query "Describe the files, services, models, tests, and ownership seams relevant to this task."
-```
-
-## Implementation Workflow
-
-For small fixes, work directly and keep the diff tight. For non-trivial CRD issues, use this sequence:
-
-1. Read `CLAUDE.md`, `AGENTS.md`, the issue spec, relevant ADRs, and Known Unknowns.
-2. Run Graphify/subagent briefing before broad manual spelunking.
-3. Produce an invariant card: scope, seams, affected services, tests, risks.
-4. Make an implementation plan and consult advisor when the issue involves architecture, ownership, routing, entitlement, safety, orchestration, RPG adjudication, migrations, or a Known Unknown.
-5. Implement in phases. End each phase with gates, `git diff --stat`, and `git status`.
-6. Commit coherent phases with conventional commits.
-7. Before PR handoff, verify tests, Architecture Notes, acceptance criteria, and no unrelated drift.
-
-## Repository and PR Rules
-
-* Feature branches: `feature/issue-N-short-description`; no direct commits to `main`.
-* Open a PR for every issue; do not merge without passing CI and Codex review.
-* PR description must include what was built, acceptance criteria coverage, test coverage summary, and **Architecture Notes**.
-* Architecture Notes must say either `No drift from design principles` or describe the deviation/rationale explicitly.
-* Conventional commits only: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`.
-* Use `CRD Issue N` for construction issues and `#N` for GitHub issues/PRs. Never use bare `Issue N`.
+* verify the requested observable behavior and required failure cases;
+* verify production entry points and downstream consumers affected by the change;
+* run the applicable repository gates on the final branch head;
+* report acceptance coverage, test evidence, and any unresolved boundary.
 
 ## Boundary, Sibling Audit, and Known Unknown Rules
 
-See `/docs/architecture/known_unknowns.md`. If implementation touches a listed unknown, stop and flag it; do not decide it in code. Codex comments are symptoms: classify the defect family, then check sibling structures before handing fixes back.
+See `/docs/architecture/known_unknowns.md`. If implementation touches a listed unknown, stop and flag it; do not decide it in code. Surface product semantics, ownership changes, specification contradictions, and materially different architectures rather than deciding them as ordinary implementation details. If a better architecture contradicts the accepted specification or ADR, reconcile the authority in the same PR or obtain an Owner Decision before implementing it.
 
-Trigger a boundary check when repeated review/fix rounds hit the same file, function, query, schema, service hotspot, invariant, or feedback shifts from defects to ownership, semantics, placement, issue scope, or a materially better architecture than the spec.
+Trigger a boundary check when repeated review/fix rounds hit the same file, function, query, schema, service hotspot, or invariant, or when feedback shifts from defects to ownership, semantics, placement, issue scope, or architecture.
 
 When triggered:
 
 1. Stop treating the latest comment as automatically the next patch.
-2. Classify remaining work: merge-blocking defect, scope boundary, Known Unknown, owner decision needed, or non-blocking improvement.
+2. Classify remaining work: merge-blocking defect, scope boundary, Known Unknown, Owner Decision, or non-blocking improvement.
 3. Surface the boundary in PR comments or Architecture Notes.
-4. Wait for owner decision when ownership, scope, or Known Unknowns are involved.
+4. Resume remediation only after boundary or owner residue is resolved or explicitly deferred.
 
-A sibling-audit gate is required when two or more review rounds on the same PR hit the same defect family, hotspot, or invariant, or when a narrow fix is followed by a sibling defect that should have been checked with it. Do not produce more one-off patches until the owner accepts or waives a short sibling-audit note.
+Codex comments are symptoms. Classify the defect family before fixing the quoted line. Run a bounded sibling audit only when two or more review rounds hit the same defect family, hotspot, or invariant, or when a narrow fix is followed by a sibling defect that should have been checked with it.
 
-The sibling-audit note may be a PR comment, handoff note, or implementation note. It must name: defect family; triggering review comments/rounds; searched sibling paths/functions; and each sibling disposition: `patched`, `already safe`, `out of scope`, `Known Unknown`, or `owner decision needed`.
+A sibling-audit note may be a PR comment, handoff note, or implementation note. Name the defect family, trigger, representative sibling structures inspected, regression coverage, and each disposition: `patched`, `already safe`, `out of scope`, `Known Unknown`, or `owner decision needed`.
 
-This gate controls scope; it does not expand it. Classify siblings before continuing. Do not silently fix `out of scope`, `Known Unknown`, or `owner decision needed` items without owner approval.
+This audit controls scope; it does not expand it. Do not silently fix `out of scope`, `Known Unknown`, or `owner decision needed` items.
+
+## Repository and PR Rules
+
+* Work on a topic branch; no direct commits to `main`.
+* Open a PR for every CRD issue; do not merge without passing CI and Codex review.
+* PR descriptions must include what was built, acceptance-criteria coverage, test evidence, and **Architecture Notes**.
+* Architecture Notes must say either `No drift from design principles` or describe the deviation and rationale explicitly.
+* Use conventional commit prefixes: `feat`, `fix`, `refactor`, `test`, `docs`, or `chore`.
+* Use `CRD Issue N` for construction issues and `#N` for GitHub issues/PRs. Never use bare `Issue N`.
 
 ## Business and Access Invariants
 
@@ -135,18 +105,5 @@ There is one canonical Sojourn orchestration path across paying access paths. No
 * Cloud Services are separable from perpetual license rights. Lapse may gate hosted storage/sync/backup/remote access/hosted ingestion, but not owned-work read/export/download.
 * Starter Access, if offered, is paid entry access using the same full pipeline and normal hosted credits. It is not a degraded free tier.
 * Extended TTL caching is required wherever provider support and adapter verification allow it; cache correctness belongs to provider adapters.
-* Entitlement routing governs access path, credits, Cloud Services, and settlement. Provider routing governs model/provider choice. Do not conflate.
+* Entitlement routing governs access path, credits, Cloud Services, and settlement. Provider routing governs model/provider choice. Do not conflate them.
 * No dark patterns in top-up, renewal, cancellation, export, or data retention.
-
-## Lessons and Self-Improvement
-
-After each task, append dated one-line lessons when corrected, an assumption fails, a pattern is discovered, or a better approach should persist. Format: `[YYYY-MM-DD] <lesson learned>`. Avoid duplicates. Preserve unless superseded:
-
-* [2026-04-02] Run the full local gate sequence on the exact branch head before pushing; a green formatter alone does not mean CI-clean.
-* [2026-04-02] When CI reports a file, verify the fix is staged, committed, and pushed by checking `git diff`, `git status`, and commit contents.
-* [2026-04-02] Pin Black exactly in dev dependencies to reduce CI/local drift, but prove drift before blaming it.
-* [2026-04-07] CRD issue numbers and GitHub issue/PR numbers are different namespaces; always write `CRD Issue N` or `#N`.
-* [2026-07-28] An operator-facing configuration name (env var, flag, path) is only correct if a test reads it through the same code the operator's command runs; documenting one name while `from_env()` reads another is invisible to every unit test that sets the name itself.
-* [2026-07-28] When a `try` block owns cross-store compensation, the boundary must open before the *first* mutation of the transactional store, and each compensating action must be armed only across the window in which its resource can exist.
-
-<!-- Claude Code appends dated one-line lessons here as they are learned -->


### PR DESCRIPTION
## What changed

- Replaced mandatory Graphify, subagent, advisor, invariant-card, compaction, phased-delivery, and phase-commit choreography in `CLAUDE.md` with engineering discretion and outcome-based verification.
- Removed automatic dated lesson accumulation from standing instructions.
- Corrected the authority hierarchy so the governing CRD issue, Owner Decisions, and accepted ADRs govern; code and tests are implementation evidence, not authority to redefine the contract.
- Removed context-process compliance review from `AGENTS.md` and made reviewer tool choice optional.
- Preserved architecture, security, business/access, Known Unknown, review-loop boundary, and recurrence-triggered sibling-audit safeguards.
- Preserved accepted issue- and ADR-specific procedures for work already in progress, including CRD Issues 15b and 19b.

## Why

The CRD Issue 5c retrospective and the Claude Code Opus 5 harness review both showed that standing instructions were over-prescribing implementation process. This docs-only ablation keeps the required product truth, authority boundaries, and verification obligations while allowing Claude Code to choose ordinary engineering methods.

## Impact

New work, beginning with CRD Issue 5d, can use the updated default posture. Existing accepted issue contracts remain authoritative and are not rewritten retroactively.

## Validation

- Verified the branch versions of both files exactly match the reviewed drafts.
- Confirmed `CLAUDE.md` is 109 lines and `AGENTS.md` is 177 lines.
- No runtime code or test configuration changed; runtime test suite not applicable.

## Architecture Notes

No drift from design principles