### PR TITLE
chore: pin Graphify to 0.9.34

### DIFF
--- a/.github/workflows/graphify-code-graph.yml
+++ b/.github/workflows/graphify-code-graph.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Graphify
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "graphifyy==0.9.31"
+          python -m pip install "graphifyy==0.9.34"
           graphify --version
 
       - name: Build code-only graph

--- a/.github/workflows/graphify-code-graph.yml
+++ b/.github/workflows/graphify-code-graph.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Graphify
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "graphifyy==0.9.25"
+          python -m pip install "graphifyy==0.9.31"
           graphify --version
 
       - name: Build code-only graph


### PR DESCRIPTION
## Summary

Pins the manual Graphify code-graph workflow from the currently integrated `graphifyy==0.9.25` to `graphifyy==0.9.34`.

## Classification and rationale

The previously reviewed `0.9.26`–`0.9.31` range contains:

- security/privacy-relevant portability fixes preventing absolute checkout paths and machine-specific identifiers from leaking into graph artifacts;
- Afterworlds-relevant correctness fixes for TSX extraction, Python/TypeScript relationship resolution, incremental extraction, ambiguous symbol lookup, and edge-direction reporting;
- material feature expansions that were withheld until explicit Owner approval, which was granted on 2026-08-01.

The newly reviewed released range `0.9.32`–`0.9.34` is primarily bug-fix/performance work. Relevant fixes include:

- `0.9.33`: fresh extraction now fails non-zero instead of silently writing a zero-node graph when the AST worker pool fails; failed worker files retry sequentially;
- `0.9.34`: `build_from_json` no longer silently loses hyperedges during load/re-cluster paths, and a complete validation wipeout is reported loudly;
- `0.9.34`: directed path queries now respect stored edge direction by default;
- `0.9.32`: `graphify query` returns the induced subgraph rather than only traversal-tree edges;
- `0.9.32`: legitimate Python packages named `coverage/` are no longer silently excluded;
- `0.9.32`: build robustness and graph-direction/incremental correctness fixes.

The only feature-like change in `0.9.32`–`0.9.34` is a one-time informational hosted-platform pointer emitted by `graphify install`; Afterworlds does not invoke `graphify install`, so this does not alter the integration surface. No new Graphify feature is enabled by this PR.

Upstream `0.9.35` is currently unreleased and is therefore reviewed but not adopted.

Selective backporting remains rejected because it would create an Afterworlds-maintained Graphify fork. The controlled action is an exact released upstream pin.

## Scope

- Changes only `.github/workflows/graphify-code-graph.yml`.
- Replaces `graphifyy==0.9.25` with `graphifyy==0.9.34`.
- Preserves the existing Afterworlds integration commands and artifact behavior:
  - `graphify src`
  - `graphify cluster-only src --no-label`
  - version logging via `graphify --version`
  - upload from `src/graphify-out/`
- No application code, runtime dependency, Issue 5d code, generated graph artifact, or test file is changed.

## Validation status

- Diff remains one line in one workflow file.
- Repository CI and an actual Graphify generation run against the updated branch are required before merge.
- Do not merge if compatibility is uncertain.

## Merge gate

Do not merge if:

- repository CI fails;
- `graphify --version` does not report `0.9.34`;
- either established Graphify command fails;
- artifact generation changes location or becomes incomplete; or
- compatibility with the Afterworlds source tree is uncertain.

## Architecture Notes

No Afterworlds architecture changes. Graphify remains a construction and orientation aid, never runtime authority. This PR changes only the exact approved/necessary tool version and preserves the existing integration boundary.