### PR TITLE
CRD Issue 5d PR 1 — semantic accounting, typed representation, projection identity, draft persistence

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -17,6 +17,7 @@ import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.story_bible  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.corpus  # noqa: F401
+import afterworlds.persistence.orm.mechanical  # noqa: F401
 import afterworlds.persistence.orm.rolling_summary  # noqa: F401
 import afterworlds.persistence.orm.rpg  # noqa: F401
 import afterworlds.persistence.orm.retrieval  # noqa: F401

--- a/alembic/versions/0021_mechanical_projection.py
+++ b/alembic/versions/0021_mechanical_projection.py
@@ -91,6 +91,11 @@ def upgrade() -> None:
             sa.Column("rule", sa.Text, nullable=False),
             sa.Column("semantic_diff_hash", sa.String(64), nullable=False),
         ),
+        # The logical identity scope and diff rows are matched on. Defence in
+        # depth; reconstruction proves the relation regardless.
+        sa.UniqueConstraint(
+            "projection_uuid", "batch_id", name="uq_rp_mech_batch_identity"
+        ),
     )
 
     op.create_table(

--- a/alembic/versions/0021_mechanical_projection.py
+++ b/alembic/versions/0021_mechanical_projection.py
@@ -1,0 +1,219 @@
+"""Mechanical-authority projection tables — CRD Issue 5d (#137).
+
+Adds the ``rp_mech_*`` family: one projection header bound to an exact
+published CRD Issue 5c release, plus typed rows for accepted spans, retained
+acceptance evidence (batches, resolved scope, canonical diff, acceptance
+actions), records, components, typed facts, prose bindings, relationships,
+build-time-resolved references, and exact leaf-subspan provenance.
+
+Additive only. Nothing existing is altered or dropped: the ``MechanicalEntity``
+authority path stays exactly as it is, and no projection is publishable or
+reachable as runtime authority at this revision.
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-07-31
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0021"
+down_revision: str | None = "0020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _scoped(*columns: sa.Column) -> tuple[sa.Column, ...]:
+    """Standard leading columns for a projection-scoped table."""
+    return (
+        sa.Column("row_id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "projection_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_mech_projections.projection_uuid", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        *columns,
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rp_mech_projections",
+        sa.Column("projection_uuid", sa.String(36), primary_key=True),
+        sa.Column(
+            "package_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_corpus_releases.package_uuid", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("release_version", sa.String(64), nullable=False),
+        sa.Column("authoritative_source_hash", sa.String(64), nullable=False),
+        sa.Column("transform_config_hash", sa.String(64), nullable=False),
+        sa.Column("bundle_root_hash", sa.String(64), nullable=False),
+        sa.Column("persisted_corpus_digest", sa.String(64), nullable=False),
+        sa.Column("semantic_policy_version", sa.String(64), nullable=False),
+        sa.Column("semantic_policy_hash", sa.String(64), nullable=False),
+        sa.Column("payload_hash", sa.String(64), nullable=False),
+        # NULL through the draft phase; set once from reconstructed state.
+        sa.Column("persisted_state_digest", sa.String(64), nullable=True),
+        sa.Column(
+            "publication_status", sa.String(32), nullable=False, server_default="draft"
+        ),
+        sa.Column("created_at", sa.String(64), nullable=False),
+    )
+
+    op.create_table(
+        "rp_mech_spans",
+        *_scoped(
+            sa.Column("span_id", sa.String(36), nullable=False, index=True),
+            sa.Column("leaf_id", sa.String(64), nullable=False, index=True),
+            sa.Column("char_start", sa.Integer, nullable=False),
+            sa.Column("char_end", sa.Integer, nullable=False),
+            sa.Column("disposition", sa.String(32), nullable=False),
+            sa.Column("review_state", sa.String(16), nullable=False),
+            sa.Column("non_mechanical_reason_code", sa.String(64), nullable=True),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_acceptance_batches",
+        *_scoped(
+            sa.Column("batch_id", sa.String(64), nullable=False, index=True),
+            sa.Column("rule", sa.Text, nullable=False),
+            sa.Column("semantic_diff_hash", sa.String(64), nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_batch_scope",
+        *_scoped(
+            sa.Column("batch_id", sa.String(64), nullable=False, index=True),
+            sa.Column("span_id", sa.String(36), nullable=False),
+            sa.Column("ordinal", sa.Integer, nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_batch_diff",
+        *_scoped(
+            sa.Column("batch_id", sa.String(64), nullable=False, index=True),
+            sa.Column("span_id", sa.String(36), nullable=False),
+            sa.Column("prior_disposition", sa.String(32), nullable=True),
+            sa.Column("prior_reason_code", sa.String(64), nullable=True),
+            sa.Column("accepted_disposition", sa.String(32), nullable=False),
+            sa.Column("accepted_reason_code", sa.String(64), nullable=True),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_acceptances",
+        *_scoped(
+            sa.Column("span_id", sa.String(36), nullable=False, index=True),
+            sa.Column("batch_id", sa.String(64), nullable=True),
+            sa.Column("reviewer", sa.String(255), nullable=False),
+            sa.Column("accepted_at", sa.String(64), nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_records",
+        *_scoped(
+            sa.Column("record_id", sa.String(36), nullable=False, index=True),
+            sa.Column("semantic_key", sa.String(255), nullable=False),
+            sa.Column("kind", sa.String(32), nullable=False),
+            sa.Column("parent_key", sa.String(255), nullable=True),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_components",
+        *_scoped(
+            sa.Column("component_id", sa.String(36), nullable=False, index=True),
+            sa.Column("record_key", sa.String(255), nullable=False, index=True),
+            sa.Column("semantic_key", sa.String(255), nullable=False),
+            sa.Column("handling", sa.String(16), nullable=False),
+            sa.Column("irreducibility_reason_code", sa.String(64), nullable=True),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_facts",
+        *_scoped(
+            sa.Column("fact_id", sa.String(36), nullable=False, index=True),
+            sa.Column("record_key", sa.String(255), nullable=False, index=True),
+            sa.Column("component_key", sa.String(255), nullable=False),
+            sa.Column("fact_key", sa.String(32), nullable=False),
+            # Closed-union discriminator; the payload is that family's
+            # validated field set, rebuilt into its declared dataclass on read.
+            sa.Column("family", sa.String(64), nullable=False, index=True),
+            sa.Column("payload", sa.JSON, nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_prose_bindings",
+        *_scoped(
+            sa.Column("record_key", sa.String(255), nullable=False, index=True),
+            sa.Column("component_key", sa.String(255), nullable=False),
+            sa.Column("chunk_id", sa.String(64), nullable=False, index=True),
+            sa.Column("irreducibility_reason_code", sa.String(64), nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_relationships",
+        *_scoped(
+            sa.Column("source_record_key", sa.String(255), nullable=False, index=True),
+            sa.Column("target_record_key", sa.String(255), nullable=False),
+            sa.Column("kind", sa.String(32), nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_references",
+        *_scoped(
+            sa.Column("from_record_key", sa.String(255), nullable=False, index=True),
+            sa.Column("from_component_key", sa.String(255), nullable=False),
+            sa.Column("source_text", sa.Text, nullable=False),
+            sa.Column("scope_key", sa.String(255), nullable=False, index=True),
+            sa.Column("target_record_key", sa.String(255), nullable=False),
+        ),
+    )
+
+    op.create_table(
+        "rp_mech_provenance",
+        *_scoped(
+            sa.Column("target_kind", sa.String(32), nullable=False, index=True),
+            sa.Column("target_key", sa.JSON, nullable=False),
+            sa.Column("span_id", sa.String(36), nullable=False, index=True),
+            sa.Column("role", sa.String(16), nullable=False),
+        ),
+    )
+
+
+def downgrade() -> None:
+    for table in (
+        "rp_mech_provenance",
+        "rp_mech_references",
+        "rp_mech_relationships",
+        "rp_mech_prose_bindings",
+        "rp_mech_facts",
+        "rp_mech_components",
+        "rp_mech_records",
+        "rp_mech_acceptances",
+        "rp_mech_batch_diff",
+        "rp_mech_batch_scope",
+        "rp_mech_acceptance_batches",
+        "rp_mech_spans",
+        "rp_mech_projections",
+    ):
+        op.drop_table(table)

--- a/src/afterworlds/ingestion/mechanical/__init__.py
+++ b/src/afterworlds/ingestion/mechanical/__init__.py
@@ -1,0 +1,7 @@
+"""Typed mechanical authority — CRD Issue 5d.
+
+Offline build, accounting, proof, and publication for the mechanical-authority
+projection over one exact published CRD Issue 5c release. Runtime authority
+(binding, slices, views, override application) lives in the service layer; this
+package never serves a turn.
+"""

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -32,6 +32,7 @@ acceptance history.
 from __future__ import annotations
 
 from afterworlds.ingestion.corpus.hashing import content_id, hash_obj
+from afterworlds.ingestion.mechanical.canonical import canonical_order
 from afterworlds.ingestion.mechanical.models import (
     AcceptanceBatch,
     ClassificationLedger,
@@ -165,20 +166,17 @@ def validate_policy_binding(ledger: ClassificationLedger) -> tuple[str, ...]:
 
 def batch_diff_payload(batch: AcceptanceBatch) -> list[dict[str, object]]:
     """Canonical serialization of a batch's retained semantic diff."""
-    return sorted(
-        (
-            {
-                "span_id": e.span_id,
-                "prior_disposition": (
-                    e.prior_disposition.value if e.prior_disposition else None
-                ),
-                "prior_reason_code": e.prior_reason_code,
-                "accepted_disposition": e.accepted_disposition.value,
-                "accepted_reason_code": e.accepted_reason_code,
-            }
-            for e in batch.diff
-        ),
-        key=lambda d: str(d["span_id"]),
+    return canonical_order(
+        {
+            "span_id": e.span_id,
+            "prior_disposition": (
+                e.prior_disposition.value if e.prior_disposition else None
+            ),
+            "prior_reason_code": e.prior_reason_code,
+            "accepted_disposition": e.accepted_disposition.value,
+            "accepted_reason_code": e.accepted_reason_code,
+        }
+        for e in batch.diff
     )
 
 
@@ -363,19 +361,16 @@ def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
         "release_version": ledger.release_version,
         "semantic_policy_version": ledger.policy_version,
         "semantic_policy_hash": ledger.policy_hash,
-        "spans": sorted(
-            (
-                {
-                    "span_id": s.span_id,
-                    "leaf_id": s.leaf_id,
-                    "char_start": s.char_start,
-                    "char_end": s.char_end,
-                    "disposition": s.disposition.value,
-                    "non_mechanical_reason_code": s.non_mechanical_reason_code,
-                }
-                for s in ledger.spans
-            ),
-            key=lambda d: str(d["span_id"]),
+        "spans": canonical_order(
+            {
+                "span_id": s.span_id,
+                "leaf_id": s.leaf_id,
+                "char_start": s.char_start,
+                "char_end": s.char_end,
+                "disposition": s.disposition.value,
+                "non_mechanical_reason_code": s.non_mechanical_reason_code,
+            }
+            for s in ledger.spans
         ),
     }
 
@@ -400,33 +395,29 @@ def acceptance_evidence_payload(ledger: ClassificationLedger) -> dict[str, objec
     is evidence, and a reordered scope is a different record of what happened.
     """
     return {
-        "review_states": sorted(
-            ([s.span_id, s.review_state.value] for s in ledger.spans),
-            key=lambda pair: pair[0],
+        "review_states": canonical_order(
+            {"span_id": s.span_id, "review_state": s.review_state.value}
+            for s in ledger.spans
         ),
-        "batches": sorted(
-            (
-                {
-                    "batch_id": b.batch_id,
-                    "rule": b.rule,
-                    "resolved_scope": list(b.resolved_scope),
-                    "diff": batch_diff_payload(b),
-                    "semantic_diff_hash": b.semantic_diff_hash,
-                }
-                for b in ledger.batches
-            ),
-            key=lambda d: str(d["batch_id"]),
+        "batches": canonical_order(
+            {
+                "batch_id": b.batch_id,
+                "rule": b.rule,
+                # Scope order is reviewer evidence, not an unordered set, so it
+                # is retained exactly as recorded rather than canonicalized.
+                "resolved_scope": list(b.resolved_scope),
+                "diff": batch_diff_payload(b),
+                "semantic_diff_hash": b.semantic_diff_hash,
+            }
+            for b in ledger.batches
         ),
-        "acceptances": sorted(
-            (
-                {
-                    "span_id": a.span_id,
-                    "batch_id": a.batch_id,
-                    "reviewer": a.reviewer,
-                    "accepted_at": a.accepted_at,
-                }
-                for a in ledger.acceptances
-            ),
-            key=lambda d: (str(d["span_id"]), str(d["batch_id"])),
+        "acceptances": canonical_order(
+            {
+                "span_id": a.span_id,
+                "batch_id": a.batch_id,
+                "reviewer": a.reviewer,
+                "accepted_at": a.accepted_at,
+            }
+            for a in ledger.acceptances
         ),
     }

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -1,0 +1,226 @@
+"""Span-exact semantic accounting — CRD Issue 5d, Decision 2.
+
+Two things happen here and nowhere else:
+
+* **partition validation** — every represented leaf's canonical text is covered
+  gap-free and overlap-free by accepted spans, so no text is silently dropped
+  and no text is claimed twice; and
+* **acceptance validation** — every span carries explicit review acceptance,
+  with batch acceptances required to record their rule, scope, and semantic
+  diff.
+
+Both return violation strings rather than raising, matching the CRD Issue 5c
+``verify_*`` convention: a caller collects every violation in one pass instead
+of discovering them one exception at a time, and the gate reports all of them.
+
+Identity is derived from accepted semantic content only. Reviewer names and
+acceptance timestamps travel in the ledger but never reach the payload, so
+re-reviewing an unchanged classification does not mint a new projection
+(#137 acceptance criterion 11).
+"""
+
+from __future__ import annotations
+
+from afterworlds.ingestion.corpus.hashing import content_id, hash_obj
+from afterworlds.ingestion.mechanical.models import (
+    ClassificationLedger,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    SEMANTIC_POLICY_VERSION,
+    non_mechanical_reason_for,
+    semantic_policy_hash,
+)
+
+__all__ = [
+    "classification_identity",
+    "classification_payload",
+    "derive_span_id",
+    "validate_acceptance",
+    "validate_partition",
+    "validate_reason_codes",
+]
+
+
+def derive_span_id(leaf_id: str, char_start: int, char_end: int) -> str:
+    """Content-derived identity for one leaf subspan.
+
+    Derived from the leaf and its exact range, never from a position in a list,
+    so inserting an unrelated span elsewhere cannot churn it.
+    """
+    return content_id("semantic_span", leaf_id, char_start, char_end)
+
+
+def validate_partition(
+    leaf_id: str, leaf_length: int, spans: tuple[SemanticSpan, ...]
+) -> tuple[str, ...]:
+    """Return violations of the gap-free, non-overlapping partition rule.
+
+    *spans* are the spans claimed for ``leaf_id``; ``leaf_length`` is the length
+    of that leaf's canonical text. A leaf with no spans is a violation, not an
+    empty success — unclassified text is the failure this check exists for.
+    """
+    findings: list[str] = []
+    mine = sorted(
+        (s for s in spans if s.leaf_id == leaf_id),
+        key=lambda s: (s.char_start, s.char_end),
+    )
+
+    if not mine:
+        return (f"leaf {leaf_id}: no semantic spans",)
+
+    cursor = 0
+    for span in mine:
+        if span.span_id != derive_span_id(span.leaf_id, span.char_start, span.char_end):
+            findings.append(
+                f"leaf {leaf_id}: span {span.span_id} id does not match its range"
+            )
+        if span.char_start < 0 or span.char_end > leaf_length:
+            findings.append(
+                f"leaf {leaf_id}: span [{span.char_start},{span.char_end}) "
+                f"outside leaf text [0,{leaf_length})"
+            )
+        if span.char_end <= span.char_start:
+            findings.append(
+                f"leaf {leaf_id}: span [{span.char_start},{span.char_end}) is empty"
+            )
+        if span.char_start > cursor:
+            findings.append(
+                f"leaf {leaf_id}: uncovered text [{cursor},{span.char_start})"
+            )
+        elif span.char_start < cursor:
+            findings.append(
+                f"leaf {leaf_id}: overlapping span at [{span.char_start},"
+                f"{span.char_end}) (covered through {cursor})"
+            )
+        cursor = max(cursor, span.char_end)
+
+    if cursor < leaf_length:
+        findings.append(f"leaf {leaf_id}: uncovered text [{cursor},{leaf_length})")
+
+    return tuple(findings)
+
+
+def validate_reason_codes(spans: tuple[SemanticSpan, ...]) -> tuple[str, ...]:
+    """Return violations of the closed non-mechanical reason catalog."""
+    findings: list[str] = []
+    for span in spans:
+        code = span.non_mechanical_reason_code
+        if span.disposition is SemanticDisposition.NON_MECHANICAL:
+            if code is None:
+                findings.append(f"span {span.span_id}: non-mechanical without reason")
+            elif non_mechanical_reason_for(code) is None:
+                findings.append(
+                    f"span {span.span_id}: reason {code!r} is not in the closed catalog"
+                )
+        elif code is not None:
+            findings.append(
+                f"span {span.span_id}: reason {code!r} on a "
+                f"{span.disposition.value} span"
+            )
+    return tuple(findings)
+
+
+def validate_acceptance(ledger: ClassificationLedger) -> tuple[str, ...]:
+    """Return violations of the explicit-acceptance rule (#137 contract 2).
+
+    Blocks publication on unreviewed residue, unresolved classification,
+    acceptance records pointing at spans that do not exist, and batch
+    acceptances that fail to record the rule, scope, or semantic diff that
+    would let a reviewer re-derive them.
+    """
+    findings: list[str] = []
+    span_ids = {s.span_id for s in ledger.spans}
+    batch_ids = {b.batch_id for b in ledger.batches}
+    accepted: set[str] = set()
+
+    for batch in ledger.batches:
+        if not batch.rule.strip():
+            findings.append(f"batch {batch.batch_id}: no acceptance rule recorded")
+        if not batch.scope:
+            findings.append(f"batch {batch.batch_id}: no acceptance scope recorded")
+        if not batch.semantic_diff_hash.strip():
+            findings.append(f"batch {batch.batch_id}: no semantic diff recorded")
+
+    for record in ledger.acceptances:
+        if record.span_id not in span_ids:
+            findings.append(f"acceptance for unknown span {record.span_id}")
+        if record.batch_id is not None and record.batch_id not in batch_ids:
+            findings.append(
+                f"span {record.span_id}: acceptance names unknown batch "
+                f"{record.batch_id}"
+            )
+        if record.span_id in accepted:
+            findings.append(f"span {record.span_id}: duplicate acceptance record")
+        accepted.add(record.span_id)
+
+    for span in ledger.spans:
+        if span.disposition is SemanticDisposition.UNRESOLVED:
+            findings.append(f"span {span.span_id}: unresolved classification")
+        # An accepted *review state* still requires the acceptance evidence that
+        # produced it; a row that simply says "accepted" is the silence this
+        # rule rejects.
+        if span.span_id not in accepted:
+            findings.append(f"span {span.span_id}: no acceptance record")
+        elif span.review_state is not ReviewState.ACCEPTED:
+            findings.append(
+                f"span {span.span_id}: accepted evidence but review state "
+                f"{span.review_state.value}"
+            )
+
+    return tuple(findings)
+
+
+def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
+    """Canonical, identity-bearing payload of the accepted classification.
+
+    Carries accepted semantic content and the batch rules that produced it.
+    Excludes reviewer identity and acceptance timestamps: audit metadata, not
+    meaning.
+    """
+    return {
+        "package_uuid": ledger.package_uuid,
+        "release_version": ledger.release_version,
+        "semantic_policy_version": SEMANTIC_POLICY_VERSION,
+        "semantic_policy_hash": semantic_policy_hash(),
+        "spans": sorted(
+            (
+                {
+                    "span_id": s.span_id,
+                    "leaf_id": s.leaf_id,
+                    "char_start": s.char_start,
+                    "char_end": s.char_end,
+                    "disposition": s.disposition.value,
+                    "non_mechanical_reason_code": s.non_mechanical_reason_code,
+                }
+                for s in ledger.spans
+            ),
+            key=lambda d: str(d["span_id"]),
+        ),
+        "batches": sorted(
+            (
+                {
+                    "batch_id": b.batch_id,
+                    "rule": b.rule,
+                    "scope": list(b.scope),
+                    "semantic_diff_hash": b.semantic_diff_hash,
+                }
+                for b in ledger.batches
+            ),
+            key=lambda d: str(d["batch_id"]),
+        ),
+        "acceptances": sorted(
+            (
+                {"span_id": a.span_id, "batch_id": a.batch_id}
+                for a in ledger.acceptances
+            ),
+            key=lambda d: str(d["span_id"]),
+        ),
+    }
+
+
+def classification_identity(ledger: ClassificationLedger) -> str:
+    """SHA-256 of the accepted classification payload."""
+    return hash_obj(classification_payload(ledger))

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -53,6 +53,7 @@ __all__ = [
     "derive_span_id",
     "validate_acceptance",
     "validate_partition",
+    "validate_policy_binding",
     "validate_reason_codes",
 ]
 
@@ -136,6 +137,31 @@ def validate_reason_codes(spans: tuple[SemanticSpan, ...]) -> tuple[str, ...]:
     return tuple(findings)
 
 
+def validate_policy_binding(ledger: ClassificationLedger) -> tuple[str, ...]:
+    """Return violations of the ledger's declared semantic-policy binding.
+
+    An accepted classification is only meaningful under the policy it was
+    accepted against: the closed reason catalogs and the canonicalization rule
+    are what make its dispositions checkable. A ledger accepted under an older
+    policy must fail here rather than be quietly reinterpreted under current
+    code — that is how a catalog change that invalidates past acceptances
+    becomes visible instead of silent.
+    """
+    findings: list[str] = []
+    if ledger.policy_version != SEMANTIC_POLICY_VERSION:
+        findings.append(
+            f"ledger declares semantic policy {ledger.policy_version!r}, "
+            f"build uses {SEMANTIC_POLICY_VERSION!r}"
+        )
+    expected = semantic_policy_hash()
+    if ledger.policy_hash != expected:
+        findings.append(
+            f"ledger declares semantic policy hash {ledger.policy_hash!r}, "
+            f"committed policy hashes to {expected!r}"
+        )
+    return tuple(findings)
+
+
 def batch_diff_payload(batch: AcceptanceBatch) -> list[dict[str, object]]:
     """Canonical serialization of a batch's retained semantic diff."""
     return sorted(
@@ -163,8 +189,16 @@ def batch_diff_hash(batch: AcceptanceBatch) -> str:
 def _validate_batch(
     batch: AcceptanceBatch,
     spans_by_id: dict[str, SemanticSpan],
+    linked_spans: set[str],
+    batch_by_span: dict[str, str | None],
 ) -> list[str]:
-    """Return violations of one batch's retained acceptance evidence."""
+    """Return violations of one batch's retained acceptance evidence.
+
+    ``resolved_scope``, the retained diff, and the acceptance records naming
+    this batch must describe exactly the same span set. Any two of them
+    agreeing while the third does not means the retained evidence no longer
+    shows what was actually accepted.
+    """
     findings: list[str] = []
     tag = f"batch {batch.batch_id}"
 
@@ -176,6 +210,8 @@ def _validate_batch(
         findings.append(f"{tag}: no semantic diff retained")
 
     scope = set(batch.resolved_scope)
+    if len(scope) != len(batch.resolved_scope):
+        findings.append(f"{tag}: duplicate span ids in resolved scope")
     for span_id in sorted(scope - spans_by_id.keys()):
         findings.append(f"{tag}: scope names unknown span {span_id}")
 
@@ -208,6 +244,17 @@ def _validate_batch(
     for span_id in sorted(scope - diff_ids):
         findings.append(f"{tag}: scope member {span_id} has no accepted diff entry")
 
+    if not linked_spans:
+        findings.append(f"{tag}: no acceptance record names this batch")
+    for span_id in sorted(scope - linked_spans):
+        named = batch_by_span.get(span_id)
+        if span_id not in batch_by_span:
+            continue  # already reported as an unknown/unaccepted span
+        findings.append(
+            f"{tag}: scope member {span_id} was accepted "
+            + ("individually" if named is None else f"under batch {named}")
+        )
+
     if batch.semantic_diff_hash != batch_diff_hash(batch):
         findings.append(f"{tag}: semantic diff digest does not match retained diff")
 
@@ -220,9 +267,9 @@ def validate_acceptance(ledger: ClassificationLedger) -> tuple[str, ...]:
     Blocks publication on unreviewed residue, unresolved classification,
     acceptance records pointing at spans that do not exist, and batch
     acceptances whose retained evidence would not let a reviewer re-check what
-    was accepted: a missing or forged diff, an acceptance outside the resolved
-    scope, a scope member with nothing accepted for it, or a blank record of
-    who accepted it and when.
+    was accepted: a missing or forged diff, a scope that disagrees with the
+    diff or with the acceptance actions that named the batch, or a blank record
+    of who accepted it and when.
     """
     findings: list[str] = []
     spans_by_id = {s.span_id: s for s in ledger.spans}
@@ -230,11 +277,27 @@ def validate_acceptance(ledger: ClassificationLedger) -> tuple[str, ...]:
     batch_ids: set[str] = set()
     accepted: set[str] = set()
 
+    # Acceptance links read once, so each batch can be checked against the
+    # actions that actually named it rather than only against its own claims.
+    linked_by_batch: dict[str, set[str]] = {}
+    batch_by_span: dict[str, str | None] = {}
+    for record in ledger.acceptances:
+        batch_by_span.setdefault(record.span_id, record.batch_id)
+        if record.batch_id is not None:
+            linked_by_batch.setdefault(record.batch_id, set()).add(record.span_id)
+
     for batch in ledger.batches:
         if batch.batch_id in batch_ids:
             findings.append(f"batch {batch.batch_id}: duplicate batch id")
         batch_ids.add(batch.batch_id)
-        findings.extend(_validate_batch(batch, spans_by_id))
+        findings.extend(
+            _validate_batch(
+                batch,
+                spans_by_id,
+                linked_by_batch.get(batch.batch_id, set()),
+                batch_by_span,
+            )
+        )
 
     scope_by_batch = {b.batch_id: set(b.resolved_scope) for b in ledger.batches}
 
@@ -286,12 +349,19 @@ def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
     timestamps are all deliberately absent: they are retained, validated review
     evidence, not authority. Review state is likewise absent, because a
     publishable ledger has no unaccepted span left to distinguish.
+
+    The policy identity comes from the ledger's *declaration*, not from the
+    module's current constants. A projection built today and read back in a
+    year states the policy it was accepted under; substituting current code
+    here would silently re-identify history.
+    :func:`validate_policy_binding` is what proves the declaration matches the
+    committed policy at build time.
     """
     return {
         "package_uuid": ledger.package_uuid,
         "release_version": ledger.release_version,
-        "semantic_policy_version": SEMANTIC_POLICY_VERSION,
-        "semantic_policy_hash": semantic_policy_hash(),
+        "semantic_policy_version": ledger.policy_version,
+        "semantic_policy_hash": ledger.policy_hash,
         "spans": sorted(
             (
                 {

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -13,16 +13,27 @@ Both return violation strings rather than raising, matching the CRD Issue 5c
 ``verify_*`` convention: a caller collects every violation in one pass instead
 of discovering them one exception at a time, and the gate reports all of them.
 
-Identity is derived from accepted semantic content only. Reviewer names and
-acceptance timestamps travel in the ledger but never reach the payload, so
-re-reviewing an unchanged classification does not mint a new projection
+Identity is derived from the accepted semantic *result* only — span boundaries,
+dispositions, reason assignments, and the identity-bound semantic policy. The
+acceptance *process* is not identity-bearing: individual versus batch review,
+batch grouping, batch rule wording, resolved scope, reviewer, timestamp, and
+acceptance history all stay out of the payload. Two ledgers that reviewed their
+way to the same accepted classification are the same authority
 (#137 acceptance criterion 11).
+
+That is a boundary, not an exemption. Acceptance evidence is validated here as
+strictly as the result — a batch retains the canonical diff it claims, not just
+a digest of it — and it is retained for audit. If a batch rule should govern
+future classification, it is promoted into the frozen semantic policy
+explicitly, where it *is* identity-bearing, rather than leaking in through
+acceptance history.
 """
 
 from __future__ import annotations
 
 from afterworlds.ingestion.corpus.hashing import content_id, hash_obj
 from afterworlds.ingestion.mechanical.models import (
+    AcceptanceBatch,
     ClassificationLedger,
     ReviewState,
     SemanticDisposition,
@@ -35,6 +46,8 @@ from afterworlds.ingestion.mechanical.policy import (
 )
 
 __all__ = [
+    "batch_diff_hash",
+    "batch_diff_payload",
     "classification_identity",
     "classification_payload",
     "derive_span_id",
@@ -123,35 +136,126 @@ def validate_reason_codes(spans: tuple[SemanticSpan, ...]) -> tuple[str, ...]:
     return tuple(findings)
 
 
+def batch_diff_payload(batch: AcceptanceBatch) -> list[dict[str, object]]:
+    """Canonical serialization of a batch's retained semantic diff."""
+    return sorted(
+        (
+            {
+                "span_id": e.span_id,
+                "prior_disposition": (
+                    e.prior_disposition.value if e.prior_disposition else None
+                ),
+                "prior_reason_code": e.prior_reason_code,
+                "accepted_disposition": e.accepted_disposition.value,
+                "accepted_reason_code": e.accepted_reason_code,
+            }
+            for e in batch.diff
+        ),
+        key=lambda d: str(d["span_id"]),
+    )
+
+
+def batch_diff_hash(batch: AcceptanceBatch) -> str:
+    """SHA-256 over a batch's canonical retained diff."""
+    return hash_obj(batch_diff_payload(batch))
+
+
+def _validate_batch(
+    batch: AcceptanceBatch,
+    spans_by_id: dict[str, SemanticSpan],
+) -> list[str]:
+    """Return violations of one batch's retained acceptance evidence."""
+    findings: list[str] = []
+    tag = f"batch {batch.batch_id}"
+
+    if not batch.rule.strip():
+        findings.append(f"{tag}: no acceptance rule recorded")
+    if not batch.resolved_scope:
+        findings.append(f"{tag}: no resolved scope recorded")
+    if not batch.diff:
+        findings.append(f"{tag}: no semantic diff retained")
+
+    scope = set(batch.resolved_scope)
+    for span_id in sorted(scope - spans_by_id.keys()):
+        findings.append(f"{tag}: scope names unknown span {span_id}")
+
+    diff_ids: set[str] = set()
+    for entry in batch.diff:
+        if entry.span_id in diff_ids:
+            findings.append(f"{tag}: duplicate diff entry for span {entry.span_id}")
+        diff_ids.add(entry.span_id)
+
+        if entry.span_id not in spans_by_id:
+            findings.append(f"{tag}: diff names unknown span {entry.span_id}")
+            continue
+        if entry.span_id not in scope:
+            findings.append(f"{tag}: diff entry {entry.span_id} outside resolved scope")
+
+        span = spans_by_id[entry.span_id]
+        if entry.accepted_disposition is not span.disposition:
+            findings.append(
+                f"{tag}: diff claims {entry.span_id} accepted as "
+                f"{entry.accepted_disposition.value}, ledger has "
+                f"{span.disposition.value}"
+            )
+        if entry.accepted_reason_code != span.non_mechanical_reason_code:
+            findings.append(
+                f"{tag}: diff claims {entry.span_id} reason "
+                f"{entry.accepted_reason_code!r}, ledger has "
+                f"{span.non_mechanical_reason_code!r}"
+            )
+
+    for span_id in sorted(scope - diff_ids):
+        findings.append(f"{tag}: scope member {span_id} has no accepted diff entry")
+
+    if batch.semantic_diff_hash != batch_diff_hash(batch):
+        findings.append(f"{tag}: semantic diff digest does not match retained diff")
+
+    return findings
+
+
 def validate_acceptance(ledger: ClassificationLedger) -> tuple[str, ...]:
     """Return violations of the explicit-acceptance rule (#137 contract 2).
 
     Blocks publication on unreviewed residue, unresolved classification,
     acceptance records pointing at spans that do not exist, and batch
-    acceptances that fail to record the rule, scope, or semantic diff that
-    would let a reviewer re-derive them.
+    acceptances whose retained evidence would not let a reviewer re-check what
+    was accepted: a missing or forged diff, an acceptance outside the resolved
+    scope, a scope member with nothing accepted for it, or a blank record of
+    who accepted it and when.
     """
     findings: list[str] = []
-    span_ids = {s.span_id for s in ledger.spans}
-    batch_ids = {b.batch_id for b in ledger.batches}
+    spans_by_id = {s.span_id: s for s in ledger.spans}
+    span_ids = spans_by_id.keys()
+    batch_ids: set[str] = set()
     accepted: set[str] = set()
 
     for batch in ledger.batches:
-        if not batch.rule.strip():
-            findings.append(f"batch {batch.batch_id}: no acceptance rule recorded")
-        if not batch.scope:
-            findings.append(f"batch {batch.batch_id}: no acceptance scope recorded")
-        if not batch.semantic_diff_hash.strip():
-            findings.append(f"batch {batch.batch_id}: no semantic diff recorded")
+        if batch.batch_id in batch_ids:
+            findings.append(f"batch {batch.batch_id}: duplicate batch id")
+        batch_ids.add(batch.batch_id)
+        findings.extend(_validate_batch(batch, spans_by_id))
+
+    scope_by_batch = {b.batch_id: set(b.resolved_scope) for b in ledger.batches}
 
     for record in ledger.acceptances:
         if record.span_id not in span_ids:
             findings.append(f"acceptance for unknown span {record.span_id}")
-        if record.batch_id is not None and record.batch_id not in batch_ids:
+        if not record.reviewer.strip() or not record.accepted_at.strip():
             findings.append(
-                f"span {record.span_id}: acceptance names unknown batch "
-                f"{record.batch_id}"
+                f"span {record.span_id}: acceptance without reviewer/timestamp evidence"
             )
+        if record.batch_id is not None:
+            if record.batch_id not in batch_ids:
+                findings.append(
+                    f"span {record.span_id}: acceptance names unknown batch "
+                    f"{record.batch_id}"
+                )
+            elif record.span_id not in scope_by_batch[record.batch_id]:
+                findings.append(
+                    f"span {record.span_id}: acceptance outside the resolved scope "
+                    f"of batch {record.batch_id}"
+                )
         if record.span_id in accepted:
             findings.append(f"span {record.span_id}: duplicate acceptance record")
         accepted.add(record.span_id)
@@ -176,9 +280,12 @@ def validate_acceptance(ledger: ClassificationLedger) -> tuple[str, ...]:
 def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
     """Canonical, identity-bearing payload of the accepted classification.
 
-    Carries accepted semantic content and the batch rules that produced it.
-    Excludes reviewer identity and acceptance timestamps: audit metadata, not
-    meaning.
+    Carries the accepted semantic result and the identity-bound semantic
+    policy — nothing about how review arrived there. Batches, acceptance
+    records, batch grouping and wording, resolved scope, reviewers, and
+    timestamps are all deliberately absent: they are retained, validated review
+    evidence, not authority. Review state is likewise absent, because a
+    publishable ledger has no unaccepted span left to distinguish.
     """
     return {
         "package_uuid": ledger.package_uuid,
@@ -196,25 +303,6 @@ def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
                     "non_mechanical_reason_code": s.non_mechanical_reason_code,
                 }
                 for s in ledger.spans
-            ),
-            key=lambda d: str(d["span_id"]),
-        ),
-        "batches": sorted(
-            (
-                {
-                    "batch_id": b.batch_id,
-                    "rule": b.rule,
-                    "scope": list(b.scope),
-                    "semantic_diff_hash": b.semantic_diff_hash,
-                }
-                for b in ledger.batches
-            ),
-            key=lambda d: str(d["batch_id"]),
-        ),
-        "acceptances": sorted(
-            (
-                {"span_id": a.span_id, "batch_id": a.batch_id}
-                for a in ledger.acceptances
             ),
             key=lambda d: str(d["span_id"]),
         ),

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -46,6 +46,7 @@ from afterworlds.ingestion.mechanical.policy import (
 )
 
 __all__ = [
+    "acceptance_evidence_payload",
     "batch_diff_hash",
     "batch_diff_payload",
     "classification_identity",
@@ -382,3 +383,50 @@ def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
 def classification_identity(ledger: ClassificationLedger) -> str:
     """SHA-256 of the accepted classification payload."""
     return hash_obj(classification_payload(ledger))
+
+
+def acceptance_evidence_payload(ledger: ClassificationLedger) -> dict[str, object]:
+    """Canonical payload of the retained review evidence.
+
+    Deliberately *not* part of semantic identity — two ledgers that reviewed
+    their way to the same accepted result are the same authority. But the
+    evidence is still retained, and retained evidence that can be rewritten
+    without detection is not evidence. This payload is what the persisted-state
+    proof digests, so a reviewer, timestamp, batch rule, scope membership,
+    scope order, diff entry, or review state cannot be silently edited after
+    the fact.
+
+    Scope order is preserved rather than sorted: the reviewer's recorded scope
+    is evidence, and a reordered scope is a different record of what happened.
+    """
+    return {
+        "review_states": sorted(
+            ([s.span_id, s.review_state.value] for s in ledger.spans),
+            key=lambda pair: pair[0],
+        ),
+        "batches": sorted(
+            (
+                {
+                    "batch_id": b.batch_id,
+                    "rule": b.rule,
+                    "resolved_scope": list(b.resolved_scope),
+                    "diff": batch_diff_payload(b),
+                    "semantic_diff_hash": b.semantic_diff_hash,
+                }
+                for b in ledger.batches
+            ),
+            key=lambda d: str(d["batch_id"]),
+        ),
+        "acceptances": sorted(
+            (
+                {
+                    "span_id": a.span_id,
+                    "batch_id": a.batch_id,
+                    "reviewer": a.reviewer,
+                    "accepted_at": a.accepted_at,
+                }
+                for a in ledger.acceptances
+            ),
+            key=lambda d: (str(d["span_id"]), str(d["batch_id"])),
+        ),
+    }

--- a/src/afterworlds/ingestion/mechanical/bound_corpus.py
+++ b/src/afterworlds/ingestion/mechanical/bound_corpus.py
@@ -1,26 +1,39 @@
 """The bound 5c corpus a candidate is validated against — CRD Issue 5d.
 
-Validation needs two things from the exact published CRD Issue 5c release: how
-long each represented leaf's canonical text is (so a span partition can be
-checked), and which chunks are authoritative governing prose for that release
-(so a prose binding resolves to real authority rather than to any non-empty
-string).
+Validation needs three things from the exact published CRD Issue 5c release:
+how long each represented leaf's canonical text is, which chunks are
+authoritative governing prose for that release, and — the part that makes exact
+prose provenance checkable — *which subspans of which leaves each chunk
+actually covers*.
 
-Both are resolved here, once, into a frozen snapshot. The validators stay pure
-functions over that snapshot instead of each growing a private query, so there
-is one source-resolution path and a validator cannot accidentally read a
-different release than the one the candidate claims.
+All three are resolved here, once, into a frozen snapshot. The validators stay
+pure functions over it, so there is one release-scoped resolution seam and no
+validator can accidentally read a different release than the candidate claims.
 
-A chunk counts as authoritative only when it satisfies *both* halves of the 5c
-contract: it exists in ``rp_chunks`` under the bound package, and it is in that
-release's declared ``rp_corpus_projections`` population. A chunk that exists but
-was never projected is not governing authority for this release, and neither is
-one belonging to some other package.
+Coverage is the single truth about chunks. Authoritative membership is derived
+from it rather than supplied alongside it, so a snapshot cannot claim a chunk
+is authoritative while carrying no projection coverage for it — the state that
+made a cross-chunk provenance claim look valid.
+
+A chunk counts as authoritative only when both halves of the 5c contract hold:
+it exists in ``rp_chunks`` under the bound package, and it has at least one
+``rp_corpus_projections`` edge under that package. A projected phantom with no
+chunk row and a persisted chunk that was never projected are both excluded, and
+because membership is derived, exclusion also removes its coverage.
+
+**Coordinate system.** ``cover_start``/``cover_end`` are half-open offsets into
+the source *leaf's* content — CRD Issue 5c states this on ``ProjectionEdge``
+and proves it by slicing ``leaf.content[cover_start:cover_end]`` in its own
+publication gate. CRD Issue 5d semantic spans index that same leaf content.
+The two coordinate systems are therefore identical, which is what makes the
+containment test below meaningful rather than a coincidence of integers.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import cached_property
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -29,7 +42,42 @@ from afterworlds.ingestion.corpus.models import Disposition
 from afterworlds.persistence.orm.corpus import CorpusProjectionORM, LedgerLeafORM
 from afterworlds.persistence.orm.rules_package import RuleChunkORM
 
-__all__ = ["BoundCorpusSnapshot", "load_bound_corpus"]
+__all__ = ["BoundCorpusSnapshot", "ChunkCoverage", "load_bound_corpus"]
+
+
+@dataclass(frozen=True)
+class ChunkCoverage:
+    """One 5c projection edge: a chunk covering a subspan of one leaf.
+
+    ``role`` and ``projection_id`` are retained rather than dropped — losing
+    them would make this a lossy copy of the 5c relation, and role is what
+    distinguishes ordinary authoritative coverage from the attribution repeat
+    5c permits to overlap.
+    """
+
+    chunk_id: str
+    leaf_id: str
+    cover_start: int
+    cover_end: int
+    role: str
+    projection_id: str
+
+
+def _merge(intervals: list[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
+    """Merge half-open intervals, joining adjacent and overlapping ones.
+
+    Adjacency counts as continuous: ``[0,10)`` followed by ``[10,20)`` is one
+    covered run, because the leaf text between them has no hole. Merging here
+    rather than at query time means a span crossing two consecutive edges of
+    the same chunk is covered, while a span crossing a genuine gap is not.
+    """
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(intervals):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return tuple(merged)
 
 
 @dataclass(frozen=True)
@@ -43,8 +91,40 @@ class BoundCorpusSnapshot:
 
     package_uuid: str
     release_version: str
-    leaf_lengths: dict[str, int]
-    authoritative_chunk_ids: frozenset[str]
+    leaf_lengths: Mapping[str, int]
+    chunk_coverage: tuple[ChunkCoverage, ...]
+
+    @cached_property
+    def authoritative_chunk_ids(self) -> frozenset[str]:
+        """Chunks that actually project into this release, derived from coverage."""
+        return frozenset(c.chunk_id for c in self.chunk_coverage)
+
+    @cached_property
+    def _covered_runs(self) -> dict[tuple[str, str], tuple[tuple[int, int], ...]]:
+        by_pair: dict[tuple[str, str], list[tuple[int, int]]] = {}
+        for edge in self.chunk_coverage:
+            by_pair.setdefault((edge.chunk_id, edge.leaf_id), []).append(
+                (edge.cover_start, edge.cover_end)
+            )
+        return {pair: _merge(spans) for pair, spans in by_pair.items()}
+
+    def covers_span(
+        self, chunk_id: str, leaf_id: str, char_start: int, char_end: int
+    ) -> bool:
+        """Does *chunk_id* cover this leaf subspan completely?
+
+        The whole span must lie inside one covered run of that chunk on that
+        leaf. Partial overlap fails, a different leaf fails, a span crossing a
+        gap fails, and a chunk this release never projected fails — in every
+        case the chunk does not actually contain the cited text, so it cannot
+        be its governing prose.
+        """
+        if char_end <= char_start:
+            return False
+        for start, end in self._covered_runs.get((chunk_id, leaf_id), ()):
+            if start <= char_start and char_end <= end:
+                return True
+        return False
 
 
 def load_bound_corpus(
@@ -63,16 +143,6 @@ def load_bound_corpus(
         .all()
     }
 
-    projected = {
-        row.chunk_id
-        for row in session.execute(
-            select(CorpusProjectionORM).where(
-                CorpusProjectionORM.package_uuid == package_uuid
-            )
-        )
-        .scalars()
-        .all()
-    }
     persisted = {
         row.chunk_id
         for row in session.execute(
@@ -82,9 +152,35 @@ def load_bound_corpus(
         .all()
     }
 
+    # Every filter is applied on the way in, so the snapshot cannot carry
+    # coverage for a chunk it does not consider authoritative.
+    coverage = tuple(
+        ChunkCoverage(
+            chunk_id=row.chunk_id,
+            leaf_id=row.leaf_id,
+            cover_start=row.cover_start,
+            cover_end=row.cover_end,
+            role=row.role,
+            projection_id=row.projection_id,
+        )
+        for row in session.execute(
+            select(CorpusProjectionORM)
+            .where(CorpusProjectionORM.package_uuid == package_uuid)
+            .order_by(
+                CorpusProjectionORM.chunk_id,
+                CorpusProjectionORM.leaf_id,
+                CorpusProjectionORM.cover_start,
+                CorpusProjectionORM.cover_end,
+            )
+        )
+        .scalars()
+        .all()
+        if row.chunk_id in persisted
+    )
+
     return BoundCorpusSnapshot(
         package_uuid=package_uuid,
         release_version=release_version,
         leaf_lengths=leaf_lengths,
-        authoritative_chunk_ids=frozenset(projected & persisted),
+        chunk_coverage=coverage,
     )

--- a/src/afterworlds/ingestion/mechanical/bound_corpus.py
+++ b/src/afterworlds/ingestion/mechanical/bound_corpus.py
@@ -1,0 +1,90 @@
+"""The bound 5c corpus a candidate is validated against — CRD Issue 5d.
+
+Validation needs two things from the exact published CRD Issue 5c release: how
+long each represented leaf's canonical text is (so a span partition can be
+checked), and which chunks are authoritative governing prose for that release
+(so a prose binding resolves to real authority rather than to any non-empty
+string).
+
+Both are resolved here, once, into a frozen snapshot. The validators stay pure
+functions over that snapshot instead of each growing a private query, so there
+is one source-resolution path and a validator cannot accidentally read a
+different release than the one the candidate claims.
+
+A chunk counts as authoritative only when it satisfies *both* halves of the 5c
+contract: it exists in ``rp_chunks`` under the bound package, and it is in that
+release's declared ``rp_corpus_projections`` population. A chunk that exists but
+was never projected is not governing authority for this release, and neither is
+one belonging to some other package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.models import Disposition
+from afterworlds.persistence.orm.corpus import CorpusProjectionORM, LedgerLeafORM
+from afterworlds.persistence.orm.rules_package import RuleChunkORM
+
+__all__ = ["BoundCorpusSnapshot", "load_bound_corpus"]
+
+
+@dataclass(frozen=True)
+class BoundCorpusSnapshot:
+    """Authoritative facts about one published 5c release, resolved once.
+
+    ``leaf_lengths`` covers exactly the ``REPRESENTED`` population — the
+    accounting population #137 contract 1 defines — so a leaf 5c excluded is
+    neither required to be classified nor allowed to be.
+    """
+
+    package_uuid: str
+    release_version: str
+    leaf_lengths: dict[str, int]
+    authoritative_chunk_ids: frozenset[str]
+
+
+def load_bound_corpus(
+    session: Session, package_uuid: str, release_version: str
+) -> BoundCorpusSnapshot:
+    """Resolve the snapshot from persisted 5c state."""
+    leaf_lengths = {
+        row.leaf_id: len(row.content)
+        for row in session.execute(
+            select(LedgerLeafORM).where(
+                LedgerLeafORM.package_uuid == package_uuid,
+                LedgerLeafORM.disposition == Disposition.REPRESENTED.value,
+            )
+        )
+        .scalars()
+        .all()
+    }
+
+    projected = {
+        row.chunk_id
+        for row in session.execute(
+            select(CorpusProjectionORM).where(
+                CorpusProjectionORM.package_uuid == package_uuid
+            )
+        )
+        .scalars()
+        .all()
+    }
+    persisted = {
+        row.chunk_id
+        for row in session.execute(
+            select(RuleChunkORM).where(RuleChunkORM.rules_package_id == package_uuid)
+        )
+        .scalars()
+        .all()
+    }
+
+    return BoundCorpusSnapshot(
+        package_uuid=package_uuid,
+        release_version=release_version,
+        leaf_lengths=leaf_lengths,
+        authoritative_chunk_ids=frozenset(projected & persisted),
+    )

--- a/src/afterworlds/ingestion/mechanical/canonical.py
+++ b/src/afterworlds/ingestion/mechanical/canonical.py
@@ -1,0 +1,33 @@
+"""Canonical ordering for unordered semantic collections — CRD Issue 5d.
+
+ADR-005d Decision 6 requires a projection identity that reproduces from
+identical content. A collection whose meaning does not depend on order must
+therefore hash the same however it was authored, and the only way to guarantee
+that is to order by the element's *complete* canonical payload.
+
+Hand-picked sort tuples cannot provide it. Any field left out of the tuple
+makes two semantically different elements compare equal, and Python's stable
+sort then preserves authoring order — so the identity silently depends on the
+order someone happened to write things in. Worse, the defect returns every time
+a field is added and the tuple is not, which is exactly how it arrived. Sorting
+by the serialized payload has no such failure mode: a new field is inside the
+bytes the moment it is inside the payload.
+
+Duplicates are preserved rather than collapsed. Two identical entries are a
+validation failure, not something canonicalization should quietly tidy away.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from afterworlds.ingestion.corpus.hashing import canonical_bytes
+
+__all__ = ["canonical_order"]
+
+
+def canonical_order(
+    payloads: Iterable[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Return *payloads* in a total order derived from their whole content."""
+    return sorted(payloads, key=canonical_bytes)

--- a/src/afterworlds/ingestion/mechanical/models.py
+++ b/src/afterworlds/ingestion/mechanical/models.py
@@ -34,6 +34,10 @@ class SemanticDisposition(StrEnum):
     """
 
     SUBSTANTIVE = "substantive"
+    # Material that identifies, limits, explains, exemplifies, or contextualizes
+    # a mechanic. Form does not decide this: a heading may be supporting
+    # authority here or non-mechanical under a closed reason there, depending on
+    # what it actually does.
     SUPPORTING_AUTHORITY = "supporting_authority"
     NON_MECHANICAL = "non_mechanical"
     UNRESOLVED = "unresolved"
@@ -99,21 +103,41 @@ class SemanticSpan:
 
 
 @dataclass(frozen=True)
+class SemanticDiffEntry:
+    """One span's transition under a batch acceptance.
+
+    ``prior_*`` is ``None`` when the batch accepted a claim that had no prior
+    proposed disposition, which is different from a batch that changed one.
+    """
+
+    span_id: str
+    prior_disposition: SemanticDisposition | None
+    prior_reason_code: str | None
+    accepted_disposition: SemanticDisposition
+    accepted_reason_code: str | None
+
+
+@dataclass(frozen=True)
 class AcceptanceBatch:
     """A rule-scoped batch acceptance (#137 contract 2).
 
-    Batch acceptance is what makes full-corpus review tractable, but it must
-    record *what rule was applied to what scope* and *what changed*, so a batch
-    can be re-derived and audited rather than taken on trust. A batch whose
-    recorded rule, scope, or semantic diff is missing is not an acceptance.
+    Batch acceptance is what makes full-corpus review tractable, but it has to
+    stay auditable afterwards, which means retaining what was accepted — not a
+    recipe for recomputing it later:
 
-    ``semantic_diff_hash`` covers the exact set of (span, disposition, reason)
-    transitions the batch produced.
+    * ``rule`` explains *how* the batch was selected. It is evidence, not
+      authority, and it is never re-run: a selector re-evaluated against
+      changed inputs would resolve to a different set than the reviewer saw.
+    * ``resolved_scope`` is the exact span set the reviewer accepted.
+    * ``diff`` is the canonical semantic diff itself, retained in full.
+    * ``semantic_diff_hash`` identifies and verifies that diff; it never
+      substitutes for it.
     """
 
     batch_id: str
     rule: str
-    scope: tuple[str, ...]
+    resolved_scope: tuple[str, ...]
+    diff: tuple[SemanticDiffEntry, ...]
     semantic_diff_hash: str
 
 
@@ -122,8 +146,9 @@ class AcceptanceRecord:
     """Evidence that one span's semantic claim was explicitly accepted.
 
     ``batch_id`` is ``None`` for an individually reviewed span and otherwise
-    names an :class:`AcceptanceBatch`. ``reviewer`` and ``accepted_at`` are
-    audit metadata excluded from identity.
+    names an :class:`AcceptanceBatch`. ``reviewer`` and ``accepted_at`` record
+    who took the acceptance action and when; both are required evidence of an
+    explicit action, and neither reaches projection identity.
     """
 
     span_id: str
@@ -139,6 +164,12 @@ class ClassificationLedger:
     This is a committed, meaning-bearing input to the build — never a product
     of it (#137 contract 4: the oracle is not regenerated from the output it
     checks).
+
+    The ledger carries both the accepted semantic *result* (``spans``) and the
+    review evidence that produced it (``batches``, ``acceptances``). Only the
+    result is identity-bearing; the evidence is immutable, persisted, and
+    reconstructable for audit, but two ledgers that reviewed their way to the
+    same accepted classification are the same authority.
     """
 
     package_uuid: str

--- a/src/afterworlds/ingestion/mechanical/models.py
+++ b/src/afterworlds/ingestion/mechanical/models.py
@@ -1,0 +1,149 @@
+"""Semantic accounting types — CRD Issue 5d, span-exact classification.
+
+ADR-005d Decision 2 partitions every 5c ``REPRESENTED`` leaf into accepted
+semantic spans. This module holds the frozen value types for that partition and
+for the acceptance evidence that makes a span publishable. It holds no policy
+(see :mod:`policy`) and performs no validation (see :mod:`accounting`).
+
+Two separations are load-bearing and appear here as distinct fields rather than
+as one status:
+
+* **semantic disposition** — what the text *is* (substantive, supporting,
+  non-mechanical, unresolved);
+* **review state** — whether a human accepted that claim. A proposal is not an
+  acceptance, and silence is never acceptance (#137 contract 2).
+
+Reviewer identity, acceptance timestamps, and comments are audit metadata: they
+travel with the record but are excluded from every identity payload, so a
+re-review that changes nothing semantic does not mint a new projection
+(#137 acceptance criterion 11).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class SemanticDisposition(StrEnum):
+    """The mechanical role of one accepted span (#137 contract 2).
+
+    ``UNRESOLVED`` is an honest "cannot classify safely yet" and blocks
+    publication; it is not a bucket for text nobody looked at, which is what
+    a missing span means instead.
+    """
+
+    SUBSTANTIVE = "substantive"
+    SUPPORTING_AUTHORITY = "supporting_authority"
+    NON_MECHANICAL = "non_mechanical"
+    UNRESOLVED = "unresolved"
+
+
+class ReviewState(StrEnum):
+    """Whether a proposal has been explicitly accepted by review."""
+
+    PROPOSED = "proposed"
+    ACCEPTED = "accepted"
+
+
+class ComponentHandling(StrEnum):
+    """How a publishable component's meaning is represented (#137 contract 2).
+
+    ``PROSE_BOUND`` is an affirmative judgement backed by a closed
+    irreducibility reason — never a backlog state and never a synonym for
+    "the adapter cannot execute it".
+    """
+
+    STRUCTURED = "structured"
+    PROSE_BOUND = "prose_bound"
+    MIXED = "mixed"
+
+
+@dataclass(frozen=True)
+class NonMechanicalReason:
+    """One entry of the closed, identity-bound non-mechanical reason catalog."""
+
+    code: str
+    description: str
+
+
+@dataclass(frozen=True)
+class IrreducibilityReason:
+    """One entry of the closed prose-bound irreducibility catalog."""
+
+    code: str
+    description: str
+
+
+@dataclass(frozen=True)
+class SemanticSpan:
+    """One accepted-or-proposed classification of an exact leaf subspan.
+
+    ``char_start``/``char_end`` are a half-open range over the leaf's canonical
+    text, so a leaf's spans form a gap-free non-overlapping partition
+    (validated in :mod:`accounting`, not here).
+
+    ``span_id`` is content-derived from the leaf and range, so an unrelated
+    edit elsewhere in the corpus never churns it (#137 acceptance criterion 6).
+    """
+
+    span_id: str
+    leaf_id: str
+    char_start: int
+    char_end: int
+    disposition: SemanticDisposition
+    review_state: ReviewState
+    # Required exactly when disposition is NON_MECHANICAL; must name a code in
+    # the frozen catalog.
+    non_mechanical_reason_code: str | None = None
+
+
+@dataclass(frozen=True)
+class AcceptanceBatch:
+    """A rule-scoped batch acceptance (#137 contract 2).
+
+    Batch acceptance is what makes full-corpus review tractable, but it must
+    record *what rule was applied to what scope* and *what changed*, so a batch
+    can be re-derived and audited rather than taken on trust. A batch whose
+    recorded rule, scope, or semantic diff is missing is not an acceptance.
+
+    ``semantic_diff_hash`` covers the exact set of (span, disposition, reason)
+    transitions the batch produced.
+    """
+
+    batch_id: str
+    rule: str
+    scope: tuple[str, ...]
+    semantic_diff_hash: str
+
+
+@dataclass(frozen=True)
+class AcceptanceRecord:
+    """Evidence that one span's semantic claim was explicitly accepted.
+
+    ``batch_id`` is ``None`` for an individually reviewed span and otherwise
+    names an :class:`AcceptanceBatch`. ``reviewer`` and ``accepted_at`` are
+    audit metadata excluded from identity.
+    """
+
+    span_id: str
+    batch_id: str | None
+    reviewer: str
+    accepted_at: str
+
+
+@dataclass(frozen=True)
+class ClassificationLedger:
+    """The complete accepted semantic accounting for one bound 5c release.
+
+    This is a committed, meaning-bearing input to the build — never a product
+    of it (#137 contract 4: the oracle is not regenerated from the output it
+    checks).
+    """
+
+    package_uuid: str
+    release_version: str
+    policy_version: str
+    spans: tuple[SemanticSpan, ...]
+    batches: tuple[AcceptanceBatch, ...]
+    acceptances: tuple[AcceptanceRecord, ...]

--- a/src/afterworlds/ingestion/mechanical/models.py
+++ b/src/afterworlds/ingestion/mechanical/models.py
@@ -170,11 +170,19 @@ class ClassificationLedger:
     result is identity-bearing; the evidence is immutable, persisted, and
     reconstructable for audit, but two ledgers that reviewed their way to the
     same accepted classification are the same authority.
+
+    ``policy_version`` and ``policy_hash`` are the ledger's own declaration of
+    the semantic policy it was accepted under. They are retained and travel
+    with the projection, so a historical projection states the policy it used
+    instead of being reinterpreted under whatever policy code is current later;
+    the build verifies the declaration against the committed policy and fails
+    when they disagree.
     """
 
     package_uuid: str
     release_version: str
     policy_version: str
+    policy_hash: str
     spans: tuple[SemanticSpan, ...]
     batches: tuple[AcceptanceBatch, ...]
     acceptances: tuple[AcceptanceRecord, ...]

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -31,7 +31,10 @@ distinction decides which may be supplied by a caller:
   release is the publication gate's job, not this module's.
 * ``persisted_state_digest`` — the only *post-persistence* proof this package
   records, and therefore the only one no caller may supply. It is derived at
-  the seam that records it, from the state it claims to prove.
+  the seam that records it, from the state it claims to prove, and
+  :func:`verify_reconstruction` re-derives it whenever one is present. What PR 1
+  does *not* do is decide whether a proven projection may be published or
+  activated; that gate is the next PR's.
 """
 
 from __future__ import annotations
@@ -57,6 +60,12 @@ from afterworlds.ingestion.mechanical.projection import (
     ReleaseBinding,
     identify_projection,
     projection_payload,
+)
+from afterworlds.ingestion.mechanical.raw_state import (
+    PersistedStateReconstructionError,
+    load_raw_state,
+    parse_enum,
+    validate_raw_closure,
 )
 from afterworlds.ingestion.mechanical.representation import (
     ComponentDraft,
@@ -94,6 +103,7 @@ from afterworlds.persistence.orm.mechanical import (
 )
 
 __all__ = [
+    "PersistedStateReconstructionError",
     "ProjectionNotPersistedError",
     "compute_persisted_state_digest",
     "delete_projection",
@@ -301,12 +311,17 @@ def _fact_from_row(row: MechanicalFactORM) -> MechanicalFact:
     columns disagree with its own content has been altered, and picking a
     winner would be repair, not reconstruction.
     """
-    fact = fact_from_payload(row.payload, declared_family=row.family)
+    try:
+        fact = fact_from_payload(row.payload, declared_family=row.family)
+    except (MalformedFactPayloadError, UnknownFactFamilyError) as exc:
+        raise PersistedStateReconstructionError(
+            f"rp_mech_facts {row.record_key}/{row.component_key}: {exc}"
+        ) from exc
     recomputed = fact_key(fact)
     if row.fact_key != recomputed:
-        raise MalformedFactPayloadError(
-            f"persisted fact_key {row.fact_key!r} disagrees with payload "
-            f"({recomputed!r})"
+        raise PersistedStateReconstructionError(
+            f"rp_mech_facts {row.record_key}/{row.component_key}: persisted "
+            f"fact_key {row.fact_key!r} disagrees with payload ({recomputed!r})"
         )
     return fact
 
@@ -327,20 +342,22 @@ def reconstruct_candidate(
 ) -> ProjectionCandidate:
     """Rebuild the complete candidate from persisted rows alone.
 
+    Two stages, in this order: the complete raw row set is loaded and proven
+    closed, and only then is semantic meaning imposed on it. Doing it the other
+    way round is what let an orphan child row vanish during a join instead of
+    failing - invisible to the candidate, and therefore invisible to the digest
+    computed over it.
+
     Takes no in-memory candidate: what comes back is what the database holds,
     which is the only way the digest can prove persistence rather than prove
-    that the builder still remembers what it meant to write.
+    that the builder still remembers what it meant to write. Every typed column
+    is parsed strictly, so a corrupted enum raises
+    PersistedStateReconstructionError rather than letting an unclassified
+    exception escape an API whose contract is to report findings.
     """
     header = _header(session, projection_uuid)
-
-    def rows(model: type) -> list:  # type: ignore[type-arg]
-        return list(
-            session.execute(
-                select(model).where(model.projection_uuid == projection_uuid)  # type: ignore[attr-defined]
-            )
-            .scalars()
-            .all()
-        )
+    raw = load_raw_state(session, projection_uuid, header)
+    validate_raw_closure(raw)
 
     spans = tuple(
         SemanticSpan(
@@ -348,15 +365,21 @@ def reconstruct_candidate(
             leaf_id=r.leaf_id,
             char_start=r.char_start,
             char_end=r.char_end,
-            disposition=SemanticDisposition(r.disposition),
-            review_state=ReviewState(r.review_state),
+            disposition=parse_enum(
+                SemanticDisposition,
+                r.disposition,
+                "rp_mech_spans",
+                r.span_id,
+                "disposition",
+            ),
+            review_state=parse_enum(
+                ReviewState, r.review_state, "rp_mech_spans", r.span_id, "review_state"
+            ),
             non_mechanical_reason_code=r.non_mechanical_reason_code,
         )
-        for r in rows(MechanicalSpanORM)
+        for r in raw.spans
     )
 
-    scope_rows = rows(MechanicalBatchScopeORM)
-    diff_rows = rows(MechanicalBatchDiffORM)
     batches = tuple(
         AcceptanceBatch(
             batch_id=b.batch_id,
@@ -364,7 +387,7 @@ def reconstruct_candidate(
             resolved_scope=tuple(
                 s.span_id
                 for s in sorted(
-                    (s for s in scope_rows if s.batch_id == b.batch_id),
+                    (s for s in raw.batch_scope if s.batch_id == b.batch_id),
                     key=lambda s: s.ordinal,
                 )
             ),
@@ -372,20 +395,32 @@ def reconstruct_candidate(
                 SemanticDiffEntry(
                     span_id=d.span_id,
                     prior_disposition=(
-                        SemanticDisposition(d.prior_disposition)
+                        parse_enum(
+                            SemanticDisposition,
+                            d.prior_disposition,
+                            "rp_mech_batch_diff",
+                            f"{d.batch_id}/{d.span_id}",
+                            "prior_disposition",
+                        )
                         if d.prior_disposition
                         else None
                     ),
                     prior_reason_code=d.prior_reason_code,
-                    accepted_disposition=SemanticDisposition(d.accepted_disposition),
+                    accepted_disposition=parse_enum(
+                        SemanticDisposition,
+                        d.accepted_disposition,
+                        "rp_mech_batch_diff",
+                        f"{d.batch_id}/{d.span_id}",
+                        "accepted_disposition",
+                    ),
                     accepted_reason_code=d.accepted_reason_code,
                 )
-                for d in diff_rows
+                for d in raw.batch_diff
                 if d.batch_id == b.batch_id
             ),
             semantic_diff_hash=b.semantic_diff_hash,
         )
-        for b in rows(MechanicalAcceptanceBatchORM)
+        for b in raw.batches
     )
 
     acceptances = tuple(
@@ -395,33 +430,40 @@ def reconstruct_candidate(
             reviewer=a.reviewer,
             accepted_at=a.accepted_at,
         )
-        for a in rows(MechanicalAcceptanceORM)
+        for a in raw.acceptances
     )
 
-    fact_rows = rows(MechanicalFactORM)
     components = tuple(
         ComponentDraft(
             record_key=c.record_key,
             semantic_key=c.semantic_key,
-            handling=ComponentHandling(c.handling),
+            handling=parse_enum(
+                ComponentHandling,
+                c.handling,
+                "rp_mech_components",
+                f"{c.record_key}/{c.semantic_key}",
+                "handling",
+            ),
             irreducibility_reason_code=c.irreducibility_reason_code,
             facts=tuple(
                 _fact_from_row(f)
-                for f in fact_rows
+                for f in raw.facts
                 if (f.record_key, f.component_key) == (c.record_key, c.semantic_key)
             ),
         )
-        for c in rows(MechanicalComponentORM)
+        for c in raw.components
     )
 
     representation = RepresentationDraft(
         records=tuple(
             RecordDraft(
                 semantic_key=r.semantic_key,
-                kind=RecordKind(r.kind),
+                kind=parse_enum(
+                    RecordKind, r.kind, "rp_mech_records", r.semantic_key, "kind"
+                ),
                 parent_key=r.parent_key,
             )
-            for r in rows(MechanicalRecordORM)
+            for r in raw.records
         ),
         components=components,
         prose_bindings=tuple(
@@ -431,15 +473,21 @@ def reconstruct_candidate(
                 chunk_id=p.chunk_id,
                 irreducibility_reason_code=p.irreducibility_reason_code,
             )
-            for p in rows(MechanicalProseBindingORM)
+            for p in raw.prose_bindings
         ),
         relationships=tuple(
             RelationshipDraft(
                 source_record_key=r.source_record_key,
                 target_record_key=r.target_record_key,
-                kind=RelationshipKind(r.kind),
+                kind=parse_enum(
+                    RelationshipKind,
+                    r.kind,
+                    "rp_mech_relationships",
+                    f"{r.source_record_key}->{r.target_record_key}",
+                    "kind",
+                ),
             )
-            for r in rows(MechanicalRelationshipORM)
+            for r in raw.relationships
         ),
         references=tuple(
             ReferenceDraft(
@@ -449,16 +497,24 @@ def reconstruct_candidate(
                 scope_key=r.scope_key,
                 target_record_key=r.target_record_key,
             )
-            for r in rows(MechanicalReferenceORM)
+            for r in raw.references
         ),
         provenance=tuple(
             ProvenanceClaim(
-                target_kind=ProvenanceTargetKind(p.target_kind),
+                target_kind=parse_enum(
+                    ProvenanceTargetKind,
+                    p.target_kind,
+                    "rp_mech_provenance",
+                    str(p.row_id),
+                    "target_kind",
+                ),
                 target_key=tuple(p.target_key),
                 span_id=p.span_id,
-                role=ProvenanceRole(p.role),
+                role=parse_enum(
+                    ProvenanceRole, p.role, "rp_mech_provenance", str(p.row_id), "role"
+                ),
             )
-            for p in rows(MechanicalProvenanceORM)
+            for p in raw.provenance
         ),
     )
 
@@ -583,7 +639,7 @@ def verify_reconstruction(
 
     try:
         reconstructed = reconstruct_candidate(session, uuid_)
-    except (MalformedFactPayloadError, UnknownFactFamilyError) as exc:
+    except PersistedStateReconstructionError as exc:
         # A row that cannot rebuild is tamper or omission, which is exactly
         # what this check reports — reporting it beats propagating an
         # exception to a caller collecting findings.
@@ -601,6 +657,18 @@ def verify_reconstruction(
             f"projection {uuid_}: persisted payload hash does not match "
             f"reconstructed state"
         )
+    # Once a proof is recorded it is a claim about persisted state, so
+    # verification re-derives it. Without this, evidence-only tamper after
+    # recording would leave the recorded digest stale but unchallenged: the
+    # payload hash and derived IDs do not cover review evidence.
+    if header.persisted_state_digest is not None:
+        current = compute_persisted_state_digest(session, uuid_)
+        if current != header.persisted_state_digest:
+            findings.append(
+                f"projection {uuid_}: recorded persisted-state digest no longer "
+                f"matches current persisted state"
+            )
+
     if header.publication_status != expected_status:
         findings.append(
             f"projection {uuid_}: expected {expected_status!r}, found "

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -489,6 +489,11 @@ def compute_persisted_state_digest(session: Session, projection_uuid: str) -> st
     determinism rule keeps timestamps out of hashed artifacts so an identical
     rebuild stays comparable. ``accepted_at`` is different — it is reviewer-
     supplied evidence of an acceptance action, so it is covered above.
+
+    Unlike :func:`verify_reconstruction`, this raises rather than reporting when
+    the state will not rebuild. The asymmetry is intentional: verification
+    collects findings for a caller deciding whether state is sound, whereas a
+    digest of unreconstructable state would be a number that means nothing.
     """
     candidate = reconstruct_candidate(session, projection_uuid)
     stored_ids = {

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -495,13 +495,21 @@ def compute_persisted_state_digest(session: Session, projection_uuid: str) -> st
 
 
 def verify_reconstruction(
-    session: Session, identified: IdentifiedProjection
+    session: Session,
+    identified: IdentifiedProjection,
+    *,
+    expected_status: str = "draft",
 ) -> tuple[str, ...]:
     """Return violations found by rebuilding the projection from the database.
 
     Catches omission (a row that never landed), tamper (a value changed after
     the fact), and stale reuse (a persisted projection whose content no longer
     derives its own identity).
+
+    ``expected_status`` is explicit because the same verification runs before
+    publication and, later, against a published projection; hard-coding
+    ``draft`` here would make every post-publication check report a spurious
+    finding.
     """
     findings: list[str] = []
     uuid_ = identified.projection_uuid
@@ -524,9 +532,9 @@ def verify_reconstruction(
             f"projection {uuid_}: persisted payload hash does not match "
             f"reconstructed state"
         )
-    if header.publication_status != "draft":
+    if header.publication_status != expected_status:
         findings.append(
-            f"projection {uuid_}: expected a draft, found "
+            f"projection {uuid_}: expected {expected_status!r}, found "
             f"{header.publication_status!r}"
         )
 

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -24,6 +24,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.mechanical.accounting import acceptance_evidence_payload
 from afterworlds.ingestion.mechanical.models import (
     AcceptanceBatch,
     AcceptanceRecord,
@@ -43,6 +44,8 @@ from afterworlds.ingestion.mechanical.projection import (
 )
 from afterworlds.ingestion.mechanical.representation import (
     ComponentDraft,
+    MalformedFactPayloadError,
+    MechanicalFact,
     ProseBindingDraft,
     ProvenanceClaim,
     ProvenanceRole,
@@ -53,6 +56,7 @@ from afterworlds.ingestion.mechanical.representation import (
     RelationshipDraft,
     RelationshipKind,
     RepresentationDraft,
+    UnknownFactFamilyError,
     fact_from_payload,
     fact_key,
     fact_payload,
@@ -272,6 +276,25 @@ def persist_draft(
     session.flush()
 
 
+def _fact_from_row(row: MechanicalFactORM) -> MechanicalFact:
+    """Rebuild one typed fact from its row, checking the duplicated columns.
+
+    ``family`` and ``fact_key`` are stored alongside the payload for querying,
+    which means they can be rewritten independently of it. Reconstruction
+    checks both against the payload rather than trusting either: a row whose
+    columns disagree with its own content has been altered, and picking a
+    winner would be repair, not reconstruction.
+    """
+    fact = fact_from_payload(row.payload, declared_family=row.family)
+    recomputed = fact_key(fact)
+    if row.fact_key != recomputed:
+        raise MalformedFactPayloadError(
+            f"persisted fact_key {row.fact_key!r} disagrees with payload "
+            f"({recomputed!r})"
+        )
+    return fact
+
+
 def _header(session: Session, projection_uuid: str) -> MechanicalProjectionORM:
     row = session.execute(
         select(MechanicalProjectionORM).where(
@@ -367,7 +390,7 @@ def reconstruct_candidate(
             handling=ComponentHandling(c.handling),
             irreducibility_reason_code=c.irreducibility_reason_code,
             facts=tuple(
-                fact_from_payload(f.payload)
+                _fact_from_row(f)
                 for f in fact_rows
                 if (f.record_key, f.component_key) == (c.record_key, c.semantic_key)
             ),
@@ -446,11 +469,26 @@ def reconstruct_candidate(
 
 
 def compute_persisted_state_digest(session: Session, projection_uuid: str) -> str:
-    """Digest the reconstructed state, including the persisted derived IDs.
+    """Digest the reconstructed state: semantics, subidentities, and evidence.
 
-    The payload alone would not notice a corrupted ``record_id`` column, so the
-    digest covers the stored subidentities too: a tampered derived ID changes
-    the digest even when every semantic value survives intact.
+    Three layers, because each covers what the others cannot:
+
+    * the **semantic payload** — what the projection means;
+    * the **persisted derived IDs** — a corrupted ``record_id`` leaves every
+      semantic value intact and would otherwise pass; and
+    * the **retained acceptance evidence** — reviewer, timestamp, batch rule,
+      ordered scope, diff, and review state are deliberately outside semantic
+      identity, so without this layer they could be rewritten after the digest
+      was recorded and nothing would notice.
+
+    The last layer is why this digest and the projection UUID are different
+    things. The UUID answers "is this the same authority"; the digest answers
+    "is this the same persisted state, including how it was reviewed".
+
+    ``created_at`` is excluded: it is build wall-clock, and the CRD Issue 5c
+    determinism rule keeps timestamps out of hashed artifacts so an identical
+    rebuild stays comparable. ``accepted_at`` is different — it is reviewer-
+    supplied evidence of an acceptance action, so it is covered above.
     """
     candidate = reconstruct_candidate(session, projection_uuid)
     stored_ids = {
@@ -490,6 +528,9 @@ def compute_persisted_state_digest(session: Session, projection_uuid: str) -> st
             "projection_uuid": projection_uuid,
             "payload": projection_payload(candidate),
             "derived_ids": stored_ids,
+            "acceptance_evidence": acceptance_evidence_payload(
+                candidate.classification
+            ),
         }
     )
 
@@ -519,7 +560,14 @@ def verify_reconstruction(
     except ProjectionNotPersistedError:
         return (f"projection {uuid_}: no persisted header row",)
 
-    reconstructed = reconstruct_candidate(session, uuid_)
+    try:
+        reconstructed = reconstruct_candidate(session, uuid_)
+    except (MalformedFactPayloadError, UnknownFactFamilyError) as exc:
+        # A row that cannot rebuild is tamper or omission, which is exactly
+        # what this check reports — reporting it beats propagating an
+        # exception to a caller collecting findings.
+        return (f"projection {uuid_}: persisted state does not reconstruct: {exc}",)
+
     reidentified = identify_projection(reconstructed)
 
     if reidentified.projection_uuid != uuid_:

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -16,6 +16,22 @@ Reconstruction is deliberately blind. If it took the candidate as a hint, a row
 that failed to persist or was altered afterwards could be silently repaired
 from memory and the digest would still match — which is exactly the tamper and
 omission case the reconstruct-before-publish step exists to catch.
+
+Hash-shaped values in this package are not all the same kind of thing, and the
+distinction decides which may be supplied by a caller:
+
+* ``payload_hash`` — a *pre-persistence* hash of the candidate. Supplied at
+  write time and later checked against reconstruction by
+  :func:`verify_reconstruction`, so a wrong value is caught, not trusted.
+* ``semantic_diff_hash`` — retained review evidence. Supplied with the batch
+  and independently recomputed from the retained diff during acceptance
+  validation, so it identifies evidence rather than asserting it.
+* ``persisted_corpus_digest`` — CRD Issue 5c's own proof, carried in the
+  binding as part of the projection's meaning. Equality against the bound 5c
+  release is the publication gate's job, not this module's.
+* ``persisted_state_digest`` — the only *post-persistence* proof this package
+  records, and therefore the only one no caller may supply. It is derived at
+  the seam that records it, from the state it claims to prove.
 """
 
 from __future__ import annotations
@@ -642,17 +658,31 @@ def verify_reconstruction(
     return tuple(findings)
 
 
-def record_persisted_state_digest(
-    session: Session, projection_uuid: str, digest: str
-) -> None:
-    """Record the digest computed from reconstructed state, exactly once."""
+def record_persisted_state_digest(session: Session, projection_uuid: str) -> str:
+    """Derive and record this projection's persisted-state digest, exactly once.
+
+    The digest is computed *here*, from this projection's own reconstructed
+    state inside the recording transaction, and returned. There is deliberately
+    no digest parameter: a caller-supplied value can be stale, computed before
+    an intervening mutation, or belong to a different projection, and the
+    exactly-once guard would then freeze that false proof in place. A proof
+    that does not derive from the state it claims to prove is not a proof.
+
+    Pending session changes are flushed first so the reconstruction sees the
+    same state the transaction holds. If reconstruction or digest computation
+    fails, the exception propagates and the header keeps ``NULL`` — an
+    unprovable projection must not carry a recorded proof.
+    """
     header = _header(session, projection_uuid)
     if header.persisted_state_digest is not None:
         raise ValueError(
             f"projection {projection_uuid}: persisted-state digest already recorded"
         )
+    session.flush()
+    digest = compute_persisted_state_digest(session, projection_uuid)
     header.persisted_state_digest = digest
     session.flush()
+    return digest
 
 
 def delete_projection(session: Session, projection_uuid: str) -> None:

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -1,0 +1,619 @@
+"""Draft persistence and exact reconstruction — CRD Issue 5d, Decision 8.
+
+The lifecycle #137 contract 5 requires is:
+
+``build candidate → persist draft → reconstruct from persisted state →
+compute persisted-state digest → run exact completeness gate → atomically
+publish``
+
+This module owns the middle three steps. It writes a **draft**, reads the
+projection back out of the database with no help from the in-memory candidate,
+and derives a digest from what it read. The gate and publication are the next
+PR; nothing here activates anything, and ``publication_status`` never leaves
+``draft``.
+
+Reconstruction is deliberately blind. If it took the candidate as a hint, a row
+that failed to persist or was altered afterwards could be silently repaired
+from memory and the digest would still match — which is exactly the tamper and
+omission case the reconstruct-before-publish step exists to catch.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceBatch,
+    AcceptanceRecord,
+    ClassificationLedger,
+    ComponentHandling,
+    ReviewState,
+    SemanticDiffEntry,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    IdentifiedProjection,
+    ProjectionCandidate,
+    ReleaseBinding,
+    identify_projection,
+    projection_payload,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RecordDraft,
+    RecordKind,
+    ReferenceDraft,
+    RelationshipDraft,
+    RelationshipKind,
+    RepresentationDraft,
+    fact_from_payload,
+    fact_key,
+    fact_payload,
+)
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalAcceptanceBatchORM,
+    MechanicalAcceptanceORM,
+    MechanicalBatchDiffORM,
+    MechanicalBatchScopeORM,
+    MechanicalComponentORM,
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+    MechanicalProseBindingORM,
+    MechanicalProvenanceORM,
+    MechanicalRecordORM,
+    MechanicalReferenceORM,
+    MechanicalRelationshipORM,
+    MechanicalSpanORM,
+)
+
+__all__ = [
+    "ProjectionNotPersistedError",
+    "compute_persisted_state_digest",
+    "delete_projection",
+    "persist_draft",
+    "reconstruct_candidate",
+    "record_persisted_state_digest",
+    "verify_reconstruction",
+]
+
+
+class ProjectionNotPersistedError(LookupError):
+    """Raised when a projection UUID has no persisted header row."""
+
+
+def persist_draft(
+    session: Session, identified: IdentifiedProjection, *, now: str
+) -> None:
+    """Write the complete projection as a draft.
+
+    Typed rows throughout: spans, acceptance evidence, records, components,
+    facts, prose bindings, relationships, references, and provenance each get
+    their own table, so the projection is reconstructable from the database
+    rather than from one opaque payload column.
+    """
+    candidate = identified.candidate
+    ledger = candidate.classification
+    draft = candidate.representation
+    uuid_ = identified.projection_uuid
+
+    session.add(
+        MechanicalProjectionORM(
+            projection_uuid=uuid_,
+            package_uuid=candidate.binding.package_uuid,
+            release_version=candidate.binding.release_version,
+            authoritative_source_hash=candidate.binding.authoritative_source_hash,
+            transform_config_hash=candidate.binding.transform_config_hash,
+            bundle_root_hash=candidate.binding.bundle_root_hash,
+            persisted_corpus_digest=candidate.binding.persisted_corpus_digest,
+            semantic_policy_version=ledger.policy_version,
+            semantic_policy_hash=ledger.policy_hash,
+            payload_hash=identified.payload_hash,
+            persisted_state_digest=None,
+            publication_status="draft",
+            created_at=now,
+        )
+    )
+    # The header lands before anything scoped to it: every child row carries a
+    # real FK, so a partially written projection cannot exist without one.
+    session.flush()
+
+    for span in ledger.spans:
+        session.add(
+            MechanicalSpanORM(
+                projection_uuid=uuid_,
+                span_id=span.span_id,
+                leaf_id=span.leaf_id,
+                char_start=span.char_start,
+                char_end=span.char_end,
+                disposition=span.disposition.value,
+                review_state=span.review_state.value,
+                non_mechanical_reason_code=span.non_mechanical_reason_code,
+            )
+        )
+
+    for batch in ledger.batches:
+        session.add(
+            MechanicalAcceptanceBatchORM(
+                projection_uuid=uuid_,
+                batch_id=batch.batch_id,
+                rule=batch.rule,
+                semantic_diff_hash=batch.semantic_diff_hash,
+            )
+        )
+        # Scope order is retained: it is the reviewer's recorded scope, not a
+        # set the build is free to re-derive.
+        for ordinal, span_id in enumerate(batch.resolved_scope):
+            session.add(
+                MechanicalBatchScopeORM(
+                    projection_uuid=uuid_,
+                    batch_id=batch.batch_id,
+                    span_id=span_id,
+                    ordinal=ordinal,
+                )
+            )
+        for entry in batch.diff:
+            session.add(
+                MechanicalBatchDiffORM(
+                    projection_uuid=uuid_,
+                    batch_id=batch.batch_id,
+                    span_id=entry.span_id,
+                    prior_disposition=(
+                        entry.prior_disposition.value
+                        if entry.prior_disposition
+                        else None
+                    ),
+                    prior_reason_code=entry.prior_reason_code,
+                    accepted_disposition=entry.accepted_disposition.value,
+                    accepted_reason_code=entry.accepted_reason_code,
+                )
+            )
+
+    for acceptance in ledger.acceptances:
+        session.add(
+            MechanicalAcceptanceORM(
+                projection_uuid=uuid_,
+                span_id=acceptance.span_id,
+                batch_id=acceptance.batch_id,
+                reviewer=acceptance.reviewer,
+                accepted_at=acceptance.accepted_at,
+            )
+        )
+
+    for record in draft.records:
+        session.add(
+            MechanicalRecordORM(
+                projection_uuid=uuid_,
+                record_id=identified.record_ids[record.semantic_key],
+                semantic_key=record.semantic_key,
+                kind=record.kind.value,
+                parent_key=record.parent_key,
+            )
+        )
+
+    for component in draft.components:
+        key = (component.record_key, component.semantic_key)
+        session.add(
+            MechanicalComponentORM(
+                projection_uuid=uuid_,
+                component_id=identified.component_ids[key],
+                record_key=component.record_key,
+                semantic_key=component.semantic_key,
+                handling=component.handling.value,
+                irreducibility_reason_code=component.irreducibility_reason_code,
+            )
+        )
+        for fact in component.facts:
+            key_ = fact_key(fact)
+            session.add(
+                MechanicalFactORM(
+                    projection_uuid=uuid_,
+                    fact_id=identified.fact_ids[
+                        (component.record_key, component.semantic_key, key_)
+                    ],
+                    record_key=component.record_key,
+                    component_key=component.semantic_key,
+                    fact_key=key_,
+                    family=str(fact_payload(fact)["family"]),
+                    payload=fact_payload(fact),
+                )
+            )
+
+    for binding in draft.prose_bindings:
+        session.add(
+            MechanicalProseBindingORM(
+                projection_uuid=uuid_,
+                record_key=binding.record_key,
+                component_key=binding.component_key,
+                chunk_id=binding.chunk_id,
+                irreducibility_reason_code=binding.irreducibility_reason_code,
+            )
+        )
+
+    for relationship in draft.relationships:
+        session.add(
+            MechanicalRelationshipORM(
+                projection_uuid=uuid_,
+                source_record_key=relationship.source_record_key,
+                target_record_key=relationship.target_record_key,
+                kind=relationship.kind.value,
+            )
+        )
+
+    for reference in draft.references:
+        session.add(
+            MechanicalReferenceORM(
+                projection_uuid=uuid_,
+                from_record_key=reference.from_record_key,
+                from_component_key=reference.from_component_key,
+                source_text=reference.source_text,
+                scope_key=reference.scope_key,
+                target_record_key=reference.target_record_key,
+            )
+        )
+
+    for claim in draft.provenance:
+        session.add(
+            MechanicalProvenanceORM(
+                projection_uuid=uuid_,
+                target_kind=claim.target_kind.value,
+                target_key=list(claim.target_key),
+                span_id=claim.span_id,
+                role=claim.role.value,
+            )
+        )
+
+    session.flush()
+
+
+def _header(session: Session, projection_uuid: str) -> MechanicalProjectionORM:
+    row = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == projection_uuid
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise ProjectionNotPersistedError(projection_uuid)
+    return row
+
+
+def reconstruct_candidate(
+    session: Session, projection_uuid: str
+) -> ProjectionCandidate:
+    """Rebuild the complete candidate from persisted rows alone.
+
+    Takes no in-memory candidate: what comes back is what the database holds,
+    which is the only way the digest can prove persistence rather than prove
+    that the builder still remembers what it meant to write.
+    """
+    header = _header(session, projection_uuid)
+
+    def rows(model: type) -> list:  # type: ignore[type-arg]
+        return list(
+            session.execute(
+                select(model).where(model.projection_uuid == projection_uuid)  # type: ignore[attr-defined]
+            )
+            .scalars()
+            .all()
+        )
+
+    spans = tuple(
+        SemanticSpan(
+            span_id=r.span_id,
+            leaf_id=r.leaf_id,
+            char_start=r.char_start,
+            char_end=r.char_end,
+            disposition=SemanticDisposition(r.disposition),
+            review_state=ReviewState(r.review_state),
+            non_mechanical_reason_code=r.non_mechanical_reason_code,
+        )
+        for r in rows(MechanicalSpanORM)
+    )
+
+    scope_rows = rows(MechanicalBatchScopeORM)
+    diff_rows = rows(MechanicalBatchDiffORM)
+    batches = tuple(
+        AcceptanceBatch(
+            batch_id=b.batch_id,
+            rule=b.rule,
+            resolved_scope=tuple(
+                s.span_id
+                for s in sorted(
+                    (s for s in scope_rows if s.batch_id == b.batch_id),
+                    key=lambda s: s.ordinal,
+                )
+            ),
+            diff=tuple(
+                SemanticDiffEntry(
+                    span_id=d.span_id,
+                    prior_disposition=(
+                        SemanticDisposition(d.prior_disposition)
+                        if d.prior_disposition
+                        else None
+                    ),
+                    prior_reason_code=d.prior_reason_code,
+                    accepted_disposition=SemanticDisposition(d.accepted_disposition),
+                    accepted_reason_code=d.accepted_reason_code,
+                )
+                for d in diff_rows
+                if d.batch_id == b.batch_id
+            ),
+            semantic_diff_hash=b.semantic_diff_hash,
+        )
+        for b in rows(MechanicalAcceptanceBatchORM)
+    )
+
+    acceptances = tuple(
+        AcceptanceRecord(
+            span_id=a.span_id,
+            batch_id=a.batch_id,
+            reviewer=a.reviewer,
+            accepted_at=a.accepted_at,
+        )
+        for a in rows(MechanicalAcceptanceORM)
+    )
+
+    fact_rows = rows(MechanicalFactORM)
+    components = tuple(
+        ComponentDraft(
+            record_key=c.record_key,
+            semantic_key=c.semantic_key,
+            handling=ComponentHandling(c.handling),
+            irreducibility_reason_code=c.irreducibility_reason_code,
+            facts=tuple(
+                fact_from_payload(f.payload)
+                for f in fact_rows
+                if (f.record_key, f.component_key) == (c.record_key, c.semantic_key)
+            ),
+        )
+        for c in rows(MechanicalComponentORM)
+    )
+
+    representation = RepresentationDraft(
+        records=tuple(
+            RecordDraft(
+                semantic_key=r.semantic_key,
+                kind=RecordKind(r.kind),
+                parent_key=r.parent_key,
+            )
+            for r in rows(MechanicalRecordORM)
+        ),
+        components=components,
+        prose_bindings=tuple(
+            ProseBindingDraft(
+                component_key=p.component_key,
+                record_key=p.record_key,
+                chunk_id=p.chunk_id,
+                irreducibility_reason_code=p.irreducibility_reason_code,
+            )
+            for p in rows(MechanicalProseBindingORM)
+        ),
+        relationships=tuple(
+            RelationshipDraft(
+                source_record_key=r.source_record_key,
+                target_record_key=r.target_record_key,
+                kind=RelationshipKind(r.kind),
+            )
+            for r in rows(MechanicalRelationshipORM)
+        ),
+        references=tuple(
+            ReferenceDraft(
+                from_record_key=r.from_record_key,
+                from_component_key=r.from_component_key,
+                source_text=r.source_text,
+                scope_key=r.scope_key,
+                target_record_key=r.target_record_key,
+            )
+            for r in rows(MechanicalReferenceORM)
+        ),
+        provenance=tuple(
+            ProvenanceClaim(
+                target_kind=ProvenanceTargetKind(p.target_kind),
+                target_key=tuple(p.target_key),
+                span_id=p.span_id,
+                role=ProvenanceRole(p.role),
+            )
+            for p in rows(MechanicalProvenanceORM)
+        ),
+    )
+
+    return ProjectionCandidate(
+        binding=ReleaseBinding(
+            package_uuid=header.package_uuid,
+            release_version=header.release_version,
+            authoritative_source_hash=header.authoritative_source_hash,
+            transform_config_hash=header.transform_config_hash,
+            bundle_root_hash=header.bundle_root_hash,
+            persisted_corpus_digest=header.persisted_corpus_digest,
+        ),
+        classification=ClassificationLedger(
+            package_uuid=header.package_uuid,
+            release_version=header.release_version,
+            policy_version=header.semantic_policy_version,
+            policy_hash=header.semantic_policy_hash,
+            spans=spans,
+            batches=batches,
+            acceptances=acceptances,
+        ),
+        representation=representation,
+    )
+
+
+def compute_persisted_state_digest(session: Session, projection_uuid: str) -> str:
+    """Digest the reconstructed state, including the persisted derived IDs.
+
+    The payload alone would not notice a corrupted ``record_id`` column, so the
+    digest covers the stored subidentities too: a tampered derived ID changes
+    the digest even when every semantic value survives intact.
+    """
+    candidate = reconstruct_candidate(session, projection_uuid)
+    stored_ids = {
+        "records": sorted(
+            (r.semantic_key, r.record_id)
+            for r in session.execute(
+                select(MechanicalRecordORM).where(
+                    MechanicalRecordORM.projection_uuid == projection_uuid
+                )
+            )
+            .scalars()
+            .all()
+        ),
+        "components": sorted(
+            (c.record_key, c.semantic_key, c.component_id)
+            for c in session.execute(
+                select(MechanicalComponentORM).where(
+                    MechanicalComponentORM.projection_uuid == projection_uuid
+                )
+            )
+            .scalars()
+            .all()
+        ),
+        "facts": sorted(
+            (f.record_key, f.component_key, f.fact_key, f.fact_id)
+            for f in session.execute(
+                select(MechanicalFactORM).where(
+                    MechanicalFactORM.projection_uuid == projection_uuid
+                )
+            )
+            .scalars()
+            .all()
+        ),
+    }
+    return hash_obj(
+        {
+            "projection_uuid": projection_uuid,
+            "payload": projection_payload(candidate),
+            "derived_ids": stored_ids,
+        }
+    )
+
+
+def verify_reconstruction(
+    session: Session, identified: IdentifiedProjection
+) -> tuple[str, ...]:
+    """Return violations found by rebuilding the projection from the database.
+
+    Catches omission (a row that never landed), tamper (a value changed after
+    the fact), and stale reuse (a persisted projection whose content no longer
+    derives its own identity).
+    """
+    findings: list[str] = []
+    uuid_ = identified.projection_uuid
+
+    try:
+        header = _header(session, uuid_)
+    except ProjectionNotPersistedError:
+        return (f"projection {uuid_}: no persisted header row",)
+
+    reconstructed = reconstruct_candidate(session, uuid_)
+    reidentified = identify_projection(reconstructed)
+
+    if reidentified.projection_uuid != uuid_:
+        findings.append(
+            f"projection {uuid_}: reconstructed state derives "
+            f"{reidentified.projection_uuid}"
+        )
+    if header.payload_hash != reidentified.payload_hash:
+        findings.append(
+            f"projection {uuid_}: persisted payload hash does not match "
+            f"reconstructed state"
+        )
+    if header.publication_status != "draft":
+        findings.append(
+            f"projection {uuid_}: expected a draft, found "
+            f"{header.publication_status!r}"
+        )
+
+    # Derived IDs are stored, so a corrupted one must be caught rather than
+    # recomputed away at read time.
+    for row in (
+        session.execute(
+            select(MechanicalRecordORM).where(
+                MechanicalRecordORM.projection_uuid == uuid_
+            )
+        )
+        .scalars()
+        .all()
+    ):
+        expected = reidentified.record_ids.get(row.semantic_key)
+        if expected != row.record_id:
+            findings.append(
+                f"record {row.semantic_key}: persisted id {row.record_id} != "
+                f"derived {expected}"
+            )
+    for crow in (
+        session.execute(
+            select(MechanicalComponentORM).where(
+                MechanicalComponentORM.projection_uuid == uuid_
+            )
+        )
+        .scalars()
+        .all()
+    ):
+        expected = reidentified.component_ids.get((crow.record_key, crow.semantic_key))
+        if expected != crow.component_id:
+            findings.append(
+                f"component {crow.record_key}/{crow.semantic_key}: persisted id "
+                f"{crow.component_id} != derived {expected}"
+            )
+    for frow in (
+        session.execute(
+            select(MechanicalFactORM).where(MechanicalFactORM.projection_uuid == uuid_)
+        )
+        .scalars()
+        .all()
+    ):
+        expected = reidentified.fact_ids.get(
+            (frow.record_key, frow.component_key, frow.fact_key)
+        )
+        if expected != frow.fact_id:
+            findings.append(
+                f"fact {frow.record_key}/{frow.component_key}/{frow.fact_key}: "
+                f"persisted id {frow.fact_id} != derived {expected}"
+            )
+
+    return tuple(findings)
+
+
+def record_persisted_state_digest(
+    session: Session, projection_uuid: str, digest: str
+) -> None:
+    """Record the digest computed from reconstructed state, exactly once."""
+    header = _header(session, projection_uuid)
+    if header.persisted_state_digest is not None:
+        raise ValueError(
+            f"projection {projection_uuid}: persisted-state digest already recorded"
+        )
+    header.persisted_state_digest = digest
+    session.flush()
+
+
+def delete_projection(session: Session, projection_uuid: str) -> None:
+    """Remove a draft projection and every row scoped to it."""
+    for model in (
+        MechanicalSpanORM,
+        MechanicalAcceptanceBatchORM,
+        MechanicalBatchScopeORM,
+        MechanicalBatchDiffORM,
+        MechanicalAcceptanceORM,
+        MechanicalRecordORM,
+        MechanicalComponentORM,
+        MechanicalFactORM,
+        MechanicalProseBindingORM,
+        MechanicalRelationshipORM,
+        MechanicalReferenceORM,
+        MechanicalProvenanceORM,
+    ):
+        session.execute(delete(model).where(model.projection_uuid == projection_uuid))
+    session.execute(
+        delete(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == projection_uuid
+        )
+    )
+    session.flush()

--- a/src/afterworlds/ingestion/mechanical/policy.py
+++ b/src/afterworlds/ingestion/mechanical/policy.py
@@ -45,9 +45,12 @@ SEMANTIC_POLICY_VERSION = "5d-semantic-policy-1"
 # ---------------------------------------------------------------------------
 
 # Headings, examples, cross-references, explanatory clauses, GameMaster
-# guidance, and repeated wording are deliberately *absent* here: they are
-# supporting authority, not blanket non-mechanical categories. Classifying them
-# away is the failure mode this catalog exists to prevent.
+# guidance, and repeated wording are deliberately *absent* here. They are not
+# blanket non-mechanical categories (#137 contract 2) and may well be
+# supporting authority, so nothing may be discarded merely for having one of
+# those forms. Each instance is classified from its actual role: a particular
+# heading or repeated item can still be non-mechanical under a valid closed
+# reason such as ``navigation_only`` when its content supports that.
 NON_MECHANICAL_REASONS: tuple[NonMechanicalReason, ...] = (
     NonMechanicalReason(
         code="legal_licensing",

--- a/src/afterworlds/ingestion/mechanical/policy.py
+++ b/src/afterworlds/ingestion/mechanical/policy.py
@@ -1,0 +1,168 @@
+"""Frozen semantic policy — CRD Issue 5d.
+
+The semantic policy is a committed build input, frozen in source before any
+projection output exists, exactly as CRD Issue 5c freezes its reconciliation
+policy. It defines, exhaustively:
+
+* the closed non-mechanical reason catalog;
+* the closed prose-bound irreducibility catalog; and
+* the canonicalization rules under which spans and payloads are compared.
+
+Because it lives in committed source it is frozen by construction, and the
+projection records the policy hash it applied. A reason code invented after
+looking at output cannot pass: it is not in the catalog, so the span carrying
+it fails accounting.
+
+Canonicalization deliberately reuses CRD Issue 5c's ``normalize`` rather than
+defining a second text-equivalence rule. Two normalization rules that drift
+apart would let a span "cover" text the corpus layer considers different.
+"""
+
+from __future__ import annotations
+
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.corpus.policy import NORMALIZATION_VERSION, normalize
+from afterworlds.ingestion.mechanical.models import (
+    IrreducibilityReason,
+    NonMechanicalReason,
+)
+
+__all__ = [
+    "IRREDUCIBILITY_REASONS",
+    "NON_MECHANICAL_REASONS",
+    "SEMANTIC_POLICY_VERSION",
+    "canonical_span_text",
+    "irreducibility_reason_for",
+    "non_mechanical_reason_for",
+    "semantic_policy_hash",
+    "semantic_policy_payload",
+]
+
+SEMANTIC_POLICY_VERSION = "5d-semantic-policy-1"
+
+# ---------------------------------------------------------------------------
+# Closed catalogs (#137 contract 2)
+# ---------------------------------------------------------------------------
+
+# Headings, examples, cross-references, explanatory clauses, GameMaster
+# guidance, and repeated wording are deliberately *absent* here: they are
+# supporting authority, not blanket non-mechanical categories. Classifying them
+# away is the failure mode this catalog exists to prevent.
+NON_MECHANICAL_REASONS: tuple[NonMechanicalReason, ...] = (
+    NonMechanicalReason(
+        code="legal_licensing",
+        description="Licence text, copyright, or legal notice.",
+    ),
+    NonMechanicalReason(
+        code="navigation_only",
+        description=(
+            "Purely navigational material — running headers/footers, page "
+            "numbers, table-of-contents entries — carrying no rule meaning."
+        ),
+    ),
+    NonMechanicalReason(
+        code="flavor_setting",
+        description=(
+            "Setting or flavour prose that neither states nor contextualizes a "
+            "mechanic."
+        ),
+    ),
+    NonMechanicalReason(
+        code="governed_attribution",
+        description=("Attribution already governed by the 5c corpus attribution role."),
+    ),
+    NonMechanicalReason(
+        code="authoring_guidance",
+        description=(
+            "Guidance addressed to the document's authors or publishers rather "
+            "than to play."
+        ),
+    ),
+)
+
+IRREDUCIBILITY_REASONS: tuple[IrreducibilityReason, ...] = (
+    IrreducibilityReason(
+        code="contextual_applicability",
+        description=(
+            "Whether the rule applies depends on fiction the projection cannot "
+            "enumerate."
+        ),
+    ),
+    IrreducibilityReason(
+        code="subjective_judgment",
+        description="Resolution requires a judgement call, not a computation.",
+    ),
+    IrreducibilityReason(
+        code="open_ended_effect",
+        description=(
+            "The effect space is unbounded — any faithful reduction would narrow it."
+        ),
+    ),
+    IrreducibilityReason(
+        code="gamemaster_latitude",
+        description="The source explicitly delegates the decision to the GM.",
+    ),
+    IrreducibilityReason(
+        code="natural_language_exception",
+        description=(
+            "A natural-language exception that cannot be reduced without "
+            "executable interpretation."
+        ),
+    ),
+    IrreducibilityReason(
+        code="fiction_dependent_consequence",
+        description=(
+            "The consequence follows from established fiction rather than from "
+            "stated mechanics."
+        ),
+    ),
+)
+
+_NON_MECHANICAL_BY_CODE = {r.code: r for r in NON_MECHANICAL_REASONS}
+_IRREDUCIBILITY_BY_CODE = {r.code: r for r in IRREDUCIBILITY_REASONS}
+
+
+def non_mechanical_reason_for(code: str) -> NonMechanicalReason | None:
+    """Return the catalog entry for *code*, or ``None`` when it is not closed."""
+    return _NON_MECHANICAL_BY_CODE.get(code)
+
+
+def irreducibility_reason_for(code: str) -> IrreducibilityReason | None:
+    """Return the catalog entry for *code*, or ``None`` when it is not closed."""
+    return _IRREDUCIBILITY_BY_CODE.get(code)
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization + policy identity
+# ---------------------------------------------------------------------------
+
+
+def canonical_span_text(leaf_content: str, char_start: int, char_end: int) -> str:
+    """Return the canonical text of a leaf subspan.
+
+    Slicing happens on the raw leaf text so offsets stay meaningful against the
+    persisted 5c leaf; normalization applies afterwards, so equivalence follows
+    the corpus rule rather than a second one.
+    """
+    return normalize(leaf_content[char_start:char_end])
+
+
+def semantic_policy_payload() -> dict[str, object]:
+    """Canonical, identity-bearing payload of the frozen semantic policy."""
+    return {
+        "semantic_policy_version": SEMANTIC_POLICY_VERSION,
+        "normalization_version": NORMALIZATION_VERSION,
+        "non_mechanical_reasons": [
+            {"code": r.code, "description": r.description}
+            for r in NON_MECHANICAL_REASONS
+        ],
+        "irreducibility_reasons": [
+            {"code": r.code, "description": r.description}
+            for r in IRREDUCIBILITY_REASONS
+        ],
+    }
+
+
+def semantic_policy_hash() -> str:
+    """SHA-256 of the frozen semantic policy payload."""
+    return hash_obj(semantic_policy_payload())

--- a/src/afterworlds/ingestion/mechanical/projection.py
+++ b/src/afterworlds/ingestion/mechanical/projection.py
@@ -1,0 +1,325 @@
+"""Projection identity and candidate assembly — CRD Issue 5d, Decisions 6 and 8.
+
+Identity derivation is acyclic, and the order matters:
+
+1. the **payload** is assembled from the exact 5c release binding, the accepted
+   classification, the declared semantic policy, and the keyed representation —
+   semantic keys only, no derived identity anywhere inside it;
+2. the **projection UUID** is content-derived from that payload; then
+3. stable record, component, and fact IDs are derived from the projection UUID
+   plus their committed semantic keys.
+
+Doing it the other way — putting derived IDs into the payload the UUID is
+computed from — would be circular, and deriving IDs from list positions would
+churn every identity whenever an unrelated sibling was inserted.
+
+**A computed identity is not a publishable projection.** This module can
+identify any candidate, including a dishonest one; that is what makes the
+identity useful for comparing candidates at all. Before a projection may be
+published or activated, every one of these must succeed: the declared policy
+binding, the span partition, explicit acceptance, representation validation,
+persistence reconstruction, and the later exact completeness gate.
+:func:`validate_candidate` covers the first four; the rest belong to the
+persistence and gate layers. Nothing here activates anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from afterworlds.ingestion.corpus.hashing import content_id, hash_obj
+from afterworlds.ingestion.mechanical.accounting import (
+    classification_payload,
+    validate_acceptance,
+    validate_partition,
+    validate_policy_binding,
+    validate_reason_codes,
+)
+from afterworlds.ingestion.mechanical.models import ClassificationLedger
+from afterworlds.ingestion.mechanical.representation import (
+    RepresentationDraft,
+    fact_key,
+    fact_payload,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+
+__all__ = [
+    "IdentifiedProjection",
+    "ProjectionCandidate",
+    "ReleaseBinding",
+    "derive_component_id",
+    "derive_fact_id",
+    "derive_record_id",
+    "identify_projection",
+    "projection_payload",
+    "projection_uuid",
+    "release_binding_payload",
+    "representation_payload",
+    "validate_candidate",
+]
+
+
+@dataclass(frozen=True)
+class ReleaseBinding:
+    """The exact published 5c release a projection is built over (#137 contract 1).
+
+    All six values are required. A matching slug, display name, source label, or
+    filename is not a binding — these are the reconstructable proof identities
+    CRD Issue 5c already publishes, so a projection cannot claim a release it
+    was not actually built from.
+    """
+
+    package_uuid: str
+    release_version: str
+    authoritative_source_hash: str
+    transform_config_hash: str
+    bundle_root_hash: str
+    persisted_corpus_digest: str
+
+
+@dataclass(frozen=True)
+class ProjectionCandidate:
+    """A built-but-unproven projection: identifiable, not yet publishable."""
+
+    binding: ReleaseBinding
+    classification: ClassificationLedger
+    representation: RepresentationDraft
+
+
+def release_binding_payload(binding: ReleaseBinding) -> dict[str, object]:
+    """Canonical payload of the 5c release binding."""
+    return {
+        "package_uuid": binding.package_uuid,
+        "release_version": binding.release_version,
+        "authoritative_source_hash": binding.authoritative_source_hash,
+        "transform_config_hash": binding.transform_config_hash,
+        "bundle_root_hash": binding.bundle_root_hash,
+        "persisted_corpus_digest": binding.persisted_corpus_digest,
+    }
+
+
+def representation_payload(draft: RepresentationDraft) -> dict[str, object]:
+    """Canonical, identity-bearing payload of the keyed representation.
+
+    Sorted throughout, so the order elements were authored in never reaches the
+    identity, and keyed throughout, so nothing derived from the identity is
+    inside the thing the identity is computed from.
+    """
+    return {
+        "records": sorted(
+            (
+                {
+                    "semantic_key": r.semantic_key,
+                    "kind": r.kind.value,
+                    "parent_key": r.parent_key,
+                }
+                for r in draft.records
+            ),
+            key=lambda d: str(d["semantic_key"]),
+        ),
+        "components": sorted(
+            (
+                {
+                    "record_key": c.record_key,
+                    "semantic_key": c.semantic_key,
+                    "handling": c.handling.value,
+                    "irreducibility_reason_code": c.irreducibility_reason_code,
+                    "facts": sorted(
+                        (fact_payload(f) for f in c.facts),
+                        key=lambda d: (str(d["family"]), str(sorted(d.items()))),
+                    ),
+                }
+                for c in draft.components
+            ),
+            key=lambda d: (str(d["record_key"]), str(d["semantic_key"])),
+        ),
+        "prose_bindings": sorted(
+            (
+                {
+                    "record_key": b.record_key,
+                    "component_key": b.component_key,
+                    "chunk_id": b.chunk_id,
+                    "irreducibility_reason_code": b.irreducibility_reason_code,
+                }
+                for b in draft.prose_bindings
+            ),
+            key=lambda d: (str(d["record_key"]), str(d["component_key"])),
+        ),
+        "relationships": sorted(
+            (
+                {
+                    "source_record_key": r.source_record_key,
+                    "target_record_key": r.target_record_key,
+                    "kind": r.kind.value,
+                }
+                for r in draft.relationships
+            ),
+            key=lambda d: (
+                str(d["source_record_key"]),
+                str(d["target_record_key"]),
+                str(d["kind"]),
+            ),
+        ),
+        "references": sorted(
+            (
+                {
+                    "from_record_key": r.from_record_key,
+                    "from_component_key": r.from_component_key,
+                    "source_text": r.source_text,
+                    "scope_key": r.scope_key,
+                    "target_record_key": r.target_record_key,
+                }
+                for r in draft.references
+            ),
+            key=lambda d: (
+                str(d["scope_key"]),
+                str(d["source_text"]),
+                str(d["from_record_key"]),
+            ),
+        ),
+        "provenance": sorted(
+            (
+                {
+                    "target_kind": p.target_kind.value,
+                    "target_key": list(p.target_key),
+                    "span_id": p.span_id,
+                    "role": p.role.value,
+                }
+                for p in draft.provenance
+            ),
+            key=lambda d: (
+                str(d["target_kind"]),
+                str(d["target_key"]),
+                str(d["span_id"]),
+                str(d["role"]),
+            ),
+        ),
+    }
+
+
+def projection_payload(candidate: ProjectionCandidate) -> dict[str, object]:
+    """The complete meaning-bearing payload a projection identity covers."""
+    return {
+        "release_binding": release_binding_payload(candidate.binding),
+        "classification": classification_payload(candidate.classification),
+        "representation": representation_payload(candidate.representation),
+    }
+
+
+def projection_uuid(candidate: ProjectionCandidate) -> str:
+    """Content-derived projection identity.
+
+    Any change to the bound release, the accepted classification, the declared
+    semantic policy, record assembly, components, facts, prose bindings,
+    relationships, references, or provenance mints a different projection.
+    """
+    return content_id("mechanical_projection", projection_payload(candidate))
+
+
+def derive_record_id(projection_uuid_: str, record_key: str) -> str:
+    """Stable record ID — projection identity plus the committed semantic key."""
+    return content_id("mechanical_record", projection_uuid_, record_key)
+
+
+def derive_component_id(
+    projection_uuid_: str, record_key: str, component_key: str
+) -> str:
+    """Stable component ID."""
+    return content_id(
+        "mechanical_component", projection_uuid_, record_key, component_key
+    )
+
+
+def derive_fact_id(
+    projection_uuid_: str, record_key: str, component_key: str, fact: object
+) -> str:
+    """Stable fact ID, keyed by the fact's content rather than its position."""
+    return content_id(
+        "mechanical_fact",
+        projection_uuid_,
+        record_key,
+        component_key,
+        fact_key(fact),
+    )
+
+
+@dataclass(frozen=True)
+class IdentifiedProjection:
+    """A candidate plus the identities derived from it, in that order."""
+
+    candidate: ProjectionCandidate
+    projection_uuid: str
+    payload_hash: str
+    record_ids: dict[str, str]
+    component_ids: dict[tuple[str, str], str]
+    fact_ids: dict[tuple[str, str, str], str]
+
+
+def identify_projection(candidate: ProjectionCandidate) -> IdentifiedProjection:
+    """Compute the projection identity, then every stable subidentity from it.
+
+    Identification is not proof: the result may still be unpublishable. See
+    :func:`validate_candidate` and the persistence/gate layers.
+    """
+    payload = projection_payload(candidate)
+    uuid_ = content_id("mechanical_projection", payload)
+    draft = candidate.representation
+
+    record_ids = {
+        r.semantic_key: derive_record_id(uuid_, r.semantic_key) for r in draft.records
+    }
+    component_ids = {
+        (c.record_key, c.semantic_key): derive_component_id(
+            uuid_, c.record_key, c.semantic_key
+        )
+        for c in draft.components
+    }
+    fact_ids = {
+        (c.record_key, c.semantic_key, fact_key(f)): derive_fact_id(
+            uuid_, c.record_key, c.semantic_key, f
+        )
+        for c in draft.components
+        for f in c.facts
+    }
+
+    return IdentifiedProjection(
+        candidate=candidate,
+        projection_uuid=uuid_,
+        payload_hash=hash_obj(payload),
+        record_ids=record_ids,
+        component_ids=component_ids,
+        fact_ids=fact_ids,
+    )
+
+
+def validate_candidate(
+    candidate: ProjectionCandidate, leaf_lengths: Mapping[str, int]
+) -> tuple[str, ...]:
+    """Return every violation that blocks this candidate from being published.
+
+    Covers the declared policy binding, the span partition over each
+    represented leaf, closed reason codes, explicit acceptance, and the keyed
+    representation. An empty result means the candidate is internally honest —
+    it does *not* mean the projection is complete, persisted, reconstructable,
+    or publishable. Those are proven by the persistence layer and the exact
+    completeness gate, against reconstructed state.
+    """
+    findings: list[str] = []
+    ledger = candidate.classification
+
+    findings.extend(validate_policy_binding(ledger))
+
+    claimed_leaves = {s.leaf_id for s in ledger.spans}
+    for leaf_id in sorted(claimed_leaves | set(leaf_lengths)):
+        if leaf_id not in leaf_lengths:
+            findings.append(f"leaf {leaf_id}: classified but not in the bound release")
+            continue
+        findings.extend(
+            validate_partition(leaf_id, leaf_lengths[leaf_id], ledger.spans)
+        )
+
+    findings.extend(validate_reason_codes(ledger.spans))
+    findings.extend(validate_acceptance(ledger))
+    findings.extend(validate_representation(candidate.representation, ledger))
+    return tuple(findings)

--- a/src/afterworlds/ingestion/mechanical/projection.py
+++ b/src/afterworlds/ingestion/mechanical/projection.py
@@ -36,6 +36,7 @@ from afterworlds.ingestion.mechanical.accounting import (
     validate_reason_codes,
 )
 from afterworlds.ingestion.mechanical.bound_corpus import BoundCorpusSnapshot
+from afterworlds.ingestion.mechanical.canonical import canonical_order
 from afterworlds.ingestion.mechanical.models import ClassificationLedger
 from afterworlds.ingestion.mechanical.representation import (
     RepresentationDraft,
@@ -102,98 +103,66 @@ def release_binding_payload(binding: ReleaseBinding) -> dict[str, object]:
 def representation_payload(draft: RepresentationDraft) -> dict[str, object]:
     """Canonical, identity-bearing payload of the keyed representation.
 
-    Sorted throughout, so the order elements were authored in never reaches the
-    identity, and keyed throughout, so nothing derived from the identity is
-    inside the thing the identity is computed from.
+    Every collection here is unordered by meaning, so each is ordered by its
+    elements' complete canonical payload rather than by a chosen subset of
+    fields — see :mod:`canonical` for why a partial sort key is a defect
+    waiting for the next field. Keyed throughout, so nothing derived from the
+    identity is inside the thing the identity is computed from.
     """
     return {
-        "records": sorted(
-            (
-                {
-                    "semantic_key": r.semantic_key,
-                    "kind": r.kind.value,
-                    "parent_key": r.parent_key,
-                }
-                for r in draft.records
-            ),
-            key=lambda d: str(d["semantic_key"]),
+        "records": canonical_order(
+            {
+                "semantic_key": r.semantic_key,
+                "kind": r.kind.value,
+                "parent_key": r.parent_key,
+            }
+            for r in draft.records
         ),
-        "components": sorted(
-            (
-                {
-                    "record_key": c.record_key,
-                    "semantic_key": c.semantic_key,
-                    "handling": c.handling.value,
-                    "irreducibility_reason_code": c.irreducibility_reason_code,
-                    "facts": sorted(
-                        (fact_payload(f) for f in c.facts),
-                        key=lambda d: (str(d["family"]), str(sorted(d.items()))),
-                    ),
-                }
-                for c in draft.components
-            ),
-            key=lambda d: (str(d["record_key"]), str(d["semantic_key"])),
+        "components": canonical_order(
+            {
+                "record_key": c.record_key,
+                "semantic_key": c.semantic_key,
+                "handling": c.handling.value,
+                "irreducibility_reason_code": c.irreducibility_reason_code,
+                "facts": canonical_order(fact_payload(f) for f in c.facts),
+            }
+            for c in draft.components
         ),
-        "prose_bindings": sorted(
-            (
-                {
-                    "record_key": b.record_key,
-                    "component_key": b.component_key,
-                    "chunk_id": b.chunk_id,
-                    "irreducibility_reason_code": b.irreducibility_reason_code,
-                }
-                for b in draft.prose_bindings
-            ),
-            key=lambda d: (str(d["record_key"]), str(d["component_key"])),
+        "prose_bindings": canonical_order(
+            {
+                "record_key": b.record_key,
+                "component_key": b.component_key,
+                "chunk_id": b.chunk_id,
+                "irreducibility_reason_code": b.irreducibility_reason_code,
+            }
+            for b in draft.prose_bindings
         ),
-        "relationships": sorted(
-            (
-                {
-                    "source_record_key": r.source_record_key,
-                    "target_record_key": r.target_record_key,
-                    "kind": r.kind.value,
-                }
-                for r in draft.relationships
-            ),
-            key=lambda d: (
-                str(d["source_record_key"]),
-                str(d["target_record_key"]),
-                str(d["kind"]),
-            ),
+        "relationships": canonical_order(
+            {
+                "source_record_key": r.source_record_key,
+                "target_record_key": r.target_record_key,
+                "kind": r.kind.value,
+            }
+            for r in draft.relationships
         ),
-        "references": sorted(
-            (
-                {
-                    "from_record_key": r.from_record_key,
-                    "from_component_key": r.from_component_key,
-                    "source_text": r.source_text,
-                    "scope_key": r.scope_key,
-                    "target_record_key": r.target_record_key,
-                }
-                for r in draft.references
-            ),
-            key=lambda d: (
-                str(d["scope_key"]),
-                str(d["source_text"]),
-                str(d["from_record_key"]),
-            ),
+        "references": canonical_order(
+            {
+                "from_record_key": r.from_record_key,
+                "from_component_key": r.from_component_key,
+                "source_text": r.source_text,
+                "scope_key": r.scope_key,
+                "target_record_key": r.target_record_key,
+            }
+            for r in draft.references
         ),
-        "provenance": sorted(
-            (
-                {
-                    "target_kind": p.target_kind.value,
-                    "target_key": list(p.target_key),
-                    "span_id": p.span_id,
-                    "role": p.role.value,
-                }
-                for p in draft.provenance
-            ),
-            key=lambda d: (
-                str(d["target_kind"]),
-                str(d["target_key"]),
-                str(d["span_id"]),
-                str(d["role"]),
-            ),
+        "provenance": canonical_order(
+            {
+                "target_kind": p.target_kind.value,
+                "target_key": list(p.target_key),
+                "span_id": p.span_id,
+                "role": p.role.value,
+            }
+            for p in draft.provenance
         ),
     }
 

--- a/src/afterworlds/ingestion/mechanical/projection.py
+++ b/src/afterworlds/ingestion/mechanical/projection.py
@@ -25,7 +25,6 @@ persistence and gate layers. Nothing here activates anything.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 
 from afterworlds.ingestion.corpus.hashing import content_id, hash_obj
@@ -36,6 +35,7 @@ from afterworlds.ingestion.mechanical.accounting import (
     validate_policy_binding,
     validate_reason_codes,
 )
+from afterworlds.ingestion.mechanical.bound_corpus import BoundCorpusSnapshot
 from afterworlds.ingestion.mechanical.models import ClassificationLedger
 from afterworlds.ingestion.mechanical.representation import (
     RepresentationDraft,
@@ -294,22 +294,51 @@ def identify_projection(candidate: ProjectionCandidate) -> IdentifiedProjection:
 
 
 def validate_candidate(
-    candidate: ProjectionCandidate, leaf_lengths: Mapping[str, int]
+    candidate: ProjectionCandidate, corpus: BoundCorpusSnapshot
 ) -> tuple[str, ...]:
     """Return every violation that blocks this candidate from being published.
 
-    Covers the declared policy binding, the span partition over each
-    represented leaf, closed reason codes, explicit acceptance, and the keyed
-    representation. An empty result means the candidate is internally honest —
-    it does *not* mean the projection is complete, persisted, reconstructable,
-    or publishable. Those are proven by the persistence layer and the exact
-    completeness gate, against reconstructed state.
+    Covers the bound release's agreement with the candidate, the declared
+    policy binding, the span partition over each represented leaf, closed
+    reason codes, explicit acceptance, and the keyed representation. An empty
+    result means the candidate is internally honest — it does *not* mean the
+    projection is complete, persisted, reconstructable, or publishable. Those
+    are proven by the persistence layer and the exact completeness gate,
+    against reconstructed state.
+
+    *corpus* is the single resolved view of the bound 5c release, so every
+    release-scoped check reads the same source rather than querying its own.
     """
     findings: list[str] = []
     ledger = candidate.classification
+    binding = candidate.binding
+
+    # The candidate, its classification, and the snapshot must all name one
+    # release. Two of the three agreeing is not agreement.
+    if binding.package_uuid != corpus.package_uuid:
+        findings.append(
+            f"binding names package {binding.package_uuid}, corpus snapshot is "
+            f"{corpus.package_uuid}"
+        )
+    if binding.release_version != corpus.release_version:
+        findings.append(
+            f"binding names release {binding.release_version}, corpus snapshot is "
+            f"{corpus.release_version}"
+        )
+    if ledger.package_uuid != binding.package_uuid:
+        findings.append(
+            f"classification names package {ledger.package_uuid}, binding is "
+            f"{binding.package_uuid}"
+        )
+    if ledger.release_version != binding.release_version:
+        findings.append(
+            f"classification names release {ledger.release_version}, binding is "
+            f"{binding.release_version}"
+        )
 
     findings.extend(validate_policy_binding(ledger))
 
+    leaf_lengths = corpus.leaf_lengths
     claimed_leaves = {s.leaf_id for s in ledger.spans}
     for leaf_id in sorted(claimed_leaves | set(leaf_lengths)):
         if leaf_id not in leaf_lengths:
@@ -321,5 +350,5 @@ def validate_candidate(
 
     findings.extend(validate_reason_codes(ledger.spans))
     findings.extend(validate_acceptance(ledger))
-    findings.extend(validate_representation(candidate.representation, ledger))
+    findings.extend(validate_representation(candidate.representation, ledger, corpus))
     return tuple(findings)

--- a/src/afterworlds/ingestion/mechanical/raw_state.py
+++ b/src/afterworlds/ingestion/mechanical/raw_state.py
@@ -1,0 +1,297 @@
+"""Raw persisted state and its closure proof — CRD Issue 5d, Decision 8.
+
+Reconstruction used to read persisted rows straight into the semantic model.
+That order hides two things. A child row whose parent does not exist is simply
+never joined, so it vanishes from the candidate *and* from the digest computed
+over that candidate — retained database state outside the audit proof. And a
+corrupted typed column raises whatever the enum constructor happens to raise,
+so a verification API whose contract is to *report* tamper crashes instead.
+
+So the pipeline is now two explicit stages:
+
+``load complete raw row set → prove raw closure → reconstruct semantic candidate``
+
+Every projection-scoped row is loaded once, into one structure, before any
+semantic meaning is imposed on it. Closure is then proven over that inventory:
+every row either contributes to the reconstructed candidate and its proof, or
+it fails reconstruction with a typed error naming the table, the row, the
+field, and the rejected value. Nothing is dropped, defaulted, or repaired.
+
+This layer owns *persistence* relationships — parentage, uniqueness,
+reconstructability, typed columns. It deliberately does not re-check semantic
+honesty: whether the accepted classification is coherent, whether provenance
+satisfies its obligations, and whether a reference resolves are the candidate
+validators' job, and duplicating them here would create two places to disagree.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalAcceptanceBatchORM,
+    MechanicalAcceptanceORM,
+    MechanicalBatchDiffORM,
+    MechanicalBatchScopeORM,
+    MechanicalComponentORM,
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+    MechanicalProseBindingORM,
+    MechanicalProvenanceORM,
+    MechanicalRecordORM,
+    MechanicalReferenceORM,
+    MechanicalRelationshipORM,
+    MechanicalSpanORM,
+)
+
+__all__ = [
+    "PersistedStateReconstructionError",
+    "RawProjectionState",
+    "load_raw_state",
+    "parse_enum",
+    "validate_raw_closure",
+]
+
+
+class PersistedStateReconstructionError(ValueError):
+    """Persisted state that cannot honestly reconstruct.
+
+    One closed family for every way the database can fail to describe a
+    projection: a malformed fact payload, an unknown fact family, an invalid
+    typed column, an orphan child row, a malformed target key, or a duplicate
+    that makes a parent ambiguous. Verification catches exactly this family and
+    reports it as a finding — a deliberately narrow target, so an ordinary
+    implementation bug still surfaces as a crash instead of being misreported
+    as database corruption.
+    """
+
+
+def parse_enum[E: StrEnum](
+    enum_cls: type[E], value: str, table: str, row: str, field: str
+) -> E:
+    """Convert one persisted string into its closed enum, or fail explicitly.
+
+    No coercion and no fallback: an unrecognised value means the column no
+    longer says what it said when it was written, and guessing which member was
+    intended would be repair rather than reconstruction.
+    """
+    try:
+        return enum_cls(value)
+    except ValueError:
+        raise PersistedStateReconstructionError(
+            f"{table} {row}: {field} {value!r} is not a valid " f"{enum_cls.__name__}"
+        ) from None
+
+
+@dataclass(frozen=True)
+class RawProjectionState:
+    """Every projection-scoped row, loaded once from one transaction state.
+
+    The header is separate because it is the projection's own row rather than
+    one scoped beneath it.
+    """
+
+    projection_uuid: str
+    header: MechanicalProjectionORM
+    spans: Sequence[MechanicalSpanORM]
+    batches: Sequence[MechanicalAcceptanceBatchORM]
+    batch_scope: Sequence[MechanicalBatchScopeORM]
+    batch_diff: Sequence[MechanicalBatchDiffORM]
+    acceptances: Sequence[MechanicalAcceptanceORM]
+    records: Sequence[MechanicalRecordORM]
+    components: Sequence[MechanicalComponentORM]
+    facts: Sequence[MechanicalFactORM]
+    prose_bindings: Sequence[MechanicalProseBindingORM]
+    relationships: Sequence[MechanicalRelationshipORM]
+    references: Sequence[MechanicalReferenceORM]
+    provenance: Sequence[MechanicalProvenanceORM]
+
+
+def load_raw_state(
+    session: Session, projection_uuid: str, header: MechanicalProjectionORM
+) -> RawProjectionState:
+    """Load every row scoped to *projection_uuid* in one pass."""
+
+    def rows(model: Any) -> list[Any]:
+        return list(
+            session.execute(
+                select(model).where(model.projection_uuid == projection_uuid)
+            )
+            .scalars()
+            .all()
+        )
+
+    return RawProjectionState(
+        projection_uuid=projection_uuid,
+        header=header,
+        spans=rows(MechanicalSpanORM),
+        batches=rows(MechanicalAcceptanceBatchORM),
+        batch_scope=rows(MechanicalBatchScopeORM),
+        batch_diff=rows(MechanicalBatchDiffORM),
+        acceptances=rows(MechanicalAcceptanceORM),
+        records=rows(MechanicalRecordORM),
+        components=rows(MechanicalComponentORM),
+        facts=rows(MechanicalFactORM),
+        prose_bindings=rows(MechanicalProseBindingORM),
+        relationships=rows(MechanicalRelationshipORM),
+        references=rows(MechanicalReferenceORM),
+        provenance=rows(MechanicalProvenanceORM),
+    )
+
+
+def _valid_target_key(value: object) -> bool:
+    """A persisted provenance target key must be a list of plain strings.
+
+    The column is JSON, so it can hold anything. Only a list of strings can
+    become the declared immutable tuple; a nested structure or a number would
+    have to be coerced, and a coerced key addresses an element nobody declared.
+    """
+    return isinstance(value, list) and all(type(v) is str for v in value)
+
+
+def validate_raw_closure(raw: RawProjectionState) -> None:
+    """Prove the raw row set is a closed, relationally valid aggregate.
+
+    Raises :class:`PersistedStateReconstructionError` listing every violation
+    found, rather than the first — a corrupted projection usually breaks in
+    more than one place, and reporting one at a time turns diagnosis into a
+    guessing game.
+    """
+    problems: list[str] = []
+
+    # Batch headers own a logical identity of (projection_uuid, batch_id); a
+    # duplicate makes every child's parent ambiguous.
+    batch_ids: set[str] = set()
+    for batch in raw.batches:
+        if batch.batch_id in batch_ids:
+            problems.append(
+                f"rp_mech_acceptance_batches: duplicate batch_id "
+                f"{batch.batch_id!r} in one projection"
+            )
+        batch_ids.add(batch.batch_id)
+
+    # Children are matched on (projection_uuid, batch_id). Because the raw set
+    # is already scoped to this projection, a same-named batch in a *different*
+    # projection cannot adopt these rows.
+    for scope in raw.batch_scope:
+        if scope.batch_id not in batch_ids:
+            problems.append(
+                f"rp_mech_batch_scope row {scope.row_id}: names batch "
+                f"{scope.batch_id!r} with no header in this projection"
+            )
+    for diff in raw.batch_diff:
+        if diff.batch_id not in batch_ids:
+            problems.append(
+                f"rp_mech_batch_diff row {diff.row_id}: names batch "
+                f"{diff.batch_id!r} with no header in this projection"
+            )
+
+    # Scope order must be unambiguous: retained reviewer order is evidence, and
+    # two rows claiming one position destroy it.
+    ordinals: dict[tuple[str, int], int] = {}
+    for scope in raw.batch_scope:
+        slot = (scope.batch_id, scope.ordinal)
+        ordinals[slot] = ordinals.get(slot, 0) + 1
+    for (batch_id, ordinal), count in sorted(ordinals.items()):
+        if count > 1:
+            problems.append(
+                f"rp_mech_batch_scope: batch {batch_id!r} has {count} rows at "
+                f"ordinal {ordinal}"
+            )
+
+    seen_diff: set[tuple[str, str]] = set()
+    for diff in raw.batch_diff:
+        diff_key = (diff.batch_id, diff.span_id)
+        if diff_key in seen_diff:
+            problems.append(
+                f"rp_mech_batch_diff: batch {diff.batch_id!r} has duplicate "
+                f"diff rows for span {diff.span_id}"
+            )
+        seen_diff.add(diff_key)
+
+    for acceptance in raw.acceptances:
+        if acceptance.batch_id is not None and acceptance.batch_id not in batch_ids:
+            problems.append(
+                f"rp_mech_acceptances row {acceptance.row_id}: names batch "
+                f"{acceptance.batch_id!r} with no header in this projection"
+            )
+
+    record_keys = {r.semantic_key for r in raw.records}
+    if len(record_keys) != len(raw.records):
+        problems.append("rp_mech_records: duplicate semantic_key in one projection")
+
+    component_keys: set[tuple[str, str]] = set()
+    for component in raw.components:
+        component_key = (component.record_key, component.semantic_key)
+        if component_key in component_keys:
+            problems.append(
+                f"rp_mech_components: duplicate component "
+                f"{list(component_key)} in one projection"
+            )
+        component_keys.add(component_key)
+        if component.record_key not in record_keys:
+            problems.append(
+                f"rp_mech_components row {component.row_id}: names record "
+                f"{component.record_key!r} with no row in this projection"
+            )
+
+    # Facts are selected while iterating components during reconstruction, so
+    # an unparented fact would simply never be visited.
+    for fact in raw.facts:
+        if (fact.record_key, fact.component_key) not in component_keys:
+            problems.append(
+                f"rp_mech_facts row {fact.row_id}: names component "
+                f"{[fact.record_key, fact.component_key]} with no row in this "
+                "projection"
+            )
+
+    for binding in raw.prose_bindings:
+        if (binding.record_key, binding.component_key) not in component_keys:
+            problems.append(
+                f"rp_mech_prose_bindings row {binding.row_id}: names component "
+                f"{[binding.record_key, binding.component_key]} with no row in "
+                "this projection"
+            )
+
+    for relationship in raw.relationships:
+        for field, related in (
+            ("source_record_key", relationship.source_record_key),
+            ("target_record_key", relationship.target_record_key),
+        ):
+            if related not in record_keys:
+                problems.append(
+                    f"rp_mech_relationships row {relationship.row_id}: {field} "
+                    f"{related!r} has no record row in this projection"
+                )
+
+    # Reference *resolution* is a semantic question owned by the candidate
+    # validator; what persistence owns is that the row attaches to real
+    # persisted structure rather than dangling.
+    for reference in raw.references:
+        if (
+            reference.from_record_key,
+            reference.from_component_key,
+        ) not in component_keys:
+            problems.append(
+                f"rp_mech_references row {reference.row_id}: names source "
+                f"component {[reference.from_record_key, reference.from_component_key]}"
+                " with no row in this projection"
+            )
+
+    for claim in raw.provenance:
+        if not _valid_target_key(claim.target_key):
+            problems.append(
+                f"rp_mech_provenance row {claim.row_id}: target_key "
+                f"{claim.target_key!r} is not a list of strings"
+            )
+
+    if problems:
+        raise PersistedStateReconstructionError(
+            f"projection {raw.projection_uuid}: " + "; ".join(problems)
+        )

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -263,8 +263,66 @@ class MalformedFactPayloadError(ValueError):
 # semantic key cannot be blank, and a stated quantity cannot be zero or less.
 
 
+# Shared primitive checks. Python's ``bool`` is a subclass of ``int``, so a bare
+# ``isinstance(value, int)`` accepts ``True`` — and a string like ``"false"`` is
+# truthy, so a mistyped Boolean silently inverts a rule downstream. Every
+# integer check below therefore excludes ``bool`` explicitly, and no check ever
+# coerces: ``"12"`` is not 12, ``1`` is not ``True``, and normalizing either
+# would be inventing authority the source never stated.
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _int_field(value: object, field: str) -> list[str]:
+    if not _is_int(value):
+        return [f"{field} must be an integer, got {type(value).__name__} {value!r}"]
+    return []
+
+
+def _optional_int_field(value: object, field: str) -> list[str]:
+    if value is None:
+        return []
+    return _int_field(value, field)
+
+
+def _bool_field(value: object, field: str) -> list[str]:
+    if not isinstance(value, bool):
+        return [f"{field} must be a boolean, got {type(value).__name__} {value!r}"]
+    return []
+
+
+def _str_field(value: object, field: str) -> list[str]:
+    if not isinstance(value, str) or isinstance(value, StrEnum):
+        return [f"{field} must be a string, got {type(value).__name__} {value!r}"]
+    return []
+
+
+def _enum_field(value: object, enum_cls: type[StrEnum], field: str) -> list[str]:
+    """The field must hold the declared enum member, not a look-alike string.
+
+    ``StrEnum`` members *are* strings, so a plain ``"wisdom"`` would satisfy a
+    string check while carrying none of the enum's guarantees.
+    """
+    if not isinstance(value, enum_cls):
+        return [
+            f"{field} must be {enum_cls.__name__}, got "
+            f"{type(value).__name__} {value!r}"
+        ]
+    return []
+
+
 def _check_ability_check(fact: AbilityCheckFact) -> list[str]:
-    findings: list[str] = []
+    findings = [
+        *_enum_field(fact.ability, AbilityScore, "ability"),
+        *_enum_field(fact.dc_kind, DcKind, "dc_kind"),
+        *_optional_int_field(fact.dc_value, "dc_value"),
+    ]
+    if findings:
+        # The DC relationship below reads dc_kind and dc_value; checking it
+        # against mistyped values would report a second, misleading violation.
+        return findings
     if fact.dc_kind is DcKind.FIXED:
         if fact.dc_value is None:
             findings.append("fixed DC without a dc_value")
@@ -277,19 +335,39 @@ def _check_ability_check(fact: AbilityCheckFact) -> list[str]:
 
 
 def _check_creature_ability_score(fact: CreatureAbilityScoreFact) -> list[str]:
+    findings = [
+        *_enum_field(fact.ability, AbilityScore, "ability"),
+        *_int_field(fact.score, "score"),
+    ]
+    if findings:
+        return findings
     if fact.score < 0:
-        return [f"negative ability score {fact.score}"]
-    return []
+        findings.append(f"negative ability score {fact.score}")
+    return findings
 
 
 def _check_spell_descriptor(fact: SpellDescriptorFact) -> list[str]:
+    findings = [
+        *_int_field(fact.level, "level"),
+        *_enum_field(fact.school, SpellSchool, "school"),
+        *_bool_field(fact.ritual, "ritual"),
+        *_bool_field(fact.concentration, "concentration"),
+    ]
+    if findings:
+        return findings
     if fact.level < 0:
-        return [f"negative spell level {fact.level}"]
-    return []
+        findings.append(f"negative spell level {fact.level}")
+    return findings
 
 
 def _check_progression_entry(fact: ProgressionEntryFact) -> list[str]:
-    findings: list[str] = []
+    findings = [
+        *_int_field(fact.level, "level"),
+        *_str_field(fact.entitlement_key, "entitlement_key"),
+        *_optional_int_field(fact.quantity, "quantity"),
+    ]
+    if findings:
+        return findings
     if fact.level < 0:
         findings.append(f"negative progression level {fact.level}")
     if not fact.entitlement_key.strip():
@@ -321,7 +399,43 @@ def fact_invariant_violations(fact: object) -> tuple[str, ...]:
     return tuple(_FACT_INVARIANTS[family](fact))
 
 
+# JSON-side primitive checks. A persisted payload arrives as plain JSON values,
+# so each builder states the exact primitive shape it accepts before it
+# constructs anything. Nothing is coerced: ``"12"`` stays a string and fails,
+# because turning it into 12 would be this layer inventing a mechanical value
+# the persisted row does not contain.
+
+
+def _json_enum(value: object, enum_cls: type[StrEnum], field: str) -> list[str]:
+    """The stored value must be a plain string naming a declared member."""
+    if type(value) is not str:
+        return [
+            f"{field} must be a string {enum_cls.__name__} value, got "
+            f"{type(value).__name__} {value!r}"
+        ]
+    try:
+        enum_cls(value)
+    except ValueError:
+        return [f"{field} {value!r} is not a declared {enum_cls.__name__}"]
+    return []
+
+
+def _reject(family: FactFamily, findings: list[str]) -> None:
+    if findings:
+        raise MalformedFactPayloadError(
+            f"{family.value} payload has mistyped fields: {'; '.join(findings)}"
+        )
+
+
 def _build_ability_check(p: Mapping[str, Any]) -> AbilityCheckFact:
+    _reject(
+        FactFamily.ABILITY_CHECK,
+        [
+            *_json_enum(p["ability"], AbilityScore, "ability"),
+            *_json_enum(p["dc_kind"], DcKind, "dc_kind"),
+            *_optional_int_field(p["dc_value"], "dc_value"),
+        ],
+    )
     return AbilityCheckFact(
         ability=AbilityScore(p["ability"]),
         dc_kind=DcKind(p["dc_kind"]),
@@ -330,12 +444,28 @@ def _build_ability_check(p: Mapping[str, Any]) -> AbilityCheckFact:
 
 
 def _build_creature_ability_score(p: Mapping[str, Any]) -> CreatureAbilityScoreFact:
+    _reject(
+        FactFamily.CREATURE_ABILITY_SCORE,
+        [
+            *_json_enum(p["ability"], AbilityScore, "ability"),
+            *_int_field(p["score"], "score"),
+        ],
+    )
     return CreatureAbilityScoreFact(
         ability=AbilityScore(p["ability"]), score=p["score"]
     )
 
 
 def _build_spell_descriptor(p: Mapping[str, Any]) -> SpellDescriptorFact:
+    _reject(
+        FactFamily.SPELL_DESCRIPTOR,
+        [
+            *_int_field(p["level"], "level"),
+            *_json_enum(p["school"], SpellSchool, "school"),
+            *_bool_field(p["ritual"], "ritual"),
+            *_bool_field(p["concentration"], "concentration"),
+        ],
+    )
     return SpellDescriptorFact(
         level=p["level"],
         school=SpellSchool(p["school"]),
@@ -345,6 +475,14 @@ def _build_spell_descriptor(p: Mapping[str, Any]) -> SpellDescriptorFact:
 
 
 def _build_progression_entry(p: Mapping[str, Any]) -> ProgressionEntryFact:
+    _reject(
+        FactFamily.PROGRESSION_ENTRY,
+        [
+            *_int_field(p["level"], "level"),
+            *_str_field(p["entitlement_key"], "entitlement_key"),
+            *_optional_int_field(p["quantity"], "quantity"),
+        ],
+    )
     return ProgressionEntryFact(
         level=p["level"],
         entitlement_key=p["entitlement_key"],

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -668,3 +668,121 @@ class RepresentationDraft:
     relationships: tuple[RelationshipDraft, ...]
     references: tuple[ReferenceDraft, ...]
     provenance: tuple[ProvenanceClaim, ...]
+
+
+# ---------------------------------------------------------------------------
+# Canonical provenance target identities
+# ---------------------------------------------------------------------------
+#
+# One definition per target kind, used everywhere a target is enumerated,
+# required, claimed, or checked. Building these tuples inline in more than one
+# place is how a key drifts: the enumerator and the validator then disagree
+# about what "the same element" means, and a claim can match an element it was
+# never about.
+#
+# Each key must identify exactly one declared element. Two elements that differ
+# semantically must not share a key — that is why a prose binding carries its
+# chunk and reason (one component may bind several passages) and a reference
+# carries its owning component (the same wording in one scope may be cited by
+# more than one component).
+
+
+def record_target_key(record: RecordDraft) -> tuple[str, ...]:
+    """Provenance key of a record."""
+    return (record.semantic_key,)
+
+
+def component_target_key(component: ComponentDraft) -> tuple[str, ...]:
+    """Provenance key of a component."""
+    return (component.record_key, component.semantic_key)
+
+
+def fact_target_key(
+    record_key: str, component_key: str, fact: object
+) -> tuple[str, ...]:
+    """Provenance key of one typed fact, keyed by content rather than position."""
+    return (record_key, component_key, fact_key(fact))
+
+
+def prose_binding_target_key(binding: ProseBindingDraft) -> tuple[str, ...]:
+    """Provenance key of one prose binding.
+
+    ``(record_key, component_key)`` alone cannot address a component that binds
+    more than one passage, so the bound chunk and the reason it is bound are
+    part of the identity.
+    """
+    return (
+        binding.record_key,
+        binding.component_key,
+        binding.chunk_id,
+        binding.irreducibility_reason_code,
+    )
+
+
+def relationship_target_key(relationship: RelationshipDraft) -> tuple[str, ...]:
+    """Provenance key of one typed relationship."""
+    return (
+        relationship.source_record_key,
+        relationship.target_record_key,
+        relationship.kind.value,
+    )
+
+
+def reference_target_key(reference: ReferenceDraft) -> tuple[str, ...]:
+    """Provenance key of one resolved reference, including its source ownership."""
+    return (
+        reference.from_record_key,
+        reference.from_component_key,
+        reference.source_text,
+        reference.scope_key,
+        reference.target_record_key,
+    )
+
+
+def declared_provenance_targets(
+    draft: RepresentationDraft,
+) -> dict[ProvenanceTargetKind, set[tuple[str, ...]]]:
+    """Every element a provenance claim may legitimately name.
+
+    Facts whose family is unknown are omitted: they have no content-derived key,
+    and they are reported separately as facts outside the closed union.
+    """
+    facts: set[tuple[str, ...]] = set()
+    for component in draft.components:
+        for fact in component.facts:
+            try:
+                facts.add(
+                    fact_target_key(component.record_key, component.semantic_key, fact)
+                )
+            except UnknownFactFamilyError:
+                continue
+
+    return {
+        ProvenanceTargetKind.RECORD: {record_target_key(r) for r in draft.records},
+        ProvenanceTargetKind.COMPONENT: {
+            component_target_key(c) for c in draft.components
+        },
+        ProvenanceTargetKind.FACT: facts,
+        ProvenanceTargetKind.PROSE_BINDING: {
+            prose_binding_target_key(b) for b in draft.prose_bindings
+        },
+        ProvenanceTargetKind.RELATIONSHIP: {
+            relationship_target_key(r) for r in draft.relationships
+        },
+        ProvenanceTargetKind.REFERENCE: {
+            reference_target_key(r) for r in draft.references
+        },
+    }
+
+
+#: Element kinds that must each carry their own provenance (ADR-005d Decision 3).
+#: Records and components are deliberately absent: their obligation is span
+#: coverage under the classification contract, not a per-element edge, and
+#: conflating the two would let a component claim stand in for the traceability
+#: of every fact beneath it.
+PROVENANCE_REQUIRED_KINDS: tuple[ProvenanceTargetKind, ...] = (
+    ProvenanceTargetKind.FACT,
+    ProvenanceTargetKind.PROSE_BINDING,
+    ProvenanceTargetKind.RELATIONSHIP,
+    ProvenanceTargetKind.REFERENCE,
+)

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -1,0 +1,358 @@
+"""Records, components, typed facts, and provenance — CRD Issue 5d, Decisions 3–4.
+
+Everything here is keyed by **committed semantic keys**, never by position and
+never by a derived identity. That ordering is deliberate: ADR-005d Decision 6
+requires identity derivation to be acyclic, so the projection identity is
+computed from this keyed content and the stable record/component/fact IDs are
+derived from that identity afterwards (see :mod:`projection`). Nothing in this
+module may contain a derived ID.
+
+The typed fact union is closed. A structure that is not one of the declared
+families is rejected — there is no generic dictionary, no expression string, no
+numeric key-value bag to fall back on. When a component's meaning cannot be
+reduced faithfully into a declared family, the honest answer is to bind exact
+governing prose under a closed irreducibility reason, not to widen the union
+into something that can hold anything.
+
+The union is deliberately small. Each family below is justified by a required
+real-corpus canary in #137, which is the source discovery available today:
+
+* ``ability_check`` — the illusion canary's typed check/DC-source authority;
+* ``creature_ability_score`` — the composite-creature canary's ability grid;
+* ``spell_descriptor`` — the Wish and spell-scoped-creature canaries; and
+* ``progression_entry`` — the class-progression-table canary.
+
+That is not a claim of corpus completeness. Full-corpus accounting has not run
+yet, and when it surfaces a substantive family this union cannot represent, the
+family is added explicitly here or the affected component is classified honestly
+as prose-bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any, ClassVar, cast
+
+from afterworlds.ingestion.corpus.hashing import canonical_bytes, sha256_hex
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+
+__all__ = [
+    "AbilityCheckFact",
+    "AbilityScore",
+    "ComponentDraft",
+    "CreatureAbilityScoreFact",
+    "DcKind",
+    "FactFamily",
+    "MechanicalFact",
+    "ProgressionEntryFact",
+    "ProseBindingDraft",
+    "ProvenanceClaim",
+    "ProvenanceRole",
+    "ProvenanceTargetKind",
+    "RecordDraft",
+    "RecordKind",
+    "ReferenceDraft",
+    "RelationshipDraft",
+    "RelationshipKind",
+    "RepresentationDraft",
+    "SpellDescriptorFact",
+    "SpellSchool",
+    "UnknownFactFamilyError",
+    "fact_key",
+    "fact_payload",
+]
+
+
+class RecordKind(StrEnum):
+    """Closed record vocabulary (#137 contract 3).
+
+    ``CREATURE`` is the record kind for every creature stat block. Source
+    ancestry such as *Animals* or *Monsters A–Z* is where a creature was found,
+    not what kind of record it is, and rules-defined creature type is a
+    descriptor rather than a kind.
+    """
+
+    GENERAL_RULE = "general_rule"
+    GLOSSARY_RULE = "glossary_rule"
+    CHARACTER_CREATION = "character_creation"
+    CHARACTER_ADVANCEMENT = "character_advancement"
+    CLASS = "class"
+    CLASS_FEATURE = "class_feature"
+    SPECIES = "species"
+    BACKGROUND = "background"
+    FEAT = "feat"
+    EQUIPMENT = "equipment"
+    SPELL = "spell"
+    CONDITION = "condition"
+    GAMEPLAY_TOOL = "gameplay_tool"
+    MAGIC_ITEM = "magic_item"
+    CREATURE = "creature"
+
+
+class RelationshipKind(StrEnum):
+    """Closed relationship vocabulary between records."""
+
+    #: A record wholly contained by another, e.g. a spell-scoped stat block.
+    SCOPED_WITHIN = "scoped_within"
+    #: One record grants another, e.g. a progression level granting a feature.
+    GRANTS = "grants"
+    #: One record is required before another applies.
+    PREREQUISITE = "prerequisite"
+
+
+class ProvenanceTargetKind(StrEnum):
+    """What a provenance claim attaches source text to."""
+
+    RECORD = "record"
+    COMPONENT = "component"
+    FACT = "fact"
+    PROSE_BINDING = "prose_binding"
+    RELATIONSHIP = "relationship"
+    REFERENCE = "reference"
+
+
+class ProvenanceRole(StrEnum):
+    """Whether a span *states* the claim or merely supports it.
+
+    Contextual claims may overlap freely — several components can legitimately
+    draw context from one sentence. Two primary claims over the same span
+    cannot: that is two structures both asserting they are what the text says.
+    """
+
+    PRIMARY = "primary"
+    CONTEXTUAL = "contextual"
+
+
+class AbilityScore(StrEnum):
+    STRENGTH = "strength"
+    DEXTERITY = "dexterity"
+    CONSTITUTION = "constitution"
+    INTELLIGENCE = "intelligence"
+    WISDOM = "wisdom"
+    CHARISMA = "charisma"
+
+
+class SpellSchool(StrEnum):
+    ABJURATION = "abjuration"
+    CONJURATION = "conjuration"
+    DIVINATION = "divination"
+    ENCHANTMENT = "enchantment"
+    EVOCATION = "evocation"
+    ILLUSION = "illusion"
+    NECROMANCY = "necromancy"
+    TRANSMUTATION = "transmutation"
+
+
+class DcKind(StrEnum):
+    """Where a check's difficulty class comes from.
+
+    A missing source value is never invented: ``FIXED`` is the only kind that
+    carries a number, and the others say *where the number comes from* rather
+    than guessing one.
+    """
+
+    FIXED = "fixed"
+    SPELL_SAVE_DC = "spell_save_dc"
+    CONTESTED = "contested"
+    GAMEMASTER_SET = "gamemaster_set"
+
+
+class FactFamily(StrEnum):
+    """The closed typed-fact union's discriminator."""
+
+    ABILITY_CHECK = "ability_check"
+    CREATURE_ABILITY_SCORE = "creature_ability_score"
+    SPELL_DESCRIPTOR = "spell_descriptor"
+    PROGRESSION_ENTRY = "progression_entry"
+
+
+@dataclass(frozen=True)
+class AbilityCheckFact:
+    """A check or save with a typed DC source."""
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.ABILITY_CHECK
+
+    ability: AbilityScore
+    dc_kind: DcKind
+    dc_value: int | None = None
+
+
+@dataclass(frozen=True)
+class CreatureAbilityScoreFact:
+    """One cell of a creature's ability grid."""
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.CREATURE_ABILITY_SCORE
+
+    ability: AbilityScore
+    score: int
+
+
+@dataclass(frozen=True)
+class SpellDescriptorFact:
+    """The typed descriptors a spell record carries.
+
+    Casting time, range, and duration are deliberately absent: representing
+    them faithfully needs their own typed families, and holding them as free
+    text here would be the untyped escape hatch this union exists to prevent.
+    Until those families are justified by accounting, that authority is
+    prose-bound.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.SPELL_DESCRIPTOR
+
+    level: int
+    school: SpellSchool
+    ritual: bool
+    concentration: bool
+
+
+@dataclass(frozen=True)
+class ProgressionEntryFact:
+    """One level-indexed entitlement from a progression table."""
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.PROGRESSION_ENTRY
+
+    level: int
+    entitlement_key: str
+    quantity: int | None = None
+
+
+MechanicalFact = (
+    AbilityCheckFact
+    | CreatureAbilityScoreFact
+    | SpellDescriptorFact
+    | ProgressionEntryFact
+)
+
+_FACT_TYPES: dict[FactFamily, type] = {
+    FactFamily.ABILITY_CHECK: AbilityCheckFact,
+    FactFamily.CREATURE_ABILITY_SCORE: CreatureAbilityScoreFact,
+    FactFamily.SPELL_DESCRIPTOR: SpellDescriptorFact,
+    FactFamily.PROGRESSION_ENTRY: ProgressionEntryFact,
+}
+
+
+class UnknownFactFamilyError(TypeError):
+    """Raised when a structure outside the closed union is offered as a fact."""
+
+
+def fact_key(fact: object) -> str:
+    """Stable content-derived key for one fact within its component.
+
+    Derived from the canonical payload, never from a position in the component's
+    fact tuple, so reordering or inserting a sibling fact cannot churn it.
+    """
+    return sha256_hex(canonical_bytes(fact_payload(fact)))[:16]
+
+
+def fact_payload(fact: object) -> dict[str, object]:
+    """Canonical payload for one typed fact.
+
+    Raises rather than returning findings: an unknown family has no canonical
+    form, so there is nothing honest to serialize. Callers that want a
+    collected report use :func:`validation.validate_representation`.
+    """
+    family = getattr(fact, "FAMILY", None)
+    if not isinstance(family, FactFamily) or _FACT_TYPES.get(family) is not type(fact):
+        raise UnknownFactFamilyError(
+            f"{type(fact).__name__} is not a member of the closed typed-fact union"
+        )
+    # Safe now: the family check above proved *fact* is one of the declared
+    # frozen dataclasses, which is what asdict needs.
+    payload: dict[str, object] = {"family": family.value}
+    for key, value in sorted(asdict(cast(Any, fact)).items()):
+        payload[key] = value.value if isinstance(value, StrEnum) else value
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Keyed drafts — semantic keys only, no derived identities
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecordDraft:
+    """A semantic record assembled from accepted membership.
+
+    ``parent_key`` is set for a nested record — the complete creature stat block
+    embedded in spell authority is a record in its own right, not a copy.
+    """
+
+    semantic_key: str
+    kind: RecordKind
+    parent_key: str | None = None
+
+
+@dataclass(frozen=True)
+class ComponentDraft:
+    """One publishable component of a record."""
+
+    record_key: str
+    semantic_key: str
+    handling: ComponentHandling
+    #: Required for PROSE_BOUND and MIXED; must name a closed catalog reason.
+    irreducibility_reason_code: str | None = None
+    facts: tuple[MechanicalFact, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProseBindingDraft:
+    """Exact governing prose for a component, bound to the 5c chunk that holds it.
+
+    Resolution goes through the authoritative ``RuleChunk`` rather than copying
+    text into a second prose store, so there is exactly one authority for what
+    the source says.
+    """
+
+    component_key: str
+    record_key: str
+    chunk_id: str
+    irreducibility_reason_code: str
+
+
+@dataclass(frozen=True)
+class RelationshipDraft:
+    """A typed relationship between two records."""
+
+    source_record_key: str
+    target_record_key: str
+    kind: RelationshipKind
+
+
+@dataclass(frozen=True)
+class ReferenceDraft:
+    """A source-authored mechanical reference resolved at build time.
+
+    ``scope_key`` is the committed source scope the reference was resolved
+    within, which is what makes a repeated name resolvable: the same wording in
+    two scopes is two references, not one ambiguity.
+    """
+
+    from_record_key: str
+    from_component_key: str
+    source_text: str
+    scope_key: str
+    target_record_key: str
+
+
+@dataclass(frozen=True)
+class ProvenanceClaim:
+    """An exact 5c leaf-subspan claim by one representation element."""
+
+    target_kind: ProvenanceTargetKind
+    target_key: tuple[str, ...]
+    span_id: str
+    role: ProvenanceRole
+
+
+@dataclass(frozen=True)
+class RepresentationDraft:
+    """The complete keyed representation for one candidate projection."""
+
+    records: tuple[RecordDraft, ...]
+    components: tuple[ComponentDraft, ...]
+    prose_bindings: tuple[ProseBindingDraft, ...]
+    relationships: tuple[RelationshipDraft, ...]
+    references: tuple[ReferenceDraft, ...]
+    provenance: tuple[ProvenanceClaim, ...]

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -30,6 +30,7 @@ as prose-bound.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 from typing import Any, ClassVar, cast
@@ -59,6 +60,7 @@ __all__ = [
     "SpellDescriptorFact",
     "SpellSchool",
     "UnknownFactFamilyError",
+    "fact_from_payload",
     "fact_key",
     "fact_payload",
 ]
@@ -235,6 +237,64 @@ _FACT_TYPES: dict[FactFamily, type] = {
 
 class UnknownFactFamilyError(TypeError):
     """Raised when a structure outside the closed union is offered as a fact."""
+
+
+def _build_ability_check(p: Mapping[str, Any]) -> AbilityCheckFact:
+    return AbilityCheckFact(
+        ability=AbilityScore(p["ability"]),
+        dc_kind=DcKind(p["dc_kind"]),
+        dc_value=p["dc_value"],
+    )
+
+
+def _build_creature_ability_score(p: Mapping[str, Any]) -> CreatureAbilityScoreFact:
+    return CreatureAbilityScoreFact(
+        ability=AbilityScore(p["ability"]), score=p["score"]
+    )
+
+
+def _build_spell_descriptor(p: Mapping[str, Any]) -> SpellDescriptorFact:
+    return SpellDescriptorFact(
+        level=p["level"],
+        school=SpellSchool(p["school"]),
+        ritual=p["ritual"],
+        concentration=p["concentration"],
+    )
+
+
+def _build_progression_entry(p: Mapping[str, Any]) -> ProgressionEntryFact:
+    return ProgressionEntryFact(
+        level=p["level"],
+        entitlement_key=p["entitlement_key"],
+        quantity=p["quantity"],
+    )
+
+
+_FACT_BUILDERS: dict[FactFamily, Callable[[Mapping[str, Any]], MechanicalFact]] = {
+    FactFamily.ABILITY_CHECK: _build_ability_check,
+    FactFamily.CREATURE_ABILITY_SCORE: _build_creature_ability_score,
+    FactFamily.SPELL_DESCRIPTOR: _build_spell_descriptor,
+    FactFamily.PROGRESSION_ENTRY: _build_progression_entry,
+}
+
+
+def fact_from_payload(payload: Mapping[str, Any]) -> MechanicalFact:
+    """Rebuild a typed fact from its persisted payload.
+
+    Explicit per-family builders rather than reflection: a persisted row with a
+    missing or extra field fails loudly here instead of being coerced into
+    something that merely resembles a fact. An unknown family is not a
+    forward-compatible unknown — it is a fact this build cannot honestly
+    represent, so it raises.
+    """
+    raw = payload.get("family")
+    try:
+        family = FactFamily(str(raw))
+    except ValueError:
+        raise UnknownFactFamilyError(
+            f"{raw!r} is not a member of the closed typed-fact union"
+        ) from None
+    return _FACT_BUILDERS[family](payload)
 
 
 def fact_key(fact: object) -> str:

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -63,6 +63,7 @@ __all__ = [
     "UnknownFactFamilyError",
     "fact_from_payload",
     "fact_invariant_violations",
+    "prose_bindings_by_target_key",
     "fact_key",
     "fact_payload",
 ]
@@ -737,6 +738,18 @@ def reference_target_key(reference: ReferenceDraft) -> tuple[str, ...]:
         reference.scope_key,
         reference.target_record_key,
     )
+
+
+def prose_bindings_by_target_key(
+    draft: RepresentationDraft,
+) -> dict[tuple[str, ...], ProseBindingDraft]:
+    """Map each prose binding's provenance key back to the binding itself.
+
+    Provenance validation needs the binding, not just its key, to check that a
+    claimed span lies inside the chunk that binding names. Recovering it
+    through the same key function keeps one definition of "the same element".
+    """
+    return {prose_binding_target_key(b): b for b in draft.prose_bindings}
 
 
 def declared_provenance_targets(

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -31,7 +31,7 @@ as prose-bound.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from enum import StrEnum
 from typing import Any, ClassVar, cast
 
@@ -59,8 +59,10 @@ __all__ = [
     "RepresentationDraft",
     "SpellDescriptorFact",
     "SpellSchool",
+    "MalformedFactPayloadError",
     "UnknownFactFamilyError",
     "fact_from_payload",
+    "fact_invariant_violations",
     "fact_key",
     "fact_payload",
 ]
@@ -239,6 +241,86 @@ class UnknownFactFamilyError(TypeError):
     """Raised when a structure outside the closed union is offered as a fact."""
 
 
+class MalformedFactPayloadError(ValueError):
+    """Raised when a persisted payload cannot rebuild its declared family."""
+
+
+# ---------------------------------------------------------------------------
+# Intrinsic family invariants
+# ---------------------------------------------------------------------------
+#
+# Class membership is not validity. A fact can belong to the closed union and
+# still contradict its own declared contract, and such a fact would persist as
+# mechanically unusable authority. Each family therefore declares its intrinsic
+# invariants here, next to the family itself, so adding a family without
+# thinking about its invariants is a visible omission rather than a silent one.
+#
+# Only constraints intrinsic to the declared fields belong here. Corpus-specific
+# limits — the SRD's 0–9 spell levels, its 1–30 ability scores — are policy about
+# a particular Rules Package, not properties of the type, and enforcing them here
+# would make the union quietly SRD-only. Bounds below are limited to what the
+# field's own meaning requires: an ordinal or magnitude cannot be negative, a
+# semantic key cannot be blank, and a stated quantity cannot be zero or less.
+
+
+def _check_ability_check(fact: AbilityCheckFact) -> list[str]:
+    findings: list[str] = []
+    if fact.dc_kind is DcKind.FIXED:
+        if fact.dc_value is None:
+            findings.append("fixed DC without a dc_value")
+    elif fact.dc_value is not None:
+        findings.append(
+            f"{fact.dc_kind.value} DC carries dc_value {fact.dc_value}; the "
+            "value comes from the named source, not from the fact"
+        )
+    return findings
+
+
+def _check_creature_ability_score(fact: CreatureAbilityScoreFact) -> list[str]:
+    if fact.score < 0:
+        return [f"negative ability score {fact.score}"]
+    return []
+
+
+def _check_spell_descriptor(fact: SpellDescriptorFact) -> list[str]:
+    if fact.level < 0:
+        return [f"negative spell level {fact.level}"]
+    return []
+
+
+def _check_progression_entry(fact: ProgressionEntryFact) -> list[str]:
+    findings: list[str] = []
+    if fact.level < 0:
+        findings.append(f"negative progression level {fact.level}")
+    if not fact.entitlement_key.strip():
+        findings.append("progression entry without an entitlement key")
+    if fact.quantity is not None and fact.quantity < 1:
+        findings.append(f"progression quantity {fact.quantity} grants nothing")
+    return findings
+
+
+_FACT_INVARIANTS: dict[FactFamily, Callable[[Any], list[str]]] = {
+    FactFamily.ABILITY_CHECK: _check_ability_check,
+    FactFamily.CREATURE_ABILITY_SCORE: _check_creature_ability_score,
+    FactFamily.SPELL_DESCRIPTOR: _check_spell_descriptor,
+    FactFamily.PROGRESSION_ENTRY: _check_progression_entry,
+}
+
+
+def fact_invariant_violations(fact: object) -> tuple[str, ...]:
+    """Return violations of *fact*'s own family contract.
+
+    Membership of the closed union is checked first: an unknown family has no
+    invariants to check because it has no contract.
+    """
+    family = getattr(fact, "FAMILY", None)
+    if not isinstance(family, FactFamily) or _FACT_TYPES.get(family) is not type(fact):
+        return (
+            f"{type(fact).__name__} is not a member of the closed typed-fact union",
+        )
+    return tuple(_FACT_INVARIANTS[family](fact))
+
+
 def _build_ability_check(p: Mapping[str, Any]) -> AbilityCheckFact:
     return AbilityCheckFact(
         ability=AbilityScore(p["ability"]),
@@ -278,14 +360,27 @@ _FACT_BUILDERS: dict[FactFamily, Callable[[Mapping[str, Any]], MechanicalFact]] 
 }
 
 
-def fact_from_payload(payload: Mapping[str, Any]) -> MechanicalFact:
+def fact_from_payload(
+    payload: Mapping[str, Any], *, declared_family: str | None = None
+) -> MechanicalFact:
     """Rebuild a typed fact from its persisted payload.
 
-    Explicit per-family builders rather than reflection: a persisted row with a
-    missing or extra field fails loudly here instead of being coerced into
-    something that merely resembles a fact. An unknown family is not a
-    forward-compatible unknown — it is a fact this build cannot honestly
-    represent, so it raises.
+    Strict by design. A persisted payload is only authority if it still says
+    exactly what it said when it was written, so this rejects rather than
+    repairs:
+
+    * an unknown family — not a forward-compatible unknown, but a fact this
+      build cannot honestly represent;
+    * a missing field, which would otherwise rebuild into a fact with a
+      silently defaulted value;
+    * an extra field, which would otherwise be dropped, hiding whatever was
+      added to the row; and
+    * a payload discriminator that disagrees with the column that stores it
+      alongside — one of the two has been rewritten, and guessing which is
+      not reconstruction.
+
+    Explicit per-family builders rather than reflection, so each family states
+    the exact field set it accepts.
     """
     raw = payload.get("family")
     try:
@@ -294,7 +389,26 @@ def fact_from_payload(payload: Mapping[str, Any]) -> MechanicalFact:
         raise UnknownFactFamilyError(
             f"{raw!r} is not a member of the closed typed-fact union"
         ) from None
-    return _FACT_BUILDERS[family](payload)
+
+    if declared_family is not None and declared_family != family.value:
+        raise MalformedFactPayloadError(
+            f"persisted family {declared_family!r} disagrees with payload family "
+            f"{family.value!r}"
+        )
+
+    expected = {f.name for f in fields(_FACT_TYPES[family])} | {"family"}
+    supplied = set(payload)
+    if missing := sorted(expected - supplied):
+        raise MalformedFactPayloadError(f"{family.value} payload is missing {missing}")
+    if extra := sorted(supplied - expected):
+        raise MalformedFactPayloadError(f"{family.value} payload carries extra {extra}")
+
+    try:
+        return _FACT_BUILDERS[family](payload)
+    except (TypeError, ValueError) as exc:
+        raise MalformedFactPayloadError(
+            f"{family.value} payload does not rebuild its declared family: {exc}"
+        ) from exc
 
 
 def fact_key(fact: object) -> str:

--- a/src/afterworlds/ingestion/mechanical/validation.py
+++ b/src/afterworlds/ingestion/mechanical/validation.py
@@ -41,6 +41,7 @@ from afterworlds.ingestion.mechanical.representation import (
     declared_provenance_targets,
     fact_invariant_violations,
     fact_key,
+    prose_bindings_by_target_key,
 )
 
 __all__ = ["validate_representation"]
@@ -242,7 +243,9 @@ _ADMISSIBLE_ROLES: dict[SemanticDisposition, frozenset[ProvenanceRole]] = {
 
 
 def _validate_provenance(
-    draft: RepresentationDraft, ledger: ClassificationLedger
+    draft: RepresentationDraft,
+    ledger: ClassificationLedger,
+    corpus: BoundCorpusSnapshot,
 ) -> list[str]:
     """Validate provenance as a closed relation, not a one-way check.
 
@@ -250,8 +253,15 @@ def _validate_provenance(
     for anything:
 
     * **forward** — the claim names a declared element and an existing span;
-    * **admissible** — the span's accepted disposition permits that role; and
+    * **admissible** — the span's accepted disposition permits that role, and a
+      prose binding's claim cites text its own chunk actually covers; and
     * **reverse** — every authoritative element carries at least one edge.
+
+    The chunk-locality half is what closes the relation over the 5c projection.
+    A prose binding names an exact chunk and a provenance edge names an exact
+    span; without joining them, a binding to chunk A could cite a span that
+    only ever projected into chunk B, and the candidate would persist governing
+    prose that does not contain the text it claims to govern.
 
     Admissibility is decided *before* an edge joins any coverage set, so an
     inadmissible claim cannot satisfy substantive coverage, supporting linkage,
@@ -261,6 +271,7 @@ def _validate_provenance(
     findings: list[str] = []
     spans_by_id = {s.span_id: s for s in ledger.spans}
     declared = declared_provenance_targets(draft)
+    bindings_by_key = prose_bindings_by_target_key(draft)
 
     primary_by_span: dict[str, list[tuple[str, ...]]] = {}
     claimed: set[str] = set()
@@ -298,6 +309,17 @@ def _validate_provenance(
             findings.append(
                 f"{tag}: {claim.role.value} claim on a "
                 f"{span.disposition.value} span {claim.span_id}"
+            )
+            admissible = False
+
+        binding = bindings_by_key.get(claim.target_key)
+        if binding is not None and not corpus.covers_span(
+            binding.chunk_id, span.leaf_id, span.char_start, span.char_end
+        ):
+            findings.append(
+                f"{tag}: span {claim.span_id} "
+                f"[{span.char_start},{span.char_end}) of leaf {span.leaf_id} is not "
+                f"covered by bound chunk {binding.chunk_id}"
             )
             admissible = False
 
@@ -357,5 +379,5 @@ def validate_representation(
     findings.extend(_validate_components(draft))
     findings.extend(_validate_prose_bindings(draft, corpus))
     findings.extend(_validate_relationships_and_references(draft))
-    findings.extend(_validate_provenance(draft, ledger))
+    findings.extend(_validate_provenance(draft, ledger, corpus))
     return tuple(findings)

--- a/src/afterworlds/ingestion/mechanical/validation.py
+++ b/src/afterworlds/ingestion/mechanical/validation.py
@@ -34,13 +34,13 @@ from afterworlds.ingestion.mechanical.models import (
 )
 from afterworlds.ingestion.mechanical.policy import irreducibility_reason_for
 from afterworlds.ingestion.mechanical.representation import (
+    PROVENANCE_REQUIRED_KINDS,
     ProvenanceRole,
     ProvenanceTargetKind,
     RepresentationDraft,
-    UnknownFactFamilyError,
+    declared_provenance_targets,
     fact_invariant_violations,
     fact_key,
-    fact_payload,
 )
 
 __all__ = ["validate_representation"]
@@ -224,46 +224,87 @@ def _validate_relationships_and_references(draft: RepresentationDraft) -> list[s
     return findings
 
 
+#: Which provenance roles a span of each disposition may carry.
+#:
+#: NON_MECHANICAL and UNRESOLVED admit nothing: the accepted classification says
+#: this text states no mechanic, so citing it as governing provenance would let
+#: licensing, navigation, or flavour text back in as authority through a side
+#: door. SUPPORTING_AUTHORITY admits contextual links only — it explains or
+#: bounds a mechanic and must never be counted as the primary statement of one.
+_ADMISSIBLE_ROLES: dict[SemanticDisposition, frozenset[ProvenanceRole]] = {
+    SemanticDisposition.SUBSTANTIVE: frozenset(
+        {ProvenanceRole.PRIMARY, ProvenanceRole.CONTEXTUAL}
+    ),
+    SemanticDisposition.SUPPORTING_AUTHORITY: frozenset({ProvenanceRole.CONTEXTUAL}),
+    SemanticDisposition.NON_MECHANICAL: frozenset(),
+    SemanticDisposition.UNRESOLVED: frozenset(),
+}
+
+
 def _validate_provenance(
     draft: RepresentationDraft, ledger: ClassificationLedger
 ) -> list[str]:
+    """Validate provenance as a closed relation, not a one-way check.
+
+    Three obligations, and an edge must satisfy all of them before it counts
+    for anything:
+
+    * **forward** — the claim names a declared element and an existing span;
+    * **admissible** — the span's accepted disposition permits that role; and
+    * **reverse** — every authoritative element carries at least one edge.
+
+    Admissibility is decided *before* an edge joins any coverage set, so an
+    inadmissible claim cannot satisfy substantive coverage, supporting linkage,
+    or an element's own traceability. An exact duplicate edge is one claim
+    recorded twice, not two, and is rejected rather than counted twice.
+    """
     findings: list[str] = []
     spans_by_id = {s.span_id: s for s in ledger.spans}
-
-    declared: dict[ProvenanceTargetKind, set[tuple[str, ...]]] = {
-        ProvenanceTargetKind.RECORD: {(r.semantic_key,) for r in draft.records},
-        ProvenanceTargetKind.COMPONENT: {
-            (c.record_key, c.semantic_key) for c in draft.components
-        },
-        ProvenanceTargetKind.FACT: {
-            (c.record_key, c.semantic_key, fact_key(f))
-            for c in draft.components
-            for f in c.facts
-            if _payloadable(f)
-        },
-        ProvenanceTargetKind.PROSE_BINDING: {
-            (b.record_key, b.component_key) for b in draft.prose_bindings
-        },
-        ProvenanceTargetKind.RELATIONSHIP: {
-            (r.source_record_key, r.target_record_key, r.kind.value)
-            for r in draft.relationships
-        },
-        ProvenanceTargetKind.REFERENCE: {
-            (r.scope_key, r.source_text, r.target_record_key) for r in draft.references
-        },
-    }
+    declared = declared_provenance_targets(draft)
 
     primary_by_span: dict[str, list[tuple[str, ...]]] = {}
     claimed: set[str] = set()
     linked: set[str] = set()
+    covered: dict[ProvenanceTargetKind, set[tuple[str, ...]]] = {
+        kind: set() for kind in ProvenanceTargetKind
+    }
+    seen_edges: set[tuple[str, tuple[str, ...], str, str]] = set()
 
     for claim in draft.provenance:
         tag = f"provenance {claim.target_kind.value}{list(claim.target_key)}"
+        edge = (
+            claim.target_kind.value,
+            claim.target_key,
+            claim.span_id,
+            claim.role.value,
+        )
+        if edge in seen_edges:
+            findings.append(
+                f"{tag}: duplicate provenance edge for span {claim.span_id}"
+            )
+            continue
+        seen_edges.add(edge)
+
+        admissible = True
         if claim.target_key not in declared[claim.target_kind]:
             findings.append(f"{tag}: claim for an undeclared element")
-        if claim.span_id not in spans_by_id:
+            admissible = False
+
+        span = spans_by_id.get(claim.span_id)
+        if span is None:
             findings.append(f"{tag}: unknown span {claim.span_id}")
             continue
+        if claim.role not in _ADMISSIBLE_ROLES[span.disposition]:
+            findings.append(
+                f"{tag}: {claim.role.value} claim on a "
+                f"{span.disposition.value} span {claim.span_id}"
+            )
+            admissible = False
+
+        if not admissible:
+            continue
+
+        covered[claim.target_kind].add(claim.target_key)
         if claim.role is ProvenanceRole.PRIMARY:
             primary_by_span.setdefault(claim.span_id, []).append(claim.target_key)
             claimed.add(claim.span_id)
@@ -275,6 +316,14 @@ def _validate_provenance(
             findings.append(
                 f"span {span_id}: conflicting primary claims by "
                 f"{sorted(str(list(o)) for o in owners)}"
+            )
+
+    # Reverse obligation. A component claiming the span a fact came from does
+    # not make that fact traceable; the element carries its own evidence.
+    for kind in PROVENANCE_REQUIRED_KINDS:
+        for target in sorted(declared[kind] - covered[kind]):
+            findings.append(
+                f"{kind.value} {list(target)}: no provenance to a 5c leaf subspan"
             )
 
     for span in ledger.spans:
@@ -290,14 +339,6 @@ def _validate_provenance(
             findings.append(f"span {span.span_id}: supporting authority but unlinked")
 
     return findings
-
-
-def _payloadable(fact: object) -> bool:
-    try:
-        fact_payload(fact)
-    except UnknownFactFamilyError:
-        return False
-    return True
 
 
 def validate_representation(

--- a/src/afterworlds/ingestion/mechanical/validation.py
+++ b/src/afterworlds/ingestion/mechanical/validation.py
@@ -26,6 +26,7 @@ here means the representation is internally honest, not that it is finished.
 
 from __future__ import annotations
 
+from afterworlds.ingestion.mechanical.bound_corpus import BoundCorpusSnapshot
 from afterworlds.ingestion.mechanical.models import (
     ClassificationLedger,
     ComponentHandling,
@@ -37,6 +38,7 @@ from afterworlds.ingestion.mechanical.representation import (
     ProvenanceTargetKind,
     RepresentationDraft,
     UnknownFactFamilyError,
+    fact_invariant_violations,
     fact_key,
     fact_payload,
 )
@@ -93,11 +95,14 @@ def _validate_components(draft: RepresentationDraft) -> list[str]:
 
         fact_keys: set[str] = set()
         for fact in component.facts:
-            try:
-                key_ = fact_key(fact)
-            except UnknownFactFamilyError as exc:
-                findings.append(f"{tag}: {exc}")
+            # Family membership *and* the family's own contract: a fact can
+            # belong to the closed union and still contradict itself, and such
+            # a fact would persist as mechanically unusable authority.
+            violations = fact_invariant_violations(fact)
+            if violations:
+                findings.extend(f"{tag}: {v}" for v in violations)
                 continue
+            key_ = fact_key(fact)
             # Facts are identified by content, so a repeat is not a second
             # claim — it is the same claim counted twice, which is exactly the
             # duplicate-as-coverage inflation the completeness proof rejects.
@@ -106,46 +111,73 @@ def _validate_components(draft: RepresentationDraft) -> list[str]:
             fact_keys.add(key_)
 
         has_prose = key in bound_prose
+        code = component.irreducibility_reason_code
         if component.handling is ComponentHandling.STRUCTURED:
             if not component.facts:
                 findings.append(f"{tag}: structured handling with no typed facts")
             if has_prose:
                 findings.append(f"{tag}: structured handling with a prose binding")
-            if component.irreducibility_reason_code is not None:
+            if code is not None:
                 findings.append(
                     f"{tag}: structured handling with an irreducibility reason"
                 )
-        elif component.handling is ComponentHandling.PROSE_BOUND:
-            if component.facts:
-                findings.append(f"{tag}: prose-bound handling with typed facts")
-            if not has_prose:
-                findings.append(f"{tag}: prose-bound handling with no bound prose")
-        else:  # MIXED
-            if not component.facts:
+        else:
+            handling = component.handling.value
+            if component.handling is ComponentHandling.PROSE_BOUND:
+                if component.facts:
+                    findings.append(f"{tag}: {handling} handling with typed facts")
+            elif not component.facts:
                 findings.append(f"{tag}: mixed handling with no typed facts")
             if not has_prose:
-                findings.append(f"{tag}: mixed handling with no bound prose")
+                findings.append(f"{tag}: {handling} handling with no bound prose")
+            # A component that says its meaning is irreducible must say *why*,
+            # under the closed catalog. Silence here is the backlog state
+            # PROSE_BOUND must never become.
+            if code is None or not code.strip():
+                findings.append(
+                    f"{tag}: {handling} handling with no irreducibility reason"
+                )
 
-        code = component.irreducibility_reason_code
-        if code is not None and irreducibility_reason_for(code) is None:
+        if (
+            code is not None
+            and code.strip()
+            and irreducibility_reason_for(code) is None
+        ):
             findings.append(f"{tag}: irreducibility reason {code!r} is not closed")
 
     return findings
 
 
-def _validate_prose_bindings(draft: RepresentationDraft) -> list[str]:
+def _validate_prose_bindings(
+    draft: RepresentationDraft, corpus: BoundCorpusSnapshot
+) -> list[str]:
     findings: list[str] = []
-    component_keys = {(c.record_key, c.semantic_key) for c in draft.components}
+    components = {(c.record_key, c.semantic_key): c for c in draft.components}
     for binding in draft.prose_bindings:
         tag = f"prose binding {binding.record_key}/{binding.component_key}"
-        if (binding.record_key, binding.component_key) not in component_keys:
+        component = components.get((binding.record_key, binding.component_key))
+        if component is None:
             findings.append(f"{tag}: unknown component")
-        if not binding.chunk_id.strip():
-            findings.append(f"{tag}: no authoritative chunk bound")
-        if irreducibility_reason_for(binding.irreducibility_reason_code) is None:
+
+        # Exact governing prose resolves through the bound release's own
+        # authoritative chunk population. A non-empty string is not resolution:
+        # a fabricated id, another package's chunk, and a chunk that exists but
+        # was never projected into this release all fail here.
+        if binding.chunk_id not in corpus.authoritative_chunk_ids:
             findings.append(
-                f"{tag}: irreducibility reason "
-                f"{binding.irreducibility_reason_code!r} is not closed"
+                f"{tag}: chunk {binding.chunk_id!r} is not authoritative prose of "
+                f"release {corpus.package_uuid}/{corpus.release_version}"
+            )
+
+        code = binding.irreducibility_reason_code
+        if irreducibility_reason_for(code) is None:
+            findings.append(f"{tag}: irreducibility reason {code!r} is not closed")
+        elif component is not None and code != component.irreducibility_reason_code:
+            # Two independently valid reasons that disagree are a contradiction
+            # about *why* this authority is prose-bound. Neither copy wins.
+            findings.append(
+                f"{tag}: reason {code!r} disagrees with its component's "
+                f"{component.irreducibility_reason_code!r}"
             )
     return findings
 
@@ -269,13 +301,20 @@ def _payloadable(fact: object) -> bool:
 
 
 def validate_representation(
-    draft: RepresentationDraft, ledger: ClassificationLedger
+    draft: RepresentationDraft,
+    ledger: ClassificationLedger,
+    corpus: BoundCorpusSnapshot,
 ) -> tuple[str, ...]:
-    """Return every violation of the keyed representation's internal honesty."""
+    """Return every violation of the keyed representation's internal honesty.
+
+    *corpus* is the resolved snapshot of the bound 5c release — the one source
+    of release-scoped truth these validators read, so no validator needs a
+    database of its own.
+    """
     findings: list[str] = []
     findings.extend(_validate_records(draft))
     findings.extend(_validate_components(draft))
-    findings.extend(_validate_prose_bindings(draft))
+    findings.extend(_validate_prose_bindings(draft, corpus))
     findings.extend(_validate_relationships_and_references(draft))
     findings.extend(_validate_provenance(draft, ledger))
     return tuple(findings)

--- a/src/afterworlds/ingestion/mechanical/validation.py
+++ b/src/afterworlds/ingestion/mechanical/validation.py
@@ -1,0 +1,281 @@
+"""Representation validation — CRD Issue 5d, Decisions 3, 4, and 7.
+
+Checks the keyed representation against the accepted classification it claims
+to represent. Like the accounting layer, every check returns violation strings
+so one pass reports everything wrong rather than stopping at the first problem.
+
+What this layer is responsible for catching:
+
+* dangling keys — a component on a record that does not exist, a relationship
+  or reference to a missing record, provenance for an element nobody declared;
+* duplicate semantic keys, which would make an identity ambiguous;
+* record assembly errors — a parent cycle, a nested record pointing at itself;
+* handling honesty — ``STRUCTURED`` with no facts, ``PROSE_BOUND`` with facts
+  and no bound prose, a prose binding without a closed irreducibility reason;
+* facts outside the closed typed union;
+* provenance errors — an unknown span, a substantive span nothing claims, a
+  supporting span nothing links, and two elements both claiming to be what one
+  span primarily says; and
+* reference resolution errors — an unresolved or ambiguous reference, where the
+  same source wording inside one committed scope resolves two ways.
+
+It is *not* responsible for completeness across the corpus. That is the later
+publication gate, which runs against reconstructed persisted state. Passing
+here means the representation is internally honest, not that it is finished.
+"""
+
+from __future__ import annotations
+
+from afterworlds.ingestion.mechanical.models import (
+    ClassificationLedger,
+    ComponentHandling,
+    SemanticDisposition,
+)
+from afterworlds.ingestion.mechanical.policy import irreducibility_reason_for
+from afterworlds.ingestion.mechanical.representation import (
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RepresentationDraft,
+    UnknownFactFamilyError,
+    fact_key,
+    fact_payload,
+)
+
+__all__ = ["validate_representation"]
+
+
+def _validate_records(draft: RepresentationDraft) -> list[str]:
+    findings: list[str] = []
+    seen: set[str] = set()
+    for record in draft.records:
+        if record.semantic_key in seen:
+            findings.append(f"record {record.semantic_key}: duplicate semantic key")
+        seen.add(record.semantic_key)
+
+    keys = {r.semantic_key for r in draft.records}
+    parents = {r.semantic_key: r.parent_key for r in draft.records}
+    for record in draft.records:
+        parent = record.parent_key
+        if parent is None:
+            continue
+        if parent not in keys:
+            findings.append(f"record {record.semantic_key}: unknown parent {parent}")
+            continue
+        # Walk up; a nested record must terminate at a root, not loop.
+        seen_path = {record.semantic_key}
+        cursor: str | None = parent
+        while cursor is not None:
+            if cursor in seen_path:
+                findings.append(
+                    f"record {record.semantic_key}: parent cycle through {cursor}"
+                )
+                break
+            seen_path.add(cursor)
+            cursor = parents.get(cursor)
+    return findings
+
+
+def _validate_components(draft: RepresentationDraft) -> list[str]:
+    findings: list[str] = []
+    record_keys = {r.semantic_key for r in draft.records}
+    bound_prose = {(b.record_key, b.component_key) for b in draft.prose_bindings}
+    seen: set[tuple[str, str]] = set()
+
+    for component in draft.components:
+        key = (component.record_key, component.semantic_key)
+        tag = f"component {component.record_key}/{component.semantic_key}"
+        if key in seen:
+            findings.append(f"{tag}: duplicate semantic key")
+        seen.add(key)
+
+        if component.record_key not in record_keys:
+            findings.append(f"{tag}: unknown record {component.record_key}")
+
+        fact_keys: set[str] = set()
+        for fact in component.facts:
+            try:
+                key_ = fact_key(fact)
+            except UnknownFactFamilyError as exc:
+                findings.append(f"{tag}: {exc}")
+                continue
+            # Facts are identified by content, so a repeat is not a second
+            # claim — it is the same claim counted twice, which is exactly the
+            # duplicate-as-coverage inflation the completeness proof rejects.
+            if key_ in fact_keys:
+                findings.append(f"{tag}: duplicate typed fact {key_}")
+            fact_keys.add(key_)
+
+        has_prose = key in bound_prose
+        if component.handling is ComponentHandling.STRUCTURED:
+            if not component.facts:
+                findings.append(f"{tag}: structured handling with no typed facts")
+            if has_prose:
+                findings.append(f"{tag}: structured handling with a prose binding")
+            if component.irreducibility_reason_code is not None:
+                findings.append(
+                    f"{tag}: structured handling with an irreducibility reason"
+                )
+        elif component.handling is ComponentHandling.PROSE_BOUND:
+            if component.facts:
+                findings.append(f"{tag}: prose-bound handling with typed facts")
+            if not has_prose:
+                findings.append(f"{tag}: prose-bound handling with no bound prose")
+        else:  # MIXED
+            if not component.facts:
+                findings.append(f"{tag}: mixed handling with no typed facts")
+            if not has_prose:
+                findings.append(f"{tag}: mixed handling with no bound prose")
+
+        code = component.irreducibility_reason_code
+        if code is not None and irreducibility_reason_for(code) is None:
+            findings.append(f"{tag}: irreducibility reason {code!r} is not closed")
+
+    return findings
+
+
+def _validate_prose_bindings(draft: RepresentationDraft) -> list[str]:
+    findings: list[str] = []
+    component_keys = {(c.record_key, c.semantic_key) for c in draft.components}
+    for binding in draft.prose_bindings:
+        tag = f"prose binding {binding.record_key}/{binding.component_key}"
+        if (binding.record_key, binding.component_key) not in component_keys:
+            findings.append(f"{tag}: unknown component")
+        if not binding.chunk_id.strip():
+            findings.append(f"{tag}: no authoritative chunk bound")
+        if irreducibility_reason_for(binding.irreducibility_reason_code) is None:
+            findings.append(
+                f"{tag}: irreducibility reason "
+                f"{binding.irreducibility_reason_code!r} is not closed"
+            )
+    return findings
+
+
+def _validate_relationships_and_references(draft: RepresentationDraft) -> list[str]:
+    findings: list[str] = []
+    record_keys = {r.semantic_key for r in draft.records}
+    component_keys = {(c.record_key, c.semantic_key) for c in draft.components}
+
+    for rel in draft.relationships:
+        tag = f"relationship {rel.source_record_key}->{rel.target_record_key}"
+        for key in (rel.source_record_key, rel.target_record_key):
+            if key not in record_keys:
+                findings.append(f"{tag}: unknown record {key}")
+        if rel.source_record_key == rel.target_record_key:
+            findings.append(f"{tag}: record related to itself")
+
+    # A reference is ambiguous when identical source wording inside one
+    # committed scope resolves to more than one target. Unique destination
+    # names alone never establish intent, so the scope is what disambiguates.
+    resolutions: dict[tuple[str, str], set[str]] = {}
+    for ref in draft.references:
+        tag = f"reference {ref.scope_key}:{ref.source_text!r}"
+        if ref.from_record_key not in record_keys:
+            findings.append(f"{tag}: unknown source record {ref.from_record_key}")
+        if (ref.from_record_key, ref.from_component_key) not in component_keys:
+            findings.append(f"{tag}: unknown source component {ref.from_component_key}")
+        if not ref.target_record_key:
+            findings.append(f"{tag}: unresolved reference")
+        elif ref.target_record_key not in record_keys:
+            findings.append(f"{tag}: unknown target record {ref.target_record_key}")
+        if not ref.scope_key.strip():
+            findings.append(f"{tag}: no committed resolution scope")
+        resolutions.setdefault((ref.scope_key, ref.source_text), set()).add(
+            ref.target_record_key
+        )
+
+    for (scope, text), targets in sorted(resolutions.items()):
+        if len(targets) > 1:
+            findings.append(
+                f"reference {scope}:{text!r}: ambiguous — resolves to "
+                f"{sorted(targets)}"
+            )
+    return findings
+
+
+def _validate_provenance(
+    draft: RepresentationDraft, ledger: ClassificationLedger
+) -> list[str]:
+    findings: list[str] = []
+    spans_by_id = {s.span_id: s for s in ledger.spans}
+
+    declared: dict[ProvenanceTargetKind, set[tuple[str, ...]]] = {
+        ProvenanceTargetKind.RECORD: {(r.semantic_key,) for r in draft.records},
+        ProvenanceTargetKind.COMPONENT: {
+            (c.record_key, c.semantic_key) for c in draft.components
+        },
+        ProvenanceTargetKind.FACT: {
+            (c.record_key, c.semantic_key, fact_key(f))
+            for c in draft.components
+            for f in c.facts
+            if _payloadable(f)
+        },
+        ProvenanceTargetKind.PROSE_BINDING: {
+            (b.record_key, b.component_key) for b in draft.prose_bindings
+        },
+        ProvenanceTargetKind.RELATIONSHIP: {
+            (r.source_record_key, r.target_record_key, r.kind.value)
+            for r in draft.relationships
+        },
+        ProvenanceTargetKind.REFERENCE: {
+            (r.scope_key, r.source_text, r.target_record_key) for r in draft.references
+        },
+    }
+
+    primary_by_span: dict[str, list[tuple[str, ...]]] = {}
+    claimed: set[str] = set()
+    linked: set[str] = set()
+
+    for claim in draft.provenance:
+        tag = f"provenance {claim.target_kind.value}{list(claim.target_key)}"
+        if claim.target_key not in declared[claim.target_kind]:
+            findings.append(f"{tag}: claim for an undeclared element")
+        if claim.span_id not in spans_by_id:
+            findings.append(f"{tag}: unknown span {claim.span_id}")
+            continue
+        if claim.role is ProvenanceRole.PRIMARY:
+            primary_by_span.setdefault(claim.span_id, []).append(claim.target_key)
+            claimed.add(claim.span_id)
+        else:
+            linked.add(claim.span_id)
+
+    for span_id, owners in sorted(primary_by_span.items()):
+        if len(owners) > 1:
+            findings.append(
+                f"span {span_id}: conflicting primary claims by "
+                f"{sorted(str(list(o)) for o in owners)}"
+            )
+
+    for span in ledger.spans:
+        if (
+            span.disposition is SemanticDisposition.SUBSTANTIVE
+            and span.span_id not in claimed
+        ):
+            findings.append(f"span {span.span_id}: substantive but unclaimed")
+        elif (
+            span.disposition is SemanticDisposition.SUPPORTING_AUTHORITY
+            and span.span_id not in claimed | linked
+        ):
+            findings.append(f"span {span.span_id}: supporting authority but unlinked")
+
+    return findings
+
+
+def _payloadable(fact: object) -> bool:
+    try:
+        fact_payload(fact)
+    except UnknownFactFamilyError:
+        return False
+    return True
+
+
+def validate_representation(
+    draft: RepresentationDraft, ledger: ClassificationLedger
+) -> tuple[str, ...]:
+    """Return every violation of the keyed representation's internal honesty."""
+    findings: list[str] = []
+    findings.extend(_validate_records(draft))
+    findings.extend(_validate_components(draft))
+    findings.extend(_validate_prose_bindings(draft))
+    findings.extend(_validate_relationships_and_references(draft))
+    findings.extend(_validate_provenance(draft, ledger))
+    return tuple(findings)

--- a/src/afterworlds/persistence/orm/mechanical.py
+++ b/src/afterworlds/persistence/orm/mechanical.py
@@ -1,0 +1,249 @@
+"""Mechanical-authority projection tables — CRD Issue 5d.
+
+Typed, reconstructable state, not an opaque blob: every span, acceptance
+record, record, component, fact, prose binding, relationship, reference, and
+provenance edge is its own row, so the complete projection and its proof can be
+rebuilt from the database alone (#137 contract 5).
+
+Facts are the one place with a JSON column, and it is deliberately *not* a
+generic escape hatch. ``family`` is the closed union's discriminator, and the
+payload is that family's validated field set — reconstruction rebuilds the
+declared frozen dataclass through it and fails on an unknown family. Storing it
+this way is what lets a later PR add a typed family without a migration, which
+is exactly the additive-extension capability #137 asks for; what it must never
+become is a bag that accepts an undeclared shape.
+
+Everything is scoped by ``projection_uuid`` and cascades from the projection
+row, so two projections over the same 5c release coexist without collision.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from afterworlds.persistence.orm.base import Base
+
+
+class MechanicalProjectionORM(Base):
+    """One mechanical-authority projection over an exact published 5c release."""
+
+    __tablename__ = "rp_mech_projections"
+
+    projection_uuid: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+
+    # Exact 5c release binding (#137 contract 1). package_uuid is a real FK, so
+    # a projection cannot outlive or precede the release it claims.
+    package_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_corpus_releases.package_uuid", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    release_version: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    authoritative_source_hash: Mapped[str] = mapped_column(
+        sa.String(64), nullable=False
+    )
+    transform_config_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    bundle_root_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    persisted_corpus_digest: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+    # Declared semantic policy, retained so a historical projection states the
+    # policy it was accepted under rather than being reinterpreted later.
+    semantic_policy_version: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    semantic_policy_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+    payload_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    # Set exactly once, from state actually read back out of these tables. It
+    # cannot be known when the draft rows are first written, so it stays NULL
+    # through the draft phase and is never caller-supplied as proof.
+    persisted_state_digest: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+    publication_status: Mapped[str] = mapped_column(
+        sa.String(32), nullable=False, default="draft"
+    )
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class _ProjectionScoped(Base):
+    """Mixin base: every projection-scoped table cascades from its projection."""
+
+    __abstract__ = True
+
+    row_id: Mapped[int] = mapped_column(
+        sa.Integer, primary_key=True, autoincrement=True
+    )
+
+    @staticmethod
+    def _projection_fk() -> Mapped[str]:
+        return mapped_column(
+            sa.String(36),
+            sa.ForeignKey("rp_mech_projections.projection_uuid", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        )
+
+
+class MechanicalSpanORM(_ProjectionScoped):
+    """One accepted semantic span of the bound release."""
+
+    __tablename__ = "rp_mech_spans"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    span_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    leaf_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    char_start: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    char_end: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    disposition: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    review_state: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    non_mechanical_reason_code: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+
+
+class MechanicalAcceptanceBatchORM(_ProjectionScoped):
+    """Retained batch-acceptance evidence header."""
+
+    __tablename__ = "rp_mech_acceptance_batches"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    batch_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    rule: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    semantic_diff_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class MechanicalBatchScopeORM(_ProjectionScoped):
+    """One member of a batch's exact resolved scope."""
+
+    __tablename__ = "rp_mech_batch_scope"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    batch_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    span_id: Mapped[str] = mapped_column(sa.String(36), nullable=False)
+    ordinal: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+
+class MechanicalBatchDiffORM(_ProjectionScoped):
+    """One retained transition of a batch's canonical semantic diff."""
+
+    __tablename__ = "rp_mech_batch_diff"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    batch_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    span_id: Mapped[str] = mapped_column(sa.String(36), nullable=False)
+    prior_disposition: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    prior_reason_code: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    accepted_disposition: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    accepted_reason_code: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+
+
+class MechanicalAcceptanceORM(_ProjectionScoped):
+    """One explicit acceptance action."""
+
+    __tablename__ = "rp_mech_acceptances"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    span_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    batch_id: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    reviewer: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    accepted_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class MechanicalRecordORM(_ProjectionScoped):
+    """One semantic record."""
+
+    __tablename__ = "rp_mech_records"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    record_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    semantic_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    kind: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    parent_key: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+
+
+class MechanicalComponentORM(_ProjectionScoped):
+    """One publishable component of a record."""
+
+    __tablename__ = "rp_mech_components"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    component_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+    semantic_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    handling: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    irreducibility_reason_code: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+
+
+class MechanicalFactORM(_ProjectionScoped):
+    """One typed fact of the closed union."""
+
+    __tablename__ = "rp_mech_facts"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    fact_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+    component_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    fact_key: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    family: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    payload: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
+
+
+class MechanicalProseBindingORM(_ProjectionScoped):
+    """Exact governing prose bound to the authoritative 5c chunk."""
+
+    __tablename__ = "rp_mech_prose_bindings"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+    component_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    chunk_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    irreducibility_reason_code: Mapped[str] = mapped_column(
+        sa.String(64), nullable=False
+    )
+
+
+class MechanicalRelationshipORM(_ProjectionScoped):
+    """A typed relationship between two records."""
+
+    __tablename__ = "rp_mech_relationships"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    source_record_key: Mapped[str] = mapped_column(
+        sa.String(255), nullable=False, index=True
+    )
+    target_record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    kind: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+
+
+class MechanicalReferenceORM(_ProjectionScoped):
+    """A build-time-resolved source reference."""
+
+    __tablename__ = "rp_mech_references"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    from_record_key: Mapped[str] = mapped_column(
+        sa.String(255), nullable=False, index=True
+    )
+    from_component_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    source_text: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    scope_key: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
+    target_record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+
+
+class MechanicalProvenanceORM(_ProjectionScoped):
+    """One exact leaf-subspan claim by a representation element."""
+
+    __tablename__ = "rp_mech_provenance"
+
+    projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
+    target_kind: Mapped[str] = mapped_column(sa.String(32), nullable=False, index=True)
+    target_key: Mapped[list[str]] = mapped_column(sa.JSON, nullable=False)
+    span_id: Mapped[str] = mapped_column(sa.String(36), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(sa.String(16), nullable=False)

--- a/src/afterworlds/persistence/orm/mechanical.py
+++ b/src/afterworlds/persistence/orm/mechanical.py
@@ -105,9 +105,20 @@ class MechanicalSpanORM(_ProjectionScoped):
 
 
 class MechanicalAcceptanceBatchORM(_ProjectionScoped):
-    """Retained batch-acceptance evidence header."""
+    """Retained batch-acceptance evidence header.
+
+    ``(projection_uuid, batch_id)`` is the logical identity its scope and diff
+    rows are matched on, so it is unique at the database level too. Defence in
+    depth only: reconstruction still proves the relation, because a corrupted
+    database or one created with constraints disabled must still be detected.
+    """
 
     __tablename__ = "rp_mech_acceptance_batches"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "projection_uuid", "batch_id", name="uq_rp_mech_batch_identity"
+        ),
+    )
 
     projection_uuid: Mapped[str] = _ProjectionScoped._projection_fk()
     batch_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -9,7 +9,10 @@ that each negative control can perturb exactly one thing.
 from __future__ import annotations
 
 from afterworlds.ingestion.mechanical.accounting import batch_diff_hash, derive_span_id
-from afterworlds.ingestion.mechanical.bound_corpus import BoundCorpusSnapshot
+from afterworlds.ingestion.mechanical.bound_corpus import (
+    BoundCorpusSnapshot,
+    ChunkCoverage,
+)
 from afterworlds.ingestion.mechanical.models import (
     AcceptanceBatch,
     AcceptanceRecord,
@@ -60,10 +63,38 @@ WISH_CHUNK = "chunk-wish-0001"
 SECOND_CHUNK = "chunk-wish-0002"
 
 
+def coverage(
+    chunk_id: str,
+    leaf_id: str,
+    cover_start: int,
+    cover_end: int,
+    role: str = "authoritative",
+) -> ChunkCoverage:
+    """One synthetic 5c projection edge."""
+    return ChunkCoverage(
+        chunk_id=chunk_id,
+        leaf_id=leaf_id,
+        cover_start=cover_start,
+        cover_end=cover_end,
+        role=role,
+        projection_id=f"proj-{chunk_id}-{leaf_id}-{cover_start}",
+    )
+
+
+#: Default synthetic coverage. Stated explicitly per chunk and leaf rather than
+#: defaulting every chunk to every leaf, so a cross-chunk claim is actually
+#: wrong here instead of accidentally allowed. Both chunks legitimately cover
+#: the prose leaf — different chunks may cover the same source range.
+DEFAULT_COVERAGE = (
+    coverage(WISH_CHUNK, PROSE_LEAF, 0, 30),
+    coverage(SECOND_CHUNK, PROSE_LEAF, 0, 30),
+)
+
+
 def bound_corpus(
     *,
     leaf_lengths: dict[str, int] | None = None,
-    chunk_ids: frozenset[str] | None = None,
+    chunk_coverage: tuple[ChunkCoverage, ...] | None = None,
     package_uuid: str = PACKAGE_UUID,
     release_version: str = RELEASE_VERSION,
 ) -> BoundCorpusSnapshot:
@@ -72,9 +103,7 @@ def bound_corpus(
         package_uuid=package_uuid,
         release_version=release_version,
         leaf_lengths=dict(LEAF_LENGTHS if leaf_lengths is None else leaf_lengths),
-        authoritative_chunk_ids=(
-            frozenset({WISH_CHUNK, SECOND_CHUNK}) if chunk_ids is None else chunk_ids
-        ),
+        chunk_coverage=(DEFAULT_COVERAGE if chunk_coverage is None else chunk_coverage),
     )
 
 

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -43,6 +43,9 @@ from afterworlds.ingestion.mechanical.representation import (
     SpellDescriptorFact,
     SpellSchool,
     fact_key,
+    prose_binding_target_key,
+    reference_target_key,
+    relationship_target_key,
 )
 
 SPELL_LEAF = "leaf-spell"
@@ -179,6 +182,48 @@ def batch_accepted_ledger() -> ClassificationLedger:
     )
 
 
+WISH_BINDING = ProseBindingDraft(
+    component_key=OPEN_ENDED_KEY,
+    record_key=SPELL_KEY,
+    chunk_id=WISH_CHUNK,
+    irreducibility_reason_code="open_ended_effect",
+)
+
+SCOPED_WITHIN = RelationshipDraft(
+    source_record_key=CREATURE_KEY,
+    target_record_key=SPELL_KEY,
+    kind=RelationshipKind.SCOPED_WITHIN,
+)
+
+
+def binding_claim(
+    binding: ProseBindingDraft,
+    span_id: str = PROSE_SPAN,
+    role: ProvenanceRole = ProvenanceRole.PRIMARY,
+) -> ProvenanceClaim:
+    """A provenance edge for one exact prose binding."""
+    return ProvenanceClaim(
+        ProvenanceTargetKind.PROSE_BINDING,
+        prose_binding_target_key(binding),
+        span_id,
+        role,
+    )
+
+
+def reference_claim(
+    reference: ReferenceDraft,
+    span_id: str = SPELL_SPAN,
+    role: ProvenanceRole = ProvenanceRole.CONTEXTUAL,
+) -> ProvenanceClaim:
+    """A provenance edge for one exact resolved reference."""
+    return ProvenanceClaim(
+        ProvenanceTargetKind.REFERENCE,
+        reference_target_key(reference),
+        span_id,
+        role,
+    )
+
+
 #: Two references whose identical wording resolves per committed scope.
 SCOPED_REFERENCES = (
     ReferenceDraft(
@@ -219,21 +264,8 @@ def build_representation(**overrides: object) -> RepresentationDraft:
             irreducibility_reason_code="open_ended_effect",
         ),
     )
-    prose_bindings = (
-        ProseBindingDraft(
-            component_key=OPEN_ENDED_KEY,
-            record_key=SPELL_KEY,
-            chunk_id="chunk-wish-0001",
-            irreducibility_reason_code="open_ended_effect",
-        ),
-    )
-    relationships = (
-        RelationshipDraft(
-            source_record_key=CREATURE_KEY,
-            target_record_key=SPELL_KEY,
-            kind=RelationshipKind.SCOPED_WITHIN,
-        ),
-    )
+    prose_bindings = (WISH_BINDING,)
+    relationships = (SCOPED_WITHIN,)
     provenance = (
         ProvenanceClaim(
             ProvenanceTargetKind.FACT,
@@ -243,7 +275,7 @@ def build_representation(**overrides: object) -> RepresentationDraft:
         ),
         ProvenanceClaim(
             ProvenanceTargetKind.PROSE_BINDING,
-            (SPELL_KEY, OPEN_ENDED_KEY),
+            prose_binding_target_key(WISH_BINDING),
             PROSE_SPAN,
             ProvenanceRole.PRIMARY,
         ),
@@ -251,6 +283,15 @@ def build_representation(**overrides: object) -> RepresentationDraft:
             ProvenanceTargetKind.RECORD,
             (SPELL_KEY,),
             SUPPORT_SPAN,
+            ProvenanceRole.CONTEXTUAL,
+        ),
+        # Every authoritative element carries its own edge: the relationship is
+        # stated by the spell text, contextually alongside the fact's primary
+        # claim on the same span.
+        ProvenanceClaim(
+            ProvenanceTargetKind.RELATIONSHIP,
+            relationship_target_key(SCOPED_WITHIN),
+            SPELL_SPAN,
             ProvenanceRole.CONTEXTUAL,
         ),
     )

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -8,12 +8,14 @@ that each negative control can perturb exactly one thing.
 
 from __future__ import annotations
 
-from afterworlds.ingestion.mechanical.accounting import derive_span_id
+from afterworlds.ingestion.mechanical.accounting import batch_diff_hash, derive_span_id
 from afterworlds.ingestion.mechanical.models import (
+    AcceptanceBatch,
     AcceptanceRecord,
     ClassificationLedger,
     ComponentHandling,
     ReviewState,
+    SemanticDiffEntry,
     SemanticDisposition,
     SemanticSpan,
 )
@@ -33,6 +35,7 @@ from afterworlds.ingestion.mechanical.representation import (
     ProvenanceTargetKind,
     RecordDraft,
     RecordKind,
+    ReferenceDraft,
     RelationshipDraft,
     RelationshipKind,
     RepresentationDraft,
@@ -104,6 +107,70 @@ def build_ledger(
             for s in spans
         ),
     )
+
+
+def batch_accepted_ledger() -> ClassificationLedger:
+    """The same accepted result, reached through one rule-scoped batch.
+
+    Used to prove the retained evidence survives persistence, and that the
+    review path does not change the projection identity.
+    """
+    base = build_ledger()
+    diff = tuple(
+        SemanticDiffEntry(
+            span_id=s.span_id,
+            prior_disposition=None,
+            prior_reason_code=None,
+            accepted_disposition=s.disposition,
+            accepted_reason_code=s.non_mechanical_reason_code,
+        )
+        for s in base.spans
+    )
+    unhashed = AcceptanceBatch(
+        batch_id="batch-wish",
+        rule="every span of the Wish authority reviewed together",
+        resolved_scope=tuple(s.span_id for s in base.spans),
+        diff=diff,
+        semantic_diff_hash="",
+    )
+    batch = AcceptanceBatch(
+        batch_id=unhashed.batch_id,
+        rule=unhashed.rule,
+        resolved_scope=unhashed.resolved_scope,
+        diff=unhashed.diff,
+        semantic_diff_hash=batch_diff_hash(unhashed),
+    )
+    return ClassificationLedger(
+        package_uuid=base.package_uuid,
+        release_version=base.release_version,
+        policy_version=base.policy_version,
+        policy_hash=base.policy_hash,
+        spans=base.spans,
+        batches=(batch,),
+        acceptances=tuple(
+            AcceptanceRecord(s.span_id, batch.batch_id, "owner", "2026-07-31T00:00:00Z")
+            for s in base.spans
+        ),
+    )
+
+
+#: Two references whose identical wording resolves per committed scope.
+SCOPED_REFERENCES = (
+    ReferenceDraft(
+        from_record_key=SPELL_KEY,
+        from_component_key=DESCRIPTOR_KEY,
+        source_text="the servant",
+        scope_key="spell:wish",
+        target_record_key=CREATURE_KEY,
+    ),
+    ReferenceDraft(
+        from_record_key=SPELL_KEY,
+        from_component_key=DESCRIPTOR_KEY,
+        source_text="the servant",
+        scope_key="chapter:appendix",
+        target_record_key=SPELL_KEY,
+    ),
+)
 
 
 def build_representation(**overrides: object) -> RepresentationDraft:

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -9,6 +9,7 @@ that each negative control can perturb exactly one thing.
 from __future__ import annotations
 
 from afterworlds.ingestion.mechanical.accounting import batch_diff_hash, derive_span_id
+from afterworlds.ingestion.mechanical.bound_corpus import BoundCorpusSnapshot
 from afterworlds.ingestion.mechanical.models import (
     AcceptanceBatch,
     AcceptanceRecord,
@@ -49,6 +50,30 @@ PROSE_LEAF = "leaf-prose"
 SUPPORT_LEAF = "leaf-support"
 
 LEAF_LENGTHS = {SPELL_LEAF: 40, PROSE_LEAF: 30, SUPPORT_LEAF: 20}
+
+PACKAGE_UUID = "pkg-5c"
+RELEASE_VERSION = "rel-5c"
+WISH_CHUNK = "chunk-wish-0001"
+SECOND_CHUNK = "chunk-wish-0002"
+
+
+def bound_corpus(
+    *,
+    leaf_lengths: dict[str, int] | None = None,
+    chunk_ids: frozenset[str] | None = None,
+    package_uuid: str = PACKAGE_UUID,
+    release_version: str = RELEASE_VERSION,
+) -> BoundCorpusSnapshot:
+    """The resolved 5c release the synthetic candidate is validated against."""
+    return BoundCorpusSnapshot(
+        package_uuid=package_uuid,
+        release_version=release_version,
+        leaf_lengths=dict(LEAF_LENGTHS if leaf_lengths is None else leaf_lengths),
+        authoritative_chunk_ids=(
+            frozenset({WISH_CHUNK, SECOND_CHUNK}) if chunk_ids is None else chunk_ids
+        ),
+    )
+
 
 SPELL_SPAN = derive_span_id(SPELL_LEAF, 0, 40)
 PROSE_SPAN = derive_span_id(PROSE_LEAF, 0, 30)

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -1,0 +1,200 @@
+"""Shared builders for the CRD Issue 5d representation suite.
+
+One small honest candidate: a spell record with a structured descriptor
+component and a prose-bound open-ended clause, plus a scoped creature record —
+the shape the Wish and spell-scoped-creature canaries exercise, small enough
+that each negative control can perturb exactly one thing.
+"""
+
+from __future__ import annotations
+
+from afterworlds.ingestion.mechanical.accounting import derive_span_id
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceRecord,
+    ClassificationLedger,
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    SEMANTIC_POLICY_VERSION,
+    semantic_policy_hash,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    ReleaseBinding,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RecordDraft,
+    RecordKind,
+    RelationshipDraft,
+    RelationshipKind,
+    RepresentationDraft,
+    SpellDescriptorFact,
+    SpellSchool,
+    fact_key,
+)
+
+SPELL_LEAF = "leaf-spell"
+PROSE_LEAF = "leaf-prose"
+SUPPORT_LEAF = "leaf-support"
+
+LEAF_LENGTHS = {SPELL_LEAF: 40, PROSE_LEAF: 30, SUPPORT_LEAF: 20}
+
+SPELL_SPAN = derive_span_id(SPELL_LEAF, 0, 40)
+PROSE_SPAN = derive_span_id(PROSE_LEAF, 0, 30)
+SUPPORT_SPAN = derive_span_id(SUPPORT_LEAF, 0, 20)
+
+SPELL_KEY = "spell:wish"
+CREATURE_KEY = "creature:wish-scoped-servant"
+DESCRIPTOR_KEY = "descriptor"
+OPEN_ENDED_KEY = "open-ended-clause"
+
+DESCRIPTOR_FACT = SpellDescriptorFact(
+    level=9, school=SpellSchool.CONJURATION, ritual=False, concentration=False
+)
+DESCRIPTOR_FACT_KEY = fact_key(DESCRIPTOR_FACT)
+
+
+def build_ledger(
+    spans: tuple[SemanticSpan, ...] | None = None,
+) -> ClassificationLedger:
+    if spans is None:
+        spans = (
+            SemanticSpan(
+                span_id=SPELL_SPAN,
+                leaf_id=SPELL_LEAF,
+                char_start=0,
+                char_end=40,
+                disposition=SemanticDisposition.SUBSTANTIVE,
+                review_state=ReviewState.ACCEPTED,
+            ),
+            SemanticSpan(
+                span_id=PROSE_SPAN,
+                leaf_id=PROSE_LEAF,
+                char_start=0,
+                char_end=30,
+                disposition=SemanticDisposition.SUBSTANTIVE,
+                review_state=ReviewState.ACCEPTED,
+            ),
+            SemanticSpan(
+                span_id=SUPPORT_SPAN,
+                leaf_id=SUPPORT_LEAF,
+                char_start=0,
+                char_end=20,
+                disposition=SemanticDisposition.SUPPORTING_AUTHORITY,
+                review_state=ReviewState.ACCEPTED,
+            ),
+        )
+    return ClassificationLedger(
+        package_uuid="pkg-5c",
+        release_version="rel-5c",
+        policy_version=SEMANTIC_POLICY_VERSION,
+        policy_hash=semantic_policy_hash(),
+        spans=spans,
+        batches=(),
+        acceptances=tuple(
+            AcceptanceRecord(s.span_id, None, "owner", "2026-07-31T00:00:00Z")
+            for s in spans
+        ),
+    )
+
+
+def build_representation(**overrides: object) -> RepresentationDraft:
+    records = (
+        RecordDraft(semantic_key=SPELL_KEY, kind=RecordKind.SPELL),
+        RecordDraft(
+            semantic_key=CREATURE_KEY, kind=RecordKind.CREATURE, parent_key=SPELL_KEY
+        ),
+    )
+    components = (
+        ComponentDraft(
+            record_key=SPELL_KEY,
+            semantic_key=DESCRIPTOR_KEY,
+            handling=ComponentHandling.STRUCTURED,
+            facts=(DESCRIPTOR_FACT,),
+        ),
+        ComponentDraft(
+            record_key=SPELL_KEY,
+            semantic_key=OPEN_ENDED_KEY,
+            handling=ComponentHandling.PROSE_BOUND,
+            irreducibility_reason_code="open_ended_effect",
+        ),
+    )
+    prose_bindings = (
+        ProseBindingDraft(
+            component_key=OPEN_ENDED_KEY,
+            record_key=SPELL_KEY,
+            chunk_id="chunk-wish-0001",
+            irreducibility_reason_code="open_ended_effect",
+        ),
+    )
+    relationships = (
+        RelationshipDraft(
+            source_record_key=CREATURE_KEY,
+            target_record_key=SPELL_KEY,
+            kind=RelationshipKind.SCOPED_WITHIN,
+        ),
+    )
+    provenance = (
+        ProvenanceClaim(
+            ProvenanceTargetKind.FACT,
+            (SPELL_KEY, DESCRIPTOR_KEY, DESCRIPTOR_FACT_KEY),
+            SPELL_SPAN,
+            ProvenanceRole.PRIMARY,
+        ),
+        ProvenanceClaim(
+            ProvenanceTargetKind.PROSE_BINDING,
+            (SPELL_KEY, OPEN_ENDED_KEY),
+            PROSE_SPAN,
+            ProvenanceRole.PRIMARY,
+        ),
+        ProvenanceClaim(
+            ProvenanceTargetKind.RECORD,
+            (SPELL_KEY,),
+            SUPPORT_SPAN,
+            ProvenanceRole.CONTEXTUAL,
+        ),
+    )
+    draft = RepresentationDraft(
+        records=records,
+        components=components,
+        prose_bindings=prose_bindings,
+        relationships=relationships,
+        references=(),
+        provenance=provenance,
+    )
+    if not overrides:
+        return draft
+    fields = {
+        "records": draft.records,
+        "components": draft.components,
+        "prose_bindings": draft.prose_bindings,
+        "relationships": draft.relationships,
+        "references": draft.references,
+        "provenance": draft.provenance,
+    }
+    fields.update(overrides)  # type: ignore[arg-type]
+    return RepresentationDraft(**fields)  # type: ignore[arg-type]
+
+
+def build_candidate(**overrides: object) -> ProjectionCandidate:
+    ledger = overrides.pop("ledger", None)
+    return ProjectionCandidate(
+        binding=ReleaseBinding(
+            package_uuid="pkg-5c",
+            release_version="rel-5c",
+            authoritative_source_hash="a" * 64,
+            transform_config_hash="b" * 64,
+            bundle_root_hash="c" * 64,
+            persisted_corpus_digest="d" * 64,
+        ),
+        classification=ledger if ledger is not None else build_ledger(),  # type: ignore[arg-type]
+        representation=build_representation(**overrides),
+    )

--- a/tests/ingestion/mechanical/test_accounting.py
+++ b/tests/ingestion/mechanical/test_accounting.py
@@ -1,0 +1,311 @@
+"""Span-exact semantic accounting — CRD Issue 5d, Decision 2.
+
+The positive cases are cheap; the negative controls are the point. Each one
+below is a way an empty or dishonest classification could otherwise pass:
+uncovered text, double-claimed text, a reason code invented after the fact, a
+row that says "accepted" with nothing behind it, and a batch acceptance that
+records no rule, scope, or diff.
+"""
+
+from __future__ import annotations
+
+from afterworlds.ingestion.mechanical.accounting import (
+    classification_identity,
+    classification_payload,
+    derive_span_id,
+    validate_acceptance,
+    validate_partition,
+    validate_reason_codes,
+)
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceBatch,
+    AcceptanceRecord,
+    ClassificationLedger,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    NON_MECHANICAL_REASONS,
+    canonical_span_text,
+    semantic_policy_hash,
+)
+
+LEAF = "leaf-0001"
+
+
+def _span(
+    start: int,
+    end: int,
+    disposition: SemanticDisposition = SemanticDisposition.SUBSTANTIVE,
+    *,
+    leaf_id: str = LEAF,
+    review_state: ReviewState = ReviewState.ACCEPTED,
+    reason: str | None = None,
+) -> SemanticSpan:
+    return SemanticSpan(
+        span_id=derive_span_id(leaf_id, start, end),
+        leaf_id=leaf_id,
+        char_start=start,
+        char_end=end,
+        disposition=disposition,
+        review_state=review_state,
+        non_mechanical_reason_code=reason,
+    )
+
+
+def _ledger(
+    spans: tuple[SemanticSpan, ...],
+    *,
+    batches: tuple[AcceptanceBatch, ...] = (),
+    acceptances: tuple[AcceptanceRecord, ...] | None = None,
+) -> ClassificationLedger:
+    if acceptances is None:
+        acceptances = tuple(
+            AcceptanceRecord(
+                span_id=s.span_id,
+                batch_id=None,
+                reviewer="owner",
+                accepted_at="2026-07-31T00:00:00Z",
+            )
+            for s in spans
+        )
+    return ClassificationLedger(
+        package_uuid="pkg-1",
+        release_version="rel-1",
+        policy_version="5d-semantic-policy-1",
+        spans=spans,
+        batches=batches,
+        acceptances=acceptances,
+    )
+
+
+# -- partition ---------------------------------------------------------------
+
+
+def test_gap_free_partition_passes() -> None:
+    spans = (_span(0, 10), _span(10, 25))
+    assert validate_partition(LEAF, 25, spans) == ()
+
+
+def test_uncovered_text_is_a_violation() -> None:
+    findings = validate_partition(LEAF, 25, (_span(0, 10), _span(15, 25)))
+    assert any("uncovered text [10,15)" in f for f in findings)
+
+
+def test_trailing_uncovered_text_is_a_violation() -> None:
+    findings = validate_partition(LEAF, 25, (_span(0, 10),))
+    assert any("uncovered text [10,25)" in f for f in findings)
+
+
+def test_overlapping_spans_are_a_violation() -> None:
+    findings = validate_partition(LEAF, 25, (_span(0, 15), _span(10, 25)))
+    assert any("overlapping span" in f for f in findings)
+
+
+def test_leaf_without_spans_is_a_violation() -> None:
+    assert validate_partition(LEAF, 25, ()) == (f"leaf {LEAF}: no semantic spans",)
+
+
+def test_span_id_must_match_its_range() -> None:
+    forged = SemanticSpan(
+        span_id=derive_span_id(LEAF, 0, 5),  # id for a different range
+        leaf_id=LEAF,
+        char_start=0,
+        char_end=25,
+        disposition=SemanticDisposition.SUBSTANTIVE,
+        review_state=ReviewState.ACCEPTED,
+    )
+    findings = validate_partition(LEAF, 25, (forged,))
+    assert any("does not match its range" in f for f in findings)
+
+
+def test_span_id_does_not_churn_when_a_sibling_is_inserted() -> None:
+    before = _span(10, 25)
+    after = _span(10, 25)  # same leaf + range, unrelated sibling added elsewhere
+    assert before.span_id == after.span_id
+
+
+# -- reason codes ------------------------------------------------------------
+
+
+def test_non_mechanical_requires_a_closed_reason() -> None:
+    findings = validate_reason_codes(
+        (_span(0, 10, SemanticDisposition.NON_MECHANICAL),)
+    )
+    assert any("without reason" in f for f in findings)
+
+
+def test_reason_invented_after_the_fact_is_rejected() -> None:
+    findings = validate_reason_codes(
+        (_span(0, 10, SemanticDisposition.NON_MECHANICAL, reason="looked_boring"),)
+    )
+    assert any("not in the closed catalog" in f for f in findings)
+
+
+def test_closed_reason_passes() -> None:
+    code = NON_MECHANICAL_REASONS[0].code
+    assert (
+        validate_reason_codes(
+            (_span(0, 10, SemanticDisposition.NON_MECHANICAL, reason=code),)
+        )
+        == ()
+    )
+
+
+def test_reason_on_a_substantive_span_is_rejected() -> None:
+    findings = validate_reason_codes((_span(0, 10, reason="legal_licensing"),))
+    assert any("on a substantive span" in f for f in findings)
+
+
+# -- acceptance --------------------------------------------------------------
+
+
+def test_accepted_ledger_passes() -> None:
+    assert validate_acceptance(_ledger((_span(0, 10),))) == ()
+
+
+def test_span_without_acceptance_evidence_is_blocked() -> None:
+    span = _span(0, 10)
+    findings = validate_acceptance(_ledger((span,), acceptances=()))
+    assert any("no acceptance record" in f for f in findings)
+
+
+def test_proposed_span_is_blocked_even_with_an_acceptance_row() -> None:
+    span = _span(0, 10, review_state=ReviewState.PROPOSED)
+    findings = validate_acceptance(_ledger((span,)))
+    assert any("review state proposed" in f for f in findings)
+
+
+def test_unresolved_span_blocks_publication() -> None:
+    findings = validate_acceptance(
+        _ledger((_span(0, 10, SemanticDisposition.UNRESOLVED),))
+    )
+    assert any("unresolved classification" in f for f in findings)
+
+
+def test_batch_acceptance_records_rule_scope_and_diff() -> None:
+    span = _span(0, 10)
+    batch = AcceptanceBatch(
+        batch_id="batch-1",
+        rule="running footers on every page are navigation-only",
+        scope=("container:page-footer",),
+        semantic_diff_hash="a" * 64,
+    )
+    ledger = _ledger(
+        (span,),
+        batches=(batch,),
+        acceptances=(
+            AcceptanceRecord(
+                span_id=span.span_id,
+                batch_id="batch-1",
+                reviewer="owner",
+                accepted_at="2026-07-31T00:00:00Z",
+            ),
+        ),
+    )
+    assert validate_acceptance(ledger) == ()
+
+
+def test_batch_without_rule_scope_or_diff_is_not_acceptance() -> None:
+    span = _span(0, 10)
+    batch = AcceptanceBatch(
+        batch_id="batch-1", rule="  ", scope=(), semantic_diff_hash=""
+    )
+    ledger = _ledger(
+        (span,),
+        batches=(batch,),
+        acceptances=(
+            AcceptanceRecord(
+                span_id=span.span_id,
+                batch_id="batch-1",
+                reviewer="owner",
+                accepted_at="2026-07-31T00:00:00Z",
+            ),
+        ),
+    )
+    findings = validate_acceptance(ledger)
+    assert any("no acceptance rule recorded" in f for f in findings)
+    assert any("no acceptance scope recorded" in f for f in findings)
+    assert any("no semantic diff recorded" in f for f in findings)
+
+
+def test_acceptance_naming_an_unknown_batch_is_rejected() -> None:
+    span = _span(0, 10)
+    ledger = _ledger(
+        (span,),
+        acceptances=(
+            AcceptanceRecord(
+                span_id=span.span_id,
+                batch_id="ghost",
+                reviewer="owner",
+                accepted_at="2026-07-31T00:00:00Z",
+            ),
+        ),
+    )
+    assert any("unknown batch" in f for f in validate_acceptance(ledger))
+
+
+# -- identity ----------------------------------------------------------------
+
+
+def test_identity_ignores_reviewer_and_timestamp() -> None:
+    span = _span(0, 10)
+    first = _ledger(
+        (span,),
+        acceptances=(
+            AcceptanceRecord(span.span_id, None, "alex", "2026-07-31T00:00:00Z"),
+        ),
+    )
+    second = _ledger(
+        (span,),
+        acceptances=(
+            AcceptanceRecord(span.span_id, None, "sam", "2026-08-02T12:34:56Z"),
+        ),
+    )
+    assert classification_identity(first) == classification_identity(second)
+
+
+def test_identity_changes_when_a_disposition_changes() -> None:
+    base = _ledger((_span(0, 10),))
+    changed = _ledger((_span(0, 10, SemanticDisposition.SUPPORTING_AUTHORITY),))
+    assert classification_identity(base) != classification_identity(changed)
+
+
+def test_identity_changes_when_a_batch_rule_changes() -> None:
+    span = _span(0, 10)
+    acceptances = (
+        AcceptanceRecord(span.span_id, "b1", "owner", "2026-07-31T00:00:00Z"),
+    )
+    first = _ledger(
+        (span,),
+        batches=(AcceptanceBatch("b1", "rule A", ("s",), "a" * 64),),
+        acceptances=acceptances,
+    )
+    second = _ledger(
+        (span,),
+        batches=(AcceptanceBatch("b1", "rule B", ("s",), "a" * 64),),
+        acceptances=acceptances,
+    )
+    assert classification_identity(first) != classification_identity(second)
+
+
+def test_identity_is_order_independent() -> None:
+    a, b = _span(0, 10), _span(10, 25)
+    assert classification_identity(_ledger((a, b))) == classification_identity(
+        _ledger((b, a))
+    )
+
+
+def test_payload_binds_the_frozen_policy_hash() -> None:
+    payload = classification_payload(_ledger((_span(0, 10),)))
+    assert payload["semantic_policy_hash"] == semantic_policy_hash()
+
+
+# -- canonicalization --------------------------------------------------------
+
+
+def test_canonical_span_text_uses_the_corpus_normalization() -> None:
+    # Ligature + typographic quote + whitespace run all fold, so a span's
+    # equivalence matches what the 5c corpus layer already considers equal.
+    assert canonical_span_text("the ﬁre  ’bolt’", 0, 15) == "the fire 'bolt'"

--- a/tests/ingestion/mechanical/test_accounting.py
+++ b/tests/ingestion/mechanical/test_accounting.py
@@ -3,13 +3,20 @@
 The positive cases are cheap; the negative controls are the point. Each one
 below is a way an empty or dishonest classification could otherwise pass:
 uncovered text, double-claimed text, a reason code invented after the fact, a
-row that says "accepted" with nothing behind it, and a batch acceptance that
-records no rule, scope, or diff.
+row that says "accepted" with nothing behind it, and a batch acceptance whose
+retained evidence does not support what it claims.
+
+The identity tests fix the other boundary: the accepted semantic *result* is
+identity-bearing, and the review path that reached it is not.
 """
 
 from __future__ import annotations
 
+import pytest
+
+from afterworlds.ingestion.mechanical import accounting
 from afterworlds.ingestion.mechanical.accounting import (
+    batch_diff_hash,
     classification_identity,
     classification_payload,
     derive_span_id,
@@ -22,6 +29,7 @@ from afterworlds.ingestion.mechanical.models import (
     AcceptanceRecord,
     ClassificationLedger,
     ReviewState,
+    SemanticDiffEntry,
     SemanticDisposition,
     SemanticSpan,
 )
@@ -51,6 +59,52 @@ def _span(
         disposition=disposition,
         review_state=review_state,
         non_mechanical_reason_code=reason,
+    )
+
+
+def _batch(
+    spans: tuple[SemanticSpan, ...],
+    *,
+    batch_id: str = "batch-1",
+    rule: str = "running footers are navigation-only",
+    scope: tuple[str, ...] | None = None,
+    diff: tuple[SemanticDiffEntry, ...] | None = None,
+    digest: str | None = None,
+) -> AcceptanceBatch:
+    """A batch whose retained diff matches *spans* unless overridden."""
+    if diff is None:
+        diff = tuple(
+            SemanticDiffEntry(
+                span_id=s.span_id,
+                prior_disposition=None,
+                prior_reason_code=None,
+                accepted_disposition=s.disposition,
+                accepted_reason_code=s.non_mechanical_reason_code,
+            )
+            for s in spans
+        )
+    batch = AcceptanceBatch(
+        batch_id=batch_id,
+        rule=rule,
+        resolved_scope=scope if scope is not None else tuple(s.span_id for s in spans),
+        diff=diff,
+        semantic_diff_hash="",
+    )
+    return AcceptanceBatch(
+        batch_id=batch.batch_id,
+        rule=batch.rule,
+        resolved_scope=batch.resolved_scope,
+        diff=batch.diff,
+        semantic_diff_hash=digest if digest is not None else batch_diff_hash(batch),
+    )
+
+
+def _batch_acceptances(
+    spans: tuple[SemanticSpan, ...], batch_id: str
+) -> tuple[AcceptanceRecord, ...]:
+    return tuple(
+        AcceptanceRecord(s.span_id, batch_id, "owner", "2026-07-31T00:00:00Z")
+        for s in spans
     )
 
 
@@ -184,50 +238,158 @@ def test_unresolved_span_blocks_publication() -> None:
     assert any("unresolved classification" in f for f in findings)
 
 
-def test_batch_acceptance_records_rule_scope_and_diff() -> None:
-    span = _span(0, 10)
-    batch = AcceptanceBatch(
-        batch_id="batch-1",
-        rule="running footers on every page are navigation-only",
-        scope=("container:page-footer",),
-        semantic_diff_hash="a" * 64,
-    )
+def test_batch_acceptance_with_retained_diff_passes() -> None:
+    spans = (_span(0, 10),)
+    batch = _batch(spans)
     ledger = _ledger(
-        (span,),
-        batches=(batch,),
-        acceptances=(
-            AcceptanceRecord(
-                span_id=span.span_id,
-                batch_id="batch-1",
-                reviewer="owner",
-                accepted_at="2026-07-31T00:00:00Z",
-            ),
-        ),
+        spans, batches=(batch,), acceptances=_batch_acceptances(spans, "batch-1")
     )
     assert validate_acceptance(ledger) == ()
 
 
 def test_batch_without_rule_scope_or_diff_is_not_acceptance() -> None:
-    span = _span(0, 10)
-    batch = AcceptanceBatch(
-        batch_id="batch-1", rule="  ", scope=(), semantic_diff_hash=""
+    spans = (_span(0, 10),)
+    empty = AcceptanceBatch(
+        batch_id="batch-1",
+        rule="  ",
+        resolved_scope=(),
+        diff=(),
+        semantic_diff_hash="",
     )
-    ledger = _ledger(
-        (span,),
-        batches=(batch,),
-        acceptances=(
-            AcceptanceRecord(
-                span_id=span.span_id,
-                batch_id="batch-1",
-                reviewer="owner",
-                accepted_at="2026-07-31T00:00:00Z",
+    findings = validate_acceptance(
+        _ledger(
+            spans,
+            batches=(empty,),
+            acceptances=_batch_acceptances(spans, "batch-1"),
+        )
+    )
+    assert any("no acceptance rule recorded" in f for f in findings)
+    assert any("no resolved scope recorded" in f for f in findings)
+    assert any("no semantic diff retained" in f for f in findings)
+
+
+def test_duplicate_batch_ids_are_rejected() -> None:
+    spans = (_span(0, 10),)
+    batch = _batch(spans)
+    findings = validate_acceptance(
+        _ledger(
+            spans,
+            batches=(batch, batch),
+            acceptances=_batch_acceptances(spans, "batch-1"),
+        )
+    )
+    assert any("duplicate batch id" in f for f in findings)
+
+
+def test_unknown_span_in_batch_scope_is_rejected() -> None:
+    spans = (_span(0, 10),)
+    batch = _batch(spans, scope=(spans[0].span_id, "ghost-span"))
+    findings = validate_acceptance(
+        _ledger(
+            spans, batches=(batch,), acceptances=_batch_acceptances(spans, "batch-1")
+        )
+    )
+    assert any("scope names unknown span ghost-span" in f for f in findings)
+
+
+def test_scope_member_without_a_diff_entry_is_rejected() -> None:
+    covered, uncovered = _span(0, 10), _span(10, 25)
+    spans = (covered, uncovered)
+    # Scope claims both spans; the retained diff only accounts for one.
+    batch = _batch(
+        spans,
+        scope=(covered.span_id, uncovered.span_id),
+        diff=(
+            SemanticDiffEntry(
+                span_id=covered.span_id,
+                prior_disposition=None,
+                prior_reason_code=None,
+                accepted_disposition=covered.disposition,
+                accepted_reason_code=None,
             ),
         ),
     )
-    findings = validate_acceptance(ledger)
-    assert any("no acceptance rule recorded" in f for f in findings)
-    assert any("no acceptance scope recorded" in f for f in findings)
-    assert any("no semantic diff recorded" in f for f in findings)
+    findings = validate_acceptance(
+        _ledger(
+            spans, batches=(batch,), acceptances=_batch_acceptances(spans, "batch-1")
+        )
+    )
+    assert any("has no accepted diff entry" in f for f in findings)
+
+
+def test_diff_entry_outside_the_resolved_scope_is_rejected() -> None:
+    inside, outside = _span(0, 10), _span(10, 25)
+    spans = (inside, outside)
+    batch = _batch(spans, scope=(inside.span_id,))
+    findings = validate_acceptance(
+        _ledger(
+            spans,
+            batches=(batch,),
+            acceptances=_batch_acceptances((inside,), "batch-1")
+            + (
+                AcceptanceRecord(
+                    outside.span_id, None, "owner", "2026-07-31T00:00:00Z"
+                ),
+            ),
+        )
+    )
+    assert any("outside resolved scope" in f for f in findings)
+
+
+def test_acceptance_outside_its_batch_scope_is_rejected() -> None:
+    inside, stranger = _span(0, 10), _span(10, 25)
+    spans = (inside, stranger)
+    batch = _batch((inside,))
+    findings = validate_acceptance(
+        _ledger(
+            spans,
+            batches=(batch,),
+            acceptances=_batch_acceptances(spans, "batch-1"),
+        )
+    )
+    assert any("outside the resolved scope of batch" in f for f in findings)
+
+
+def test_diff_disagreeing_with_the_accepted_ledger_is_rejected() -> None:
+    spans = (_span(0, 10),)
+    batch = _batch(
+        spans,
+        diff=(
+            SemanticDiffEntry(
+                span_id=spans[0].span_id,
+                prior_disposition=SemanticDisposition.SUBSTANTIVE,
+                prior_reason_code=None,
+                # Claims an acceptance the ledger does not carry.
+                accepted_disposition=SemanticDisposition.NON_MECHANICAL,
+                accepted_reason_code="navigation_only",
+            ),
+        ),
+    )
+    findings = validate_acceptance(
+        _ledger(
+            spans, batches=(batch,), acceptances=_batch_acceptances(spans, "batch-1")
+        )
+    )
+    assert any("ledger has substantive" in f for f in findings)
+
+
+def test_forged_semantic_diff_digest_is_rejected() -> None:
+    spans = (_span(0, 10),)
+    batch = _batch(spans, digest="f" * 64)
+    findings = validate_acceptance(
+        _ledger(
+            spans, batches=(batch,), acceptances=_batch_acceptances(spans, "batch-1")
+        )
+    )
+    assert any("digest does not match retained diff" in f for f in findings)
+
+
+def test_acceptance_without_reviewer_or_timestamp_is_rejected() -> None:
+    span = _span(0, 10)
+    findings = validate_acceptance(
+        _ledger((span,), acceptances=(AcceptanceRecord(span.span_id, None, " ", ""),))
+    )
+    assert any("without reviewer/timestamp evidence" in f for f in findings)
 
 
 def test_acceptance_naming_an_unknown_batch_is_rejected() -> None:
@@ -266,28 +428,85 @@ def test_identity_ignores_reviewer_and_timestamp() -> None:
     assert classification_identity(first) == classification_identity(second)
 
 
+def test_identity_ignores_individual_versus_batch_review() -> None:
+    spans = (_span(0, 10), _span(10, 25))
+    individually_reviewed = _ledger(spans)
+    batch_reviewed = _ledger(
+        spans,
+        batches=(_batch(spans),),
+        acceptances=_batch_acceptances(spans, "batch-1"),
+    )
+    assert validate_acceptance(individually_reviewed) == ()
+    assert validate_acceptance(batch_reviewed) == ()
+    assert classification_identity(individually_reviewed) == classification_identity(
+        batch_reviewed
+    )
+
+
+def test_identity_ignores_batch_grouping_and_rule_wording() -> None:
+    a, b = _span(0, 10), _span(10, 25)
+    spans = (a, b)
+    one_batch = _ledger(
+        spans,
+        batches=(_batch(spans, rule="everything on this page"),),
+        acceptances=_batch_acceptances(spans, "batch-1"),
+    )
+    two_batches = _ledger(
+        spans,
+        batches=(
+            _batch((a,), batch_id="first", rule="the opening clause"),
+            _batch((b,), batch_id="second", rule="the trailing clause"),
+        ),
+        acceptances=_batch_acceptances((a,), "first")
+        + _batch_acceptances((b,), "second"),
+    )
+    assert validate_acceptance(one_batch) == ()
+    assert validate_acceptance(two_batches) == ()
+    assert classification_identity(one_batch) == classification_identity(two_batches)
+
+
 def test_identity_changes_when_a_disposition_changes() -> None:
     base = _ledger((_span(0, 10),))
     changed = _ledger((_span(0, 10, SemanticDisposition.SUPPORTING_AUTHORITY),))
     assert classification_identity(base) != classification_identity(changed)
 
 
-def test_identity_changes_when_a_batch_rule_changes() -> None:
+def test_identity_changes_when_a_span_boundary_changes() -> None:
+    base = _ledger((_span(0, 10), _span(10, 25)))
+    changed = _ledger((_span(0, 12), _span(12, 25)))
+    assert classification_identity(base) != classification_identity(changed)
+
+
+def test_identity_changes_when_a_reason_assignment_changes() -> None:
+    base = _ledger(
+        (_span(0, 10, SemanticDisposition.NON_MECHANICAL, reason="navigation_only"),)
+    )
+    changed = _ledger(
+        (_span(0, 10, SemanticDisposition.NON_MECHANICAL, reason="flavor_setting"),)
+    )
+    assert classification_identity(base) != classification_identity(changed)
+
+
+def test_identity_changes_when_the_semantic_policy_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ledger = _ledger((_span(0, 10),))
+    before = classification_identity(ledger)
+    monkeypatch.setattr(accounting, "semantic_policy_hash", lambda: "0" * 64)
+    assert classification_identity(ledger) != before
+
+
+def test_identity_ignores_acceptance_history_entirely() -> None:
     span = _span(0, 10)
-    acceptances = (
-        AcceptanceRecord(span.span_id, "b1", "owner", "2026-07-31T00:00:00Z"),
+    payload = classification_payload(
+        _ledger(
+            (span,),
+            batches=(_batch((span,)),),
+            acceptances=_batch_acceptances((span,), "batch-1"),
+        )
     )
-    first = _ledger(
-        (span,),
-        batches=(AcceptanceBatch("b1", "rule A", ("s",), "a" * 64),),
-        acceptances=acceptances,
-    )
-    second = _ledger(
-        (span,),
-        batches=(AcceptanceBatch("b1", "rule B", ("s",), "a" * 64),),
-        acceptances=acceptances,
-    )
-    assert classification_identity(first) != classification_identity(second)
+    assert "batches" not in payload
+    assert "acceptances" not in payload
 
 
 def test_identity_is_order_independent() -> None:

--- a/tests/ingestion/mechanical/test_accounting.py
+++ b/tests/ingestion/mechanical/test_accounting.py
@@ -22,6 +22,7 @@ from afterworlds.ingestion.mechanical.accounting import (
     derive_span_id,
     validate_acceptance,
     validate_partition,
+    validate_policy_binding,
     validate_reason_codes,
 )
 from afterworlds.ingestion.mechanical.models import (
@@ -35,6 +36,7 @@ from afterworlds.ingestion.mechanical.models import (
 )
 from afterworlds.ingestion.mechanical.policy import (
     NON_MECHANICAL_REASONS,
+    SEMANTIC_POLICY_VERSION,
     canonical_span_text,
     semantic_policy_hash,
 )
@@ -113,6 +115,8 @@ def _ledger(
     *,
     batches: tuple[AcceptanceBatch, ...] = (),
     acceptances: tuple[AcceptanceRecord, ...] | None = None,
+    policy_version: str = SEMANTIC_POLICY_VERSION,
+    policy_hash: str | None = None,
 ) -> ClassificationLedger:
     if acceptances is None:
         acceptances = tuple(
@@ -127,7 +131,8 @@ def _ledger(
     return ClassificationLedger(
         package_uuid="pkg-1",
         release_version="rel-1",
-        policy_version="5d-semantic-policy-1",
+        policy_version=policy_version,
+        policy_hash=policy_hash if policy_hash is not None else semantic_policy_hash(),
         spans=spans,
         batches=batches,
         acceptances=acceptances,
@@ -384,6 +389,55 @@ def test_forged_semantic_diff_digest_is_rejected() -> None:
     assert any("digest does not match retained diff" in f for f in findings)
 
 
+def test_orphan_batch_with_no_acceptance_records_is_rejected() -> None:
+    spans = (_span(0, 10),)
+    findings = validate_acceptance(_ledger(spans, batches=(_batch(spans),)))
+    assert any("no acceptance record names this batch" in f for f in findings)
+
+
+def test_scope_member_accepted_individually_is_rejected() -> None:
+    a, b = _span(0, 10), _span(10, 25)
+    spans = (a, b)
+    # The batch claims both spans, but only one was accepted under it.
+    findings = validate_acceptance(
+        _ledger(
+            spans,
+            batches=(_batch(spans),),
+            acceptances=_batch_acceptances((a,), "batch-1")
+            + (AcceptanceRecord(b.span_id, None, "owner", "2026-07-31T00:00:00Z"),),
+        )
+    )
+    assert any("was accepted individually" in f for f in findings)
+
+
+def test_scope_member_accepted_under_another_batch_is_rejected() -> None:
+    a, b = _span(0, 10), _span(10, 25)
+    spans = (a, b)
+    findings = validate_acceptance(
+        _ledger(
+            spans,
+            batches=(
+                _batch(spans, batch_id="claiming"),
+                _batch((b,), batch_id="actual"),
+            ),
+            acceptances=_batch_acceptances((a,), "claiming")
+            + _batch_acceptances((b,), "actual"),
+        )
+    )
+    assert any("was accepted under batch actual" in f for f in findings)
+
+
+def test_duplicate_span_ids_in_resolved_scope_are_rejected() -> None:
+    spans = (_span(0, 10),)
+    batch = _batch(spans, scope=(spans[0].span_id, spans[0].span_id))
+    findings = validate_acceptance(
+        _ledger(
+            spans, batches=(batch,), acceptances=_batch_acceptances(spans, "batch-1")
+        )
+    )
+    assert any("duplicate span ids in resolved scope" in f for f in findings)
+
+
 def test_acceptance_without_reviewer_or_timestamp_is_rejected() -> None:
     span = _span(0, 10)
     findings = validate_acceptance(
@@ -487,13 +541,29 @@ def test_identity_changes_when_a_reason_assignment_changes() -> None:
     assert classification_identity(base) != classification_identity(changed)
 
 
-def test_identity_changes_when_the_semantic_policy_changes(
+def test_identity_changes_when_the_semantic_policy_changes() -> None:
+    ledger = _ledger((_span(0, 10),))
+    under_other_policy = _ledger(
+        (_span(0, 10),), policy_version="5d-semantic-policy-0", policy_hash="0" * 64
+    )
+    assert classification_identity(ledger) != classification_identity(
+        under_other_policy
+    )
+
+
+def test_identity_uses_the_declared_policy_not_current_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # A later policy edit must not silently re-identify a historical ledger:
+    # the payload states what the ledger declared, and validation is what
+    # catches the disagreement.
     ledger = _ledger((_span(0, 10),))
     before = classification_identity(ledger)
     monkeypatch.setattr(accounting, "semantic_policy_hash", lambda: "0" * 64)
-    assert classification_identity(ledger) != before
+    assert classification_identity(ledger) == before
+    assert any(
+        "committed policy hashes to" in f for f in validate_policy_binding(ledger)
+    )
 
 
 def test_identity_ignores_acceptance_history_entirely() -> None:
@@ -516,9 +586,30 @@ def test_identity_is_order_independent() -> None:
     )
 
 
-def test_payload_binds_the_frozen_policy_hash() -> None:
-    payload = classification_payload(_ledger((_span(0, 10),)))
-    assert payload["semantic_policy_hash"] == semantic_policy_hash()
+def test_payload_binds_the_declared_policy_hash() -> None:
+    ledger = _ledger((_span(0, 10),))
+    payload = classification_payload(ledger)
+    assert payload["semantic_policy_hash"] == ledger.policy_hash
+    assert payload["semantic_policy_version"] == ledger.policy_version
+
+
+# -- declared policy binding -------------------------------------------------
+
+
+def test_matching_policy_declaration_passes() -> None:
+    assert validate_policy_binding(_ledger((_span(0, 10),))) == ()
+
+
+def test_stale_declared_policy_version_is_rejected() -> None:
+    ledger = _ledger((_span(0, 10),), policy_version="5d-semantic-policy-0")
+    assert any("build uses" in f for f in validate_policy_binding(ledger))
+
+
+def test_mismatched_declared_policy_hash_is_rejected() -> None:
+    ledger = _ledger((_span(0, 10),), policy_hash="0" * 64)
+    assert any(
+        "committed policy hashes to" in f for f in validate_policy_binding(ledger)
+    )
 
 
 # -- canonicalization --------------------------------------------------------

--- a/tests/ingestion/mechanical/test_bound_corpus.py
+++ b/tests/ingestion/mechanical/test_bound_corpus.py
@@ -178,3 +178,41 @@ def test_unknown_package_resolves_to_an_empty_snapshot(session: Session) -> None
     snapshot = load_bound_corpus(session, "pkg-missing", "rel-1")
     assert snapshot.leaf_lengths == {}
     assert snapshot.authoritative_chunk_ids == frozenset()
+
+
+def test_coverage_edges_round_trip_from_real_projection_rows(session: Session) -> None:
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    edges = {
+        (c.chunk_id, c.leaf_id, c.cover_start, c.cover_end, c.role)
+        for c in snapshot.chunk_coverage
+    }
+    assert edges == {("chunk-projected", "leaf-represented", 0, 10, "primary")}
+    # projection_id survives too, so the relation is not a lossy copy.
+    assert all(c.projection_id for c in snapshot.chunk_coverage)
+
+
+def test_phantom_and_unprojected_chunks_carry_no_coverage(session: Session) -> None:
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    assert not snapshot.covers_span("chunk-phantom", "leaf-represented", 0, 5)
+    assert not snapshot.covers_span("chunk-unprojected", "leaf-represented", 0, 5)
+    assert "chunk-phantom" not in snapshot.authoritative_chunk_ids
+    assert "chunk-unprojected" not in snapshot.authoritative_chunk_ids
+
+
+def test_coverage_answers_containment_for_the_bound_release(session: Session) -> None:
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    assert snapshot.covers_span("chunk-projected", "leaf-represented", 0, 10)
+    assert snapshot.covers_span("chunk-projected", "leaf-represented", 2, 8)
+    assert not snapshot.covers_span("chunk-projected", "leaf-represented", 0, 11)
+    assert not snapshot.covers_span("chunk-projected", "leaf-elsewhere", 0, 5)
+
+
+def test_another_packages_projection_edges_are_never_read(session: Session) -> None:
+    # The validator must not claim to resolve one release while reading
+    # another package's edges.
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    assert all(c.chunk_id != "chunk-other-package" for c in snapshot.chunk_coverage)
+    other = load_bound_corpus(session, OTHER, "rel-1")
+    assert other.authoritative_chunk_ids == frozenset({"chunk-other-package"})
+    assert other.covers_span("chunk-other-package", "leaf-elsewhere", 0, 10)
+    assert not other.covers_span("chunk-projected", "leaf-represented", 0, 10)

--- a/tests/ingestion/mechanical/test_bound_corpus.py
+++ b/tests/ingestion/mechanical/test_bound_corpus.py
@@ -1,0 +1,180 @@
+"""Bound-corpus resolution — CRD Issue 5d, against real persisted 5c rows.
+
+The snapshot is the single source of release-scoped truth the validators read,
+so what it includes and excludes decides whether a prose binding resolves to
+real authority. These tests use actual `rp_ledger_leaves`, `rp_chunks`, and
+`rp_corpus_projections` rows rather than a hand-built snapshot.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.bound_corpus import load_bound_corpus
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import (
+    CorpusProjectionORM,
+    CorpusReleaseORM,
+    LedgerLeafORM,
+)
+from afterworlds.persistence.orm.rules_package import (
+    RuleChunkORM,
+    RuleSourceORM,
+    RulesPackageORM,
+)
+
+BOUND = "pkg-bound"
+OTHER = "pkg-other"
+NOW = "2026-07-31T00:00:00Z"
+
+
+def _package(session: Session, package_uuid: str) -> None:
+    session.add(
+        RulesPackageORM(
+            rules_package_id=package_uuid,
+            name=f"SRD ({package_uuid})",
+            system="dnd5e",
+            version="5.2.1",
+            is_enabled=True,
+            publication_status="published",
+            created_at=NOW,
+            updated_at=NOW,
+        )
+    )
+    session.flush()
+    session.add(
+        CorpusReleaseORM(
+            package_uuid=package_uuid,
+            release_version="rel-1",
+            authoritative_source_hash="a" * 64,
+            transform_config_hash="b" * 64,
+            bundle_root_hash="c" * 64,
+            ledger_hash="1" * 64,
+            policy_hash="2" * 64,
+            reconciliation_hash="3" * 64,
+            transform_config={},
+            publication_status="published",
+            created_at=NOW,
+        )
+    )
+    session.add(
+        RuleSourceORM(
+            source_id=f"src-{package_uuid}",
+            rules_package_id=package_uuid,
+            name="SRD",
+            category="core",
+            precedence_rank=1,
+            is_enabled=True,
+            created_at=NOW,
+        )
+    )
+    session.flush()
+
+
+def _leaf(
+    session: Session, package_uuid: str, leaf_id: str, content: str, disposition: str
+) -> None:
+    session.add(
+        LedgerLeafORM(
+            package_uuid=package_uuid,
+            leaf_id=leaf_id,
+            printed_page=1,
+            page_index=0,
+            leaf_type="paragraph",
+            content=content,
+            char_start=0,
+            char_end=len(content),
+            occurrence_index=0,
+            container_path=[],
+            disposition=disposition,
+        )
+    )
+
+
+def _chunk(session: Session, package_uuid: str, chunk_id: str) -> None:
+    session.add(
+        RuleChunkORM(
+            chunk_id=chunk_id,
+            rules_package_id=package_uuid,
+            source_id=f"src-{package_uuid}",
+            subsystem="general",
+            content="governing prose",
+            source_document="SRD",
+            source_locator_type="page",
+            source_locator_value="1",
+            created_at=NOW,
+        )
+    )
+
+
+def _projected(
+    session: Session, package_uuid: str, chunk_id: str, leaf_id: str
+) -> None:
+    session.add(
+        CorpusProjectionORM(
+            package_uuid=package_uuid,
+            projection_id=f"proj-{chunk_id}",
+            leaf_id=leaf_id,
+            chunk_id=chunk_id,
+            role="primary",
+            cover_start=0,
+            cover_end=10,
+        )
+    )
+
+
+@pytest.fixture()
+def session(tmp_path) -> Iterator[Session]:  # type: ignore[no-untyped-def]
+    engine = create_engine(f"sqlite:///{tmp_path / 'corpus.db'}")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as s:
+        _package(s, BOUND)
+        _package(s, OTHER)
+
+        _leaf(s, BOUND, "leaf-represented", "twelve chars", "represented")
+        _leaf(s, BOUND, "leaf-excluded", "excluded text", "excluded")
+        _leaf(s, OTHER, "leaf-elsewhere", "other package", "represented")
+
+        _chunk(s, BOUND, "chunk-projected")
+        _chunk(s, BOUND, "chunk-unprojected")
+        _chunk(s, OTHER, "chunk-other-package")
+        _projected(s, BOUND, "chunk-projected", "leaf-represented")
+        # Projected in the other package only.
+        _projected(s, OTHER, "chunk-other-package", "leaf-elsewhere")
+        # Declared projected here but with no chunk row behind it.
+        _projected(s, BOUND, "chunk-phantom", "leaf-represented")
+        s.flush()
+        yield s
+
+
+def test_leaf_lengths_cover_only_the_represented_population(session: Session) -> None:
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    # 5c exclusions stay excluded: an excluded leaf is neither required to be
+    # classified nor allowed to be.
+    assert snapshot.leaf_lengths == {"leaf-represented": len("twelve chars")}
+
+
+def test_snapshot_is_scoped_to_the_bound_package(session: Session) -> None:
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    assert "leaf-elsewhere" not in snapshot.leaf_lengths
+    assert "chunk-other-package" not in snapshot.authoritative_chunk_ids
+
+
+def test_authoritative_chunks_require_both_halves(session: Session) -> None:
+    snapshot = load_bound_corpus(session, BOUND, "rel-1")
+    # Projected *and* persisted under this package.
+    assert snapshot.authoritative_chunk_ids == frozenset({"chunk-projected"})
+    # Exists in rp_chunks but was never projected into this release.
+    assert "chunk-unprojected" not in snapshot.authoritative_chunk_ids
+    # Projected but has no chunk row behind it.
+    assert "chunk-phantom" not in snapshot.authoritative_chunk_ids
+
+
+def test_unknown_package_resolves_to_an_empty_snapshot(session: Session) -> None:
+    snapshot = load_bound_corpus(session, "pkg-missing", "rel-1")
+    assert snapshot.leaf_lengths == {}
+    assert snapshot.authoritative_chunk_ids == frozenset()

--- a/tests/ingestion/mechanical/test_canonical_ordering.py
+++ b/tests/ingestion/mechanical/test_canonical_ordering.py
@@ -1,0 +1,243 @@
+"""Authoring order never reaches the identity — CRD Issue 5d, review round 3.
+
+The defect these cover is structural, not a list of examples: a sort key that
+names some fields makes two semantically different elements compare equal, and
+Python's stable sort then leaks the order they were written in into the
+projection UUID. So the tests are permutation-driven — every unordered
+collection, every permutation, one assertion — rather than one test per
+handwritten tuple.
+"""
+
+from __future__ import annotations
+
+from itertools import permutations
+from typing import Any
+
+import pytest
+
+from afterworlds.ingestion.mechanical.accounting import classification_payload
+from afterworlds.ingestion.mechanical.canonical import canonical_order
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    projection_payload,
+    projection_uuid,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    ComponentDraft,
+    DcKind,
+    ProseBindingDraft,
+    ProvenanceRole,
+    ReferenceDraft,
+    RelationshipDraft,
+    RelationshipKind,
+)
+from tests.ingestion.mechanical.conftest import (
+    CREATURE_KEY,
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_KEY,
+    OPEN_ENDED_KEY,
+    PROSE_SPAN,
+    SECOND_CHUNK,
+    SPELL_KEY,
+    WISH_CHUNK,
+    binding_claim,
+    build_candidate,
+    build_ledger,
+    build_representation,
+    reference_claim,
+)
+
+# Collections whose order carries no meaning, and therefore must not reach the
+# identity. `resolved_scope` is deliberately absent: it is retained reviewer
+# evidence whose order *is* meaningful.
+UNORDERED = (
+    "records",
+    "components",
+    "prose_bindings",
+    "relationships",
+    "references",
+    "provenance",
+)
+
+
+def _candidate(**overrides: object) -> ProjectionCandidate:
+    return build_candidate(**overrides)
+
+
+def _permuted(draft: Any, field: str, order: tuple[int, ...]) -> dict[str, Any]:
+    items = getattr(draft, field)
+    return {field: tuple(items[i] for i in order)}
+
+
+@pytest.mark.parametrize("field", UNORDERED)
+def test_reordering_an_unordered_collection_changes_nothing(field: str) -> None:
+    draft = build_representation()
+    base = _candidate()
+    baseline_payload = projection_payload(base)
+    baseline_uuid = projection_uuid(base)
+
+    for order in permutations(range(len(getattr(draft, field)))):
+        candidate = _candidate(**_permuted(draft, field, order))
+        assert projection_payload(candidate) == baseline_payload, field
+        assert projection_uuid(candidate) == baseline_uuid, field
+
+
+def test_reordering_facts_within_a_component_changes_nothing() -> None:
+    facts = (
+        DESCRIPTOR_FACT,
+        AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED, 15),
+    )
+    forward, reverse = (
+        _candidate(
+            components=(
+                ComponentDraft(
+                    SPELL_KEY,
+                    DESCRIPTOR_KEY,
+                    ComponentHandling.STRUCTURED,
+                    facts=ordered,
+                ),
+                build_representation().components[1],
+            )
+        )
+        for ordered in (facts, tuple(reversed(facts)))
+    )
+    assert projection_payload(forward) == projection_payload(reverse)
+    assert projection_uuid(forward) == projection_uuid(reverse)
+
+
+def test_reordering_classification_spans_changes_nothing() -> None:
+    spans = build_ledger().spans
+    for order in permutations(range(len(spans))):
+        permuted = build_ledger(spans=tuple(spans[i] for i in order))
+        assert classification_payload(permuted) == classification_payload(
+            build_ledger()
+        )
+
+
+# -- the exact collisions the partial sort keys allowed ----------------------
+
+
+def _two_reference_candidates(a: ReferenceDraft, b: ReferenceDraft) -> tuple[str, str]:
+    base = build_representation().provenance
+    forward = _candidate(
+        references=(a, b), provenance=base + (reference_claim(a), reference_claim(b))
+    )
+    reverse = _candidate(
+        references=(b, a), provenance=base + (reference_claim(b), reference_claim(a))
+    )
+    return projection_uuid(forward), projection_uuid(reverse)
+
+
+def test_references_differing_only_in_source_component() -> None:
+    a = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    b = ReferenceDraft(
+        SPELL_KEY, OPEN_ENDED_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    forward, reverse = _two_reference_candidates(a, b)
+    assert forward == reverse
+
+
+def test_references_differing_only_in_target_record() -> None:
+    a = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    b = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", SPELL_KEY
+    )
+    forward, reverse = _two_reference_candidates(a, b)
+    assert forward == reverse
+
+
+def _two_binding_candidates(
+    a: ProseBindingDraft, b: ProseBindingDraft
+) -> tuple[str, str]:
+    base = build_representation().provenance
+    extra = (binding_claim(b, PROSE_SPAN, ProvenanceRole.CONTEXTUAL),)
+    forward = _candidate(prose_bindings=(a, b), provenance=base + extra)
+    reverse = _candidate(prose_bindings=(b, a), provenance=base + extra)
+    return projection_uuid(forward), projection_uuid(reverse)
+
+
+def test_prose_bindings_on_one_component_differing_in_chunk() -> None:
+    a = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect")
+    b = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect")
+    forward, reverse = _two_binding_candidates(a, b)
+    assert forward == reverse
+
+
+def test_prose_bindings_differing_only_in_the_reason() -> None:
+    a = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect")
+    b = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "subjective_judgment")
+    forward, reverse = _two_binding_candidates(a, b)
+    assert forward == reverse
+
+
+def test_relationships_differing_only_in_kind() -> None:
+    a = RelationshipDraft(CREATURE_KEY, SPELL_KEY, RelationshipKind.SCOPED_WITHIN)
+    b = RelationshipDraft(CREATURE_KEY, SPELL_KEY, RelationshipKind.PREREQUISITE)
+    forward = projection_uuid(_candidate(relationships=(a, b)))
+    reverse = projection_uuid(_candidate(relationships=(b, a)))
+    assert forward == reverse
+
+
+# -- ordering must not flatten meaning ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {
+            "references": (
+                ReferenceDraft(
+                    SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+                ),
+            )
+        },
+        {
+            "prose_bindings": (
+                ProseBindingDraft(
+                    OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
+                ),
+            )
+        },
+        {
+            "relationships": (
+                RelationshipDraft(
+                    CREATURE_KEY, SPELL_KEY, RelationshipKind.PREREQUISITE
+                ),
+            )
+        },
+    ],
+)
+def test_changing_an_identity_bearing_value_changes_the_identity(
+    overrides: dict[str, Any],
+) -> None:
+    assert projection_uuid(_candidate(**overrides)) != projection_uuid(_candidate())
+
+
+def test_canonical_order_preserves_duplicates() -> None:
+    # Deduplicating here would hide a duplicate from the validator that exists
+    # to reject it.
+    payloads = [{"a": 1}, {"a": 1}, {"a": 0}]
+    assert canonical_order(payloads) == [{"a": 0}, {"a": 1}, {"a": 1}]
+
+
+def test_canonical_order_is_independent_of_input_order() -> None:
+    payloads = [{"b": 2, "a": 1}, {"a": 1, "b": 3}, {"a": 0, "b": 9}]
+    assert canonical_order(payloads) == canonical_order(list(reversed(payloads)))
+
+
+def test_provenance_claims_differing_only_in_role_are_ordered() -> None:
+    base = build_representation().provenance
+    extra = base[0]
+    swapped = (extra,) + base[1:] + (base[0],)
+    # A duplicated edge is still ordered deterministically even though the
+    # validator rejects it; canonicalization is not where duplicates die.
+    assert projection_payload(_candidate(provenance=swapped)) == projection_payload(
+        _candidate(provenance=tuple(reversed(swapped)))
+    )

--- a/tests/ingestion/mechanical/test_chunk_locality.py
+++ b/tests/ingestion/mechanical/test_chunk_locality.py
@@ -1,0 +1,253 @@
+"""Prose provenance is chunk-local — CRD Issue 5d, review round 4.
+
+The round-3 correction closed provenance over element identity and span
+admissibility, but not over the CRD Issue 5c projection relation. A prose
+binding names an exact chunk and a provenance edge names an exact span; until
+those two are joined, a binding to chunk A could cite a span that only ever
+projected into chunk B and satisfy every check.
+
+The join is possible because both coordinate systems are the same: 5c's
+``cover_start``/``cover_end`` are offsets into the source leaf's content, and a
+5d semantic span indexes that same text.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from afterworlds.ingestion.mechanical.bound_corpus import BoundCorpusSnapshot
+from afterworlds.ingestion.mechanical.representation import (
+    ProseBindingDraft,
+    ProvenanceRole,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from tests.ingestion.mechanical.conftest import (
+    DEFAULT_COVERAGE,
+    OPEN_ENDED_KEY,
+    PROSE_LEAF,
+    PROSE_SPAN,
+    SECOND_CHUNK,
+    SPELL_KEY,
+    SPELL_LEAF,
+    WISH_CHUNK,
+    binding_claim,
+    bound_corpus,
+    build_ledger,
+    build_representation,
+    coverage,
+)
+
+OTHER_CHUNK = "chunk-elsewhere"
+
+
+def _findings(**overrides: object) -> tuple[str, ...]:
+    corpus = overrides.pop("corpus", None)
+    return validate_representation(
+        build_representation(**overrides),
+        build_ledger(),
+        corpus if corpus is not None else bound_corpus(),  # type: ignore[arg-type]
+    )
+
+
+def _binding(chunk_id: str) -> ProseBindingDraft:
+    return ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, chunk_id, "open_ended_effect")
+
+
+def _with_binding(binding: ProseBindingDraft, **kwargs: object) -> tuple[str, ...]:
+    """Findings for a candidate whose sole prose binding is *binding*."""
+    claims = tuple(
+        c
+        for c in build_representation().provenance
+        if c.target_kind.value != "prose_binding"
+    ) + (binding_claim(binding),)
+    return _findings(prose_bindings=(binding,), provenance=claims, **kwargs)
+
+
+# -- negative controls -------------------------------------------------------
+
+
+def test_span_projected_only_into_another_chunk_is_rejected() -> None:
+    corpus = bound_corpus(chunk_coverage=(coverage(SECOND_CHUNK, PROSE_LEAF, 0, 30),))
+    findings = _with_binding(_binding(WISH_CHUNK), corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+def test_disjoint_chunks_on_one_leaf_cannot_borrow_each_others_range() -> None:
+    # A covers [0,10); B covers [10,30). The binding to A claims B's range.
+    corpus = bound_corpus(
+        chunk_coverage=(
+            coverage(WISH_CHUNK, PROSE_LEAF, 0, 10),
+            coverage(SECOND_CHUNK, PROSE_LEAF, 10, 30),
+        )
+    )
+    findings = _with_binding(_binding(WISH_CHUNK), corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+def test_span_extending_beyond_the_chunk_range_is_rejected() -> None:
+    corpus = bound_corpus(chunk_coverage=(coverage(WISH_CHUNK, PROSE_LEAF, 0, 20),))
+    findings = _with_binding(_binding(WISH_CHUNK), corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+def test_span_crossing_a_gap_between_two_ranges_is_rejected() -> None:
+    corpus = bound_corpus(
+        chunk_coverage=(
+            coverage(WISH_CHUNK, PROSE_LEAF, 0, 10),
+            coverage(WISH_CHUNK, PROSE_LEAF, 20, 30),
+        )
+    )
+    findings = _with_binding(_binding(WISH_CHUNK), corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+def test_coverage_on_the_wrong_leaf_is_rejected() -> None:
+    corpus = bound_corpus(chunk_coverage=(coverage(WISH_CHUNK, SPELL_LEAF, 0, 40),))
+    findings = _with_binding(_binding(WISH_CHUNK), corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+def test_non_authoritative_chunk_is_rejected() -> None:
+    findings = _with_binding(_binding(OTHER_CHUNK))
+    assert any("is not authoritative prose of release" in f for f in findings)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+def test_cross_chunk_edge_cannot_satisfy_the_reverse_obligation() -> None:
+    # The binding's only edge is the invalid one, so the reverse obligation
+    # must remain unmet rather than being satisfied by a rejected claim.
+    corpus = bound_corpus(chunk_coverage=(coverage(SECOND_CHUNK, PROSE_LEAF, 0, 30),))
+    findings = _with_binding(_binding(WISH_CHUNK), corpus=corpus)
+    assert any("prose_binding" in f and "no provenance" in f for f in findings)
+
+
+def test_one_valid_edge_does_not_excuse_a_second_invalid_edge() -> None:
+    # Chunk-locality is a property of every edge, not a box ticked once.
+    binding = _binding(WISH_CHUNK)
+    claims = build_representation().provenance + (
+        binding_claim(binding, PROSE_SPAN, ProvenanceRole.CONTEXTUAL),
+    )
+    corpus = bound_corpus(chunk_coverage=(coverage(WISH_CHUNK, PROSE_LEAF, 0, 10),))
+    findings = _findings(prose_bindings=(binding,), provenance=claims, corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+@pytest.mark.parametrize("role", [ProvenanceRole.PRIMARY, ProvenanceRole.CONTEXTUAL])
+def test_both_roles_obey_chunk_locality(role: ProvenanceRole) -> None:
+    binding = _binding(WISH_CHUNK)
+    claims = tuple(
+        c
+        for c in build_representation().provenance
+        if c.target_kind.value != "prose_binding"
+    ) + (
+        binding_claim(binding, PROSE_SPAN, role),
+    )
+    corpus = bound_corpus(chunk_coverage=(coverage(SECOND_CHUNK, PROSE_LEAF, 0, 30),))
+    findings = _findings(prose_bindings=(binding,), provenance=claims, corpus=corpus)
+    assert any("is not covered by bound chunk" in f for f in findings)
+
+
+# -- positive controls -------------------------------------------------------
+
+
+def test_exact_range_equality_passes() -> None:
+    corpus = bound_corpus(chunk_coverage=(coverage(WISH_CHUNK, PROSE_LEAF, 0, 30),))
+    assert _with_binding(_binding(WISH_CHUNK), corpus=corpus) == ()
+
+
+def test_span_inside_a_larger_range_passes() -> None:
+    corpus = bound_corpus(chunk_coverage=(coverage(WISH_CHUNK, PROSE_LEAF, 0, 100),))
+    assert _with_binding(_binding(WISH_CHUNK), corpus=corpus) == ()
+
+
+def test_span_spanning_adjacent_ranges_of_one_chunk_passes() -> None:
+    # Adjacency is continuity: [0,10) then [10,30) has no hole between them.
+    corpus = bound_corpus(
+        chunk_coverage=(
+            coverage(WISH_CHUNK, PROSE_LEAF, 0, 10),
+            coverage(WISH_CHUNK, PROSE_LEAF, 10, 30),
+        )
+    )
+    assert _with_binding(_binding(WISH_CHUNK), corpus=corpus) == ()
+
+
+def test_overlapping_ranges_of_one_chunk_merge() -> None:
+    corpus = bound_corpus(
+        chunk_coverage=(
+            coverage(WISH_CHUNK, PROSE_LEAF, 0, 20),
+            coverage(WISH_CHUNK, PROSE_LEAF, 15, 30),
+        )
+    )
+    assert _with_binding(_binding(WISH_CHUNK), corpus=corpus) == ()
+
+
+def test_two_chunks_may_legitimately_cover_the_same_range() -> None:
+    # Each binding claims only what its own chunk covers; overlapping source
+    # coverage between chunks is legal (5c's attribution-repeat role, and
+    # ordinary shared ranges), and neither binding borrows the other's.
+    first, second = _binding(WISH_CHUNK), _binding(SECOND_CHUNK)
+    claims = build_representation().provenance + (
+        binding_claim(second, PROSE_SPAN, ProvenanceRole.CONTEXTUAL),
+    )
+    assert _findings(prose_bindings=(first, second), provenance=claims) == ()
+
+
+def test_attribution_role_coverage_still_establishes_containment() -> None:
+    # Role is retained but does not decide containment: chunk membership does.
+    # Whether attribution text may serve as governing prose is already decided
+    # by the span's own disposition, which rejects non-mechanical text.
+    corpus = bound_corpus(
+        chunk_coverage=(
+            coverage(WISH_CHUNK, PROSE_LEAF, 0, 30, role="attribution_repeat"),
+        )
+    )
+    assert _with_binding(_binding(WISH_CHUNK), corpus=corpus) == ()
+
+
+def test_the_default_honest_candidate_is_unaffected() -> None:
+    assert _findings() == ()
+
+
+# -- the coverage primitive itself -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        (0, 10, True),  # exact
+        (2, 8, True),  # inside
+        (0, 11, False),  # extends past
+        (10, 20, False),  # outside
+        (5, 5, False),  # empty span is never covered
+    ],
+)
+def test_covers_span_boundaries(start: int, end: int, expected: bool) -> None:
+    snapshot = bound_corpus(chunk_coverage=(coverage(WISH_CHUNK, PROSE_LEAF, 0, 10),))
+    assert snapshot.covers_span(WISH_CHUNK, PROSE_LEAF, start, end) is expected
+
+
+def test_membership_is_derived_from_coverage() -> None:
+    snapshot = bound_corpus()
+    assert snapshot.authoritative_chunk_ids == frozenset({WISH_CHUNK, SECOND_CHUNK})
+    # A snapshot cannot claim a chunk is authoritative while carrying no
+    # coverage for it: there is only one place the answer comes from.
+    empty = bound_corpus(chunk_coverage=())
+    assert empty.authoritative_chunk_ids == frozenset()
+    assert not empty.covers_span(WISH_CHUNK, PROSE_LEAF, 0, 30)
+
+
+def test_default_coverage_is_stated_per_chunk_and_leaf() -> None:
+    # Guards the fixture itself: defaulting every chunk to every leaf would
+    # make the cross-chunk negatives above vacuous.
+    assert {(c.chunk_id, c.leaf_id) for c in DEFAULT_COVERAGE} == {
+        (WISH_CHUNK, PROSE_LEAF),
+        (SECOND_CHUNK, PROSE_LEAF),
+    }
+
+
+def test_snapshot_is_frozen() -> None:
+    snapshot: BoundCorpusSnapshot = bound_corpus()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        snapshot.package_uuid = "other"  # type: ignore[misc]

--- a/tests/ingestion/mechanical/test_digest_recording.py
+++ b/tests/ingestion/mechanical/test_digest_recording.py
@@ -23,7 +23,9 @@ from afterworlds.ingestion.mechanical.persistence import (
     record_persisted_state_digest,
 )
 from afterworlds.ingestion.mechanical.projection import identify_projection
-from afterworlds.ingestion.mechanical.representation import MalformedFactPayloadError
+from afterworlds.ingestion.mechanical.raw_state import (
+    PersistedStateReconstructionError,
+)
 from afterworlds.persistence.database import create_engine, create_session_factory
 from afterworlds.persistence.orm.base import Base
 from afterworlds.persistence.orm.corpus import CorpusReleaseORM
@@ -156,7 +158,7 @@ def test_reconstruction_failure_leaves_the_digest_unrecorded(
     row.family = "progression_entry"  # disagrees with its own payload
     session.flush()
 
-    with pytest.raises(MalformedFactPayloadError):
+    with pytest.raises(PersistedStateReconstructionError):
         record_persisted_state_digest(session, identified.projection_uuid)
     assert _header(session, identified.projection_uuid).persisted_state_digest is None
 
@@ -167,7 +169,7 @@ def test_mistyped_persisted_fact_blocks_recording(session: Session) -> None:
     row.payload = {**row.payload, "ritual": "false"}
     session.flush()
 
-    with pytest.raises(MalformedFactPayloadError):
+    with pytest.raises(PersistedStateReconstructionError):
         record_persisted_state_digest(session, identified.projection_uuid)
     assert _header(session, identified.projection_uuid).persisted_state_digest is None
 

--- a/tests/ingestion/mechanical/test_digest_recording.py
+++ b/tests/ingestion/mechanical/test_digest_recording.py
@@ -1,0 +1,188 @@
+"""The recording seam derives its own proof — CRD Issue 5d, review round 2.
+
+``record_persisted_state_digest`` used to accept whatever digest a caller
+handed it and freeze it under an exactly-once guard. A stale value, a value
+computed before an intervening mutation, or another projection's value could
+therefore become the immutable proof — and the guard then prevented correcting
+it. The seam now computes the digest from the projection's own reconstructed
+state inside the recording transaction.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.persistence import (
+    compute_persisted_state_digest,
+    persist_draft,
+    record_persisted_state_digest,
+)
+from afterworlds.ingestion.mechanical.projection import identify_projection
+from afterworlds.ingestion.mechanical.representation import MalformedFactPayloadError
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalAcceptanceORM,
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from tests.ingestion.mechanical.conftest import (
+    batch_accepted_ledger,
+    build_candidate,
+    build_representation,
+)
+
+NOW = "2026-07-31T00:00:00Z"
+
+
+@pytest.fixture()
+def session(tmp_path) -> Iterator[Session]:  # type: ignore[no-untyped-def]
+    engine = create_engine(f"sqlite:///{tmp_path / 'digest.db'}")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as s:
+        s.add(
+            RulesPackageORM(
+                rules_package_id="pkg-5c",
+                name="SRD 5.2.1",
+                system="dnd5e",
+                version="5.2.1",
+                is_enabled=True,
+                publication_status="published",
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        s.flush()
+        s.add(
+            CorpusReleaseORM(
+                package_uuid="pkg-5c",
+                release_version="rel-5c",
+                authoritative_source_hash="a" * 64,
+                transform_config_hash="b" * 64,
+                bundle_root_hash="c" * 64,
+                ledger_hash="1" * 64,
+                policy_hash="2" * 64,
+                reconciliation_hash="3" * 64,
+                transform_config={},
+                publication_status="published",
+                created_at=NOW,
+            )
+        )
+        s.flush()
+        yield s
+
+
+def _persist(session: Session, **overrides: object):  # type: ignore[no-untyped-def]
+    identified = identify_projection(build_candidate(**overrides))
+    persist_draft(session, identified, now=NOW)
+    return identified
+
+
+def _header(session: Session, uuid_: str) -> MechanicalProjectionORM:
+    return session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == uuid_
+        )
+    ).scalar_one()
+
+
+def test_recorded_value_equals_a_fresh_digest_of_current_state(
+    session: Session,
+) -> None:
+    identified = _persist(session)
+    recorded = record_persisted_state_digest(session, identified.projection_uuid)
+    assert recorded == compute_persisted_state_digest(
+        session, identified.projection_uuid
+    )
+    assert (
+        _header(session, identified.projection_uuid).persisted_state_digest == recorded
+    )
+
+
+def test_the_seam_takes_no_caller_digest(session: Session) -> None:
+    # The false-authority input is gone rather than merely discouraged.
+    parameters = inspect.signature(record_persisted_state_digest).parameters
+    assert list(parameters) == ["session", "projection_uuid"]
+    identified = _persist(session)
+    with pytest.raises(TypeError):
+        record_persisted_state_digest(  # type: ignore[call-arg]
+            session, identified.projection_uuid, "f" * 64
+        )
+
+
+def test_a_digest_computed_before_a_mutation_is_not_what_gets_recorded(
+    session: Session,
+) -> None:
+    identified = _persist(session, ledger=batch_accepted_ledger())
+    stale = compute_persisted_state_digest(session, identified.projection_uuid)
+
+    # An acceptance row is edited between computing and recording — exactly the
+    # window in which a caller-supplied value would freeze a false proof.
+    row = session.execute(select(MechanicalAcceptanceORM)).scalars().first()
+    assert row is not None
+    row.reviewer = "someone-else"
+    session.flush()
+
+    recorded = record_persisted_state_digest(session, identified.projection_uuid)
+    assert recorded != stale
+    assert recorded == compute_persisted_state_digest(
+        session, identified.projection_uuid
+    )
+
+
+def test_another_projections_digest_cannot_be_recorded(session: Session) -> None:
+    first = _persist(session)
+    second = _persist(session, provenance=build_representation().provenance[:2])
+    assert first.projection_uuid != second.projection_uuid
+
+    other_digest = compute_persisted_state_digest(session, second.projection_uuid)
+    recorded = record_persisted_state_digest(session, first.projection_uuid)
+    assert recorded != other_digest
+    assert recorded == compute_persisted_state_digest(session, first.projection_uuid)
+
+
+def test_reconstruction_failure_leaves_the_digest_unrecorded(
+    session: Session,
+) -> None:
+    identified = _persist(session)
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    row.family = "progression_entry"  # disagrees with its own payload
+    session.flush()
+
+    with pytest.raises(MalformedFactPayloadError):
+        record_persisted_state_digest(session, identified.projection_uuid)
+    assert _header(session, identified.projection_uuid).persisted_state_digest is None
+
+
+def test_mistyped_persisted_fact_blocks_recording(session: Session) -> None:
+    identified = _persist(session)
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    row.payload = {**row.payload, "ritual": "false"}
+    session.flush()
+
+    with pytest.raises(MalformedFactPayloadError):
+        record_persisted_state_digest(session, identified.projection_uuid)
+    assert _header(session, identified.projection_uuid).persisted_state_digest is None
+
+
+def test_second_recording_attempt_is_rejected(session: Session) -> None:
+    identified = _persist(session)
+    first = record_persisted_state_digest(session, identified.projection_uuid)
+    with pytest.raises(ValueError, match="already recorded"):
+        record_persisted_state_digest(session, identified.projection_uuid)
+    assert _header(session, identified.projection_uuid).persisted_state_digest == first
+
+
+def test_honest_recording_returns_and_stores_one_value(session: Session) -> None:
+    identified = _persist(session, ledger=batch_accepted_ledger())
+    recorded = record_persisted_state_digest(session, identified.projection_uuid)
+    stored = _header(session, identified.projection_uuid).persisted_state_digest
+    assert recorded == stored
+    assert recorded

--- a/tests/ingestion/mechanical/test_fact_field_types.py
+++ b/tests/ingestion/mechanical/test_fact_field_types.py
@@ -1,0 +1,277 @@
+"""Runtime field types inside the closed union — CRD Issue 5d, review round 2.
+
+Field-set validation stopped missing and extra keys; it did not stop a key
+holding the wrong kind of value. That gap matters most for Booleans: JSON
+``"false"`` is a truthy string, and Python's ``bool`` is a subclass of ``int``,
+so ``True`` slips through a bare integer check. Either one silently inverts a
+mechanical rule downstream.
+
+Both paths are covered here — a dataclass constructed directly in memory, and a
+payload rebuilt from a persisted row — because a fact reaching authority
+through either path is equally authoritative.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    CreatureAbilityScoreFact,
+    DcKind,
+    MalformedFactPayloadError,
+    ProgressionEntryFact,
+    SpellDescriptorFact,
+    SpellSchool,
+    fact_from_payload,
+    fact_invariant_violations,
+    fact_key,
+    fact_payload,
+)
+
+HONEST = (
+    AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED, 15),
+    AbilityCheckFact(AbilityScore.DEXTERITY, DcKind.SPELL_SAVE_DC),
+    CreatureAbilityScoreFact(AbilityScore.CONSTITUTION, 14),
+    SpellDescriptorFact(
+        level=0, school=SpellSchool.EVOCATION, ritual=False, concentration=False
+    ),
+    SpellDescriptorFact(
+        level=3, school=SpellSchool.ILLUSION, ritual=True, concentration=True
+    ),
+    ProgressionEntryFact(level=5, entitlement_key="feature:extra"),
+    ProgressionEntryFact(level=5, entitlement_key="feature:extra", quantity=2),
+)
+
+
+def _payload(family: str, **fields: Any) -> dict[str, Any]:
+    return {"family": family, **fields}
+
+
+def _check_payload(family: str, **fields: Any) -> dict[str, Any]:
+    """A complete payload for *family*, with *fields* overriding the honest ones."""
+    base = {
+        "ability_check": {
+            "ability": "wisdom",
+            "dc_kind": "fixed",
+            "dc_value": 15,
+        },
+        "creature_ability_score": {"ability": "strength", "score": 12},
+        "spell_descriptor": {
+            "level": 3,
+            "school": "illusion",
+            "ritual": False,
+            "concentration": False,
+        },
+        "progression_entry": {
+            "level": 5,
+            "entitlement_key": "feature:extra",
+            "quantity": 2,
+        },
+    }[family]
+    return _payload(family, **{**base, **fields})
+
+
+# -- honest facts are unchanged ----------------------------------------------
+
+
+@pytest.mark.parametrize("fact", HONEST)
+def test_honest_facts_round_trip_with_identical_payload_and_key(fact: object) -> None:
+    payload = fact_payload(fact)
+    rebuilt = fact_from_payload(payload)
+    assert rebuilt == fact
+    assert fact_payload(rebuilt) == payload
+    assert fact_key(rebuilt) == fact_key(fact)
+    assert fact_invariant_violations(rebuilt) == ()
+
+
+# -- in-memory: a well-formed dataclass with mistyped fields -----------------
+#
+# Every case below constructs the declared dataclass, so class membership is
+# satisfied and only the field types are wrong.
+
+
+@pytest.mark.parametrize(
+    ("fact", "expected"),
+    [
+        (
+            AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED, "15"),  # type: ignore[arg-type]
+            "dc_value must be an integer",
+        ),
+        (
+            AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED, True),  # type: ignore[arg-type]
+            "dc_value must be an integer",
+        ),
+        (
+            AbilityCheckFact("wisdom", DcKind.FIXED, 15),  # type: ignore[arg-type]
+            "ability must be AbilityScore",
+        ),
+        (
+            AbilityCheckFact(AbilityScore.WISDOM, "fixed", 15),  # type: ignore[arg-type]
+            "dc_kind must be DcKind",
+        ),
+        (
+            CreatureAbilityScoreFact(AbilityScore.STRENGTH, True),  # type: ignore[arg-type]
+            "score must be an integer",
+        ),
+        (
+            CreatureAbilityScoreFact(AbilityScore.STRENGTH, "12"),  # type: ignore[arg-type]
+            "score must be an integer",
+        ),
+        (
+            CreatureAbilityScoreFact("strength", 12),  # type: ignore[arg-type]
+            "ability must be AbilityScore",
+        ),
+        (
+            SpellDescriptorFact("3", SpellSchool.ILLUSION, False, False),  # type: ignore[arg-type]
+            "level must be an integer",
+        ),
+        (
+            SpellDescriptorFact(True, SpellSchool.ILLUSION, False, False),  # type: ignore[arg-type]
+            "level must be an integer",
+        ),
+        (
+            SpellDescriptorFact(3, "illusion", False, False),  # type: ignore[arg-type]
+            "school must be SpellSchool",
+        ),
+        (
+            SpellDescriptorFact(3, SpellSchool.ILLUSION, "false", False),  # type: ignore[arg-type]
+            "ritual must be a boolean",
+        ),
+        (
+            SpellDescriptorFact(3, SpellSchool.ILLUSION, 1, False),  # type: ignore[arg-type]
+            "ritual must be a boolean",
+        ),
+        (
+            SpellDescriptorFact(3, SpellSchool.ILLUSION, False, "false"),  # type: ignore[arg-type]
+            "concentration must be a boolean",
+        ),
+        (
+            SpellDescriptorFact(3, SpellSchool.ILLUSION, False, 0),  # type: ignore[arg-type]
+            "concentration must be a boolean",
+        ),
+        (
+            ProgressionEntryFact(True, "feature:x"),  # type: ignore[arg-type]
+            "level must be an integer",
+        ),
+        (
+            ProgressionEntryFact(5, 42),  # type: ignore[arg-type]
+            "entitlement_key must be a string",
+        ),
+        (
+            ProgressionEntryFact(5, "feature:x", "2"),  # type: ignore[arg-type]
+            "quantity must be an integer",
+        ),
+        (
+            ProgressionEntryFact(5, "feature:x", True),  # type: ignore[arg-type]
+            "quantity must be an integer",
+        ),
+    ],
+)
+def test_mistyped_in_memory_field_is_reported(fact: object, expected: str) -> None:
+    violations = fact_invariant_violations(fact)
+    assert any(expected in v for v in violations), violations
+
+
+def test_mistyped_field_suppresses_the_misleading_semantic_finding() -> None:
+    # dc_value is a string, so the fixed/non-fixed relationship cannot be
+    # judged; reporting "fixed DC without a dc_value" would be noise.
+    violations = fact_invariant_violations(
+        AbilityCheckFact(AbilityScore.WISDOM, DcKind.SPELL_SAVE_DC, "15")  # type: ignore[arg-type]
+    )
+    assert any("dc_value must be an integer" in v for v in violations)
+    assert not any("carries dc_value" in v for v in violations)
+
+
+# -- persisted payloads: nothing is coerced ----------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (_check_payload("ability_check", dc_value="15"), "dc_value must be an integer"),
+        (_check_payload("ability_check", dc_value=True), "dc_value must be an integer"),
+        (
+            _check_payload("ability_check", ability="luck"),
+            "not a declared AbilityScore",
+        ),
+        (_check_payload("ability_check", ability=12), "must be a string AbilityScore"),
+        (_check_payload("ability_check", dc_kind=False), "must be a string DcKind"),
+        (
+            _check_payload("creature_ability_score", score=True),
+            "score must be an integer",
+        ),
+        (
+            _check_payload("creature_ability_score", score="12"),
+            "score must be an integer",
+        ),
+        (
+            _check_payload("creature_ability_score", ability="fortitude"),
+            "not a declared AbilityScore",
+        ),
+        (_check_payload("spell_descriptor", level="3"), "level must be an integer"),
+        (_check_payload("spell_descriptor", level=True), "level must be an integer"),
+        (
+            _check_payload("spell_descriptor", school="chronomancy"),
+            "not a declared SpellSchool",
+        ),
+        (
+            _check_payload("spell_descriptor", ritual="false"),
+            "ritual must be a boolean",
+        ),
+        (_check_payload("spell_descriptor", ritual=1), "ritual must be a boolean"),
+        (_check_payload("spell_descriptor", ritual=0), "ritual must be a boolean"),
+        (
+            _check_payload("spell_descriptor", concentration="false"),
+            "concentration must be a boolean",
+        ),
+        (_check_payload("progression_entry", level=True), "level must be an integer"),
+        (
+            _check_payload("progression_entry", entitlement_key=42),
+            "entitlement_key must be a string",
+        ),
+        (
+            _check_payload("progression_entry", quantity="2"),
+            "quantity must be an integer",
+        ),
+        (
+            _check_payload("progression_entry", quantity=True),
+            "quantity must be an integer",
+        ),
+    ],
+)
+def test_mistyped_persisted_field_is_rejected(
+    payload: dict[str, Any], expected: str
+) -> None:
+    with pytest.raises(MalformedFactPayloadError, match="mistyped fields"):
+        fact_from_payload(payload)
+    with pytest.raises(MalformedFactPayloadError) as exc:
+        fact_from_payload(payload)
+    assert expected in str(exc.value)
+
+
+def test_string_number_is_not_coerced_to_an_integer() -> None:
+    with pytest.raises(MalformedFactPayloadError):
+        fact_from_payload(_check_payload("spell_descriptor", level="3"))
+
+
+def test_integer_is_not_coerced_to_a_boolean() -> None:
+    with pytest.raises(MalformedFactPayloadError):
+        fact_from_payload(_check_payload("spell_descriptor", concentration=1))
+
+
+def test_null_is_not_accepted_for_a_required_field() -> None:
+    with pytest.raises(MalformedFactPayloadError):
+        fact_from_payload(_check_payload("creature_ability_score", score=None))
+
+
+def test_optional_fields_still_accept_null() -> None:
+    fact = fact_from_payload(
+        _check_payload("ability_check", dc_kind="contested", dc_value=None)
+    )
+    assert isinstance(fact, AbilityCheckFact)
+    assert fact.dc_value is None
+    assert fact_invariant_violations(fact) == ()

--- a/tests/ingestion/mechanical/test_invariants_and_binding.py
+++ b/tests/ingestion/mechanical/test_invariants_and_binding.py
@@ -23,6 +23,7 @@ from afterworlds.ingestion.mechanical.representation import (
     DcKind,
     ProgressionEntryFact,
     ProseBindingDraft,
+    ProvenanceRole,
     ReferenceDraft,
     RelationshipDraft,
     RelationshipKind,
@@ -37,9 +38,11 @@ from tests.ingestion.mechanical.conftest import (
     DESCRIPTOR_FACT,
     DESCRIPTOR_KEY,
     OPEN_ENDED_KEY,
+    PROSE_SPAN,
     SECOND_CHUNK,
     SPELL_KEY,
     WISH_CHUNK,
+    binding_claim,
     bound_corpus,
     build_ledger,
     build_representation,
@@ -225,15 +228,19 @@ def test_component_and_binding_reasons_valid_but_unequal_are_rejected() -> None:
 
 
 def test_multiple_bindings_sharing_the_component_reason_pass() -> None:
+    # Two passages bound by one component: each is a distinct authoritative
+    # element with its own provenance, which is why the binding key carries
+    # the chunk rather than stopping at the component.
+    first = ProseBindingDraft(
+        OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect"
+    )
+    second = ProseBindingDraft(
+        OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
+    )
     findings = _findings(
-        prose_bindings=(
-            ProseBindingDraft(
-                OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect"
-            ),
-            ProseBindingDraft(
-                OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
-            ),
-        )
+        prose_bindings=(first, second),
+        provenance=build_representation().provenance
+        + (binding_claim(second, PROSE_SPAN, ProvenanceRole.CONTEXTUAL),),
     )
     assert findings == ()
 

--- a/tests/ingestion/mechanical/test_invariants_and_binding.py
+++ b/tests/ingestion/mechanical/test_invariants_and_binding.py
@@ -279,7 +279,7 @@ def test_fabricated_chunk_is_rejected() -> None:
 
 def test_chunk_absent_from_the_bound_population_is_rejected() -> None:
     findings = validate_representation(
-        build_representation(), build_ledger(), bound_corpus(chunk_ids=frozenset())
+        build_representation(), build_ledger(), bound_corpus(chunk_coverage=())
     )
     assert any("is not authoritative prose of release" in f for f in findings)
 

--- a/tests/ingestion/mechanical/test_invariants_and_binding.py
+++ b/tests/ingestion/mechanical/test_invariants_and_binding.py
@@ -23,9 +23,14 @@ from afterworlds.ingestion.mechanical.representation import (
     DcKind,
     ProgressionEntryFact,
     ProseBindingDraft,
+    ReferenceDraft,
+    RelationshipDraft,
+    RelationshipKind,
     SpellDescriptorFact,
     SpellSchool,
+    fact_from_payload,
     fact_invariant_violations,
+    fact_payload,
 )
 from afterworlds.ingestion.mechanical.validation import validate_representation
 from tests.ingestion.mechanical.conftest import (
@@ -274,3 +279,101 @@ def test_chunk_absent_from_the_bound_population_is_rejected() -> None:
 
 def test_authoritative_chunk_of_the_bound_release_passes() -> None:
     assert _findings() == ()
+
+
+# -- guards that had no negative control -------------------------------------
+
+
+def test_structured_component_carrying_prose_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(DESCRIPTOR_FACT,),
+            ),
+        )
+    )
+    assert any("structured handling with a prose binding" in f for f in findings)
+
+
+def test_duplicate_component_semantic_key_is_rejected() -> None:
+    duplicate = ComponentDraft(
+        record_key=SPELL_KEY,
+        semantic_key=DESCRIPTOR_KEY,
+        handling=ComponentHandling.STRUCTURED,
+        facts=(DESCRIPTOR_FACT,),
+    )
+    findings = _findings(
+        components=(duplicate, duplicate, build_representation().components[1])
+    )
+    assert any("duplicate semantic key" in f for f in findings)
+
+
+def test_record_related_to_itself_is_rejected() -> None:
+    findings = _findings(
+        relationships=(
+            RelationshipDraft(SPELL_KEY, SPELL_KEY, RelationshipKind.PREREQUISITE),
+        )
+    )
+    assert any("record related to itself" in f for f in findings)
+
+
+def test_reference_from_an_unknown_record_is_rejected() -> None:
+    findings = _findings(
+        references=(
+            ReferenceDraft(
+                "spell:ghost", DESCRIPTOR_KEY, "the servant", "spell:wish", SPELL_KEY
+            ),
+        )
+    )
+    assert any("unknown source record spell:ghost" in f for f in findings)
+
+
+def test_reference_from_an_unknown_component_is_rejected() -> None:
+    findings = _findings(
+        references=(
+            ReferenceDraft(
+                SPELL_KEY, "ghost-component", "the servant", "spell:wish", SPELL_KEY
+            ),
+        )
+    )
+    assert any("unknown source component ghost-component" in f for f in findings)
+
+
+def test_reference_to_an_unknown_record_is_rejected() -> None:
+    findings = _findings(
+        references=(
+            ReferenceDraft(
+                SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", "spell:ghost"
+            ),
+        )
+    )
+    assert any("unknown target record spell:ghost" in f for f in findings)
+
+
+def test_negative_progression_level_is_rejected() -> None:
+    fact = ProgressionEntryFact(level=-1, entitlement_key="feature:x")
+    assert any("negative progression level" in f for f in _with_facts(fact))
+
+
+# -- persisted payloads rebuild every declared family -------------------------
+
+
+@pytest.mark.parametrize(
+    "fact",
+    [
+        AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED, 15),
+        AbilityCheckFact(AbilityScore.DEXTERITY, DcKind.SPELL_SAVE_DC),
+        CreatureAbilityScoreFact(AbilityScore.CONSTITUTION, 14),
+        SpellDescriptorFact(
+            level=3, school=SpellSchool.ILLUSION, ritual=True, concentration=True
+        ),
+        ProgressionEntryFact(level=5, entitlement_key="feature:extra", quantity=2),
+    ],
+)
+def test_every_declared_family_round_trips_through_its_payload(fact: object) -> None:
+    rebuilt = fact_from_payload(fact_payload(fact))
+    assert rebuilt == fact
+    assert fact_invariant_violations(rebuilt) == ()

--- a/tests/ingestion/mechanical/test_invariants_and_binding.py
+++ b/tests/ingestion/mechanical/test_invariants_and_binding.py
@@ -1,0 +1,276 @@
+"""Family invariants, reason coherence, and release-bound prose — CRD Issue 5d.
+
+Three review findings share one shape: a declaration that is *well-formed* was
+being accepted as *valid*. A fact could belong to the closed union and still
+contradict its own DC contract; a component could claim its meaning is
+irreducible without saying why, or disagree with its own binding about why; and
+a prose binding could name any non-empty string instead of authority that
+exists in the bound release.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    ComponentDraft,
+    CreatureAbilityScoreFact,
+    DcKind,
+    ProgressionEntryFact,
+    ProseBindingDraft,
+    SpellDescriptorFact,
+    SpellSchool,
+    fact_invariant_violations,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from tests.ingestion.mechanical.conftest import (
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_KEY,
+    OPEN_ENDED_KEY,
+    SECOND_CHUNK,
+    SPELL_KEY,
+    WISH_CHUNK,
+    bound_corpus,
+    build_ledger,
+    build_representation,
+)
+
+NON_FIXED = [DcKind.SPELL_SAVE_DC, DcKind.CONTESTED, DcKind.GAMEMASTER_SET]
+
+
+def _findings(**overrides: object) -> tuple[str, ...]:
+    return validate_representation(
+        build_representation(**overrides), build_ledger(), bound_corpus()
+    )
+
+
+def _with_facts(*facts: object) -> tuple[str, ...]:
+    """Findings for a structured descriptor component carrying *facts*."""
+    return _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=facts,  # type: ignore[arg-type]
+            ),
+            build_representation().components[1],
+        )
+    )
+
+
+# -- family A: invariants inside the closed union ----------------------------
+
+
+def test_fixed_dc_without_a_value_is_rejected() -> None:
+    assert any(
+        "fixed DC without a dc_value" in f
+        for f in _with_facts(AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED))
+    )
+
+
+def test_fixed_dc_with_a_value_passes() -> None:
+    assert (
+        fact_invariant_violations(
+            AbilityCheckFact(AbilityScore.WISDOM, DcKind.FIXED, 15)
+        )
+        == ()
+    )
+
+
+@pytest.mark.parametrize("kind", NON_FIXED)
+def test_non_fixed_dc_carrying_a_value_is_rejected(kind: DcKind) -> None:
+    assert any(
+        "carries dc_value 15" in f
+        for f in _with_facts(AbilityCheckFact(AbilityScore.WISDOM, kind, 15))
+    )
+
+
+@pytest.mark.parametrize("kind", NON_FIXED)
+def test_non_fixed_dc_without_a_value_passes(kind: DcKind) -> None:
+    assert fact_invariant_violations(AbilityCheckFact(AbilityScore.WISDOM, kind)) == ()
+
+
+def test_negative_ability_score_is_rejected() -> None:
+    assert any(
+        "negative ability score" in f
+        for f in _with_facts(CreatureAbilityScoreFact(AbilityScore.STRENGTH, -1))
+    )
+
+
+def test_negative_spell_level_is_rejected() -> None:
+    fact = SpellDescriptorFact(
+        level=-1, school=SpellSchool.EVOCATION, ritual=False, concentration=False
+    )
+    assert any("negative spell level" in f for f in _with_facts(fact))
+
+
+def test_cantrip_level_zero_passes() -> None:
+    # Level 0 is a cantrip, not an error. Only a negative ordinal is intrinsic
+    # nonsense; an upper bound would be SRD policy, not a property of the type.
+    fact = SpellDescriptorFact(
+        level=0, school=SpellSchool.EVOCATION, ritual=False, concentration=False
+    )
+    assert fact_invariant_violations(fact) == ()
+
+
+def test_progression_entry_without_an_entitlement_key_is_rejected() -> None:
+    fact = ProgressionEntryFact(level=3, entitlement_key="   ")
+    assert any("without an entitlement key" in f for f in _with_facts(fact))
+
+
+def test_progression_quantity_below_one_is_rejected() -> None:
+    fact = ProgressionEntryFact(level=3, entitlement_key="feature:x", quantity=0)
+    assert any("grants nothing" in f for f in _with_facts(fact))
+
+
+def test_unspecified_progression_quantity_passes() -> None:
+    fact = ProgressionEntryFact(level=3, entitlement_key="feature:x")
+    assert fact_invariant_violations(fact) == ()
+
+
+def test_unknown_family_reports_through_the_invariant_seam() -> None:
+    @dataclass(frozen=True)
+    class ImprovisedFact:
+        anything: str
+
+    assert any(
+        "closed typed-fact union" in v
+        for v in fact_invariant_violations(ImprovisedFact("x"))
+    )
+
+
+# -- family B: irreducibility reason coherence -------------------------------
+
+
+def test_prose_bound_component_without_a_reason_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(SPELL_KEY, OPEN_ENDED_KEY, ComponentHandling.PROSE_BOUND),
+        )
+    )
+    assert any(
+        "prose_bound handling with no irreducibility reason" in f for f in findings
+    )
+
+
+def test_mixed_component_without_a_reason_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.MIXED,
+                facts=(DESCRIPTOR_FACT,),
+            ),
+        )
+    )
+    assert any("mixed handling with no irreducibility reason" in f for f in findings)
+
+
+def test_blank_component_reason_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                SPELL_KEY, OPEN_ENDED_KEY, ComponentHandling.PROSE_BOUND, "   "
+            ),
+        )
+    )
+    assert any(
+        "prose_bound handling with no irreducibility reason" in f for f in findings
+    )
+
+
+def test_component_reason_outside_the_closed_catalog_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                SPELL_KEY, OPEN_ENDED_KEY, ComponentHandling.PROSE_BOUND, "too_hard"
+            ),
+        )
+    )
+    assert any("irreducibility reason 'too_hard' is not closed" in f for f in findings)
+
+
+def test_binding_reason_outside_the_closed_catalog_is_rejected() -> None:
+    findings = _findings(
+        prose_bindings=(
+            ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "too_hard"),
+        )
+    )
+    assert any("irreducibility reason 'too_hard' is not closed" in f for f in findings)
+
+
+def test_component_and_binding_reasons_valid_but_unequal_are_rejected() -> None:
+    # Both closed, both plausible, and they disagree about *why* this authority
+    # is prose-bound. Neither copy wins.
+    findings = _findings(
+        prose_bindings=(
+            ProseBindingDraft(
+                OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "subjective_judgment"
+            ),
+        )
+    )
+    assert any("disagrees with its component's" in f for f in findings)
+
+
+def test_multiple_bindings_sharing_the_component_reason_pass() -> None:
+    findings = _findings(
+        prose_bindings=(
+            ProseBindingDraft(
+                OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect"
+            ),
+            ProseBindingDraft(
+                OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
+            ),
+        )
+    )
+    assert findings == ()
+
+
+def test_structured_component_carrying_a_reason_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                irreducibility_reason_code="open_ended_effect",
+                facts=(DESCRIPTOR_FACT,),
+            ),
+            build_representation().components[1],
+        )
+    )
+    assert any(
+        "structured handling with an irreducibility reason" in f for f in findings
+    )
+
+
+# -- family C: prose resolves against the bound release ----------------------
+
+
+def test_fabricated_chunk_is_rejected() -> None:
+    findings = _findings(
+        prose_bindings=(
+            ProseBindingDraft(
+                OPEN_ENDED_KEY, SPELL_KEY, "chunk-invented", "open_ended_effect"
+            ),
+        )
+    )
+    assert any("is not authoritative prose of release" in f for f in findings)
+
+
+def test_chunk_absent_from_the_bound_population_is_rejected() -> None:
+    findings = validate_representation(
+        build_representation(), build_ledger(), bound_corpus(chunk_ids=frozenset())
+    )
+    assert any("is not authoritative prose of release" in f for f in findings)
+
+
+def test_authoritative_chunk_of_the_bound_release_passes() -> None:
+    assert _findings() == ()

--- a/tests/ingestion/mechanical/test_persisted_evidence.py
+++ b/tests/ingestion/mechanical/test_persisted_evidence.py
@@ -1,0 +1,291 @@
+"""Persisted-state proof covers retained review evidence — CRD Issue 5d.
+
+The two identities answer different questions and must keep answering them
+separately:
+
+* the **projection UUID** — is this the same authority? Review path excluded.
+* the **persisted-state digest** — is this the same persisted state, including
+  how it was reviewed? Review evidence included.
+
+Every test below edits one retained row and asserts exactly that split, plus
+the persistence-side strictness that stops a rewritten fact row from
+reconstructing into apparently valid authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.persistence import (
+    compute_persisted_state_digest,
+    persist_draft,
+    reconstruct_candidate,
+    verify_reconstruction,
+)
+from afterworlds.ingestion.mechanical.projection import identify_projection
+from afterworlds.ingestion.mechanical.representation import (
+    MalformedFactPayloadError,
+    UnknownFactFamilyError,
+    fact_from_payload,
+)
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalAcceptanceBatchORM,
+    MechanicalAcceptanceORM,
+    MechanicalBatchDiffORM,
+    MechanicalBatchScopeORM,
+    MechanicalFactORM,
+    MechanicalSpanORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from tests.ingestion.mechanical.conftest import (
+    batch_accepted_ledger,
+    build_candidate,
+    build_ledger,
+)
+
+NOW = "2026-07-31T00:00:00Z"
+
+
+@pytest.fixture()
+def session(tmp_path) -> Iterator[Session]:  # type: ignore[no-untyped-def]
+    engine = create_engine(f"sqlite:///{tmp_path / 'evidence.db'}")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as s:
+        s.add(
+            RulesPackageORM(
+                rules_package_id="pkg-5c",
+                name="SRD 5.2.1",
+                system="dnd5e",
+                version="5.2.1",
+                is_enabled=True,
+                publication_status="published",
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        s.flush()
+        s.add(
+            CorpusReleaseORM(
+                package_uuid="pkg-5c",
+                release_version="rel-5c",
+                authoritative_source_hash="a" * 64,
+                transform_config_hash="b" * 64,
+                bundle_root_hash="c" * 64,
+                ledger_hash="1" * 64,
+                policy_hash="2" * 64,
+                reconciliation_hash="3" * 64,
+                transform_config={},
+                publication_status="published",
+                created_at=NOW,
+            )
+        )
+        s.flush()
+        yield s
+
+
+def _persist_batch_reviewed(session: Session):  # type: ignore[no-untyped-def]
+    identified = identify_projection(build_candidate(ledger=batch_accepted_ledger()))
+    persist_draft(session, identified, now=NOW)
+    return identified
+
+
+def _identity_and_digest(session: Session, uuid_: str) -> tuple[str, str]:
+    """The two answers, recomputed from persisted state."""
+    rebuilt = reconstruct_candidate(session, uuid_)
+    return (
+        identify_projection(rebuilt).projection_uuid,
+        compute_persisted_state_digest(session, uuid_),
+    )
+
+
+def _assert_evidence_only_change(
+    session: Session, uuid_: str, before: tuple[str, str]
+) -> None:
+    """Digest moves, projection identity does not."""
+    after = _identity_and_digest(session, uuid_)
+    assert after[0] == before[0], "review evidence must not change the authority"
+    assert after[1] != before[1], "review evidence must be covered by the digest"
+
+
+# -- evidence changes: digest moves, identity does not ------------------------
+
+
+def test_changed_reviewer_changes_only_the_digest(session: Session) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalAcceptanceORM)).scalars().first()
+    assert row is not None
+    row.reviewer = "someone-else"
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_changed_acceptance_timestamp_changes_only_the_digest(
+    session: Session,
+) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalAcceptanceORM)).scalars().first()
+    assert row is not None
+    row.accepted_at = "2026-08-09T09:09:09Z"
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_changed_batch_rule_changes_only_the_digest(session: Session) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalAcceptanceBatchORM)).scalars().one()
+    row.rule = "a rule nobody applied"
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_changed_scope_membership_changes_only_the_digest(session: Session) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalBatchScopeORM)).scalars().first()
+    assert row is not None
+    row.span_id = "span-substituted"
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_reordered_scope_changes_only_the_digest(session: Session) -> None:
+    # The reviewer's recorded scope order is evidence of what they reviewed, so
+    # a reshuffle is a different record even though the set is unchanged.
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    rows = (
+        session.execute(
+            select(MechanicalBatchScopeORM).order_by(MechanicalBatchScopeORM.ordinal)
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) >= 2
+    rows[0].ordinal, rows[-1].ordinal = rows[-1].ordinal, rows[0].ordinal
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_rewritten_diff_evidence_changes_only_the_digest(session: Session) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalBatchDiffORM)).scalars().first()
+    assert row is not None
+    row.prior_disposition = "non_mechanical"
+    row.prior_reason_code = "navigation_only"
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_changed_batch_digest_column_changes_the_persisted_digest(
+    session: Session,
+) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalAcceptanceBatchORM)).scalars().one()
+    row.semantic_diff_hash = "f" * 64
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+def test_changed_review_state_changes_the_digest(session: Session) -> None:
+    identified = _persist_batch_reviewed(session)
+    before = _identity_and_digest(session, identified.projection_uuid)
+    row = session.execute(select(MechanicalSpanORM)).scalars().first()
+    assert row is not None
+    row.review_state = "proposed"
+    session.flush()
+    _assert_evidence_only_change(session, identified.projection_uuid, before)
+
+
+# -- the identity boundary still holds ---------------------------------------
+
+
+def test_individual_and_batch_review_share_one_identity(session: Session) -> None:
+    individually = identify_projection(build_candidate(ledger=build_ledger()))
+    by_batch = identify_projection(build_candidate(ledger=batch_accepted_ledger()))
+    assert individually.projection_uuid == by_batch.projection_uuid
+
+    # ...and the persisted proofs differ, because the retained evidence differs.
+    persist_draft(session, by_batch, now=NOW)
+    batch_digest = compute_persisted_state_digest(session, by_batch.projection_uuid)
+    assert verify_reconstruction(session, by_batch) == ()
+    assert batch_digest
+
+
+# -- persisted fact payloads are strict --------------------------------------
+
+
+def test_missing_payload_field_is_rejected() -> None:
+    with pytest.raises(MalformedFactPayloadError, match="missing"):
+        fact_from_payload({"family": "spell_descriptor", "level": 9})
+
+
+def test_extra_payload_field_is_rejected() -> None:
+    with pytest.raises(MalformedFactPayloadError, match="extra"):
+        fact_from_payload(
+            {
+                "family": "creature_ability_score",
+                "ability": "strength",
+                "score": 12,
+                "smuggled": {"dc": 15},
+            }
+        )
+
+
+def test_discriminator_disagreement_is_rejected() -> None:
+    with pytest.raises(MalformedFactPayloadError, match="disagrees"):
+        fact_from_payload(
+            {
+                "family": "creature_ability_score",
+                "ability": "strength",
+                "score": 12,
+            },
+            declared_family="spell_descriptor",
+        )
+
+
+def test_unknown_persisted_family_is_rejected() -> None:
+    with pytest.raises(UnknownFactFamilyError):
+        fact_from_payload({"family": "improvised", "anything": 1})
+
+
+def test_bad_enum_value_is_rejected() -> None:
+    with pytest.raises(MalformedFactPayloadError, match="does not rebuild"):
+        fact_from_payload(
+            {
+                "family": "creature_ability_score",
+                "ability": "luck",
+                "score": 12,
+            }
+        )
+
+
+def test_tampered_family_column_is_reported_not_reconstructed(
+    session: Session,
+) -> None:
+    identified = _persist_batch_reviewed(session)
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    row.family = "progression_entry"
+    session.flush()
+    findings = verify_reconstruction(session, identified)
+    assert any("does not reconstruct" in f for f in findings)
+
+
+def test_tampered_fact_key_column_is_reported(session: Session) -> None:
+    identified = _persist_batch_reviewed(session)
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    row.fact_key = "0" * 16
+    session.flush()
+    findings = verify_reconstruction(session, identified)
+    assert any("does not reconstruct" in f for f in findings)

--- a/tests/ingestion/mechanical/test_persistence.py
+++ b/tests/ingestion/mechanical/test_persistence.py
@@ -49,6 +49,7 @@ from tests.ingestion.mechanical.conftest import (
     SPELL_KEY,
     batch_accepted_ledger,
     build_candidate,
+    build_representation,
 )
 
 NOW = "2026-07-31T00:00:00Z"
@@ -304,3 +305,87 @@ def test_relationships_round_trip(session: Session) -> None:
     (relationship,) = rebuilt.representation.relationships
     assert relationship.kind is RelationshipKind.SCOPED_WITHIN
     assert relationship.source_record_key == CREATURE_KEY
+
+
+# -- corrected provenance target keys survive the database -------------------
+
+
+def test_longer_target_keys_round_trip_without_normalization(
+    session: Session,
+) -> None:
+    from afterworlds.ingestion.mechanical.representation import (
+        prose_binding_target_key,
+        reference_target_key,
+    )
+    from tests.ingestion.mechanical.conftest import (
+        SCOPED_REFERENCES,
+        WISH_BINDING,
+        reference_claim,
+    )
+
+    reference = SCOPED_REFERENCES[0]
+    identified = identify_projection(
+        build_candidate(
+            references=(reference,),
+            provenance=build_representation().provenance
+            + (reference_claim(reference),),
+        )
+    )
+    persist_draft(session, identified, now=NOW)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+
+    keys = {
+        (c.target_kind.value, c.target_key) for c in rebuilt.representation.provenance
+    }
+    # Four and five members respectively — the JSON column stores the exact
+    # tuple, with no truncation, padding, or repair.
+    assert ("prose_binding", prose_binding_target_key(WISH_BINDING)) in keys
+    assert ("reference", reference_target_key(reference)) in keys
+    assert all(isinstance(k, tuple) for _, k in keys)
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_digest_changes_when_a_provenance_target_identity_changes(
+    session: Session,
+) -> None:
+    identified = _persist(session)
+    before = compute_persisted_state_digest(session, identified.projection_uuid)
+    row = (
+        session.execute(
+            select(MechanicalProvenanceORM).where(
+                MechanicalProvenanceORM.target_kind == "prose_binding"
+            )
+        )
+        .scalars()
+        .one()
+    )
+    row.target_key = [*row.target_key[:2], "chunk-substituted", row.target_key[3]]
+    session.flush()
+    assert compute_persisted_state_digest(session, identified.projection_uuid) != before
+
+
+def test_digest_changes_when_a_provenance_span_or_role_changes(
+    session: Session,
+) -> None:
+    identified = _persist(session)
+    before = compute_persisted_state_digest(session, identified.projection_uuid)
+    row = (
+        session.execute(
+            select(MechanicalProvenanceORM).where(
+                MechanicalProvenanceORM.target_kind == "record"
+            )
+        )
+        .scalars()
+        .one()
+    )
+    row.role = "primary"
+    session.flush()
+    after_role = compute_persisted_state_digest(session, identified.projection_uuid)
+    assert after_role != before
+
+    row.span_id = "span-substituted"
+    session.flush()
+    assert (
+        compute_persisted_state_digest(session, identified.projection_uuid)
+        != after_role
+    )

--- a/tests/ingestion/mechanical/test_persistence.py
+++ b/tests/ingestion/mechanical/test_persistence.py
@@ -142,10 +142,9 @@ def test_digest_covers_reconstructed_state(session: Session) -> None:
 
 def test_digest_is_recorded_once(session: Session) -> None:
     identified = _persist(session)
-    digest = compute_persisted_state_digest(session, identified.projection_uuid)
-    record_persisted_state_digest(session, identified.projection_uuid, digest)
+    record_persisted_state_digest(session, identified.projection_uuid)
     with pytest.raises(ValueError):
-        record_persisted_state_digest(session, identified.projection_uuid, digest)
+        record_persisted_state_digest(session, identified.projection_uuid)
 
 
 # -- omission, tamper, corrupted identity ------------------------------------

--- a/tests/ingestion/mechanical/test_persistence.py
+++ b/tests/ingestion/mechanical/test_persistence.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import pytest
 from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from afterworlds.ingestion.mechanical.accounting import validate_acceptance
 from afterworlds.ingestion.mechanical.persistence import (
     ProjectionNotPersistedError,
     compute_persisted_state_digest,
@@ -25,11 +27,15 @@ from afterworlds.ingestion.mechanical.projection import (
     identify_projection,
     projection_payload,
 )
-from afterworlds.ingestion.mechanical.representation import fact_from_payload
+from afterworlds.ingestion.mechanical.representation import (
+    RelationshipKind,
+    fact_from_payload,
+)
 from afterworlds.persistence.database import create_engine, create_session_factory
 from afterworlds.persistence.orm.base import Base
 from afterworlds.persistence.orm.corpus import CorpusReleaseORM
 from afterworlds.persistence.orm.mechanical import (
+    MechanicalBatchDiffORM,
     MechanicalFactORM,
     MechanicalProjectionORM,
     MechanicalProvenanceORM,
@@ -37,7 +43,13 @@ from afterworlds.persistence.orm.mechanical import (
     MechanicalSpanORM,
 )
 from afterworlds.persistence.orm.rules_package import RulesPackageORM
-from tests.ingestion.mechanical.conftest import SPELL_KEY, build_candidate
+from tests.ingestion.mechanical.conftest import (
+    CREATURE_KEY,
+    SCOPED_REFERENCES,
+    SPELL_KEY,
+    batch_accepted_ledger,
+    build_candidate,
+)
 
 NOW = "2026-07-31T00:00:00Z"
 
@@ -219,11 +231,75 @@ def test_delete_removes_every_scoped_row(session: Session) -> None:
 
 def test_two_projections_over_one_release_coexist(session: Session) -> None:
     first = _persist(session)
-    other = identify_projection(build_candidate(references=()))
     second = identify_projection(
         build_candidate(provenance=build_candidate().representation.provenance[:2])
     )
-    assert other.projection_uuid == first.projection_uuid  # references were empty
-    persist_draft(session, second, now=NOW)
     assert second.projection_uuid != first.projection_uuid
+    persist_draft(session, second, now=NOW)
     assert verify_reconstruction(session, first) == ()
+    assert verify_reconstruction(session, second) == ()
+
+
+def test_re_persisting_the_same_projection_conflicts(session: Session) -> None:
+    # The UUID is the primary key, so an identical rebuild collides rather than
+    # silently duplicating. Making that idempotent is publication/activation
+    # work and belongs to the next PR; what matters here is that it cannot
+    # quietly write a second copy.
+    identified = _persist(session)
+    with pytest.raises(IntegrityError):
+        persist_draft(session, identified, now=NOW)
+
+
+# -- retained acceptance evidence and references round-trip -------------------
+
+
+def test_batch_acceptance_evidence_round_trips(session: Session) -> None:
+    identified = identify_projection(build_candidate(ledger=batch_accepted_ledger()))
+    persist_draft(session, identified, now=NOW)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+
+    (batch,) = rebuilt.classification.batches
+    original = identified.candidate.classification.batches[0]
+    # Ordered scope, the canonical diff, and the digest all survive intact —
+    # the retained evidence is what replay reads, so a lossy round-trip here
+    # would be the identifier-without-contents failure again.
+    assert batch.resolved_scope == original.resolved_scope
+    assert batch.diff == original.diff
+    assert batch.semantic_diff_hash == original.semantic_diff_hash
+    assert validate_acceptance(rebuilt.classification) == ()
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_omitted_batch_diff_row_is_detected(session: Session) -> None:
+    identified = identify_projection(build_candidate(ledger=batch_accepted_ledger()))
+    persist_draft(session, identified, now=NOW)
+    session.execute(
+        delete(MechanicalBatchDiffORM).where(
+            MechanicalBatchDiffORM.projection_uuid == identified.projection_uuid
+        )
+    )
+    session.flush()
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    # The diff is acceptance evidence, not identity, so the projection UUID is
+    # unchanged — the loss surfaces as an acceptance-evidence violation.
+    assert identify_projection(rebuilt).projection_uuid == identified.projection_uuid
+    findings = validate_acceptance(rebuilt.classification)
+    assert any("no semantic diff retained" in f for f in findings)
+
+
+def test_resolved_references_round_trip(session: Session) -> None:
+    identified = identify_projection(build_candidate(references=SCOPED_REFERENCES))
+    persist_draft(session, identified, now=NOW)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert sorted(r.scope_key for r in rebuilt.representation.references) == sorted(
+        r.scope_key for r in SCOPED_REFERENCES
+    )
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_relationships_round_trip(session: Session) -> None:
+    identified = _persist(session)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    (relationship,) = rebuilt.representation.relationships
+    assert relationship.kind is RelationshipKind.SCOPED_WITHIN
+    assert relationship.source_record_key == CREATURE_KEY

--- a/tests/ingestion/mechanical/test_persistence.py
+++ b/tests/ingestion/mechanical/test_persistence.py
@@ -185,8 +185,10 @@ def test_tampered_fact_payload_is_detected(session: Session) -> None:
     ).scalar_one()
     row.payload = {**row.payload, "level": 1}
     session.flush()
+    # Caught at rebuild: the row's own fact_key column no longer agrees with
+    # its payload, so the state does not reconstruct at all.
     findings = verify_reconstruction(session, identified)
-    assert any("derives" in f for f in findings)
+    assert any("does not reconstruct" in f for f in findings)
 
 
 def test_corrupted_derived_record_id_is_detected(session: Session) -> None:

--- a/tests/ingestion/mechanical/test_persistence.py
+++ b/tests/ingestion/mechanical/test_persistence.py
@@ -1,0 +1,229 @@
+"""Draft persistence and exact reconstruction — CRD Issue 5d, Decision 8.
+
+Reconstruction reads only the database. Every negative control below perturbs
+persisted state *after* the write and asserts the rebuild notices — omission,
+tamper, and a corrupted derived identity that leaves every semantic value
+intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.persistence import (
+    ProjectionNotPersistedError,
+    compute_persisted_state_digest,
+    delete_projection,
+    persist_draft,
+    reconstruct_candidate,
+    record_persisted_state_digest,
+    verify_reconstruction,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    identify_projection,
+    projection_payload,
+)
+from afterworlds.ingestion.mechanical.representation import fact_from_payload
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+    MechanicalProvenanceORM,
+    MechanicalRecordORM,
+    MechanicalSpanORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from tests.ingestion.mechanical.conftest import SPELL_KEY, build_candidate
+
+NOW = "2026-07-31T00:00:00Z"
+
+
+@pytest.fixture()
+def session(tmp_path) -> Session:  # type: ignore[no-untyped-def]
+    engine = create_engine(f"sqlite:///{tmp_path / 'mech.db'}")
+    Base.metadata.create_all(engine)
+    factory = create_session_factory(engine)
+    with factory() as s:
+        # The projection FKs a real published 5c release row.
+        s.add(
+            RulesPackageORM(
+                rules_package_id="pkg-5c",
+                name="SRD 5.2.1",
+                system="dnd5e",
+                version="5.2.1",
+                is_enabled=True,
+                publication_status="published",
+                created_at="2026-07-31T00:00:00Z",
+                updated_at="2026-07-31T00:00:00Z",
+            )
+        )
+        s.flush()
+        s.add(
+            CorpusReleaseORM(
+                package_uuid="pkg-5c",
+                release_version="rel-5c",
+                authoritative_source_hash="a" * 64,
+                transform_config_hash="b" * 64,
+                bundle_root_hash="c" * 64,
+                ledger_hash="1" * 64,
+                policy_hash="2" * 64,
+                reconciliation_hash="3" * 64,
+                transform_config={},
+                publication_status="published",
+                created_at=NOW,
+            )
+        )
+        s.flush()
+        yield s
+
+
+def _persist(session: Session):  # type: ignore[no-untyped-def]
+    identified = identify_projection(build_candidate())
+    persist_draft(session, identified, now=NOW)
+    return identified
+
+
+def test_roundtrip_reconstructs_the_exact_candidate(session: Session) -> None:
+    identified = _persist(session)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert projection_payload(rebuilt) == projection_payload(identified.candidate)
+    assert identify_projection(rebuilt).projection_uuid == identified.projection_uuid
+
+
+def test_reconstruction_of_an_honest_draft_has_no_findings(session: Session) -> None:
+    identified = _persist(session)
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_persisted_draft_is_never_published(session: Session) -> None:
+    identified = _persist(session)
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    assert header.publication_status == "draft"
+    assert header.persisted_state_digest is None
+
+
+def test_facts_rebuild_into_their_declared_dataclass(session: Session) -> None:
+    identified = _persist(session)
+    row = session.execute(
+        select(MechanicalFactORM).where(
+            MechanicalFactORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    rebuilt = fact_from_payload(row.payload)
+    assert type(rebuilt).__name__ == "SpellDescriptorFact"
+    assert rebuilt.level == 9
+
+
+def test_digest_covers_reconstructed_state(session: Session) -> None:
+    identified = _persist(session)
+    first = compute_persisted_state_digest(session, identified.projection_uuid)
+    assert first == compute_persisted_state_digest(session, identified.projection_uuid)
+
+
+def test_digest_is_recorded_once(session: Session) -> None:
+    identified = _persist(session)
+    digest = compute_persisted_state_digest(session, identified.projection_uuid)
+    record_persisted_state_digest(session, identified.projection_uuid, digest)
+    with pytest.raises(ValueError):
+        record_persisted_state_digest(session, identified.projection_uuid, digest)
+
+
+# -- omission, tamper, corrupted identity ------------------------------------
+
+
+def test_omitted_span_row_is_detected(session: Session) -> None:
+    identified = _persist(session)
+    before = compute_persisted_state_digest(session, identified.projection_uuid)
+    session.execute(
+        delete(MechanicalSpanORM).where(
+            MechanicalSpanORM.projection_uuid == identified.projection_uuid,
+            MechanicalSpanORM.leaf_id == "leaf-support",
+        )
+    )
+    session.flush()
+    assert verify_reconstruction(session, identified) != ()
+    assert compute_persisted_state_digest(session, identified.projection_uuid) != before
+
+
+def test_omitted_provenance_row_is_detected(session: Session) -> None:
+    identified = _persist(session)
+    session.execute(
+        delete(MechanicalProvenanceORM).where(
+            MechanicalProvenanceORM.projection_uuid == identified.projection_uuid
+        )
+    )
+    session.flush()
+    assert verify_reconstruction(session, identified) != ()
+
+
+def test_tampered_fact_payload_is_detected(session: Session) -> None:
+    identified = _persist(session)
+    row = session.execute(
+        select(MechanicalFactORM).where(
+            MechanicalFactORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    row.payload = {**row.payload, "level": 1}
+    session.flush()
+    findings = verify_reconstruction(session, identified)
+    assert any("derives" in f for f in findings)
+
+
+def test_corrupted_derived_record_id_is_detected(session: Session) -> None:
+    # Every semantic value survives; only the stored identity is wrong. The
+    # payload digest alone would miss this, which is why the digest and the
+    # verification both cover persisted subidentities.
+    identified = _persist(session)
+    row = session.execute(
+        select(MechanicalRecordORM).where(
+            MechanicalRecordORM.projection_uuid == identified.projection_uuid,
+            MechanicalRecordORM.semantic_key == SPELL_KEY,
+        )
+    ).scalar_one()
+    before = compute_persisted_state_digest(session, identified.projection_uuid)
+    row.record_id = "00000000-0000-0000-0000-000000000000"
+    session.flush()
+    findings = verify_reconstruction(session, identified)
+    assert any("persisted id" in f for f in findings)
+    assert compute_persisted_state_digest(session, identified.projection_uuid) != before
+
+
+def test_missing_projection_raises(session: Session) -> None:
+    with pytest.raises(ProjectionNotPersistedError):
+        reconstruct_candidate(session, "no-such-projection")
+
+
+def test_delete_removes_every_scoped_row(session: Session) -> None:
+    identified = _persist(session)
+    delete_projection(session, identified.projection_uuid)
+    for model in (MechanicalSpanORM, MechanicalRecordORM, MechanicalFactORM):
+        remaining = (
+            session.execute(
+                select(model).where(
+                    model.projection_uuid == identified.projection_uuid  # type: ignore[attr-defined]
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert remaining == []
+
+
+def test_two_projections_over_one_release_coexist(session: Session) -> None:
+    first = _persist(session)
+    other = identify_projection(build_candidate(references=()))
+    second = identify_projection(
+        build_candidate(provenance=build_candidate().representation.provenance[:2])
+    )
+    assert other.projection_uuid == first.projection_uuid  # references were empty
+    persist_draft(session, second, now=NOW)
+    assert second.projection_uuid != first.projection_uuid
+    assert verify_reconstruction(session, first) == ()

--- a/tests/ingestion/mechanical/test_projection.py
+++ b/tests/ingestion/mechanical/test_projection.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from afterworlds.ingestion.corpus.hashing import canonical_json
 from afterworlds.ingestion.mechanical.models import (
+    ClassificationLedger,
     ComponentHandling,
     ReviewState,
     SemanticDisposition,
@@ -294,3 +295,74 @@ def test_fact_families_stay_distinct_under_identity() -> None:
             )
         )
     )
+
+
+# -- release agreement: candidate, ledger, and snapshot must all match -------
+
+
+def _candidate_with_binding(**binding_overrides: str) -> ProjectionCandidate:
+    base = build_candidate().binding
+    fields = {
+        "package_uuid": base.package_uuid,
+        "release_version": base.release_version,
+        "authoritative_source_hash": base.authoritative_source_hash,
+        "transform_config_hash": base.transform_config_hash,
+        "bundle_root_hash": base.bundle_root_hash,
+        "persisted_corpus_digest": base.persisted_corpus_digest,
+    }
+    fields.update(binding_overrides)
+    return ProjectionCandidate(
+        binding=ReleaseBinding(**fields),
+        classification=build_ledger(),
+        representation=build_representation(),
+    )
+
+
+def test_binding_package_disagreeing_with_the_snapshot_is_rejected() -> None:
+    findings = validate_candidate(
+        _candidate_with_binding(package_uuid="pkg-other"), bound_corpus()
+    )
+    assert any("corpus snapshot is pkg-5c" in f for f in findings)
+
+
+def test_binding_release_disagreeing_with_the_snapshot_is_rejected() -> None:
+    findings = validate_candidate(
+        _candidate_with_binding(release_version="rel-other"), bound_corpus()
+    )
+    assert any("corpus snapshot is rel-5c" in f for f in findings)
+
+
+def test_classification_package_disagreeing_with_the_binding_is_rejected() -> None:
+    ledger = build_ledger()
+    strayed = ClassificationLedger(
+        package_uuid="pkg-elsewhere",
+        release_version=ledger.release_version,
+        policy_version=ledger.policy_version,
+        policy_hash=ledger.policy_hash,
+        spans=ledger.spans,
+        batches=ledger.batches,
+        acceptances=ledger.acceptances,
+    )
+    findings = validate_candidate(
+        ProjectionCandidate(build_candidate().binding, strayed, build_representation()),
+        bound_corpus(),
+    )
+    assert any("classification names package pkg-elsewhere" in f for f in findings)
+
+
+def test_classification_release_disagreeing_with_the_binding_is_rejected() -> None:
+    ledger = build_ledger()
+    strayed = ClassificationLedger(
+        package_uuid=ledger.package_uuid,
+        release_version="rel-elsewhere",
+        policy_version=ledger.policy_version,
+        policy_hash=ledger.policy_hash,
+        spans=ledger.spans,
+        batches=ledger.batches,
+        acceptances=ledger.acceptances,
+    )
+    findings = validate_candidate(
+        ProjectionCandidate(build_candidate().binding, strayed, build_representation()),
+        bound_corpus(),
+    )
+    assert any("classification names release rel-elsewhere" in f for f in findings)

--- a/tests/ingestion/mechanical/test_projection.py
+++ b/tests/ingestion/mechanical/test_projection.py
@@ -38,6 +38,7 @@ from tests.ingestion.mechanical.conftest import (
     OPEN_ENDED_KEY,
     SPELL_KEY,
     SPELL_LEAF,
+    bound_corpus,
     build_candidate,
     build_ledger,
     build_representation,
@@ -218,7 +219,7 @@ def test_identity_changes_when_the_accepted_classification_changes() -> None:
 
 
 def test_honest_candidate_has_no_blocking_findings() -> None:
-    assert validate_candidate(build_candidate(), LEAF_LENGTHS) == ()
+    assert validate_candidate(build_candidate(), bound_corpus()) == ()
 
 
 def test_a_dishonest_candidate_still_computes_an_identity() -> None:
@@ -230,19 +231,23 @@ def test_a_dishonest_candidate_still_computes_an_identity() -> None:
         )
     )
     assert projection_uuid(broken)
-    assert validate_candidate(broken, LEAF_LENGTHS) != ()
+    assert validate_candidate(broken, bound_corpus()) != ()
 
 
 def test_classified_leaf_outside_the_bound_release_is_rejected() -> None:
     findings = validate_candidate(
-        build_candidate(), {k: v for k, v in LEAF_LENGTHS.items() if k != SPELL_LEAF}
+        build_candidate(),
+        bound_corpus(
+            leaf_lengths={k: v for k, v in LEAF_LENGTHS.items() if k != SPELL_LEAF}
+        ),
     )
     assert any("classified but not in the bound release" in f for f in findings)
 
 
 def test_release_leaf_with_no_classification_is_rejected() -> None:
     findings = validate_candidate(
-        build_candidate(), {**LEAF_LENGTHS, "leaf-unreviewed": 12}
+        build_candidate(),
+        bound_corpus(leaf_lengths={**LEAF_LENGTHS, "leaf-unreviewed": 12}),
     )
     assert any("leaf-unreviewed: no semantic spans" in f for f in findings)
 
@@ -260,7 +265,7 @@ def test_candidate_under_a_stale_policy_declaration_is_rejected() -> None:
     )
     findings = validate_candidate(
         ProjectionCandidate(build_candidate().binding, stale, build_representation()),
-        LEAF_LENGTHS,
+        bound_corpus(),
     )
     assert any("build uses" in f for f in findings)
 

--- a/tests/ingestion/mechanical/test_projection.py
+++ b/tests/ingestion/mechanical/test_projection.py
@@ -1,0 +1,291 @@
+"""Projection identity — CRD Issue 5d, Decisions 6 and 8.
+
+Two properties matter here and are easy to lose: identity derivation is
+acyclic (payload → projection UUID → subidentities, never the reverse), and a
+computed identity is not a licence to publish.
+"""
+
+from __future__ import annotations
+
+from afterworlds.ingestion.corpus.hashing import canonical_json
+from afterworlds.ingestion.mechanical.models import (
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    ReleaseBinding,
+    identify_projection,
+    projection_payload,
+    projection_uuid,
+    validate_candidate,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    ProgressionEntryFact,
+    RecordDraft,
+    RecordKind,
+    SpellDescriptorFact,
+    SpellSchool,
+)
+from tests.ingestion.mechanical.conftest import (
+    CREATURE_KEY,
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_KEY,
+    LEAF_LENGTHS,
+    OPEN_ENDED_KEY,
+    SPELL_KEY,
+    SPELL_LEAF,
+    build_candidate,
+    build_ledger,
+    build_representation,
+)
+
+# -- acyclic derivation ------------------------------------------------------
+
+
+def test_payload_contains_no_derived_identity() -> None:
+    identified = identify_projection(build_candidate())
+    serialized = canonical_json(projection_payload(identified.candidate))
+    assert identified.projection_uuid not in serialized
+    for derived in (
+        *identified.record_ids.values(),
+        *identified.component_ids.values(),
+        *identified.fact_ids.values(),
+    ):
+        assert derived not in serialized
+
+
+def test_subidentities_derive_from_the_projection_identity() -> None:
+    identified = identify_projection(build_candidate())
+    assert set(identified.record_ids) == {SPELL_KEY, CREATURE_KEY}
+    assert (SPELL_KEY, DESCRIPTOR_KEY) in identified.component_ids
+    assert len(identified.fact_ids) == 1
+    # Distinct kinds never collide even on identical semantic keys.
+    assert (
+        identified.record_ids[SPELL_KEY]
+        != identified.component_ids[(SPELL_KEY, DESCRIPTOR_KEY)]
+    )
+
+
+def test_identity_is_reproducible_for_identical_content() -> None:
+    assert projection_uuid(build_candidate()) == projection_uuid(build_candidate())
+
+
+def test_identity_is_order_independent() -> None:
+    draft = build_representation()
+    reordered = build_representation(
+        records=tuple(reversed(draft.records)),
+        components=tuple(reversed(draft.components)),
+        provenance=tuple(reversed(draft.provenance)),
+    )
+    assert projection_uuid(build_candidate()) == projection_uuid(
+        ProjectionCandidate(
+            binding=build_candidate().binding,
+            classification=build_ledger(),
+            representation=reordered,
+        )
+    )
+
+
+def test_unrelated_sibling_insertion_does_not_churn_existing_subidentities() -> None:
+    before = identify_projection(build_candidate())
+    draft = build_representation()
+    with_sibling = build_representation(
+        records=draft.records + (RecordDraft("spell:other", RecordKind.SPELL),)
+    )
+    after = identify_projection(
+        ProjectionCandidate(
+            binding=before.candidate.binding,
+            classification=build_ledger(),
+            representation=with_sibling,
+        )
+    )
+    # The projection identity changes — meaning changed. What must not happen is
+    # a *positional* churn: the surviving keys keep deriving the same way from
+    # whatever projection identity they belong to.
+    assert after.projection_uuid != before.projection_uuid
+    assert set(before.record_ids) < set(after.record_ids)
+    assert after.record_ids[SPELL_KEY] != before.record_ids[SPELL_KEY]
+
+
+# -- meaning-bearing payload -------------------------------------------------
+
+
+def _uuid_with(**overrides: object) -> str:
+    return projection_uuid(build_candidate(**overrides))
+
+
+def test_identity_changes_when_the_bound_release_changes() -> None:
+    base = build_candidate()
+    other = ProjectionCandidate(
+        binding=ReleaseBinding(
+            package_uuid=base.binding.package_uuid,
+            release_version=base.binding.release_version,
+            authoritative_source_hash=base.binding.authoritative_source_hash,
+            transform_config_hash=base.binding.transform_config_hash,
+            bundle_root_hash=base.binding.bundle_root_hash,
+            persisted_corpus_digest="e" * 64,
+        ),
+        classification=base.classification,
+        representation=base.representation,
+    )
+    assert projection_uuid(other) != projection_uuid(base)
+
+
+def test_identity_changes_when_a_fact_value_changes() -> None:
+    changed = build_representation(
+        components=(
+            ComponentDraft(
+                SPELL_KEY,
+                DESCRIPTOR_KEY,
+                ComponentHandling.STRUCTURED,
+                facts=(
+                    SpellDescriptorFact(
+                        level=8,  # was 9
+                        school=SpellSchool.CONJURATION,
+                        ritual=False,
+                        concentration=False,
+                    ),
+                ),
+            ),
+            build_representation().components[1],
+        )
+    )
+    assert projection_uuid(
+        ProjectionCandidate(build_candidate().binding, build_ledger(), changed)
+    ) != projection_uuid(build_candidate())
+
+
+def test_identity_changes_when_record_assembly_changes() -> None:
+    assert _uuid_with(
+        records=(
+            RecordDraft(SPELL_KEY, RecordKind.SPELL),
+            RecordDraft(CREATURE_KEY, RecordKind.CREATURE),  # no longer nested
+        )
+    ) != projection_uuid(build_candidate())
+
+
+def test_identity_changes_when_a_prose_binding_changes() -> None:
+    draft = build_representation()
+    rebound = build_representation(
+        prose_bindings=(
+            type(draft.prose_bindings[0])(
+                component_key=OPEN_ENDED_KEY,
+                record_key=SPELL_KEY,
+                chunk_id="chunk-wish-0002",
+                irreducibility_reason_code="open_ended_effect",
+            ),
+        )
+    )
+    assert projection_uuid(
+        ProjectionCandidate(build_candidate().binding, build_ledger(), rebound)
+    ) != projection_uuid(build_candidate())
+
+
+def test_identity_changes_when_provenance_changes() -> None:
+    draft = build_representation()
+    assert _uuid_with(provenance=draft.provenance[:-1]) != projection_uuid(
+        build_candidate()
+    )
+
+
+def test_identity_changes_when_the_accepted_classification_changes() -> None:
+    spans = build_ledger().spans
+    relabelled = build_ledger(
+        spans=(
+            SemanticSpan(
+                span_id=spans[0].span_id,
+                leaf_id=spans[0].leaf_id,
+                char_start=0,
+                char_end=40,
+                disposition=SemanticDisposition.SUPPORTING_AUTHORITY,
+                review_state=ReviewState.ACCEPTED,
+            ),
+            *spans[1:],
+        )
+    )
+    assert projection_uuid(
+        ProjectionCandidate(
+            build_candidate().binding, relabelled, build_representation()
+        )
+    ) != projection_uuid(build_candidate())
+
+
+# -- identification is not publication ---------------------------------------
+
+
+def test_honest_candidate_has_no_blocking_findings() -> None:
+    assert validate_candidate(build_candidate(), LEAF_LENGTHS) == ()
+
+
+def test_a_dishonest_candidate_still_computes_an_identity() -> None:
+    # This is the invariant: identity is computable for anything, so it can
+    # never stand in for proof. The findings are what block publication.
+    broken = build_candidate(
+        components=(
+            ComponentDraft(SPELL_KEY, DESCRIPTOR_KEY, ComponentHandling.STRUCTURED),
+        )
+    )
+    assert projection_uuid(broken)
+    assert validate_candidate(broken, LEAF_LENGTHS) != ()
+
+
+def test_classified_leaf_outside_the_bound_release_is_rejected() -> None:
+    findings = validate_candidate(
+        build_candidate(), {k: v for k, v in LEAF_LENGTHS.items() if k != SPELL_LEAF}
+    )
+    assert any("classified but not in the bound release" in f for f in findings)
+
+
+def test_release_leaf_with_no_classification_is_rejected() -> None:
+    findings = validate_candidate(
+        build_candidate(), {**LEAF_LENGTHS, "leaf-unreviewed": 12}
+    )
+    assert any("leaf-unreviewed: no semantic spans" in f for f in findings)
+
+
+def test_candidate_under_a_stale_policy_declaration_is_rejected() -> None:
+    stale = build_ledger()
+    stale = type(stale)(
+        package_uuid=stale.package_uuid,
+        release_version=stale.release_version,
+        policy_version="5d-semantic-policy-0",
+        policy_hash=stale.policy_hash,
+        spans=stale.spans,
+        batches=stale.batches,
+        acceptances=stale.acceptances,
+    )
+    findings = validate_candidate(
+        ProjectionCandidate(build_candidate().binding, stale, build_representation()),
+        LEAF_LENGTHS,
+    )
+    assert any("build uses" in f for f in findings)
+
+
+def test_fact_families_stay_distinct_under_identity() -> None:
+    # Two different families with coincidentally similar values must not
+    # collapse: the discriminator is part of the payload.
+    a = ProgressionEntryFact(level=9, entitlement_key="x")
+    b = DESCRIPTOR_FACT
+    assert projection_uuid(
+        build_candidate(
+            components=(
+                ComponentDraft(
+                    SPELL_KEY, DESCRIPTOR_KEY, ComponentHandling.STRUCTURED, facts=(a,)
+                ),
+                build_representation().components[1],
+            )
+        )
+    ) != projection_uuid(
+        build_candidate(
+            components=(
+                ComponentDraft(
+                    SPELL_KEY, DESCRIPTOR_KEY, ComponentHandling.STRUCTURED, facts=(b,)
+                ),
+                build_representation().components[1],
+            )
+        )
+    )

--- a/tests/ingestion/mechanical/test_provenance_relation.py
+++ b/tests/ingestion/mechanical/test_provenance_relation.py
@@ -1,0 +1,340 @@
+"""Provenance as a closed relation — CRD Issue 5d, review round 3.
+
+Forward validation alone let two things through: an authoritative element with
+no evidence of its own (because some *other* element happened to claim the same
+span), and a claim citing text the accepted classification says states no
+mechanic. Both are covered here, together with the target-key precision that
+makes the reverse obligation addressable at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from afterworlds.ingestion.mechanical.models import (
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    ReferenceDraft,
+    RelationshipDraft,
+    RelationshipKind,
+    fact_target_key,
+    prose_binding_target_key,
+    reference_target_key,
+    relationship_target_key,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from tests.ingestion.mechanical.conftest import (
+    CREATURE_KEY,
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_KEY,
+    OPEN_ENDED_KEY,
+    PROSE_SPAN,
+    SCOPED_WITHIN,
+    SECOND_CHUNK,
+    SPELL_KEY,
+    SPELL_SPAN,
+    SUPPORT_LEAF,
+    SUPPORT_SPAN,
+    WISH_BINDING,
+    WISH_CHUNK,
+    binding_claim,
+    bound_corpus,
+    build_ledger,
+    build_representation,
+    reference_claim,
+)
+
+FACT_KEY = fact_target_key(SPELL_KEY, DESCRIPTOR_KEY, DESCRIPTOR_FACT)
+
+
+def _findings(ledger=None, **overrides: object) -> tuple[str, ...]:  # type: ignore[no-untyped-def]
+    return validate_representation(
+        build_representation(**overrides),
+        ledger if ledger is not None else build_ledger(),
+        bound_corpus(),
+    )
+
+
+def _without(kind: ProvenanceTargetKind) -> tuple[ProvenanceClaim, ...]:
+    """The default provenance minus every claim of *kind*."""
+    return tuple(
+        c for c in build_representation().provenance if c.target_kind is not kind
+    )
+
+
+# -- reverse obligation: every authoritative element carries its own edge -----
+
+
+def test_fact_without_provenance_is_rejected_when_only_its_component_claims() -> None:
+    # The component claims the very span the fact came from. That is coverage
+    # of the span, not traceability of the fact.
+    claims = _without(ProvenanceTargetKind.FACT) + (
+        ProvenanceClaim(
+            ProvenanceTargetKind.COMPONENT,
+            (SPELL_KEY, DESCRIPTOR_KEY),
+            SPELL_SPAN,
+            ProvenanceRole.PRIMARY,
+        ),
+    )
+    findings = _findings(provenance=claims)
+    assert any("fact" in f and "no provenance" in f for f in findings)
+
+
+def test_prose_binding_without_provenance_is_rejected() -> None:
+    findings = _findings(provenance=_without(ProvenanceTargetKind.PROSE_BINDING))
+    assert any("prose_binding" in f and "no provenance" in f for f in findings)
+
+
+def test_relationship_without_provenance_is_rejected() -> None:
+    findings = _findings(provenance=_without(ProvenanceTargetKind.RELATIONSHIP))
+    assert any("relationship" in f and "no provenance" in f for f in findings)
+
+
+def test_resolved_reference_without_provenance_is_rejected() -> None:
+    reference = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    findings = _findings(references=(reference,))
+    assert any("reference" in f and "no provenance" in f for f in findings)
+
+
+def test_one_of_several_bindings_lacking_provenance_is_rejected() -> None:
+    second = ProseBindingDraft(
+        OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
+    )
+    findings = _findings(prose_bindings=(WISH_BINDING, second))
+    assert any(SECOND_CHUNK in f and "no provenance" in f for f in findings)
+
+
+def test_one_of_two_similar_references_lacking_provenance_is_rejected() -> None:
+    a = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    b = ReferenceDraft(
+        SPELL_KEY, OPEN_ENDED_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    findings = _findings(
+        references=(a, b),
+        provenance=build_representation().provenance + (reference_claim(a),),
+    )
+    assert any(OPEN_ENDED_KEY in f and "reference" in f for f in findings)
+
+
+def test_every_element_with_its_own_edge_passes() -> None:
+    reference = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    findings = _findings(
+        references=(reference,),
+        provenance=build_representation().provenance + (reference_claim(reference),),
+    )
+    assert findings == ()
+
+
+# -- disposition / role admissibility ----------------------------------------
+
+
+def _ledger_with_support_disposition(
+    disposition: SemanticDisposition, reason: str | None = None
+):  # type: ignore[no-untyped-def]
+    spans = build_ledger().spans
+    return build_ledger(
+        spans=spans[:2]
+        + (
+            SemanticSpan(
+                span_id=SUPPORT_SPAN,
+                leaf_id=SUPPORT_LEAF,
+                char_start=0,
+                char_end=20,
+                disposition=disposition,
+                review_state=ReviewState.ACCEPTED,
+                non_mechanical_reason_code=reason,
+            ),
+        )
+    )
+
+
+@pytest.mark.parametrize("role", [ProvenanceRole.PRIMARY, ProvenanceRole.CONTEXTUAL])
+def test_claim_on_a_non_mechanical_span_is_rejected(role: ProvenanceRole) -> None:
+    ledger = _ledger_with_support_disposition(
+        SemanticDisposition.NON_MECHANICAL, "navigation_only"
+    )
+    claims = _without(ProvenanceTargetKind.RECORD) + (
+        ProvenanceClaim(ProvenanceTargetKind.RECORD, (SPELL_KEY,), SUPPORT_SPAN, role),
+    )
+    findings = _findings(ledger=ledger, provenance=claims)
+    assert any(f"{role.value} claim on a non_mechanical span" in f for f in findings)
+
+
+def test_primary_claim_on_a_supporting_span_is_rejected() -> None:
+    # Supporting authority explains a mechanic; it is never the primary
+    # statement of one.
+    claims = _without(ProvenanceTargetKind.RECORD) + (
+        ProvenanceClaim(
+            ProvenanceTargetKind.RECORD,
+            (SPELL_KEY,),
+            SUPPORT_SPAN,
+            ProvenanceRole.PRIMARY,
+        ),
+    )
+    findings = _findings(provenance=claims)
+    assert any("primary claim on a supporting_authority span" in f for f in findings)
+
+
+def test_contextual_claim_on_a_supporting_span_is_permitted() -> None:
+    assert _findings() == ()
+
+
+def test_inadmissible_claim_does_not_satisfy_span_coverage() -> None:
+    # The only claim on the substantive prose span is inadmissible, so the span
+    # must still report as unclaimed rather than being covered by it.
+    ledger = _ledger_with_support_disposition(
+        SemanticDisposition.NON_MECHANICAL, "navigation_only"
+    )
+    # The relationship's only edge is the inadmissible one.
+    claims = tuple(
+        c
+        for c in build_representation().provenance
+        if c.target_kind
+        not in (ProvenanceTargetKind.RELATIONSHIP, ProvenanceTargetKind.RECORD)
+    ) + (
+        ProvenanceClaim(
+            ProvenanceTargetKind.RELATIONSHIP,
+            relationship_target_key(SCOPED_WITHIN),
+            SUPPORT_SPAN,
+            ProvenanceRole.CONTEXTUAL,
+        ),
+    )
+    findings = _findings(ledger=ledger, provenance=claims)
+    assert any("claim on a non_mechanical span" in f for f in findings)
+    assert any("relationship" in f and "no provenance" in f for f in findings)
+
+
+def test_inadmissible_claim_does_not_satisfy_the_reverse_obligation() -> None:
+    ledger = _ledger_with_support_disposition(
+        SemanticDisposition.NON_MECHANICAL, "navigation_only"
+    )
+    claims = _without(ProvenanceTargetKind.PROSE_BINDING) + (
+        binding_claim(WISH_BINDING, SUPPORT_SPAN, ProvenanceRole.CONTEXTUAL),
+    )
+    findings = _findings(ledger=ledger, provenance=claims)
+    assert any("prose_binding" in f and "no provenance" in f for f in findings)
+
+
+# -- uniqueness and closure --------------------------------------------------
+
+
+def test_duplicate_edge_is_rejected() -> None:
+    base = build_representation().provenance
+    findings = _findings(provenance=base + (base[0],))
+    assert any("duplicate provenance edge" in f for f in findings)
+
+
+def test_duplicate_edges_do_not_satisfy_a_missing_obligation() -> None:
+    fact_claim = ProvenanceClaim(
+        ProvenanceTargetKind.FACT, FACT_KEY, SPELL_SPAN, ProvenanceRole.PRIMARY
+    )
+    claims = _without(ProvenanceTargetKind.RELATIONSHIP) + (fact_claim,)
+    findings = _findings(provenance=claims)
+    assert any("duplicate provenance edge" in f for f in findings)
+    assert any("relationship" in f and "no provenance" in f for f in findings)
+
+
+def test_claim_with_an_obsolete_prose_binding_key_is_rejected() -> None:
+    # The pre-correction two-tuple no longer addresses any element.
+    claims = _without(ProvenanceTargetKind.PROSE_BINDING) + (
+        ProvenanceClaim(
+            ProvenanceTargetKind.PROSE_BINDING,
+            (SPELL_KEY, OPEN_ENDED_KEY),
+            PROSE_SPAN,
+            ProvenanceRole.PRIMARY,
+        ),
+    )
+    findings = _findings(provenance=claims)
+    assert any("claim for an undeclared element" in f for f in findings)
+    assert any("prose_binding" in f and "no provenance" in f for f in findings)
+
+
+def test_incomplete_reference_key_cannot_match_a_different_element() -> None:
+    # Two references share scope, wording, and owning record but differ in the
+    # component that cites them. The old three-field key matched both; the
+    # complete key matches exactly one.
+    a = ReferenceDraft(
+        SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    b = ReferenceDraft(
+        SPELL_KEY, OPEN_ENDED_KEY, "the servant", "spell:wish", CREATURE_KEY
+    )
+    assert reference_target_key(a) != reference_target_key(b)
+
+    findings = _findings(
+        references=(a, b),
+        provenance=build_representation().provenance
+        + (reference_claim(a), reference_claim(a)),
+    )
+    assert any("duplicate provenance edge" in f for f in findings)
+    assert any(OPEN_ENDED_KEY in f and "reference" in f for f in findings)
+
+
+def test_claim_with_a_wrong_shaped_target_key_is_rejected() -> None:
+    claims = build_representation().provenance + (
+        ProvenanceClaim(
+            ProvenanceTargetKind.FACT,
+            (SPELL_KEY,),  # too short to address a fact
+            SPELL_SPAN,
+            ProvenanceRole.CONTEXTUAL,
+        ),
+    )
+    findings = _findings(provenance=claims)
+    assert any("claim for an undeclared element" in f for f in findings)
+
+
+def test_binding_key_distinguishes_two_bindings_of_one_component() -> None:
+    second = ProseBindingDraft(
+        OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
+    )
+    assert prose_binding_target_key(WISH_BINDING) != prose_binding_target_key(second)
+    assert WISH_BINDING.chunk_id == WISH_CHUNK
+
+
+def test_many_to_many_provenance_is_still_permitted() -> None:
+    # One span may support several elements contextually; that is the
+    # many-to-many contract, not an overlap defect.
+    extra = ProvenanceClaim(
+        ProvenanceTargetKind.COMPONENT,
+        (SPELL_KEY, DESCRIPTOR_KEY),
+        SPELL_SPAN,
+        ProvenanceRole.CONTEXTUAL,
+    )
+    assert _findings(provenance=build_representation().provenance + (extra,)) == ()
+
+
+def test_component_without_facts_still_relies_on_span_coverage() -> None:
+    # A prose-bound component carries no facts, so its obligation stays span
+    # coverage rather than a per-element edge.
+    findings = _findings(
+        components=(
+            build_representation().components[0],
+            ComponentDraft(
+                SPELL_KEY,
+                OPEN_ENDED_KEY,
+                ComponentHandling.PROSE_BOUND,
+                "open_ended_effect",
+            ),
+        )
+    )
+    assert findings == ()
+
+
+def test_relationship_key_includes_its_kind() -> None:
+    other = RelationshipDraft(CREATURE_KEY, SPELL_KEY, RelationshipKind.PREREQUISITE)
+    assert relationship_target_key(SCOPED_WITHIN) != relationship_target_key(other)

--- a/tests/ingestion/mechanical/test_raw_state_closure.py
+++ b/tests/ingestion/mechanical/test_raw_state_closure.py
@@ -1,0 +1,620 @@
+"""Raw persisted closure and typed columns — CRD Issue 5d, review round 5.
+
+Two symptoms, one defect: persisted rows were projected into the semantic model
+before anything proved the raw row set was a closed, typed aggregate. An orphan
+child then vanished during a join — out of the candidate and out of the digest
+computed over it — and a corrupted enum escaped as an unclassified exception
+from an API whose contract is to report findings.
+
+Every test here corrupts real persisted rows after a successful write, because
+that is the only state this boundary exists to catch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.persistence import (
+    compute_persisted_state_digest,
+    persist_draft,
+    reconstruct_candidate,
+    record_persisted_state_digest,
+    verify_reconstruction,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    identify_projection,
+    projection_payload,
+)
+from afterworlds.ingestion.mechanical.raw_state import (
+    PersistedStateReconstructionError,
+    RawProjectionState,
+    validate_raw_closure,
+)
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalAcceptanceBatchORM,
+    MechanicalAcceptanceORM,
+    MechanicalBatchDiffORM,
+    MechanicalBatchScopeORM,
+    MechanicalComponentORM,
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+    MechanicalProseBindingORM,
+    MechanicalProvenanceORM,
+    MechanicalRecordORM,
+    MechanicalReferenceORM,
+    MechanicalRelationshipORM,
+    MechanicalSpanORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from tests.ingestion.mechanical.conftest import (
+    SCOPED_REFERENCES,
+    batch_accepted_ledger,
+    build_candidate,
+    build_representation,
+    reference_claim,
+)
+
+NOW = "2026-08-01T00:00:00Z"
+
+#: Every rp_mech_* table, with how its rows participate in the proof. A new
+#: table without a policy fails the inventory test below rather than quietly
+#: sitting outside both reconstruction and the digest.
+TABLE_POLICY: dict[type, str] = {
+    MechanicalProjectionORM: "header",
+    MechanicalSpanORM: "semantic",
+    MechanicalAcceptanceBatchORM: "evidence",
+    MechanicalBatchScopeORM: "evidence",
+    MechanicalBatchDiffORM: "evidence",
+    MechanicalAcceptanceORM: "evidence",
+    MechanicalRecordORM: "semantic+derived_id",
+    MechanicalComponentORM: "semantic+derived_id",
+    MechanicalFactORM: "semantic+derived_id",
+    MechanicalProseBindingORM: "semantic",
+    MechanicalRelationshipORM: "semantic",
+    MechanicalReferenceORM: "semantic",
+    MechanicalProvenanceORM: "semantic",
+}
+
+
+@pytest.fixture()
+def session(tmp_path) -> Iterator[Session]:  # type: ignore[no-untyped-def]
+    engine = create_engine(f"sqlite:///{tmp_path / 'raw.db'}")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as s:
+        s.add(
+            RulesPackageORM(
+                rules_package_id="pkg-5c",
+                name="SRD 5.2.1",
+                system="dnd5e",
+                version="5.2.1",
+                is_enabled=True,
+                publication_status="published",
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        s.flush()
+        s.add(
+            CorpusReleaseORM(
+                package_uuid="pkg-5c",
+                release_version="rel-5c",
+                authoritative_source_hash="a" * 64,
+                transform_config_hash="b" * 64,
+                bundle_root_hash="c" * 64,
+                ledger_hash="1" * 64,
+                policy_hash="2" * 64,
+                reconciliation_hash="3" * 64,
+                transform_config={},
+                publication_status="published",
+                created_at=NOW,
+            )
+        )
+        s.flush()
+        yield s
+
+
+def _persist(session: Session, **overrides: object):  # type: ignore[no-untyped-def]
+    identified = identify_projection(build_candidate(**overrides))
+    persist_draft(session, identified, now=NOW)
+    return identified
+
+
+def _persist_batch(session: Session):  # type: ignore[no-untyped-def]
+    return _persist(session, ledger=batch_accepted_ledger())
+
+
+def _assert_rejected(session: Session, identified, fragment: str) -> None:  # type: ignore[no-untyped-def]
+    """The corruption must be a finding, a digest failure, and unrecordable."""
+    findings = verify_reconstruction(session, identified)
+    assert any("does not reconstruct" in f for f in findings), findings
+    assert any(fragment in f for f in findings), findings
+    with pytest.raises(PersistedStateReconstructionError):
+        compute_persisted_state_digest(session, identified.projection_uuid)
+    with pytest.raises(PersistedStateReconstructionError):
+        record_persisted_state_digest(session, identified.projection_uuid)
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    assert header.persisted_state_digest is None
+
+
+# -- orphan child rows -------------------------------------------------------
+
+
+def test_orphan_batch_scope_row_is_rejected(session: Session) -> None:
+    identified = _persist_batch(session)
+    session.add(
+        MechanicalBatchScopeORM(
+            projection_uuid=identified.projection_uuid,
+            batch_id="batch-that-never-existed",
+            span_id="span-x",
+            ordinal=0,
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_batch_scope")
+
+
+def test_orphan_batch_diff_row_is_rejected(session: Session) -> None:
+    identified = _persist_batch(session)
+    session.add(
+        MechanicalBatchDiffORM(
+            projection_uuid=identified.projection_uuid,
+            batch_id="batch-that-never-existed",
+            span_id="span-x",
+            prior_disposition=None,
+            prior_reason_code=None,
+            accepted_disposition="substantive",
+            accepted_reason_code=None,
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_batch_diff")
+
+
+def test_orphan_acceptance_naming_a_nonexistent_batch_is_rejected(
+    session: Session,
+) -> None:
+    identified = _persist(session)
+    row = session.execute(select(MechanicalAcceptanceORM)).scalars().first()
+    assert row is not None
+    row.batch_id = "batch-that-never-existed"
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_acceptances")
+
+
+def test_batch_child_cannot_borrow_a_batch_from_another_projection(
+    session: Session,
+) -> None:
+    # A batch with the same id exists — in a different projection. Matching on
+    # batch_id alone would adopt this row; the relation is scoped, so it does
+    # not.
+    other = _persist_batch(session)
+    plain = _persist(session, provenance=build_representation().provenance[:2])
+    assert other.projection_uuid != plain.projection_uuid
+
+    session.add(
+        MechanicalBatchScopeORM(
+            projection_uuid=plain.projection_uuid,
+            batch_id="batch-wish",  # exists, but under `other`
+            span_id="span-x",
+            ordinal=0,
+        )
+    )
+    session.flush()
+    _assert_rejected(session, plain, "no header in this projection")
+
+
+def test_orphan_fact_row_is_rejected(session: Session) -> None:
+    identified = _persist(session)
+    template = session.execute(select(MechanicalFactORM)).scalars().one()
+    session.add(
+        MechanicalFactORM(
+            projection_uuid=identified.projection_uuid,
+            fact_id="fact-orphan",
+            record_key="record:that-never-existed",
+            component_key="component:none",
+            fact_key=template.fact_key,
+            family=template.family,
+            payload=dict(template.payload),
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_facts")
+
+
+def test_orphan_component_and_binding_rows_are_rejected(session: Session) -> None:
+    identified = _persist(session)
+    session.add(
+        MechanicalProseBindingORM(
+            projection_uuid=identified.projection_uuid,
+            record_key="record:that-never-existed",
+            component_key="component:none",
+            chunk_id="chunk-x",
+            irreducibility_reason_code="open_ended_effect",
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_prose_bindings")
+
+
+def test_orphan_relationship_row_is_rejected(session: Session) -> None:
+    identified = _persist(session)
+    session.add(
+        MechanicalRelationshipORM(
+            projection_uuid=identified.projection_uuid,
+            source_record_key="record:that-never-existed",
+            target_record_key="spell:wish",
+            kind="grants",
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_relationships")
+
+
+def test_orphan_reference_row_is_rejected(session: Session) -> None:
+    identified = _persist(session)
+    session.add(
+        MechanicalReferenceORM(
+            projection_uuid=identified.projection_uuid,
+            from_record_key="record:that-never-existed",
+            from_component_key="component:none",
+            source_text="the servant",
+            scope_key="spell:wish",
+            target_record_key="spell:wish",
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_references")
+
+
+def test_one_valid_row_plus_one_orphan_sibling_still_fails(session: Session) -> None:
+    identified = _persist_batch(session)
+    valid = session.execute(select(MechanicalBatchScopeORM)).scalars().first()
+    assert valid is not None
+    session.add(
+        MechanicalBatchScopeORM(
+            projection_uuid=identified.projection_uuid,
+            batch_id="batch-that-never-existed",
+            span_id=valid.span_id,
+            ordinal=99,
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "rp_mech_batch_scope")
+
+
+def test_orphan_rows_cannot_leave_the_digest_unchanged(session: Session) -> None:
+    # The precise defect: before this correction the digest was computed over
+    # the reconstructed ledger, so a dropped orphan left it identical.
+    identified = _persist_batch(session)
+    before = compute_persisted_state_digest(session, identified.projection_uuid)
+    session.add(
+        MechanicalBatchDiffORM(
+            projection_uuid=identified.projection_uuid,
+            batch_id="batch-that-never-existed",
+            span_id="span-x",
+            prior_disposition=None,
+            prior_reason_code=None,
+            accepted_disposition="substantive",
+            accepted_reason_code=None,
+        )
+    )
+    session.flush()
+    with pytest.raises(PersistedStateReconstructionError):
+        compute_persisted_state_digest(session, identified.projection_uuid)
+    assert before  # the honest digest existed; the corrupted state has none
+
+
+def test_duplicate_scope_ordinal_is_rejected(session: Session) -> None:
+    identified = _persist_batch(session)
+    existing = session.execute(select(MechanicalBatchScopeORM)).scalars().first()
+    assert existing is not None
+    session.add(
+        MechanicalBatchScopeORM(
+            projection_uuid=identified.projection_uuid,
+            batch_id=existing.batch_id,
+            span_id=existing.span_id,
+            ordinal=existing.ordinal,
+        )
+    )
+    session.flush()
+    _assert_rejected(session, identified, "ordinal")
+
+
+def test_malformed_provenance_target_key_is_rejected(session: Session) -> None:
+    identified = _persist(session)
+    row = session.execute(select(MechanicalProvenanceORM)).scalars().first()
+    assert row is not None
+    row.target_key = {"record": "spell:wish"}  # a dict, not a list of strings
+    session.flush()
+    _assert_rejected(session, identified, "not a list of strings")
+
+
+def test_target_key_with_non_string_members_is_rejected(session: Session) -> None:
+    identified = _persist(session)
+    row = session.execute(select(MechanicalProvenanceORM)).scalars().first()
+    assert row is not None
+    row.target_key = ["spell:wish", 7]
+    session.flush()
+    _assert_rejected(session, identified, "not a list of strings")
+
+
+# -- corrupted typed columns -------------------------------------------------
+
+ENUM_CORRUPTIONS = [
+    ("span disposition", MechanicalSpanORM, "disposition", "rp_mech_spans"),
+    ("span review state", MechanicalSpanORM, "review_state", "rp_mech_spans"),
+    (
+        "prior batch disposition",
+        MechanicalBatchDiffORM,
+        "prior_disposition",
+        "rp_mech_batch_diff",
+    ),
+    (
+        "accepted batch disposition",
+        MechanicalBatchDiffORM,
+        "accepted_disposition",
+        "rp_mech_batch_diff",
+    ),
+    ("component handling", MechanicalComponentORM, "handling", "rp_mech_components"),
+    ("record kind", MechanicalRecordORM, "kind", "rp_mech_records"),
+    (
+        "relationship kind",
+        MechanicalRelationshipORM,
+        "kind",
+        "rp_mech_relationships",
+    ),
+    (
+        "provenance target kind",
+        MechanicalProvenanceORM,
+        "target_kind",
+        "rp_mech_provenance",
+    ),
+    ("provenance role", MechanicalProvenanceORM, "role", "rp_mech_provenance"),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "model", "field", "table"),
+    ENUM_CORRUPTIONS,
+    ids=[c[0] for c in ENUM_CORRUPTIONS],
+)
+def test_invalid_persisted_enum_is_reported_not_raised(
+    session: Session, label: str, model: type, field: str, table: str
+) -> None:
+    identified = _persist_batch(session)
+    row = session.execute(select(model)).scalars().first()  # type: ignore[arg-type]
+    assert row is not None, label
+    setattr(row, field, "corrupt")
+    session.flush()
+    _assert_rejected(session, identified, table)
+
+
+def test_invalid_enum_message_names_field_and_value(session: Session) -> None:
+    identified = _persist(session)
+    row = session.execute(select(MechanicalSpanORM)).scalars().first()
+    assert row is not None
+    row.disposition = "corrupt"
+    session.flush()
+    (finding,) = verify_reconstruction(session, identified)
+    assert "rp_mech_spans" in finding
+    assert "disposition" in finding
+    assert "'corrupt'" in finding
+    assert "SemanticDisposition" in finding
+
+
+# -- positive controls -------------------------------------------------------
+
+
+def test_honest_batch_evidence_still_reconstructs(session: Session) -> None:
+    identified = _persist_batch(session)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert projection_payload(rebuilt) == projection_payload(identified.candidate)
+    assert rebuilt.classification.batches == (
+        identified.candidate.classification.batches[0],
+    )
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_honest_individual_acceptance_still_reconstructs(session: Session) -> None:
+    identified = _persist(session)
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert rebuilt.classification.acceptances == (
+        identified.candidate.classification.acceptances
+    )
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_honest_references_and_provenance_still_reconstruct(session: Session) -> None:
+    reference = SCOPED_REFERENCES[0]
+    identified = _persist(
+        session,
+        references=(reference,),
+        provenance=build_representation().provenance + (reference_claim(reference),),
+    )
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert rebuilt.representation.references == (reference,)
+    assert len(rebuilt.representation.provenance) == 5
+    assert verify_reconstruction(session, identified) == ()
+
+
+def test_recorded_digest_is_reverified(session: Session) -> None:
+    # Evidence-only tamper after recording used to pass: the payload hash and
+    # derived ids do not cover review evidence.
+    identified = _persist_batch(session)
+    record_persisted_state_digest(session, identified.projection_uuid)
+    assert verify_reconstruction(session, identified) == ()
+
+    row = session.execute(select(MechanicalAcceptanceORM)).scalars().first()
+    assert row is not None
+    row.reviewer = "someone-else"
+    session.flush()
+    findings = verify_reconstruction(session, identified)
+    assert any(
+        "recorded persisted-state digest no longer matches" in f for f in findings
+    )
+
+
+# -- sibling inventory -------------------------------------------------------
+
+
+def test_every_rp_mech_table_has_a_proof_policy() -> None:
+    declared = {name for name in Base.metadata.tables if name.startswith("rp_mech_")}
+    classified = {model.__tablename__ for model in TABLE_POLICY}  # type: ignore[attr-defined]
+    assert declared == classified, (
+        "every rp_mech_* table needs a reconstruction/proof policy: "
+        f"unclassified={sorted(declared - classified)}, "
+        f"stale={sorted(classified - declared)}"
+    )
+
+
+def test_every_scoped_table_is_loaded_into_the_raw_state(session: Session) -> None:
+    from afterworlds.ingestion.mechanical.raw_state import RawProjectionState
+
+    identified = _persist_batch(session)
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    from afterworlds.ingestion.mechanical.raw_state import load_raw_state
+
+    raw = load_raw_state(session, identified.projection_uuid, header)
+    loaded = {
+        type(row).__tablename__  # type: ignore[attr-defined]
+        for field in RawProjectionState.__dataclass_fields__
+        if field not in {"projection_uuid", "header"}
+        for row in getattr(raw, field)
+    }
+    scoped = {
+        model.__tablename__  # type: ignore[attr-defined]
+        for model, policy in TABLE_POLICY.items()
+        if policy != "header"
+    }
+    # The default batch-reviewed candidate populates every scoped table except
+    # references, which the honest fixture leaves empty.
+    assert loaded == scoped - {"rp_mech_references"}
+
+
+# -- closure rules validated directly over a raw row set ---------------------
+#
+# These duplicates cannot be produced through the write path any more — the
+# batch-identity constraint blocks one, and honest writes never emit the rest —
+# but a corrupted database or one created with constraints disabled still can,
+# which is precisely what the reconstruction check exists for. Validation is
+# pure over the raw structure, so it is exercised directly.
+
+
+def _raw(**overrides: object) -> RawProjectionState:
+    empty: dict[str, object] = {
+        "spans": (),
+        "batches": (),
+        "batch_scope": (),
+        "batch_diff": (),
+        "acceptances": (),
+        "records": (),
+        "components": (),
+        "facts": (),
+        "prose_bindings": (),
+        "relationships": (),
+        "references": (),
+        "provenance": (),
+    }
+    empty.update(overrides)
+    return RawProjectionState(
+        projection_uuid="proj-1",
+        header=MechanicalProjectionORM(projection_uuid="proj-1"),
+        **empty,  # type: ignore[arg-type]
+    )
+
+
+def _closure_problem(raw: RawProjectionState) -> str:
+    with pytest.raises(PersistedStateReconstructionError) as exc:
+        validate_raw_closure(raw)
+    return str(exc.value)
+
+
+def test_duplicate_batch_id_makes_parentage_ambiguous() -> None:
+    batch = MechanicalAcceptanceBatchORM(
+        projection_uuid="proj-1", batch_id="b1", rule="r", semantic_diff_hash="h"
+    )
+    problem = _closure_problem(_raw(batches=(batch, batch)))
+    assert "duplicate batch_id" in problem
+
+
+def test_duplicate_diff_rows_for_one_span_are_rejected() -> None:
+    batch = MechanicalAcceptanceBatchORM(
+        projection_uuid="proj-1", batch_id="b1", rule="r", semantic_diff_hash="h"
+    )
+    diff = MechanicalBatchDiffORM(
+        projection_uuid="proj-1",
+        batch_id="b1",
+        span_id="s1",
+        prior_disposition=None,
+        prior_reason_code=None,
+        accepted_disposition="substantive",
+        accepted_reason_code=None,
+    )
+    problem = _closure_problem(_raw(batches=(batch,), batch_diff=(diff, diff)))
+    assert "duplicate diff rows" in problem
+
+
+def test_duplicate_record_semantic_key_is_rejected() -> None:
+    record = MechanicalRecordORM(
+        projection_uuid="proj-1",
+        record_id="r-1",
+        semantic_key="spell:wish",
+        kind="spell",
+        parent_key=None,
+    )
+    problem = _closure_problem(_raw(records=(record, record)))
+    assert "duplicate semantic_key" in problem
+
+
+def test_duplicate_component_key_is_rejected() -> None:
+    record = MechanicalRecordORM(
+        projection_uuid="proj-1",
+        record_id="r-1",
+        semantic_key="spell:wish",
+        kind="spell",
+        parent_key=None,
+    )
+    component = MechanicalComponentORM(
+        projection_uuid="proj-1",
+        component_id="c-1",
+        record_key="spell:wish",
+        semantic_key="descriptor",
+        handling="structured",
+        irreducibility_reason_code=None,
+    )
+    problem = _closure_problem(
+        _raw(records=(record,), components=(component, component))
+    )
+    assert "duplicate component" in problem
+
+
+def test_component_naming_an_absent_record_is_rejected() -> None:
+    component = MechanicalComponentORM(
+        projection_uuid="proj-1",
+        component_id="c-1",
+        record_key="spell:ghost",
+        semantic_key="descriptor",
+        handling="structured",
+        irreducibility_reason_code=None,
+    )
+    problem = _closure_problem(_raw(components=(component,)))
+    assert "names record 'spell:ghost'" in problem
+
+
+def test_an_empty_projection_is_closed() -> None:
+    validate_raw_closure(_raw())

--- a/tests/ingestion/mechanical/test_representation.py
+++ b/tests/ingestion/mechanical/test_representation.py
@@ -37,13 +37,17 @@ from tests.ingestion.mechanical.conftest import (
     SPELL_KEY,
     SPELL_SPAN,
     SUPPORT_SPAN,
+    WISH_CHUNK,
+    bound_corpus,
     build_ledger,
     build_representation,
 )
 
 
 def _findings(**overrides: object) -> tuple[str, ...]:
-    return validate_representation(build_representation(**overrides), build_ledger())
+    return validate_representation(
+        build_representation(**overrides), build_ledger(), bound_corpus()
+    )
 
 
 # -- the closed typed-fact union ---------------------------------------------
@@ -175,7 +179,7 @@ def test_structured_component_without_facts_is_rejected() -> None:
 
 def test_prose_bound_component_without_bound_prose_is_rejected() -> None:
     findings = _findings(prose_bindings=())
-    assert any("prose-bound handling with no bound prose" in f for f in findings)
+    assert any("prose_bound handling with no bound prose" in f for f in findings)
 
 
 def test_prose_bound_component_carrying_facts_is_rejected() -> None:
@@ -190,7 +194,7 @@ def test_prose_bound_component_carrying_facts_is_rejected() -> None:
             ),
         )
     )
-    assert any("prose-bound handling with typed facts" in f for f in findings)
+    assert any("prose_bound handling with typed facts" in f for f in findings)
 
 
 def test_mixed_component_requires_both() -> None:
@@ -213,7 +217,7 @@ def test_irreducibility_reason_must_be_closed() -> None:
             ProseBindingDraft(
                 component_key=OPEN_ENDED_KEY,
                 record_key=SPELL_KEY,
-                chunk_id="chunk-wish-0001",
+                chunk_id=WISH_CHUNK,
                 irreducibility_reason_code="too_hard",
             ),
         )
@@ -224,10 +228,12 @@ def test_irreducibility_reason_must_be_closed() -> None:
 def test_prose_binding_requires_an_authoritative_chunk() -> None:
     findings = _findings(
         prose_bindings=(
-            ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, "  ", "open_ended_effect"),
+            ProseBindingDraft(
+                OPEN_ENDED_KEY, SPELL_KEY, "fabricated", "open_ended_effect"
+            ),
         )
     )
-    assert any("no authoritative chunk bound" in f for f in findings)
+    assert any("is not authoritative prose of release" in f for f in findings)
 
 
 # -- relationships and references --------------------------------------------

--- a/tests/ingestion/mechanical/test_representation.py
+++ b/tests/ingestion/mechanical/test_representation.py
@@ -1,0 +1,384 @@
+"""Representation validation — CRD Issue 5d, Decisions 3, 4, and 7."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    ComponentDraft,
+    DcKind,
+    ProgressionEntryFact,
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RecordDraft,
+    RecordKind,
+    ReferenceDraft,
+    RelationshipDraft,
+    RelationshipKind,
+    UnknownFactFamilyError,
+    fact_key,
+    fact_payload,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from tests.ingestion.mechanical.conftest import (
+    CREATURE_KEY,
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_FACT_KEY,
+    DESCRIPTOR_KEY,
+    OPEN_ENDED_KEY,
+    PROSE_SPAN,
+    SPELL_KEY,
+    SPELL_SPAN,
+    SUPPORT_SPAN,
+    build_ledger,
+    build_representation,
+)
+
+
+def _findings(**overrides: object) -> tuple[str, ...]:
+    return validate_representation(build_representation(**overrides), build_ledger())
+
+
+# -- the closed typed-fact union ---------------------------------------------
+
+
+def test_honest_representation_passes() -> None:
+    assert _findings() == ()
+
+
+def test_declared_family_serializes_with_its_discriminator() -> None:
+    payload = fact_payload(AbilityCheckFact(AbilityScore.WISDOM, DcKind.SPELL_SAVE_DC))
+    assert payload["family"] == "ability_check"
+    assert payload["ability"] == "wisdom"
+    assert payload["dc_value"] is None
+
+
+def test_unknown_family_is_rejected_not_absorbed() -> None:
+    @dataclass(frozen=True)
+    class ImprovisedFact:
+        anything: dict[str, str]
+
+    with pytest.raises(UnknownFactFamilyError):
+        fact_payload(ImprovisedFact({"dc": "12"}))
+
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(ImprovisedFact({"dc": "12"}),),  # type: ignore[arg-type]
+            ),
+        )
+    )
+    assert any("not a member of the closed typed-fact union" in f for f in findings)
+
+
+def test_a_plain_dict_is_not_a_fact() -> None:
+    with pytest.raises(UnknownFactFamilyError):
+        fact_payload({"family": "ability_check", "ability": "wisdom"})
+
+
+def test_fact_key_is_content_derived_not_positional() -> None:
+    first = ProgressionEntryFact(level=3, entitlement_key="feature:x")
+    same = ProgressionEntryFact(level=3, entitlement_key="feature:x")
+    other = ProgressionEntryFact(level=4, entitlement_key="feature:x")
+    assert fact_key(first) == fact_key(same)
+    assert fact_key(first) != fact_key(other)
+
+
+def test_duplicate_facts_on_one_component_are_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(DESCRIPTOR_FACT, DESCRIPTOR_FACT),
+            ),
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+        )
+    )
+    assert any("duplicate typed fact" in f for f in findings)
+
+
+# -- records and assembly ----------------------------------------------------
+
+
+def test_duplicate_record_keys_are_rejected() -> None:
+    findings = _findings(
+        records=(
+            RecordDraft(SPELL_KEY, RecordKind.SPELL),
+            RecordDraft(SPELL_KEY, RecordKind.CONDITION),
+        )
+    )
+    assert any("duplicate semantic key" in f for f in findings)
+
+
+def test_nested_record_with_unknown_parent_is_rejected() -> None:
+    findings = _findings(
+        records=(
+            RecordDraft(SPELL_KEY, RecordKind.SPELL),
+            RecordDraft(CREATURE_KEY, RecordKind.CREATURE, parent_key="spell:ghost"),
+        )
+    )
+    assert any("unknown parent spell:ghost" in f for f in findings)
+
+
+def test_parent_cycle_is_rejected() -> None:
+    findings = _findings(
+        records=(
+            RecordDraft(SPELL_KEY, RecordKind.SPELL, parent_key=CREATURE_KEY),
+            RecordDraft(CREATURE_KEY, RecordKind.CREATURE, parent_key=SPELL_KEY),
+        )
+    )
+    assert any("parent cycle" in f for f in findings)
+
+
+def test_component_on_an_unknown_record_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key="spell:ghost",
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(DESCRIPTOR_FACT,),
+            ),
+        )
+    )
+    assert any("unknown record spell:ghost" in f for f in findings)
+
+
+# -- handling honesty --------------------------------------------------------
+
+
+def test_structured_component_without_facts_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(SPELL_KEY, DESCRIPTOR_KEY, ComponentHandling.STRUCTURED),
+        )
+    )
+    assert any("structured handling with no typed facts" in f for f in findings)
+
+
+def test_prose_bound_component_without_bound_prose_is_rejected() -> None:
+    findings = _findings(prose_bindings=())
+    assert any("prose-bound handling with no bound prose" in f for f in findings)
+
+
+def test_prose_bound_component_carrying_facts_is_rejected() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+                facts=(DESCRIPTOR_FACT,),
+            ),
+        )
+    )
+    assert any("prose-bound handling with typed facts" in f for f in findings)
+
+
+def test_mixed_component_requires_both() -> None:
+    findings = _findings(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.MIXED,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+        )
+    )
+    assert any("mixed handling with no typed facts" in f for f in findings)
+
+
+def test_irreducibility_reason_must_be_closed() -> None:
+    findings = _findings(
+        prose_bindings=(
+            ProseBindingDraft(
+                component_key=OPEN_ENDED_KEY,
+                record_key=SPELL_KEY,
+                chunk_id="chunk-wish-0001",
+                irreducibility_reason_code="too_hard",
+            ),
+        )
+    )
+    assert any("is not closed" in f for f in findings)
+
+
+def test_prose_binding_requires_an_authoritative_chunk() -> None:
+    findings = _findings(
+        prose_bindings=(
+            ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, "  ", "open_ended_effect"),
+        )
+    )
+    assert any("no authoritative chunk bound" in f for f in findings)
+
+
+# -- relationships and references --------------------------------------------
+
+
+def test_relationship_to_an_unknown_record_is_rejected() -> None:
+    findings = _findings(
+        relationships=(
+            RelationshipDraft(SPELL_KEY, "creature:ghost", RelationshipKind.GRANTS),
+        )
+    )
+    assert any("unknown record creature:ghost" in f for f in findings)
+
+
+def test_unresolved_reference_is_rejected() -> None:
+    findings = _findings(
+        references=(
+            ReferenceDraft(SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", ""),
+        )
+    )
+    assert any("unresolved reference" in f for f in findings)
+
+
+def test_ambiguous_reference_within_one_scope_is_rejected() -> None:
+    findings = _findings(
+        references=(
+            ReferenceDraft(
+                SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", SPELL_KEY
+            ),
+            ReferenceDraft(
+                SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+            ),
+        )
+    )
+    assert any("ambiguous" in f for f in findings)
+
+
+def test_same_wording_in_two_scopes_is_not_ambiguous() -> None:
+    # The scoped-collision canary: a repeated name resolves per committed scope.
+    findings = _findings(
+        references=(
+            ReferenceDraft(
+                SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", CREATURE_KEY
+            ),
+            ReferenceDraft(
+                SPELL_KEY, DESCRIPTOR_KEY, "the servant", "chapter:appendix", SPELL_KEY
+            ),
+        )
+    )
+    assert not any("ambiguous" in f for f in findings)
+
+
+def test_reference_without_a_committed_scope_is_rejected() -> None:
+    findings = _findings(
+        references=(
+            ReferenceDraft(SPELL_KEY, DESCRIPTOR_KEY, "the servant", " ", CREATURE_KEY),
+        )
+    )
+    assert any("no committed resolution scope" in f for f in findings)
+
+
+# -- provenance --------------------------------------------------------------
+
+
+def test_substantive_span_nothing_claims_is_rejected() -> None:
+    findings = _findings(
+        provenance=(
+            ProvenanceClaim(
+                ProvenanceTargetKind.FACT,
+                (SPELL_KEY, DESCRIPTOR_KEY, DESCRIPTOR_FACT_KEY),
+                SPELL_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.RECORD,
+                (SPELL_KEY,),
+                SUPPORT_SPAN,
+                ProvenanceRole.CONTEXTUAL,
+            ),
+        )
+    )
+    assert any(f"span {PROSE_SPAN}: substantive but unclaimed" in f for f in findings)
+
+
+def test_supporting_span_nothing_links_is_rejected() -> None:
+    keep = build_representation().provenance[:2]
+    findings = _findings(provenance=keep)
+    assert any(
+        f"span {SUPPORT_SPAN}: supporting authority but unlinked" in f for f in findings
+    )
+
+
+def test_conflicting_primary_claims_are_rejected() -> None:
+    base = build_representation().provenance
+    findings = _findings(
+        provenance=base
+        + (
+            ProvenanceClaim(
+                ProvenanceTargetKind.RECORD,
+                (SPELL_KEY,),
+                SPELL_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+        )
+    )
+    assert any("conflicting primary claims" in f for f in findings)
+
+
+def test_contextual_overlap_is_permitted() -> None:
+    base = build_representation().provenance
+    findings = _findings(
+        provenance=base
+        + (
+            ProvenanceClaim(
+                ProvenanceTargetKind.COMPONENT,
+                (SPELL_KEY, DESCRIPTOR_KEY),
+                SPELL_SPAN,
+                ProvenanceRole.CONTEXTUAL,
+            ),
+        )
+    )
+    assert findings == ()
+
+
+def test_provenance_for_an_undeclared_element_is_rejected() -> None:
+    base = build_representation().provenance
+    findings = _findings(
+        provenance=base
+        + (
+            ProvenanceClaim(
+                ProvenanceTargetKind.COMPONENT,
+                (SPELL_KEY, "ghost-component"),
+                SUPPORT_SPAN,
+                ProvenanceRole.CONTEXTUAL,
+            ),
+        )
+    )
+    assert any("claim for an undeclared element" in f for f in findings)
+
+
+def test_provenance_naming_an_unknown_span_is_rejected() -> None:
+    base = build_representation().provenance
+    findings = _findings(
+        provenance=base
+        + (
+            ProvenanceClaim(
+                ProvenanceTargetKind.RECORD,
+                (SPELL_KEY,),
+                "span-ghost",
+                ProvenanceRole.CONTEXTUAL,
+            ),
+        )
+    )
+    assert any("unknown span span-ghost" in f for f in findings)

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -25,6 +25,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 import afterworlds.persistence.orm.corpus  # noqa: F401
+import afterworlds.persistence.orm.mechanical  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 from afterworlds.models.enums import (
     MechanicalEntityTypeEnum,
@@ -242,6 +243,20 @@ class TestRpTablePrefix:
             "rp_reconciliation_policies",
             "rp_reconciliations",
             "rp_corpus_projections",
+            # CRD Issue 5d (#137) mechanical-authority projection tables.
+            "rp_mech_projections",
+            "rp_mech_spans",
+            "rp_mech_acceptance_batches",
+            "rp_mech_batch_scope",
+            "rp_mech_batch_diff",
+            "rp_mech_acceptances",
+            "rp_mech_records",
+            "rp_mech_components",
+            "rp_mech_facts",
+            "rp_mech_prose_bindings",
+            "rp_mech_relationships",
+            "rp_mech_references",
+            "rp_mech_provenance",
         }
         actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
         assert (

--- a/tests/services/test_schema_separation_invariant.py
+++ b/tests/services/test_schema_separation_invariant.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.corpus  # noqa: F401
+import afterworlds.persistence.orm.mechanical  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
@@ -148,6 +149,20 @@ def test_rules_package_tables_exist_with_rp_prefix() -> None:
         "rp_reconciliation_policies",
         "rp_reconciliations",
         "rp_corpus_projections",
+        # CRD Issue 5d (#137) mechanical-authority projection tables.
+        "rp_mech_projections",
+        "rp_mech_spans",
+        "rp_mech_acceptance_batches",
+        "rp_mech_batch_scope",
+        "rp_mech_batch_diff",
+        "rp_mech_acceptances",
+        "rp_mech_records",
+        "rp_mech_components",
+        "rp_mech_facts",
+        "rp_mech_prose_bindings",
+        "rp_mech_relationships",
+        "rp_mech_references",
+        "rp_mech_provenance",
     }
     actual = {name for name in Base.metadata.tables if name.startswith(_RP_PREFIX)}
     assert (


### PR DESCRIPTION
CRD Issue 5d (#137) PR 1 of a planned sequence: the semantic accounting, representation, identity, and
persistence foundation for the typed mechanical-authority projection.

**Non-activating by construction.** `publication_status` never leaves `draft`, no runtime surface reads
`rp_mech_*`, and the `MechanicalEntity` authority path is untouched. Nothing here can be reached as
mechanical authority.

## What was built

**Semantic accounting** (`ingestion/mechanical/{models,policy,accounting}.py`)
- Semantic disposition and review state are separate fields, so a proposal can never read as an
  acceptance. Gap-free, non-overlapping span partition over each represented leaf.
- Frozen semantic policy with closed catalogs (non-mechanical reasons, prose-bound irreducibility),
  reusing CRD Issue 5c's `normalize` rather than defining a second text-equivalence rule. Headings,
  examples, cross-references, explanatory clauses, GM guidance, and repeated wording are deliberately
  absent from the non-mechanical catalog — they are not blanket categories, and each instance is
  classified from its actual role.
- The ledger declares the policy it was accepted under (`policy_version` + `policy_hash`); the payload
  carries that declaration and `validate_policy_binding()` fails when it disagrees with the committed
  policy, so a historical projection is never silently reinterpreted under later code.
- Acceptance evidence: individual and rule-scoped batch acceptance. A batch retains its exact resolved
  span scope and the canonical semantic diff itself; the digest identifies and verifies that diff rather
  than replacing it, and the free-form rule is selection evidence that is never re-run.

**Identity boundary.** The accepted semantic *result* is identity-bearing; the review *path* is not.
Individual-vs-batch review, batch grouping, rule wording, resolved scope, reviewer, timestamp, and
acceptance history are all outside `classification_payload()`. A batch rule governs future classification
only by being promoted into the frozen policy, where it *is* identity-bearing.

**Representation** (`representation.py`, `validation.py`)
- Closed record vocabulary (`CREATURE` for every stat block; source ancestry is not a record kind), keyed
  records and components, prose bindings resolved through the authoritative 5c `RuleChunk` rather than a
  second prose store, typed relationships, build-time-resolved references, and exact many-to-many
  provenance to 5c leaf subspans with primary and contextual roles distinct.
- Closed discriminated typed-fact union: `ability_check`, `creature_ability_score`, `spell_descriptor`,
  `progression_entry`. Each family declares its own intrinsic invariants through one validation seam
  (`fact_invariant_violations`), so membership of the union is not mistaken for validity — a `FIXED` DC
  must carry a value and a non-fixed one must not. Only constraints intrinsic to the declared fields are
  enforced; SRD-specific bounds are Rules Package policy, not properties of the type. Each is justified by a required real-corpus canary in #137 — the source discovery
  available today. **No corpus-completeness claim is made.** Anything outside the union raises rather than
  degrading into a dict, expression, or key-value bag. Spell casting time/range/duration are left
  prose-bound rather than smuggled in as free text.
- Validation covers dangling keys, duplicate semantic keys, parent cycles, handling honesty, non-closed
  irreducibility reasons, duplicate facts, unresolved and scope-ambiguous references, undeclared
  provenance targets, unclaimed substantive spans, unlinked supporting spans, and conflicting primary
  claims. Contextual overlap stays permitted. `PROSE_BOUND` and `MIXED` must each state one closed
  component-level irreducibility reason, and every associated prose binding must use exactly that reason —
  two independently valid reasons that disagree are a contradiction, and neither copy wins.

**Bound-corpus resolution** (`bound_corpus.py`) — one `BoundCorpusSnapshot` resolves the bound release's
represented-leaf lengths and authoritative chunk population from persisted 5c state, and the validators
are pure functions over it. A prose binding resolves only to a chunk that is both persisted under the
bound package and present in that release's declared corpus-projection population; a fabricated id,
another package's chunk, and an unprojected chunk all fail. The candidate binding, the classification
ledger, and the snapshot must all name one release — two of three agreeing is not agreement.

**Projection identity** (`projection.py`) — the exact 5c release binding (six proof identities, not a
slug), and acyclic derivation: keyed payload → projection UUID → record/component/fact IDs from that UUID
plus their semantic keys. A test asserts no derived identity appears inside the payload the identity is
computed from, and fact keys are content-derived so reordering cannot churn them.

**Persistence** (`persistence.py`, `orm/mechanical.py`, migration `0021`) — thirteen `rp_mech_*` tables,
additive only. Typed rows throughout, not one opaque payload column. Reconstruction reads only the
database — never the in-memory candidate — so a row that failed to land cannot be repaired from memory.
The digest covers three layers, because each catches what the others cannot: the reconstructed semantic
payload, the persisted derived IDs (a corrupted `record_id` leaves every semantic value intact), and a
separate canonical **acceptance-evidence payload** — review state, batch id, rule, ordered resolved scope,
full retained diff, diff digest, and each acceptance's span, linkage, reviewer, and timestamp. Review
history stays outside the projection UUID and inside the persisted-state proof, so it cannot be silently
rewritten. Persisted fact payloads rebuild strictly: a missing field, an extra field, an unknown family, or
a `family`/`fact_key` column disagreeing with its own payload is reported rather than repaired.

## How this satisfies each acceptance criterion

#137's acceptance criteria are proven at completion, against the real corpus. PR 1 establishes the
machinery and proves its behaviour against synthetic accepted inputs. Coverage so far, stated as partial:

| Criterion | Status in PR 1 |
|---|---|
| 1 — exact release binding, rejects stale/mismatched | Binding type + `validate_policy_binding`; release-equality proof at the gate (PR 2) |
| 2–4 — accepted gap-free partition, span roles, handling | Enforced by `accounting` + `validation`; full-corpus coverage is the content PRs |
| 5–6 — record assembly, non-ordinal stable identities | Simple, composite, and nested assembly supported; sibling insertion cannot churn a key |
| 7 — exact provenance, overlap policy | Enforced, incl. conflicting-primary rejection |
| 8 — closed fact union, no escape hatches | Enforced; union completeness deferred to full-corpus accounting |
| 11 — meaning changes identity, audit metadata does not | Proven for classification, representation, binding, and policy |
| 12 — reproducible identity from identical inputs | Proven (content-derived, order-independent) |
| 13 — reconstruction detects tamper/omission/stale | Proven by negative controls |
| 9, 10, 14–23 | Not claimed by this PR — gate, publication, runtime binding, legacy retirement, real-corpus proof |

## Test coverage summary

334 tests in `tests/ingestion/mechanical/`, negative-control heavy: uncovered/overlapping/unclaimed text,
forged span ids, invented reason codes, acceptance without evidence, proposed-but-claimed-accepted,
unresolved classification, batch evidence that does not support what it claims (missing rule/scope/diff,
duplicate batch id, unknown spans, scope-diff-acceptance mismatch, forged digest, missing
reviewer/timestamp), unknown fact families, duplicate facts, parent cycles, dishonest handling, ambiguous
references, persistence-side omission, tamper, and corrupted derived identity, every invalid DC combination,
mistyped fact fields in both directions (a directly constructed dataclass and a persisted payload) across
every primitive category including `bool`-as-`int` and truthy `"false"`, digest recording that derives its
own proof rather than trusting a caller,
malformed persisted payloads and discriminators, missing/blank/non-closed/disagreeing irreducibility
reasons, fabricated and unprojected prose chunks, release disagreement between binding, ledger, and
snapshot, and one evidence-only edit per retained audit column proving the digest moves while the
projection UUID does not.

Full default suite on head `e0e0734`: **2897 passed, 10 skipped**, total coverage **93.25%**. New-code
coverage over the 5d modules alone: **99%** — `bound_corpus`, `canonical`, `models`, `policy`,
`projection`, `raw_state`, `representation`, and `validation` at 100%, `persistence` 98%,
`accounting` 95%. Black, Ruff,
and mypy
strict clean on that head. Migration verified
applying from a clean database through `0021`; all thirteen tables match the ORM with no column drift.
That verification used the gitignored repo-root dev database; nothing generated was committed. Black,
Ruff, and mypy strict clean.

## Architecture Notes

**What this PR does not prove.** Validation here proves the representation is internally honest, not that
it is complete. The exact completeness gate, publication, and the real-corpus proof are PR 2 and the
content PRs. The real-corpus gate fails closed by construction until the full accepted-input set lands.

**Fact-union scope.** Four families, each traceable to a named canary. Adding a family later is additive:
facts persist as `family` + validated payload and rebuild through explicit per-family builders, so a new
typed family needs no migration while an unknown family still raises. What the union must never become is
a bag that accepts an undeclared shape.

**Known shape-risk (surfaced, not decided).** Facts currently attach to components only. #137 contract 3
describes facts as component-level, so this follows the spec — but the composite-creature canary's ability
grid is arguably record-level. If full-corpus accounting shows record-level facts are needed, that is a
schema change to `rp_mech_facts`, not an additive family. Flagging now rather than discovering it later.

**Review round 5 (two P2s), fixed on this head — a separate persistence/reconstruction closure family.**
Not a return to canonicalization or provenance integrity, but it still trips the general repeated-review
boundary because earlier rounds landed in `persistence.py`. The two symptoms — an orphan batch-evidence row
and an unclassified enum failure — were one defect: **persisted rows were being projected into the semantic
model before anything proved the raw row set was a closed, relationally valid, typed aggregate.** An orphan
child vanished during a join, leaving retained database state outside both the candidate and the digest
computed over it; a corrupted typed column escaped as an unclassified `ValueError` from an API whose
contract is to report findings.

The pipeline is now two explicit stages — *load complete raw row set → prove raw closure → reconstruct* —
with one `RawProjectionState` describing a single transaction state across all thirteen tables, one closed
`PersistedStateReconstructionError` family carrying table/row/field/value, and strict parsing for all nine
persisted enum columns. Parentage, uniqueness, and target-key shape are proven before any semantic meaning
is imposed; nothing is dropped, defaulted, or repaired. A sibling defect surfaced while auditing the digest
boundary: a *recorded* `persisted_state_digest` was never re-derived, so evidence-only tamper after
recording left a stale proof unchallenged — `verify_reconstruction` now recomputes and compares whenever a
digest is present, while publication stays PR 2's. Migration 0021 (unmerged) gained a
`(projection_uuid, batch_id)` uniqueness constraint as defence in depth; composite FKs were deliberately
not added, because they would make orphan-row corruption impossible to exercise while the threat model is
exactly a corrupted or constraint-disabled database. **No Owner decision, Known Unknown, Issue change, or
ADR change was required.**

**Review round 4 (one P1), fixed on this head — the round that invoked the declared stop condition.**
Because the finding returned to the provenance-integrity family, this round began with an architectural
reassessment rather than another validation branch. The reassessment found that the round-3 relation had
been closed over element identity and span admissibility but **not over the CRD Issue 5c chunk-projection
relation**: `BoundCorpusSnapshot` kept represented-leaf lengths and a release-wide chunk-id set while
discarding the `CorpusProjectionORM` edges that state which leaf ranges belong to which chunk. A binding
to chunk A could therefore cite an admissible span that only ever projected into chunk B and satisfy every
check, persisting governing prose that does not contain the text it claims to govern.

The snapshot now retains exact chunk coverage as a first-class relation
(`chunk → leaf → merged half-open ranges`, with role and projection id preserved), authoritative
membership is *derived* from that coverage so "authoritative but uncovered" is unrepresentable, and
prose-binding provenance performs the missing relational join: every edge must cite a span wholly inside
its own binding's chunk, checked before the edge counts toward reverse coverage, claiming, or linkage.
5c's coordinates are the same coordinate system as 5d spans — both index the source leaf's content, which
5c states on `ProjectionEdge` and proves by slicing `leaf.content[cover_start:cover_end]` in its own gate.
**No Owner decision, Known Unknown, migration, Issue change, or ADR change was required**, and no target
key gained coordinates: binding→chunk, edge→span, and span→leaf range already existed separately; only
their relationship was unvalidated.

**Review round 3 (three P2 findings), fixed on this head — the point at which the repeated-review
boundary first triggered.** The three symptoms were treated as two structural families rather than three
conditionals. *Canonical ordering was not exhaustive*: hand-picked sort tuples let semantically different
elements compare equal, so Python's stable sort leaked authoring order into the projection UUID. Every
unordered collection now orders by its elements' complete canonical payload, which cannot regress by
omission the way a field list can. *Provenance was not a closed relation*: it validated claim → element
but never element → claim, and never checked whether the cited span was mechanically eligible at all. It
now enforces forward, reverse, and admissibility obligations through one set of canonical target-key
helpers — prose-binding keys carry chunk and reason, reference keys carry their owning component and
target, `NON_MECHANICAL`/`UNRESOLVED` spans admit no claims, `SUPPORTING_AUTHORITY` admits contextual
links only, and admissibility is decided before an edge counts toward anything. Sibling defects fixed in
the same round: relationships and references had no reverse obligation at all, reference provenance keys
omitted source ownership, and duplicate edges could inflate coverage. No migration was required — the
`target_key` JSON column stores the longer tuples exactly.

**Review round 2 (two P2 findings), fixed on this head.** Both returned to the round-1 hotspots. The
closed union checked semantic invariants but not runtime field types, so `{"ritual": "false"}` rebuilt
happily — and `"false"` is truthy, while Python's `bool` is a subclass of `int`, so a bare integer check
also accepted `True`. Shared primitive helpers now sit inside each family's existing explicit checker and
builder (no reflective annotation validator), covering both the in-memory and persisted paths with no
coercion. Separately, `record_persisted_state_digest` accepted a caller-supplied proof and froze it under
the exactly-once guard; it now takes only `(session, projection_uuid)` and derives the digest from that
projection's reconstructed state inside the recording transaction, leaving the column `NULL` if
reconstruction fails. Sibling audit distinguished the three legitimately supplied hash values
(`payload_hash` pre-persistence and later verified, `semantic_diff_hash` independently recomputed,
`persisted_corpus_digest` owned by 5c) from the one post-persistence proof that must derive itself.

**Review round 1 (four P2 findings), all fixed on this head.** All four shared one shape: a declaration
that was *well-formed* being accepted as *valid*. Typed facts were closed by class but not by invariant;
`PROSE_BOUND`/`MIXED` could omit or contradict their irreducibility reason; any non-blank string passed as
a prose chunk; and the persisted digest omitted the retained acceptance evidence. The bounded sibling
audits also turned up four defects the comments did not name: `fact_from_payload` accepted missing and
extra fields, the `family` and `fact_key` columns were never checked against their own payload, and the
classification ledger's package/release were never checked against the candidate binding.

**Deferred to PR 2, stated rather than left to be found.** Re-persisting an identical projection UUID
currently conflicts on the primary key. #137 contract 5 requires concurrent identical builds to be
idempotent; that belongs with publication and atomic activation.

**Acceptance mechanism (owner-visible).** Completed 5d needs accepted, committed semantic inputs across
all 28,109 represented leaves, and #137 forbids implicit acceptance. The proposal in flight: a
deterministic proposer plus a committed acceptance ledger supporting both per-span and rule-scoped batch
acceptance, each batch recording rule, exact resolved scope, and semantic diff, accepted in review-sized
units. Because acceptance records are identity-adjacent, both forms are supported from this first
migration rather than retrofitted.

**Delivery sequence.** PR 1 accounting/representation/identity/persistence → PR 2 completeness gate,
publication, evidence report → PR 3 runtime binding, selectors, views, typed overrides wired *alongside*
the still-runnable `MechanicalEntity` path → PRs 4…N review-sized inactive content PRs → final PR
full-corpus coverage, activation, then legacy retirement. No merged state will have neither usable old
authority nor complete new authority, and no combining or fallback between old and new authority within
one resolution.

No drift from ADR-005d or #137.

## Review-Loop / Boundary Check

- [x] This PR still fits the intended scope of the issue.
- [ ] Repeated review churn has **not** accumulated on the same file or function.
- [x] The remaining work is still concrete implementation, not an ownership or boundary dispute.

Reported honestly: **the repeated-review boundary triggered at round 3, round 4 invoked the declared stop
condition, and round 5 opened a second defect family in `persistence.py`.** Five rounds have now landed in
this package, and rounds 3–5 each exposed a systemic pattern rather than isolated conditionals — partial
canonical ordering; one-way provenance validation; a provenance relation that never closed over the 5c
projection edges; and persisted rows projected into the semantic model before raw relational and typed
closure was established. Each round began with reassessment and replaced a class of defect rather than the
quoted example.

- **Hotspots:** `validation.py` (`_validate_provenance`, `_validate_components`),
  `projection.py` (`representation_payload`), `representation.py` (target keys and the fact union),
  `bound_corpus.py` (release-scoped source resolution), `persistence.py`/`raw_state.py` (reconstruction
  and persisted-state proof).
- **Classification:** in scope for PR 1 and already governed by #137 and ADR-005d Decisions 3 and 6. **No
  Owner decision, Known Unknown, or specification change was required**, and no ADR contradiction was
  found.
- **Remediation shape:** each round replaced a class of defect rather than the quoted example — partial
  sort keys became ordering over the complete canonical payload, and one-way provenance checks became a
  closed relation with forward, reverse, and admissibility obligations.
- **Stop condition (invoked at round 4, extended at round 5, and still standing):** a finding returning
  to the provenance-integrity, canonicalization, or persistence-closure families triggers an architectural
  reassessment before any code change. Rounds 4 and 5 each followed that path and each found the relation
  genuinely incomplete rather than the example merely unhandled. A further finding in these families stops
  the patch loop again for the same reassessment, not another remediation round.

Earlier owner corrections in this PR (classification identity boundary, retained batch diff, declared
policy binding) were applied as follow-up commits and are reflected above.
