### PR TITLE
Add ADR-005d for complete typed mechanical authority

### DIFF
--- a/docs/decisions/ADR-0007-rules-package-entity-patch-deferral.md
+++ b/docs/decisions/ADR-0007-rules-package-entity-patch-deferral.md
@@ -1,8 +1,15 @@
 # ADR-0007 — Rules Package: Entity-Targeting Override Patch Shape Deferral
 
-**Status:** Accepted  
+**Status:** Accepted — **discharged by ADR-005d / CRD Issue 5d (2026-07-30)**  
 **Date:** 2026-04-09  
 **Issue:** CRD Issue 5a (Rules Package Schema and Data Model)
+
+> **Discharged by ADR-005d / CRD Issue 5d.** The typed mechanical projection now defines the concrete
+> record/component/fact patch families and applies them while preserving existing override precedence and
+> operations. See [ADR-005d](adr-005d-complete-typed-mechanical-authority.md) Decisions 9 and 10; the
+> effective runtime binding identifies the applied override set by its own immutable override-set UUID.
+> The historical Context, Decision, and Consequences below record the CRD Issue 5a deferral as made and
+> are unchanged.
 
 ## Context
 

--- a/docs/decisions/adr-005c-rules-authority-repair.md
+++ b/docs/decisions/adr-005c-rules-authority-repair.md
@@ -234,6 +234,11 @@ sentence into executable mechanics. This directly targets defect items 1 and 6: 
 repair efforts with separate acceptance criteria — conflating them is what let a 50-entity subset with
 prose-only mechanics stand in for both at once.
 
+**Forward reference (ADR-005d, 2026-07-30):** the executable mechanical projection layer is specified by
+[ADR-005d](adr-005d-complete-typed-mechanical-authority.md), which settles complete 5d scope as the full
+mechanically substantive SRD 5.2.1 corpus represented as typed facts, exact prose-bound GameMaster
+authority, or both. This decision's text is unchanged.
+
 ### Decision 3 — Ingestion does not generate a rules engine
 
 The ingestion pipeline may produce declarative, typed mechanical facts. It must not produce or execute
@@ -283,6 +288,11 @@ deterministic package-reference resolution and authoritative selector constructi
 either by requiring non-default selectors before a slice request is honored, or by a documented, explicit
 "whole-package slice" request shape distinguishable from an accidentally-empty one. CRD Issue 15c owns
 ensuring adjudication fails closed when the resolved authority is absent or empty.
+
+**Forward reference (ADR-005d, 2026-07-30):** [ADR-005d](adr-005d-complete-typed-mechanical-authority.md)
+Decision 9 supplies the deterministic binding this decision requires and extends it: the effective runtime
+binding is package UUID, release version, immutable mechanical-projection UUID, and an immutable
+override-set UUID identifying the exact applied override state. This decision's text is unchanged.
 
 ### Decision 6 — Advertised supported mechanics fail closed when authority is missing
 

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -3,7 +3,8 @@
 **Issue:** CRD Issue 5d  
 **Date:** 2026-07-30  
 **Status:** Accepted — finalized by Owner 2026-07-30; amended by Owner Decision 2026-07-30 (PR #138
-review) so the effective runtime binding also carries an immutable override-set identity  
+review) so the effective runtime binding also carries an immutable override-set identity, and clarified
+in the same review so the contents that identity names are retained as immutable replay evidence  
 **Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
 
 ---
@@ -187,11 +188,31 @@ enablement, and validated payloads. Adding, removing, enabling, disabling, repri
 changing the payload of an applicable override yields a different override-set UUID. The no-overrides
 state has its own deterministic override-set UUID; it is not the absence of one.
 
+Each override-set UUID identifies one immutable, content-addressed override-set **version**. That version
+preserves — or is deterministically reconstructable from append-only retained evidence that preserves —
+the exact canonical ordered override state the UUID was derived from: targets, operations,
+precedence/order, enablement state, and complete validated payloads. Historical override-set versions
+remain retrievable after the source `RuleOverride` rows are edited, disabled, reprioritized, retargeted,
+or deleted. Recording the override-set UUID while retaining only mutable current override rows is
+insufficient. Current override rows remain the authoring surface; they are not historical replay evidence.
+Whether that retention takes the shape of immutable content-addressed snapshots, append-only version
+records, or an event history that deterministically reconstructs the canonical set is an implementation
+choice this ADR does not make. Override-set version retention is runtime state and is separate from the
+Decision 8 projection publication lifecycle.
+
 Rule slices, deterministic-consumer views, GameMaster authority views, applied-override provenance,
 stale/mismatch validation, and replay/audit evidence identify the exact effective binding — all four
-components — that produced them. A recorded binding whose override-set UUID no longer matches the
-recomputed effective override state is `STALE` and fails explicitly; it is never silently re-resolved
-against current overrides. Overrides never mutate or remint the base projection UUID.
+components — that produced them. Two operations follow, and they are distinct:
+
+- **Runtime resolution and adjudication.** A recorded binding whose override-set UUID no longer matches
+  the override-set UUID recomputed from current override state is `STALE` and fails explicitly; it is
+  never silently re-resolved against current overrides.
+- **Audit, replay, and provenance reads.** These resolve against the retained immutable override-set
+  version and must succeed, reconstructing the exact effective mechanical authority originally applied
+  rather than merely reporting that it differs from current override state. `STALE` is not a valid answer
+  here; a failure to reconstruct is a retention defect, not a divergence signal.
+
+Overrides never mutate or remint the base projection UUID.
 
 A human-facing slug may resolve through one code-owned service but cannot serve as canonical authority.
 Every rule-slice request carries the exact effective binding plus deterministic selectors or an explicit
@@ -207,6 +228,11 @@ effective mechanical view. Existing override precedence and `DISABLE` / `REPLACE
 remain unchanged. Overrides never mutate the immutable base projection and never remint its identity;
 the applied ordered override state is identified instead by the override-set UUID of the effective
 binding (Decision 9), and applied-override provenance is reported against that binding.
+
+Applied-override provenance resolves through the retained immutable override-set version, not through
+current override rows, so an effective view recorded earlier remains reconstructable after the source
+overrides are edited, disabled, reprioritized, retargeted, or deleted. The base projection and its
+identity are unaffected either way.
 
 `DISABLE` suppresses an exact typed target; `REPLACE` supplies a complete validated replacement for a
 component or fact; and `APPEND` adds a complete typed component or fact only where the owning schema
@@ -297,9 +323,10 @@ narrowly scoped cross-reference as of this change.
 - Deterministic consumers receive typed, source-linked facts instead of parsing prose.
 - Missing or ambiguous authority becomes visible and typed.
 - Mechanical corrections mint new immutable identity rather than silently reusing stale releases.
-- Replay, audit, and stale detection reconstruct the exact effective authority — base projection plus the
-  identified applied override set — instead of an ambiguous package/release pair that could resolve to
-  different trust-relevant values over time.
+- Replay and audit reconstruct the exact effective authority — base projection plus the retained
+  override-set version — instead of an ambiguous package/release pair that could resolve to different
+  trust-relevant values over time, and they keep working after the current override rows are edited or
+  deleted. Runtime stale detection remains a separate fail-closed check against current override state.
 - 2b and 15c receive stable upstream contracts.
 
 ### Costs
@@ -310,6 +337,8 @@ narrowly scoped cross-reference as of this change.
 - Typed fact and override families require maintenance as new authorized Rules Packages add mechanics.
 - Every effective override change mints a new override-set identity, so consumers that record or cache an
   effective binding must revalidate it rather than assume stability across override edits.
+- Retained override-set versions accumulate alongside override authoring, and pruning them forfeits the
+  replay and audit reconstruction they exist to provide.
 - Delivery requires multiple PRs before 5d is complete.
 
 ### Rejected alternatives
@@ -335,6 +364,12 @@ narrowly scoped cross-reference as of this change.
     2026-07-30 (PR #138): overrides change the effective mechanical view, so one such binding could
     resolve to different DCs, effects, or disabled mechanics over time and neither stale detection nor
     replay could reconstruct the authority actually used.
+12. **Record the override-set identity but retain only current override rows.** Rejected in the same
+    review: the identifier would name state that no longer exists once an override is edited, disabled,
+    reprioritized, retargeted, or deleted, leaving audit and replay able to detect divergence but not to
+    reconstruct the authority actually applied. This is the standing auditability invariant — operational
+    state must be reconstructable from explicit retained evidence, not inferred from mutable current
+    state — applied to override sets.
 
 ---
 

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -1,0 +1,315 @@
+# ADR-005d — Complete Typed Mechanical Authority and Deterministic Rules-Package Binding
+
+**Issue:** CRD Issue 5d  
+**Date:** 2026-07-30  
+**Status:** Accepted — finalized by Owner 2026-07-30  
+**Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
+
+---
+
+## Context
+
+ADR-005c established the Rules Authority repair sequence:
+
+```text
+5c source-corpus integrity
+→ 5d typed mechanical authority and deterministic binding
+→ 2b package-bound character state
+→ 15c repaired bounded-d20 execution and certification
+```
+
+CRD Issue 5c now publishes the complete authoritative SRD 5.2.1 source corpus with deterministic
+identity, exact source accounting, provenance, persisted-state verification, and a publication gate. It
+deliberately does not decide which text is mechanically substantive or produce typed mechanical
+authority.
+
+Discovery against the real 5c pipeline found:
+
+- 28,109 represented leaves in the measured release, including rules, headings, legal text, examples,
+  explanatory prose, and other non-mechanical material;
+- 2,422 `ENTRY` containers, whose geometry-derived boundaries are reliable for some categories but not
+  for composite stat blocks, non-entry general rules, nested creature records, or many tables;
+- 683 logical tables, including stat-block prose fragmented across cells;
+- 1,533 represented leaves with at least two lexical mechanical-signal families;
+- multiple mechanical facts spanning several leaves/table cells; and
+- 203 colliding names among 1,893 distinct container names.
+
+Therefore:
+
+1. 5c `REPRESENTED` cannot mean "mechanically substantive."
+2. One record per `ENTRY` and one component per leaf are unsound.
+3. Reference coverage alone cannot prove faithful mechanical representation.
+4. A projection identity that omits actual facts and relationships can reuse stale authority.
+5. Aggregate extraction floors or prose percentages cannot prove per-record completeness.
+6. Complete representation must not be confused with how much the bounded-d20 adapter executes.
+
+The Owner has settled completed 5d scope as the full mechanically substantive SRD 5.2.1 corpus.
+
+---
+
+## Central Decision
+
+Afterworlds will publish one complete typed mechanical-authority projection for an exact published 5c
+release. Every mechanically substantive source component is represented:
+
+- through typed declarative facts where meaning can be preserved faithfully;
+- through exact governing prose where contextual, subjective, or open-ended GameMaster judgment remains
+  necessary; or
+- through both.
+
+This projection is complete mechanical **representation**, not universal deterministic **execution**.
+The hand-authored Rules System Adapter separately declares and proves the component shapes it can execute.
+
+---
+
+## Decisions
+
+### Decision 1 — Complete source accounting, selective execution
+
+The completed first projection accounts for the full mechanically substantive content of SRD 5.2.1.
+Implementation phasing cannot redefine a partial projection as completed 5d.
+
+Structured/prose-bound handling follows representability of source meaning. No owner-selected extraction
+percentage, prose ceiling, or adapter-coverage target determines that classification.
+
+### Decision 2 — Span-exact semantic classification
+
+Every 5c `REPRESENTED` leaf is partitioned into accepted semantic spans classified as:
+
+- substantive mechanical authority;
+- supporting authority;
+- non-mechanical material under a closed reason;
+- or unresolved.
+
+Unreviewed/proposed and unresolved spans block publication. `PROSE_BOUND` is not a classification default;
+it is an affirmative component-handling judgment requiring a closed irreducibility reason.
+
+Supporting authority is first-class. Headings, examples, cross-references, explanatory clauses, and
+GameMaster guidance may identify, limit, explain, or exemplify mechanics even when they are not
+independent structured facts.
+
+### Decision 3 — Semantic records and many-to-many provenance
+
+Mechanical records are assembled from a committed accepted inventory. A 5c `ENTRY` is structural evidence,
+not universal semantic authority.
+
+Records and components use stable semantic keys rather than positional ordinals. Facts, prose bindings,
+and relationships carry exact many-to-many provenance to 5c leaf subspans. Primary and contextual roles
+are distinct; contextual overlap is permitted while conflicting primary claims fail.
+
+### Decision 4 — Closed typed facts, no generated rules engine
+
+Structured authority uses a closed, versioned discriminated union of fact families. A new mechanical
+family requires a typed schema and tests or an honest prose-bound classification.
+
+The projection cannot contain:
+
+- arbitrary executable expressions;
+- runtime-interpreted scripts or a general rules DSL;
+- model-authored mechanical logic;
+- generic numeric/key-value escape hatches; or
+- mechanically authoritative values inferred from source prose at runtime.
+
+The projection is declarative data consumed by hand-authored code.
+
+### Decision 5 — Exact completeness, not aggregate thresholds
+
+Publication is proven through exact full-corpus accounting and accepted per-record/component obligations.
+Every expected record, component, fact family, prose-bound claim, provenance edge, and reference must be
+present exactly as required.
+
+Counts, extraction floors, prose percentages, and category ceilings may detect regressions but cannot
+prove completeness. An all-prose projection and a duplicated-fact projection must both fail.
+
+### Decision 6 — Complete meaning-bearing identity
+
+Mechanical projection identity binds:
+
+- the exact published 5c source release;
+- semantic classification;
+- record assembly and membership;
+- actual components and handling;
+- actual structured facts and relationships;
+- prose bindings and exact provenance;
+- reference resolutions;
+- representation schema and semantic policy; and
+- normalization/canonicalization rules.
+
+Reviewer names, timestamps, proposal origins, and comments are audit metadata and do not change semantic
+identity unless the accepted semantic content changes.
+
+Identity derivation is acyclic. Stable record/component/fact IDs derive from the projection UUID and
+committed semantic keys, never local ordinals.
+
+### Decision 7 — Build-time reference resolution
+
+Mechanical references resolve at build time through committed source scope, aliases, and exact target
+semantic keys. Unique destination names alone do not establish source intent. Bare strings, runtime
+similarity, and model selection are never authoritative references.
+
+Ambiguous, unresolved, invalid, or cross-release references block publication.
+
+### Decision 8 — Persist, reconstruct, prove, then publish
+
+5d follows:
+
+```text
+build candidate
+→ persist draft
+→ reconstruct from persisted state
+→ compute persisted-state digest
+→ run exact completeness gate
+→ atomically publish
+```
+
+Draft/partial projections are not active authority. Published projections are immutable. Meaning-changing
+corrections mint a new projection UUID.
+
+### Decision 9 — Deterministic binding and selector ownership
+
+5d supplies a typed binding of:
+
+- package UUID;
+- release version; and
+- mechanical projection UUID.
+
+A human-facing slug may resolve through one code-owned service but cannot serve as canonical authority.
+Every rule-slice request carries deterministic selectors or an explicit whole-package flag. Invalid slugs,
+accidentally empty selectors, stale bindings, and mismatched releases fail explicitly.
+
+### Decision 10 — Typed override completion
+
+ADR-0007's entity-targeting override deferral is discharged by 5d.
+
+5d defines typed patch shapes for the new record/component/fact representation and applies them in the
+effective mechanical view. Existing override precedence and `DISABLE` / `REPLACE` / `APPEND` semantics
+remain unchanged. Overrides never mutate the immutable base projection.
+
+`DISABLE` suppresses an exact typed target; `REPLACE` supplies a complete validated replacement for a
+component or fact; and `APPEND` adds a complete typed component or fact only where the owning schema
+permits multiplicity. A whole-record replacement requires an explicit record-kind-specific patch and is
+never a generic JSON overwrite.
+
+The obsolete prose-only `MechanicalEntity` target is removed under ADR-005c's pre-release clean-baseline
+authority. Unmappable development targets are not guessed into new identities.
+
+### Decision 11 — Downstream ownership remains downstream
+
+5d does not decide:
+
+- Character Sheet Model completeness or storage of the typed binding (2b);
+- adapter capability, certification, or execution (15c);
+- how GameMaster-adjudicated outcomes become trusted mechanical state or narrative canon (15c and the
+  applicable canon/state owners); or
+- frozen #129 / CRD Issue 15b Phase 3 / CRD Issue 19b disposition.
+
+5d exposes exact authority seams for those later decisions.
+
+---
+
+## ADR Reconciliation
+
+### ADR-005c
+
+ADR-005c remains authoritative and is not superseded.
+
+| ADR-005c decision | Reconciliation |
+|---|---|
+| **D1 — Corpus publication and adapter certification are separate** | Preserved. 5d adds a third explicit state: mechanical-projection publication, which still does not imply adapter certification. |
+| **D2 — Source corpus and executable mechanical projection are distinct** | Clarified. "Executable projection" means typed executable-facing authority, not that every represented component is code-executable. Complete 5d scope includes prose-bound GameMaster authority as part of the mechanical projection. |
+| **D3 — Ingestion does not generate a rules engine** | Preserved. Typed facts are declarative; execution remains hand-authored adapter code. |
+| **D4 — Semantic retrieval is never mechanical authority** | Preserved. GameMaster prose retrieval resolves to exact source-bound authority; retrieval never supplies a trust-relevant value. |
+| **D5 — Deterministic binding** | Implemented by 5d's package/release/projection binding and selector contract. |
+| **D6 — Advertised mechanics fail closed** | Preserved for 15c. 5d supplies typed absence/ambiguity/stale/mismatch failures but does not certify adapter capability. |
+| **D7 — #129 remains frozen** | Unchanged. |
+| **Pre-release clean-baseline correction** | Governs 5d legacy removal. Obsolete mechanical entities and development rows receive no compatibility guarantee. |
+
+No historical ADR-005c text is deleted. Add a forward reference from ADR-005c Decisions 2 and 5 to this
+ADR when repository documentation is updated.
+
+### ADR-0007
+
+ADR-0007 remains a correct historical deferral for CRD Issue 5a. This ADR records that CRD Issue 5d is
+the first issue requiring typed entity/component/fact override application and therefore **discharges**
+the deferral.
+
+Add a status note to ADR-0007:
+
+> **Discharged by ADR-005d / CRD Issue 5d.** The typed mechanical projection now defines the concrete
+> record/component/fact patch families and applies them while preserving existing override precedence and
+> operations.
+
+### ADR-015
+
+ADR-015 remains authoritative.
+
+- Decision 3's roll-authorship invariant is unchanged.
+- Decision 7's hand-authored bounded-d20 boundary is unchanged.
+- 5d supplies the typed Rules Package authority from which later 15c code may verify DCs, modifiers,
+  actions, costs, and effects.
+- 5d projection publication does not convert ADR-015's `undetermined` behavior into adapter support.
+- 15c still distinguishes truly unsupported mechanics from missing/incomplete authority.
+
+Add a forward reference to ADR-005d from ADR-015 Decision 7 when repository documentation is updated.
+
+### ADR-018
+
+ADR-018's semantic-retrieval boundary remains unchanged. Exact governing prose may be located for
+GameMaster context, but no semantic retrieval path may author, infer, or select a trust-relevant
+mechanical value. No amendment beyond a cross-reference is required.
+
+---
+
+## Consequences
+
+### Positive
+
+- The shipped SRD Rules Package can support complete basic-game authority without pretending every rule
+  is algorithmically resolvable.
+- Open-ended mechanics such as Wish and illusion effects remain playable through exact GameMaster
+  authority.
+- Deterministic consumers receive typed, source-linked facts instead of parsing prose.
+- Missing or ambiguous authority becomes visible and typed.
+- Mechanical corrections mint new immutable identity rather than silently reusing stale releases.
+- 2b and 15c receive stable upstream contracts.
+
+### Costs
+
+- The accepted classification and mechanical declaration artifacts are substantial.
+- Full semantic review cannot be replaced by a corpus count or unattended classifier.
+- Table/stat-block reconstruction and scoped reference resolution require committed domain work.
+- Typed fact and override families require maintenance as new authorized Rules Packages add mechanics.
+- Delivery requires multiple PRs before 5d is complete.
+
+### Rejected alternatives
+
+1. **Treat all 5c represented text as mechanical.** Rejected: 5c includes legal, navigational, flavor, and
+   explanatory material.
+2. **Default unreviewed text to prose-bound.** Rejected: an empty extraction could pass.
+3. **One record per `ENTRY`.** Rejected: real stat blocks, general rules, tables, and nested records
+   contradict it.
+4. **One component per leaf.** Rejected: real mechanics are many-to-many across spans and cells.
+5. **Use extraction floors or prose ceilings as completeness proof.** Rejected: duplicates and omissions
+   can satisfy aggregates.
+6. **Hash only schema/classification manifests.** Rejected: actual facts could change under stale identity.
+7. **Let adapter breadth decide representation breadth.** Rejected: representation and execution are
+   independent.
+8. **Resolve references by bare name or retrieval.** Rejected: source scope and name collisions make the
+   result ambiguous.
+9. **Preserve the old `MechanicalEntity` for compatibility.** Rejected: it is obsolete, prose-only, and
+   authorized for removal under the pre-release clean baseline.
+10. **Compile the SRD into a universal rules engine.** Rejected: many mechanics are contextual or
+    open-ended, and execution remains hand-authored.
+
+---
+
+## Implementation Authority
+
+The construction-ready CRD Issue 5d specification governs required outcomes, scope, architectural
+boundaries, failure behavior, and acceptance evidence. Repository-native schema, module organization,
+internal decomposition, implementation phases, migration design, and test organization remain engineering
+decisions unless this ADR or the Issue explicitly makes a particular choice contractual.
+
+If implementation discovers a materially better architecture that contradicts this ADR, amend the ADR and
+the affected specification in advance of, or in the same PR as, the implementation. Do not merge a quiet
+contradiction.

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -2,7 +2,8 @@
 
 **Issue:** CRD Issue 5d  
 **Date:** 2026-07-30  
-**Status:** Accepted — finalized by Owner 2026-07-30  
+**Status:** Accepted — finalized by Owner 2026-07-30; amended by Owner Decision 2026-07-30 (PR #138
+review) so the effective runtime binding also carries an immutable override-set identity  
 **Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
 
 ---
@@ -141,6 +142,10 @@ identity unless the accepted semantic content changes.
 Identity derivation is acyclic. Stable record/component/fact IDs derive from the projection UUID and
 committed semantic keys, never local ordinals.
 
+This identity covers the immutable base projection only. `RuleOverride` state is deliberately outside it
+and carries its own separate identity under Decisions 9 and 10, so an override change never mutates or
+remints the base projection UUID.
+
 ### Decision 7 — Build-time reference resolution
 
 Mechanical references resolve at build time through committed source scope, aliases, and exact target
@@ -163,19 +168,35 @@ build candidate
 ```
 
 Draft/partial projections are not active authority. Published projections are immutable. Meaning-changing
-corrections mint a new projection UUID.
+corrections *to the projection itself* mint a new projection UUID; changes to override state do not (see
+Decision 9).
 
-### Decision 9 — Deterministic binding and selector ownership
+### Decision 9 — Deterministic effective binding and selector ownership
 
-5d supplies a typed binding of:
+5d supplies a typed, immutable **effective** binding of:
 
 - package UUID;
-- release version; and
-- mechanical projection UUID.
+- release version;
+- mechanical projection UUID — the immutable base projection; and
+- override-set UUID — the exact applied effective override set.
+
+Base-projection identity and override-set identity remain distinct and are never collapsed into one
+value. The override-set UUID is derived deterministically at binding-resolution time from the canonical
+ordered effective override state that will actually be applied: targets, operations, precedence order,
+enablement, and validated payloads. Adding, removing, enabling, disabling, reprioritizing, retargeting, or
+changing the payload of an applicable override yields a different override-set UUID. The no-overrides
+state has its own deterministic override-set UUID; it is not the absence of one.
+
+Rule slices, deterministic-consumer views, GameMaster authority views, applied-override provenance,
+stale/mismatch validation, and replay/audit evidence identify the exact effective binding — all four
+components — that produced them. A recorded binding whose override-set UUID no longer matches the
+recomputed effective override state is `STALE` and fails explicitly; it is never silently re-resolved
+against current overrides. Overrides never mutate or remint the base projection UUID.
 
 A human-facing slug may resolve through one code-owned service but cannot serve as canonical authority.
-Every rule-slice request carries deterministic selectors or an explicit whole-package flag. Invalid slugs,
-accidentally empty selectors, stale bindings, and mismatched releases fail explicitly.
+Every rule-slice request carries the exact effective binding plus deterministic selectors or an explicit
+whole-package flag. Invalid slugs, accidentally empty selectors, stale bindings, and mismatched releases
+fail explicitly.
 
 ### Decision 10 — Typed override completion
 
@@ -183,7 +204,9 @@ ADR-0007's entity-targeting override deferral is discharged by 5d.
 
 5d defines typed patch shapes for the new record/component/fact representation and applies them in the
 effective mechanical view. Existing override precedence and `DISABLE` / `REPLACE` / `APPEND` semantics
-remain unchanged. Overrides never mutate the immutable base projection.
+remain unchanged. Overrides never mutate the immutable base projection and never remint its identity;
+the applied ordered override state is identified instead by the override-set UUID of the effective
+binding (Decision 9), and applied-override provenance is reported against that binding.
 
 `DISABLE` suppresses an exact typed target; `REPLACE` supplies a complete validated replacement for a
 component or fact; and `APPEND` adds a complete typed component or fact only where the owning schema
@@ -197,7 +220,7 @@ authority. Unmappable development targets are not guessed into new identities.
 
 5d does not decide:
 
-- Character Sheet Model completeness or storage of the typed binding (2b);
+- Character Sheet Model completeness or storage and revalidation of the typed effective binding (2b);
 - adapter capability, certification, or execution (15c);
 - how GameMaster-adjudicated outcomes become trusted mechanical state or narrative canon (15c and the
   applicable canon/state owners); or
@@ -219,13 +242,13 @@ ADR-005c remains authoritative and is not superseded.
 | **D2 — Source corpus and executable mechanical projection are distinct** | Clarified. "Executable projection" means typed executable-facing authority, not that every represented component is code-executable. Complete 5d scope includes prose-bound GameMaster authority as part of the mechanical projection. |
 | **D3 — Ingestion does not generate a rules engine** | Preserved. Typed facts are declarative; execution remains hand-authored adapter code. |
 | **D4 — Semantic retrieval is never mechanical authority** | Preserved. GameMaster prose retrieval resolves to exact source-bound authority; retrieval never supplies a trust-relevant value. |
-| **D5 — Deterministic binding** | Implemented by 5d's package/release/projection binding and selector contract. |
+| **D5 — Deterministic binding** | Implemented by 5d's package/release/base-projection/override-set effective binding and selector contract. |
 | **D6 — Advertised mechanics fail closed** | Preserved for 15c. 5d supplies typed absence/ambiguity/stale/mismatch failures but does not certify adapter capability. |
 | **D7 — #129 remains frozen** | Unchanged. |
 | **Pre-release clean-baseline correction** | Governs 5d legacy removal. Obsolete mechanical entities and development rows receive no compatibility guarantee. |
 
-No historical ADR-005c text is deleted. Add a forward reference from ADR-005c Decisions 2 and 5 to this
-ADR when repository documentation is updated.
+No historical ADR-005c text is deleted. ADR-005c Decisions 2 and 5 carry forward references to this ADR
+as of this change.
 
 ### ADR-0007
 
@@ -233,7 +256,8 @@ ADR-0007 remains a correct historical deferral for CRD Issue 5a. This ADR record
 the first issue requiring typed entity/component/fact override application and therefore **discharges**
 the deferral.
 
-Add a status note to ADR-0007:
+ADR-0007 carries this status note as of this change, with its historical Context, Decision, and
+Consequences text preserved:
 
 > **Discharged by ADR-005d / CRD Issue 5d.** The typed mechanical projection now defines the concrete
 > record/component/fact patch families and applies them while preserving existing override precedence and
@@ -250,13 +274,15 @@ ADR-015 remains authoritative.
 - 5d projection publication does not convert ADR-015's `undetermined` behavior into adapter support.
 - 15c still distinguishes truly unsupported mechanics from missing/incomplete authority.
 
-Add a forward reference to ADR-005d from ADR-015 Decision 7 when repository documentation is updated.
+ADR-015 Decision 7 carries a forward reference to this ADR as of this change; its historical text and
+`Accepted` status are otherwise unchanged.
 
 ### ADR-018
 
 ADR-018's semantic-retrieval boundary remains unchanged. Exact governing prose may be located for
 GameMaster context, but no semantic retrieval path may author, infer, or select a trust-relevant
-mechanical value. No amendment beyond a cross-reference is required.
+mechanical value. No amendment beyond a cross-reference is required, and ADR-018 Decision 10 carries that
+narrowly scoped cross-reference as of this change.
 
 ---
 
@@ -271,6 +297,9 @@ mechanical value. No amendment beyond a cross-reference is required.
 - Deterministic consumers receive typed, source-linked facts instead of parsing prose.
 - Missing or ambiguous authority becomes visible and typed.
 - Mechanical corrections mint new immutable identity rather than silently reusing stale releases.
+- Replay, audit, and stale detection reconstruct the exact effective authority — base projection plus the
+  identified applied override set — instead of an ambiguous package/release pair that could resolve to
+  different trust-relevant values over time.
 - 2b and 15c receive stable upstream contracts.
 
 ### Costs
@@ -279,6 +308,8 @@ mechanical value. No amendment beyond a cross-reference is required.
 - Full semantic review cannot be replaced by a corpus count or unattended classifier.
 - Table/stat-block reconstruction and scoped reference resolution require committed domain work.
 - Typed fact and override families require maintenance as new authorized Rules Packages add mechanics.
+- Every effective override change mints a new override-set identity, so consumers that record or cache an
+  effective binding must revalidate it rather than assume stability across override edits.
 - Delivery requires multiple PRs before 5d is complete.
 
 ### Rejected alternatives
@@ -300,6 +331,10 @@ mechanical value. No amendment beyond a cross-reference is required.
    authorized for removal under the pre-release clean baseline.
 10. **Compile the SRD into a universal rules engine.** Rejected: many mechanics are contextual or
     open-ended, and execution remains hand-authored.
+11. **Bind runtime authority to package, release, and base projection alone.** Rejected by Owner Decision
+    2026-07-30 (PR #138): overrides change the effective mechanical view, so one such binding could
+    resolve to different DCs, effects, or disabled mechanics over time and neither stale detection nor
+    replay could reconstruct the authority actually used.
 
 ---
 

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -256,8 +256,8 @@ ADR-0007 remains a correct historical deferral for CRD Issue 5a. This ADR record
 the first issue requiring typed entity/component/fact override application and therefore **discharges**
 the deferral.
 
-ADR-0007 carries this status note as of this change, with its historical Context, Decision, and
-Consequences text preserved:
+ADR-0007 carries this status note as of this change — followed there by a link to Decisions 9 and 10 and
+a statement that its historical Context, Decision, and Consequences text is preserved:
 
 > **Discharged by ADR-005d / CRD Issue 5d.** The typed mechanical projection now defines the concrete
 > record/component/fact patch families and applies them while preserving existing override precedence and

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -4,7 +4,8 @@
 **Date:** 2026-07-30  
 **Status:** Accepted — finalized by Owner 2026-07-30; amended by Owner Decision 2026-07-30 (PR #138
 review) so the effective runtime binding also carries an immutable override-set identity, and clarified
-in the same review so the contents that identity names are retained as immutable replay evidence  
+in the same review so the contents that identity names are retained as immutable, provenance-exact replay
+evidence  
 **Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
 
 ---
@@ -182,22 +183,41 @@ Decision 9).
 - override-set UUID — the exact applied effective override set.
 
 Base-projection identity and override-set identity remain distinct and are never collapsed into one
-value. The override-set UUID is derived deterministically at binding-resolution time from the canonical
-ordered effective override state that will actually be applied: targets, operations, precedence order,
-enablement, and validated payloads. Adding, removing, enabling, disabling, reprioritizing, retargeting, or
-changing the payload of an applicable override yields a different override-set UUID. The no-overrides
-state has its own deterministic override-set UUID; it is not the absence of one.
+value. The effective binding is **provenance-exact**, not merely mechanically equivalent: the override-set
+identity names both the exact effective mechanical state applied and the exact authoritative override
+records that supplied it. The canonical identity-bearing representation of every override entry therefore
+carries:
 
-Each override-set UUID identifies one immutable, content-addressed override-set **version**. That version
-preserves — or is deterministically reconstructable from append-only retained evidence that preserves —
-the exact canonical ordered override state the UUID was derived from: targets, operations,
-precedence/order, enablement state, and complete validated payloads. Historical override-set versions
-remain retrievable after the source `RuleOverride` rows are edited, disabled, reprioritized, retargeted,
-or deleted. Recording the override-set UUID while retaining only mutable current override rows is
-insufficient. Current override rows remain the authoring surface; they are not historical replay evidence.
-Whether that retention takes the shape of immutable content-addressed snapshots, append-only version
-records, or an event history that deterministically reconstructs the canonical set is an implementation
-choice this ADR does not make. Override-set version retention is runtime state and is separate from the
+- stable override identity (`override_id` or its repository-native successor);
+- override origin (`house_rule`, `package_patch`, or its typed successor);
+- exact typed target identity;
+- operation;
+- precedence/order;
+- enablement state; and
+- complete validated payload.
+
+The override-set UUID is derived deterministically at binding-resolution time from that canonical ordered
+state. Adding, removing, enabling, disabling, reprioritizing, retargeting, or changing the payload of an
+applicable override yields a different override-set UUID, and so does deleting and recreating an otherwise
+identical override under a different identity or origin: a house rule and a package patch with identical
+mechanical contents are not the same provenance-exact authority. The no-overrides state has its own
+deterministic override-set UUID; it is not the absence of one.
+
+Identity is not silently broadened to incidental audit metadata. Creation timestamps, authors, comments,
+and proposal history remain non-identity audit metadata unless they participate in override applicability,
+ordering, or resolution. The enclosing package UUID already supplies package scope.
+
+Each override-set UUID is the content-derived identity of one immutable, replayable override-set
+**version**. That version preserves — or is deterministically reconstructable from append-only retained
+evidence that preserves — the exact canonical ordered override state enumerated above. Historical
+override-set versions remain retrievable after the source `RuleOverride` rows are edited, disabled,
+reprioritized, retargeted, or deleted. Recording the override-set UUID while retaining only mutable
+current override rows is insufficient. Current override rows remain the authoring surface; they are not
+historical replay evidence. That version may be retained as a content-addressed snapshot, as append-only
+version records, or as append-only events that deterministically reconstruct the canonical version; an
+event log need not itself be content-addressed, but its reconstructed canonical version must reproduce and
+verify the recorded override-set UUID. Which of those shapes a repository uses is an implementation choice
+this ADR does not make. Override-set version retention is runtime state and is separate from the
 Decision 8 projection publication lifecycle.
 
 Rule slices, deterministic-consumer views, GameMaster authority views, applied-override provenance,
@@ -231,8 +251,11 @@ binding (Decision 9), and applied-override provenance is reported against that b
 
 Applied-override provenance resolves through the retained immutable override-set version, not through
 current override rows, so an effective view recorded earlier remains reconstructable after the source
-overrides are edited, disabled, reprioritized, retargeted, or deleted. The base projection and its
-identity are unaffected either way.
+overrides are edited, disabled, reprioritized, retargeted, or deleted. That provenance is
+provenance-exact: it reports the stable override identity and origin of each applied override alongside
+its target, operation, order, enablement, and payload, so an audit can name which authoritative override
+record supplied each change rather than only what the change was. The base projection and its identity are
+unaffected either way.
 
 `DISABLE` suppresses an exact typed target; `REPLACE` supplies a complete validated replacement for a
 component or fact; and `APPEND` adds a complete typed component or fact only where the owning schema
@@ -326,7 +349,9 @@ narrowly scoped cross-reference as of this change.
 - Replay and audit reconstruct the exact effective authority — base projection plus the retained
   override-set version — instead of an ambiguous package/release pair that could resolve to different
   trust-relevant values over time, and they keep working after the current override rows are edited or
-  deleted. Runtime stale detection remains a separate fail-closed check against current override state.
+  deleted. Because the binding is provenance-exact, they also name which override record and origin
+  supplied each applied change. Runtime stale detection remains a separate fail-closed check against
+  current override state.
 - 2b and 15c receive stable upstream contracts.
 
 ### Costs
@@ -339,6 +364,9 @@ narrowly scoped cross-reference as of this change.
   effective binding must revalidate it rather than assume stability across override edits.
 - Retained override-set versions accumulate alongside override authoring, and pruning them forfeits the
   replay and audit reconstruction they exist to provide.
+- Because identity is provenance-exact, recreating an override under a new identity or changing its origin
+  mints a new override-set identity even when the mechanical result is unchanged, so authoring churn is
+  visible in the binding rather than hidden by it.
 - Delivery requires multiple PRs before 5d is complete.
 
 ### Rejected alternatives
@@ -370,6 +398,13 @@ narrowly scoped cross-reference as of this change.
     reconstruct the authority actually applied. This is the standing auditability invariant — operational
     state must be reconstructable from explicit retained evidence, not inferred from mutable current
     state — applied to override sets.
+13. **Identify a retained override-set version by its mechanical contents alone.** Rejected in the same
+    review: deleting and recreating an otherwise identical override, or changing only its origin, would
+    reuse the same identity and leave no evidence of which authoritative record actually applied, which is
+    the applied-override provenance Decision 10 promises. The retained state carries stable override
+    identity and origin as well. Identity is not broadened past that: creation timestamps, authors,
+    comments, and proposal history stay non-identity audit metadata unless they participate in
+    applicability, ordering, or resolution.
 
 ---
 

--- a/docs/decisions/adr-015-rpg-adjudication.md
+++ b/docs/decisions/adr-015-rpg-adjudication.md
@@ -188,6 +188,14 @@ supported boundary, rather than inventing a result.
 RPG dice-handling Known Unknown resolution. Hand-authored adapters prevent
 mechanic drift and keep auditability deterministic.
 
+**Forward reference (ADR-005d, 2026-07-30):**
+[ADR-005d](adr-005d-complete-typed-mechanical-authority.md) supplies the typed
+Rules Package authority a later CRD Issue 15c adapter verifies against, and keeps
+representation separate from execution: projection publication never converts
+`undetermined` into adapter support. Adjudication records the exact effective
+binding — package, release, mechanical projection, and override set — that
+supplied its authority. This decision's boundary is unchanged.
+
 ---
 
 ## Decision 8: Active mechanical conditions/effects are sheet-owned concrete d20 state (owner decision)

--- a/docs/decisions/adr-018-retrieval-memory.md
+++ b/docs/decisions/adr-018-retrieval-memory.md
@@ -666,6 +666,12 @@ service, or runtime mechanical decision may consume semantic rules retrieval as 
 rule inclusion remains exclusively through `get_active_rule_slice`. Wiring semantic rules discovery
 into any runtime path — even as a "hint" — is a future issue plus ADR.
 
+**Cross-reference (ADR-005d, 2026-07-30):** this boundary is unchanged by
+[ADR-005d](adr-005d-complete-typed-mechanical-authority.md). Retrieval may locate candidate governing
+prose for the ADR-005d GameMaster authority view, but the returned authority must resolve to the exact
+effective Rules Package binding (package, release, mechanical projection, and override set); retrieval
+never supplies or selects a trust-relevant mechanical value.
+
 ## Decision 11 (D11) — Update/Delete/Reindex Semantics
 
 **Decision:** In-place re-upsert keyed by deterministic IDs, with orphan sweep by `story_id` filter,


### PR DESCRIPTION
Documentation-only PR. Adds accepted ADR-005d (Complete Typed Mechanical Authority and Deterministic
Rules-Package Binding) for CRD Issue 5d (#137), and applies the ADR-chain reconciliation ADR-005d
requires.

## What was built

- **`docs/decisions/adr-005d-complete-typed-mechanical-authority.md`** — accepted ADR for CRD Issue 5d:
  complete typed mechanical-authority projection over one exact published CRD Issue 5c release; span-exact
  semantic classification; semantic records with many-to-many provenance; a closed typed fact union with no
  generated rules engine; exact completeness proof instead of aggregate thresholds; meaning-bearing
  immutable identity; build-time reference resolution; persist → reconstruct → prove → publish;
  deterministic runtime binding and selector ownership; typed override completion; and the downstream
  ownership boundary for CRD Issues 2b and 15c.

- **Owner Decision 2026-07-30 (this PR's review, Codex P1) — effective mechanical-authority identity.**
  The immutable base mechanical-projection identity is preserved, and the effective runtime binding now
  also carries an immutable, versioned identity for the exact applied override set:

  ```text
  RulesPackageBinding(package_uuid, release_version, mechanical_projection_uuid, override_set_uuid)
  ```

  The override-set identity is derived deterministically at binding-resolution time from the canonical
  ordered effective override state. Adding, removing, enabling, disabling, reprioritizing, retargeting, or
  changing an override payload mints a different override-set identity; the no-overrides state has its own
  deterministic identity. Rule slices, deterministic-consumer views, GameMaster authority views,
  stale/mismatch validation, replay/audit evidence, and applied-override provenance identify the exact
  effective binding. Overrides never mutate or remint the base projection. Updated in ADR-005d Decisions 6,
  8, 9, 10, the ADR-005c D5 reconciliation row, Consequences, and Rejected alternatives; and in the
  accepted CRD Issue 5d source (#137) contract 5, contract 6, acceptance criteria 11 and 18–21 (21 is new),
  the non-discretion list, and the 2b downstream seam. Exact naming and repository-native representation
  remain engineering choices at implementation time.

- **Clarification in the same review (Codex round 2 P1) — immutable override-set contents are retained
  as replay evidence.** Each `override_set_uuid` identifies one immutable, content-addressed override-set
  **version** that preserves — or is deterministically reconstructable from append-only retained evidence
  preserving — the exact canonical ordered state the identity was derived from: targets, operations,
  precedence/order, enablement state, and complete validated payloads. Historical versions stay retrievable
  after the source `RuleOverride` rows are edited, disabled, reprioritized, retargeted, or deleted.
  Recording the identity while retaining only mutable current rows is insufficient; current rows remain the
  authoring surface, not historical replay evidence. Runtime staleness and replay reconstruction are now
  stated as distinct operations: `STALE` is a fail-closed runtime result, while an audit/replay read
  resolves against the retained version and must succeed, so a failure to reconstruct is a retention defect
  rather than a divergence signal. Updated in ADR-005d Decisions 9 and 10, Consequences (replay + cost),
  and new rejected alternative 12; and in #137 contract 5 (retention clause, `STALE` split, negative
  control), contract 6, acceptance criterion 21, and the non-discretion list. Immutable content-addressed
  snapshots, append-only version records, and event history are all acceptable; no table layout is
  prescribed.

- **Final Owner clarification in the same family (Codex round 3 P1) — the effective binding is
  provenance-exact.** The retained override-set version identifies both the exact effective mechanical
  state applied *and* the exact authoritative override records that supplied it. The canonical
  identity-bearing representation of every override entry carries stable override identity (`override_id`
  or its repository-native successor), override origin (`house_rule` / `package_patch` or its typed
  successor), exact typed target identity, operation, precedence/order, enablement state, and complete
  validated payload. Deleting and recreating an otherwise identical override under a different identity,
  or changing only its origin, mints a different `override_set_uuid` — a house rule and a package patch
  with identical mechanical contents are not the same authority. Identity is *not* broadened to incidental
  audit metadata: creation timestamps, authors, comments, and proposal history stay non-identity unless
  they participate in applicability, ordering, or resolution, and the enclosing package UUID already
  supplies package scope. Applied-override provenance now names identity and origin, not only the
  mechanical change.

  **Terminology corrected** so no storage shape is implied: each `override_set_uuid` is the
  *content-derived identity* of one immutable, *replayable* override-set version. That version may be
  retained as a content-addressed snapshot, append-only version records, or append-only events that
  deterministically reconstruct the canonical version; an event log need not itself be content-addressed,
  provided its reconstructed canonical version reproduces and verifies the recorded identity.

  Updated in ADR-005d Decisions 9 and 10, Consequences, and new rejected alternative 13; and in #137
  contract 5 (canonical field list, retention shapes, non-identity metadata, negative controls), contract
  6, acceptance criterion 21, and the non-discretion list.

- **ADR-chain reconciliation applied here rather than deferred (Codex P2).** ADR-005d's reconciliation
  language is now past-tense/applied, and the four edits it promised are in this change:
  - `ADR-0007-rules-package-entity-patch-deferral.md` — discharge status note (`Accepted — discharged by
    ADR-005d / CRD Issue 5d`) plus the note body; historical Context/Decision/Consequences unchanged.
  - `adr-005c-rules-authority-repair.md` — ADR-005d forward references at Decisions 2 and 5; decision text
    unchanged.
  - `adr-015-rpg-adjudication.md` — ADR-005d forward reference at Decision 7; boundary text unchanged.
  - `adr-018-retrieval-memory.md` — narrowly scoped ADR-005d cross-reference at Decision 10
    (rules-corpus/semantic-retrieval boundary); boundary unchanged, Central Invariant untouched.

## How this satisfies each acceptance criterion

CRD Issue 5d's acceptance criteria are implementation criteria and are not claimed by this PR — no code,
schema, migration, or projection is delivered here. This PR satisfies the governing-document obligations
that precede that work:

| Obligation | Coverage |
|---|---|
| ADR-005d is accepted, complete, and internally consistent | ADR-005d Context, Central Decision, Decisions 1–11, Reconciliation, Consequences, Implementation Authority |
| Effective runtime binding carries base-projection **and** override-set identity, kept distinct | ADR-005d Decisions 6, 8, 9, 10; #137 contract 6, AC 11, AC 21 |
| Override changes never remint base projection identity | ADR-005d Decisions 6, 8, 10; #137 contract 5 and 6 |
| Override-set contents retained as immutable replay evidence, distinct from mutable current rows | ADR-005d Decisions 9, 10, rejected alternative 12; #137 contract 5 (retention clause + negative controls), contract 6, AC 21 |
| Retained version is provenance-exact — override identity and origin included, incidental audit metadata excluded | ADR-005d Decisions 9, 10, rejected alternative 13; #137 contract 5 canonical field list, contract 6, AC 21 |
| Stale/mismatch, replay, and provenance identify the exact effective binding | ADR-005d Decision 9; #137 contract 5 failure states, contract 6, AC 19–21 |
| Reconciliation promised by ADR-005d is applied, not deferred | ADR-0007, ADR-005c D2/D5, ADR-015 D7, ADR-018 D10 |
| Historical ADR text and status preserved | Only status note / forward references added; no decision text removed or rewritten |

## Test coverage summary

No production or test code changes; the 80%-on-new-code gate does not apply. Documentation verification
performed on the branch head:

- every relative markdown link added resolves to a case-exact file in `docs/decisions/`
  (`adr-005d-complete-typed-mechanical-authority.md`, verified against real directory entries rather than
  case-insensitive `Test-Path`);
- no remaining text in ADR-005d or #137 defines the effective runtime binding as package/release/base
  projection alone (`RulesPackageBinding` appears nowhere in `src/`, so there is no code definition to
  reconcile yet);
- base-projection identity and override-set identity are stated as distinct in every place the binding is
  defined or referenced;
- every statement that derives the override-set identity at binding-resolution time carries adjacent
  retention language, so no wording permits UUID-only retention;
- immutable historical override-set versions and mutable current `RuleOverride` rows are distinguished
  wherever either is described, and `STALE` is scoped to runtime resolution rather than replay reads;
- no enumeration of retained override state lists mechanical fields alone — every one carries override
  identity and origin — and no remaining wording requires a snapshot storage shape (`content-addressed`
  now appears only as one permitted retention option, never as the identity requirement);
- `override_id`, `override_origin`, `house_rule`, and `package_patch` are the repository's live names,
  verified against `src/afterworlds/models/rules_package.py` and `src/afterworlds/models/enums.py`;
- the live #137 body was refetched before and after each edit and verified intact (589 lines,
  18 headings).

Docs-only diff with no Python or frontend surface touched. On head `d189284` at time of writing, the
frontend job is green and the E2E and `Lint, Type-check, Test, Audit` jobs are still running; earlier
heads in this PR had E2E and frontend green. No job has been observed failing.

## Architecture Notes

**Correction accepted in this PR (Owner Decision, 2026-07-30).** The originally merged ADR-005d Decision 9
bound runtime authority to package UUID, release version, and mechanical-projection UUID only. Because
Decision 10 lets overrides change the effective mechanical view, one such binding could resolve to
different trust-relevant DCs, effects, or disabled mechanics over time, and neither stale detection nor
replay could reconstruct which authority was actually used. The effective binding now carries an
immutable, versioned override-set identity as a fourth component, distinct from the immutable base
projection identity. This is recorded as ADR-005d rejected alternative 11 so the superseded shape stays
visible.

**Clarification accepted in the same review (round 2, Codex P1).** The correction above required a
deterministic `override_set_uuid` but did not state strongly enough that the contents that identity names
must survive. Deriving the identity from current rows lets audit and replay detect that a recorded binding
diverges; it does not preserve the payloads and ordering needed to reconstruct the authority actually
applied once an override is edited, disabled, reprioritized, retargeted, or deleted. ADR-005d now requires
each identity to name a retained immutable override-set version, and splits runtime staleness from
audit/replay reconstruction so the two are not asserted of the same operation. This is architecture
invariant 11 — operational state affecting auditability must be reconstructable from explicit retained
evidence, not inferred from opaque mutable state — applied to override sets, so it is recorded as a
clarification of the existing Owner Decision rather than a further one. Repository-native persistence
design (content-addressed snapshots, append-only version records, or event history) is left to
implementation; no table layout is prescribed.

**Final clarification in the same family (round 3, Owner rule).** The retained-contents requirement
enumerated mechanical fields only, so two provenance-distinct authorities — an override deleted and
recreated under a new identity, or a house rule reclassified as a package patch — collapsed to one
`override_set_uuid` while Decision 10 promised applied-override provenance. The Owner rule is that the
effective binding is **provenance-exact**: it identifies the exact effective mechanical state *and* the
exact authoritative override records that supplied it, so stable override identity and origin are part of
the canonical identity-bearing state. Identity stops there — incidental audit metadata is explicitly
excluded, so this narrows rather than broadens what the UUID depends on. The accompanying terminology
correction removes any implication of a required snapshot storage shape. This closes the family; no
further reactive change in it will be made without a fresh scope or owner-boundary assessment.

**Reconciliation is applied in the same PR that promises it.** ADR-005d previously instructed future edits
to ADR-0007, ADR-005c, ADR-015, and ADR-018. Because those ADRs remain accepted and authoritative, that
deferral would have left contradictory implementation guidance live at merge (ADR-0007 still directing
implementers to a deferral ADR-005d had discharged). Those edits are now made here and ADR-005d's
reconciliation language is past-tense.

**Boundaries preserved.** No 5d architecture beyond the identity correction is reopened. ADR-005c
Decisions 2 and 5, ADR-015 Decision 7, and ADR-018 Decision 10 keep their historical text, status, and
boundaries; only a status note or forward reference is added. Retrieval remains non-authoritative.
Adapter capability, Character Sheet Model storage, and adjudicated-effect mutation remain owned by CRD
Issues 15c and 2b. Deriving the override-set identity at binding-resolution time keeps ADR-005d Decision
11's deferral of binding *storage* to CRD Issue 2b coherent, and CRD Issue 2b now explicitly owns
revalidation of a recorded binding when the effective override set changes.

Otherwise, no drift from design principles.

## Review-Loop / Boundary Check

- [x] This PR still fits the intended scope of the issue.
- [ ] Repeated review churn has **not** accumulated on the same file or function.
- [ ] The remaining work is still concrete defect-fixing, not an ownership or boundary dispute.

Reported honestly: churn **has** accumulated, and the feedback did shift out of concrete defect-fixing.

- **Hotspot file/function:** ADR-005d Decisions 9–10 and CRD Issue 5d (#137) Contracts 5–6.
- **What shifted from bug-fix to boundary question:** three consecutive rounds landed in the same
  effective-authority identity family — (1) the binding omitted override-set identity, (2) the identity
  named contents that were not retained, (3) the retained contents omitted override identity and origin.
  Each round moved further into identity *semantics* — what the identity must mean and what it must
  depend on — rather than into new defects, which is why it required an explicit Owner rule instead of
  another patch.
- **Is this now:** Owner decision needed → **obtained**. Each finding was flagged `[OWNER DECISION]` by
  Codex and accepted by the Owner before the corresponding edit; nothing was resolved unilaterally in the
  documents.
- **Proposed handling:** the Owner rule that the effective binding is **provenance-exact** closes the
  family. Sibling check across it — the base mechanical-projection identity (ADR-005d Decision 6) is
  already immutable, meaning-bound, and published under the Decision 8 persist → reconstruct → prove →
  publish lifecycle, so it already carries the retention and provenance properties added here for override
  sets; the 5c source-release binding is likewise immutable and reconstructable under ADR-005c. No fourth
  identifier-over-mutable-state sibling remains in the binding.
- **Stop condition:** no further reactive change in this semantic family without a new scope or
  owner-boundary assessment first. The broader projection identity architecture is not reopened, no table
  layout is prescribed, and no unrelated scope is added.
