### PR TITLE
feat(mechanical): complete typed authority publication

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,8 @@ recursive-include src/afterworlds/modes/personas/profiles *.json
 # CRD Issue 5c committed expected-table oracle, read at runtime by
 # table_inventory.py (candidate construction/finalization fail without it).
 include src/afterworlds/ingestion/corpus/srd_table_inventory.json
+# CRD Issue 5d committed accepted oracles, resolved at runtime by
+# oracle.committed_oracle_for. Empty of production content today; the rule has to
+# exist before the accepted-content PR adds a file, or an sdist install would
+# publish nothing because it can see no accepted authority.
+recursive-include src/afterworlds/ingestion/mechanical/oracles *.json

--- a/alembic/versions/0023_mechanical_publication.py
+++ b/alembic/versions/0023_mechanical_publication.py
@@ -1,0 +1,71 @@
+"""Mechanical-projection publication evidence and activation — CRD Issue 5d (#137).
+
+Adds the publication half of the Decision 8 lifecycle:
+
+* four nullable evidence columns on ``rp_mech_projections`` — accepted-oracle
+  identity, evidence-report hash, report payload, and publication time. Every
+  one of them is a *post-gate* value derived from reconstructed persisted
+  state, so none can exist while the projection is still a draft; they follow
+  the same NULL-through-draft rule the header already documents for
+  ``persisted_state_digest``.
+* ``rp_mech_active_projections``, whose primary key is ``package_uuid``. One
+  active projection per package is a database constraint rather than an
+  application convention, so competing activation cannot split active
+  authority.
+
+Additive only. Nothing existing is altered or dropped, no projection becomes
+active by migrating, and the legacy ``MechanicalEntity`` path is untouched.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-08-01
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0023"
+down_revision: str | None = "0022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_EVIDENCE_COLUMNS = (
+    sa.Column("oracle_identity", sa.String(64), nullable=True),
+    sa.Column("evidence_report_hash", sa.String(64), nullable=True),
+    sa.Column("report_payload", sa.JSON, nullable=True),
+    sa.Column("published_at", sa.String(64), nullable=True),
+)
+
+
+def upgrade() -> None:
+    for column in _EVIDENCE_COLUMNS:
+        op.add_column("rp_mech_projections", column)
+
+    op.create_table(
+        "rp_mech_active_projections",
+        sa.Column(
+            "package_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_corpus_releases.package_uuid", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "projection_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_mech_projections.projection_uuid", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("activated_at", sa.String(64), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("rp_mech_active_projections")
+    for column in _EVIDENCE_COLUMNS:
+        op.drop_column("rp_mech_projections", column.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,13 @@ afterworlds = [
     # importlib.resources (table_inventory.py); required by candidate
     # construction/finalization, so it must ship in the wheel.
     "ingestion/corpus/srd_table_inventory.json",
+    # CRD Issue 5d committed accepted oracles, resolved at runtime by
+    # oracle.committed_oracle_for from the fixed packaged directory. The
+    # directory is deliberately empty of production content today; the glob has
+    # to exist before the accepted-content PR adds a file, or an installed
+    # distribution would resolve no accepted authority and publication would
+    # return ABSENT for reasons that have nothing to do with the oracle.
+    "ingestion/mechanical/oracles/*.json",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -53,6 +53,7 @@ __all__ = [
     "classification_identity",
     "classification_payload",
     "derive_span_id",
+    "span_payload",
     "validate_acceptance",
     "validate_partition",
     "validate_policy_binding",
@@ -339,6 +340,27 @@ def validate_acceptance(ledger: ClassificationLedger) -> tuple[str, ...]:
     return tuple(findings)
 
 
+def span_payload(spans: tuple[SemanticSpan, ...]) -> list[dict[str, object]]:
+    """Canonical, identity-bearing payload of an accepted span set.
+
+    One definition, used by the classification payload and by the accepted
+    completeness oracle. Review state is deliberately absent: it is acceptance
+    evidence, and a span set that means the same thing must compare equal
+    however it was reviewed.
+    """
+    return canonical_order(
+        {
+            "span_id": s.span_id,
+            "leaf_id": s.leaf_id,
+            "char_start": s.char_start,
+            "char_end": s.char_end,
+            "disposition": s.disposition.value,
+            "non_mechanical_reason_code": s.non_mechanical_reason_code,
+        }
+        for s in spans
+    )
+
+
 def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
     """Canonical, identity-bearing payload of the accepted classification.
 
@@ -361,17 +383,7 @@ def classification_payload(ledger: ClassificationLedger) -> dict[str, object]:
         "release_version": ledger.release_version,
         "semantic_policy_version": ledger.policy_version,
         "semantic_policy_hash": ledger.policy_hash,
-        "spans": canonical_order(
-            {
-                "span_id": s.span_id,
-                "leaf_id": s.leaf_id,
-                "char_start": s.char_start,
-                "char_end": s.char_end,
-                "disposition": s.disposition.value,
-                "non_mechanical_reason_code": s.non_mechanical_reason_code,
-            }
-            for s in ledger.spans
-        ),
+        "spans": span_payload(ledger.spans),
     }
 
 

--- a/src/afterworlds/ingestion/mechanical/bound_corpus.py
+++ b/src/afterworlds/ingestion/mechanical/bound_corpus.py
@@ -39,10 +39,16 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.corpus.models import Disposition
+from afterworlds.ingestion.corpus.operational import OperationalCorpusSnapshot
 from afterworlds.persistence.orm.corpus import CorpusProjectionORM, LedgerLeafORM
 from afterworlds.persistence.orm.rules_package import RuleChunkORM
 
-__all__ = ["BoundCorpusSnapshot", "ChunkCoverage", "load_bound_corpus"]
+__all__ = [
+    "BoundCorpusSnapshot",
+    "ChunkCoverage",
+    "bound_corpus_from_operational",
+    "load_bound_corpus",
+]
 
 
 @dataclass(frozen=True)
@@ -125,6 +131,30 @@ class BoundCorpusSnapshot:
             if start <= char_start and char_end <= end:
                 return True
         return False
+
+
+def bound_corpus_from_operational(
+    snapshot: OperationalCorpusSnapshot,
+) -> BoundCorpusSnapshot:
+    """Adapt the verified 5c-owned trust seam to 5d's validation view."""
+    persisted = {chunk.chunk_id for chunk in snapshot.chunks}
+    return BoundCorpusSnapshot(
+        package_uuid=snapshot.package_uuid,
+        release_version=snapshot.release_version,
+        leaf_lengths={leaf.leaf_id: len(leaf.content) for leaf in snapshot.leaves},
+        chunk_coverage=tuple(
+            ChunkCoverage(
+                chunk_id=edge.chunk_id,
+                leaf_id=edge.leaf_id,
+                cover_start=edge.cover_start,
+                cover_end=edge.cover_end,
+                role=edge.role,
+                projection_id=edge.projection_id,
+            )
+            for edge in snapshot.projections
+            if edge.chunk_id in persisted
+        ),
+    )
 
 
 def load_bound_corpus(

--- a/src/afterworlds/ingestion/mechanical/gate.py
+++ b/src/afterworlds/ingestion/mechanical/gate.py
@@ -10,7 +10,7 @@ Neither is derived from the projection under test. That is the whole point: a
 gate whose expectations come from the output it checks reports only that the
 build is self-consistent.
 
-The bound release is verified through Issue 5c's versioned operational trust
+The bound release is verified through CRD Issue 5c's versioned operational trust
 seam before anything is read from it. A projection and an oracle can state the
 same six-value binding and still describe a release that was never published
 or whose authoritative rows were corrupted; agreement between two claims is
@@ -48,7 +48,6 @@ from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.corpus.hashing import canonical_bytes
 from afterworlds.ingestion.corpus.operational import (
-    CORPUS_CONTRACT_VERSION,
     OperationalCorpusVerificationError,
     load_verified_operational_corpus,
 )
@@ -88,12 +87,19 @@ __all__ = [
     "GateResult",
     "ObligationOutcome",
     "PUBLISHABLE_STATUSES",
+    "SUPPORTED_CORPUS_CONTRACT_VERSIONS",
     "run_publication_gate",
 ]
 
 #: The only two statuses a projection may be gated in. Anything else is state
 #: no publication path produces, so it is rejected rather than interpreted.
 PUBLISHABLE_STATUSES = ("draft", "published")
+
+#: Corpus-contract versions whose shape and semantics this 5d transformation
+#: has explicitly reviewed. This is downstream-owned compatibility policy:
+#: importing 5c's current producer version here would make a future 5c bump
+#: silently compatible instead of failing closed pending 5d review.
+SUPPORTED_CORPUS_CONTRACT_VERSIONS = frozenset({"5c-operational-1"})
 
 
 class GateFailureCategory(StrEnum):
@@ -493,7 +499,7 @@ def run_publication_gate(
             transform_config_hash=binding.transform_config_hash,
             bundle_root_hash=binding.bundle_root_hash,
             persisted_corpus_digest=binding.persisted_corpus_digest,
-            supported_contract_versions=frozenset({CORPUS_CONTRACT_VERSION}),
+            supported_contract_versions=SUPPORTED_CORPUS_CONTRACT_VERSIONS,
         )
     except OperationalCorpusVerificationError as exc:
         return _failed(

--- a/src/afterworlds/ingestion/mechanical/gate.py
+++ b/src/afterworlds/ingestion/mechanical/gate.py
@@ -1,0 +1,676 @@
+"""The exact completeness gate — CRD Issue 5d, Decisions 5 and 8.
+
+Runs over **reconstructed persisted state**, never over the in-memory candidate
+that produced it, and compares it against two independent authorities:
+
+* the bound CRD Issue 5c release, for the represented-leaf population; and
+* the committed accepted oracle (:mod:`oracle`), for the accepted semantics.
+
+Neither is derived from the projection under test. That is the whole point: a
+gate whose expectations come from the output it checks reports only that the
+build is self-consistent.
+
+The bound release is verified through Issue 5c's versioned operational trust
+seam before anything is read from it. A projection and an oracle can state the
+same six-value binding and still describe a release that was never published
+or whose authoritative rows were corrupted; agreement between two claims is
+not authority.
+
+**What this module does not re-implement.** The persisted-state proof
+(:func:`verify_persisted_state`) and the candidate's internal honesty
+(:func:`validate_candidate`) already exist and already run against reconstructed
+state; the gate calls them and categorizes what they report. Its own new work
+is exactly the part nothing else can do — comparing persisted state to
+independent accepted authority:
+
+* exact represented-leaf population equality against the bound release;
+* exact accepted-classification equality against the oracle;
+* exact element-level equality of records, components, facts, prose bindings,
+  relationships, references, and provenance, as *multisets* — so a duplicated
+  element is a distinct failure from an unexpected one, and neither can pad
+  coverage;
+* the accepted per-record obligations; and
+* one semantic identity comparison that proves all of the above at once.
+
+Counts appear only in :attr:`GateResult.diagnostics`, which the evidence report
+carries as drift signal. No count is ever a pass condition: an all-prose
+projection and a duplicated-fact projection both have plausible totals.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from enum import StrEnum
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.hashing import canonical_bytes
+from afterworlds.ingestion.corpus.operational import (
+    CORPUS_CONTRACT_VERSION,
+    OperationalCorpusVerificationError,
+    load_verified_operational_corpus,
+)
+from afterworlds.ingestion.mechanical.accounting import span_payload
+from afterworlds.ingestion.mechanical.bound_corpus import (
+    bound_corpus_from_operational,
+)
+from afterworlds.ingestion.mechanical.canonical import canonical_order
+from afterworlds.ingestion.mechanical.models import (
+    ClassificationLedger,
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+)
+from afterworlds.ingestion.mechanical.oracle import AcceptedOracle, oracle_identity
+from afterworlds.ingestion.mechanical.persistence import (
+    PersistedStateReconstructionError,
+    reconstruct_candidate,
+    verify_persisted_state,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    identify_projection,
+    representation_payload,
+    validate_candidate,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    FactFamily,
+    RepresentationDraft,
+    fact_payload,
+)
+from afterworlds.persistence.orm.mechanical import MechanicalProjectionORM
+
+__all__ = [
+    "GateFailure",
+    "GateFailureCategory",
+    "GateResult",
+    "ObligationOutcome",
+    "PUBLISHABLE_STATUSES",
+    "run_publication_gate",
+]
+
+#: The only two statuses a projection may be gated in. Anything else is state
+#: no publication path produces, so it is rejected rather than interpreted.
+PUBLISHABLE_STATUSES = ("draft", "published")
+
+
+class GateFailureCategory(StrEnum):
+    """Why publication was refused.
+
+    Categories exist so a failure is actionable and so the publication layer
+    can map a result to a typed outcome without parsing prose. They are
+    deliberately about *what kind of authority is wrong*, not about which
+    function noticed.
+    """
+
+    #: No persisted header, an unreadable row set, a status outside
+    #: PUBLISHABLE_STATUSES, or a missing/mismatched persisted-state digest.
+    PERSISTED_STATE = "persisted_state"
+    #: The 5c release the projection binds is not published and operationally
+    #: trustworthy: absent, draft, incompatible, binding-mismatched, or no
+    #: longer matching its direct authoritative SQLite digest.
+    BOUND_RELEASE = "bound_release"
+    #: The oracle was accepted over a different 5c release than the projection
+    #: is bound to, so it judges nothing here.
+    MISMATCHED_RELEASE = "mismatched_release"
+    #: The oracle declares a different semantic policy than the projection.
+    POLICY_MISMATCH = "policy_mismatch"
+    #: Classified leaves are not exactly the bound release's REPRESENTED set.
+    POPULATION_MISMATCH = "population_mismatch"
+    #: The accepted span partition differs from the oracle's.
+    CLASSIFICATION_MISMATCH = "classification_mismatch"
+    #: A span is still unreviewed or only proposed.
+    UNREVIEWED_RESIDUE = "unreviewed_residue"
+    #: A span's classification is still UNRESOLVED.
+    UNRESOLVED_RESIDUE = "unresolved_residue"
+    #: Accepted authority the projection does not carry.
+    MISSING_AUTHORITY = "missing_authority"
+    #: Authority the projection carries that no accepted input declares.
+    UNEXPECTED_AUTHORITY = "unexpected_authority"
+    #: An accepted element repeated, inflating coverage without adding meaning.
+    DUPLICATE_AUTHORITY = "duplicate_authority"
+    #: An accepted per-record obligation is not satisfied.
+    UNSATISFIED_OBLIGATION = "unsatisfied_obligation"
+    #: The candidate is not internally honest (partition, acceptance evidence,
+    #: handling, provenance closure, reference resolution).
+    SEMANTIC_VALIDATION = "semantic_validation"
+    #: Persisted state does not derive the identity the accepted authority does.
+    IDENTITY_MISMATCH = "identity_mismatch"
+
+
+@dataclass(frozen=True)
+class GateFailure:
+    """One categorized reason publication was refused."""
+
+    category: GateFailureCategory
+    detail: str
+
+
+@dataclass(frozen=True)
+class ObligationOutcome:
+    """The result of one accepted per-record obligation.
+
+    Recorded whether or not it was satisfied: the evidence report has to show
+    which obligations were *met*, not only which failed, or a passing gate
+    would be an assertion with no evidence behind it.
+    """
+
+    record_key: str
+    satisfied: bool
+    failures: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """The complete, deterministic verdict for one persisted projection."""
+
+    passed: bool
+    projection_uuid: str
+    oracle_identity: str
+    failures: tuple[GateFailure, ...]
+    obligations: tuple[ObligationOutcome, ...]
+    #: Identity the accepted authority derives, and the one persisted state
+    #: derives. Equal exactly when every meaning-bearing comparison above holds.
+    expected_projection_uuid: str | None
+    persisted_state_digest: str | None
+    #: Regression canaries only — never a pass condition (ADR-005d Decision 5).
+    diagnostics: dict[str, int]
+
+    def categories(self) -> frozenset[GateFailureCategory]:
+        """The distinct failure categories present."""
+        return frozenset(f.category for f in self.failures)
+
+
+def _fail(
+    findings: list[GateFailure], category: GateFailureCategory, *details: str
+) -> None:
+    findings.extend(GateFailure(category, d) for d in details)
+
+
+#: The three ways one collection can differ, in the categories used for the
+#: representation. Spans get their own triple: a classification difference is
+#: not "authority the projection carries", it is the accounting disagreeing.
+_AUTHORITY_CATEGORIES = (
+    GateFailureCategory.MISSING_AUTHORITY,
+    GateFailureCategory.UNEXPECTED_AUTHORITY,
+    GateFailureCategory.DUPLICATE_AUTHORITY,
+)
+_CLASSIFICATION_CATEGORIES = (
+    GateFailureCategory.CLASSIFICATION_MISMATCH,
+    GateFailureCategory.CLASSIFICATION_MISMATCH,
+    GateFailureCategory.CLASSIFICATION_MISMATCH,
+)
+
+
+def _compare_elements(
+    persisted: list[dict[str, object]],
+    accepted: list[dict[str, object]],
+    collection: str,
+    findings: list[GateFailure],
+    categories: tuple[
+        GateFailureCategory, GateFailureCategory, GateFailureCategory
+    ] = _AUTHORITY_CATEGORIES,
+) -> None:
+    """Compare one collection as a multiset of canonical element payloads.
+
+    Multiset, not set: an element repeated in the projection but declared once
+    is duplicate-as-coverage, which is a different defect from carrying
+    something nobody accepted, and collapsing the two would let the first hide
+    inside the second.
+
+    Comparing whole canonical payloads means a change to any field of any
+    element is caught, including fields added to the representation later —
+    the same reason :mod:`canonical` orders by whole payload rather than by a
+    hand-picked key.
+    """
+    missing, unexpected, duplicate = categories
+    p_by_key = {canonical_bytes(e): e for e in persisted}
+    a_by_key = {canonical_bytes(e): e for e in accepted}
+    p_counts = Counter(canonical_bytes(e) for e in persisted)
+    a_counts = Counter(canonical_bytes(e) for e in accepted)
+
+    for key in sorted(a_counts.keys() - p_counts.keys()):
+        _fail(
+            findings,
+            missing,
+            f"{collection}: accepted element absent from persisted state: "
+            f"{a_by_key[key]}",
+        )
+    for key in sorted(p_counts.keys() - a_counts.keys()):
+        _fail(
+            findings,
+            unexpected,
+            f"{collection}: persisted element outside accepted authority: "
+            f"{p_by_key[key]}",
+        )
+    for key in sorted(p_counts.keys() & a_counts.keys()):
+        if p_counts[key] > a_counts[key]:
+            _fail(
+                findings,
+                duplicate,
+                f"{collection}: accepted element persisted {p_counts[key]} times, "
+                f"accepted {a_counts[key]}: {p_by_key[key]}",
+            )
+        elif p_counts[key] < a_counts[key]:
+            _fail(
+                findings,
+                missing,
+                f"{collection}: accepted element persisted {p_counts[key]} times, "
+                f"accepted {a_counts[key]}: {a_by_key[key]}",
+            )
+
+
+def _comparable_collections(
+    draft: RepresentationDraft,
+) -> dict[str, list[dict[str, object]]]:
+    """Flatten the representation into the collections the gate compares.
+
+    Two departures from :func:`representation_payload`, which exists to derive
+    identity and must not change:
+
+    * **facts are their own collection**, keyed by their owning record and
+      component. Nested inside a component, one fact persisted twice reads as a
+      *different component* — reported as one missing and one unexpected
+      element, which is precisely the duplicate-as-coverage inflation this gate
+      has to name.
+    * **components carry no facts**, so the same difference is not reported
+      twice under two categories.
+    """
+    payload = representation_payload(draft)
+    collections: dict[str, list[dict[str, object]]] = {}
+    for key in (
+        "records",
+        "prose_bindings",
+        "relationships",
+        "references",
+        "provenance",
+    ):
+        elements = payload[key]
+        assert isinstance(elements, list)
+        collections[key] = elements
+
+    collections["components"] = canonical_order(
+        {
+            "record_key": c.record_key,
+            "semantic_key": c.semantic_key,
+            "handling": c.handling.value,
+            "irreducibility_reason_code": c.irreducibility_reason_code,
+        }
+        for c in draft.components
+    )
+    collections["facts"] = canonical_order(
+        {
+            "record_key": c.record_key,
+            "component_key": c.semantic_key,
+            **fact_payload(f),
+        }
+        for c in draft.components
+        for f in c.facts
+    )
+    return collections
+
+
+def _check_obligations(
+    candidate: ProjectionCandidate, oracle: AcceptedOracle
+) -> tuple[ObligationOutcome, ...]:
+    """Evaluate every accepted per-record obligation against persisted state.
+
+    An obligation is satisfied only by the authority it names. A record covered
+    by references, or re-described entirely as prose, satisfies nothing — which
+    is how reference-only coverage and all-prose under-extraction fail here by
+    name rather than as an anonymous element difference.
+
+    Reads structured families and prose-bound handling the same way
+    :func:`oracle.derive_obligations` does, which is what makes every obligation
+    that survives loading one this evaluation can actually satisfy.
+    """
+    draft = candidate.representation
+    records = {r.semantic_key: r for r in draft.records}
+    components = {(c.record_key, c.semantic_key): c for c in draft.components}
+    bound_prose = {(b.record_key, b.component_key) for b in draft.prose_bindings}
+
+    families_by_record: dict[str, set[FactFamily]] = {}
+    for component in draft.components:
+        for fact in component.facts:
+            family = getattr(fact, "FAMILY", None)
+            if isinstance(family, FactFamily):
+                families_by_record.setdefault(component.record_key, set()).add(family)
+
+    outcomes: list[ObligationOutcome] = []
+    for obligation in oracle.obligations:
+        failures: list[str] = []
+        record = records.get(obligation.record_key)
+        if record is None:
+            failures.append("accepted record absent from persisted state")
+        elif record.kind is not obligation.kind:
+            failures.append(
+                f"record kind {record.kind.value!r}, accepted as "
+                f"{obligation.kind.value!r}"
+            )
+
+        present = families_by_record.get(obligation.record_key, set())
+        for family in sorted(obligation.structured_fact_families - present, key=str):
+            failures.append(
+                f"no {family.value} fact: accepted structured authority is not "
+                "represented by typed facts"
+            )
+
+        for component_key in sorted(obligation.prose_bound_components):
+            bound = components.get((obligation.record_key, component_key))
+            if bound is None:
+                failures.append(f"component {component_key!r} absent")
+                continue
+            if bound.handling is ComponentHandling.STRUCTURED:
+                failures.append(
+                    f"component {component_key!r} is structured, accepted as "
+                    "prose-bound authority"
+                )
+            if (obligation.record_key, component_key) not in bound_prose:
+                failures.append(
+                    f"component {component_key!r} carries no exact governing prose"
+                )
+
+        outcomes.append(
+            ObligationOutcome(
+                record_key=obligation.record_key,
+                satisfied=not failures,
+                failures=tuple(failures),
+            )
+        )
+    return tuple(outcomes)
+
+
+def _accepted_identity(oracle: AcceptedOracle) -> str:
+    """The projection identity the accepted authority alone derives.
+
+    Built from the oracle's own binding, declared policy, accepted spans, and
+    accepted representation — never from the persisted state it is compared
+    with. Acceptance evidence is empty because it is not identity-bearing
+    (:mod:`accounting`), so an oracle need not — and must not — restate how
+    review happened in order to say what was accepted.
+    """
+    return identify_projection(
+        ProjectionCandidate(
+            binding=oracle.binding,
+            classification=ClassificationLedger(
+                package_uuid=oracle.binding.package_uuid,
+                release_version=oracle.binding.release_version,
+                policy_version=oracle.policy_version,
+                policy_hash=oracle.policy_hash,
+                spans=oracle.spans,
+                batches=(),
+                acceptances=(),
+            ),
+            representation=oracle.representation,
+        )
+    ).projection_uuid
+
+
+def _failed(
+    projection_uuid: str, oracle: AcceptedOracle, *failures: GateFailure
+) -> GateResult:
+    return GateResult(
+        passed=False,
+        projection_uuid=projection_uuid,
+        oracle_identity=oracle_identity(oracle),
+        failures=failures,
+        obligations=(),
+        expected_projection_uuid=None,
+        persisted_state_digest=None,
+        diagnostics={},
+    )
+
+
+def run_publication_gate(
+    session: Session, projection_uuid: str, oracle: AcceptedOracle
+) -> GateResult:
+    """Judge one persisted projection against independent accepted authority.
+
+    Read-only. It never writes, never activates, and never repairs: a caller
+    that receives a failing result has exactly the state it had before.
+
+    The bound release is read from the *persisted header*, and the corpus
+    snapshot is resolved from that. A caller cannot supply the snapshot, so it
+    cannot hand the gate a different release than the projection actually
+    claims.
+    """
+    identity = oracle_identity(oracle)
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == projection_uuid
+        )
+    ).scalar_one_or_none()
+    if header is None:
+        return _failed(
+            projection_uuid,
+            oracle,
+            GateFailure(
+                GateFailureCategory.PERSISTED_STATE,
+                f"projection {projection_uuid}: no persisted header row",
+            ),
+        )
+    if header.publication_status not in PUBLISHABLE_STATUSES:
+        return _failed(
+            projection_uuid,
+            oracle,
+            GateFailure(
+                GateFailureCategory.PERSISTED_STATE,
+                f"projection {projection_uuid}: publication_status "
+                f"{header.publication_status!r} is outside "
+                f"{list(PUBLISHABLE_STATUSES)}",
+            ),
+        )
+
+    try:
+        candidate = reconstruct_candidate(session, projection_uuid)
+    except PersistedStateReconstructionError as exc:
+        return _failed(
+            projection_uuid,
+            oracle,
+            GateFailure(
+                GateFailureCategory.PERSISTED_STATE,
+                f"projection {projection_uuid}: persisted state does not "
+                f"reconstruct: {exc}",
+            ),
+        )
+
+    # 0. The 5c release itself, before anything derived from it is read. The
+    #    binding comes from *reconstructed* state, never from the oracle, so
+    #    this is the one comparison the candidate and the oracle cannot satisfy
+    #    between themselves: a six-value binding both of them state is checked
+    #    against the authoritative published release through 5c's versioned,
+    #    direct SQLite seam. A release that fails here has no trustworthy
+    #    represented-leaf population, so the gate stops before reading it.
+    binding = candidate.binding
+    try:
+        operational_corpus = load_verified_operational_corpus(
+            session,
+            binding.package_uuid,
+            release_version=binding.release_version,
+            authoritative_source_hash=binding.authoritative_source_hash,
+            transform_config_hash=binding.transform_config_hash,
+            bundle_root_hash=binding.bundle_root_hash,
+            persisted_corpus_digest=binding.persisted_corpus_digest,
+            supported_contract_versions=frozenset({CORPUS_CONTRACT_VERSION}),
+        )
+    except OperationalCorpusVerificationError as exc:
+        return _failed(
+            projection_uuid,
+            oracle,
+            *(
+                GateFailure(GateFailureCategory.BOUND_RELEASE, detail)
+                for detail in exc.violations
+            ),
+        )
+
+    findings: list[GateFailure] = []
+
+    # 1. The persisted-state proof itself: tamper, omission, stale identity,
+    #    corrupted derived IDs, and a recorded digest that no longer matches.
+    _fail(
+        findings,
+        GateFailureCategory.PERSISTED_STATE,
+        *verify_persisted_state(
+            session, projection_uuid, expected_status=header.publication_status
+        ),
+    )
+    if header.persisted_state_digest is None:
+        _fail(
+            findings,
+            GateFailureCategory.PERSISTED_STATE,
+            f"projection {projection_uuid}: no persisted-state digest recorded",
+        )
+
+    # 2. The oracle must be accepted over this exact release, under this exact
+    #    policy. Comparing accepted semantics across either boundary would be
+    #    judging one release's content by another's authority.
+    if oracle.binding != binding:
+        _fail(
+            findings,
+            GateFailureCategory.MISMATCHED_RELEASE,
+            f"accepted oracle binds {oracle.binding.package_uuid}/"
+            f"{oracle.binding.release_version} with source "
+            f"{oracle.binding.authoritative_source_hash[:12]}…, projection binds "
+            f"{binding.package_uuid}/{binding.release_version} with source "
+            f"{binding.authoritative_source_hash[:12]}…",
+        )
+    ledger = candidate.classification
+    if (oracle.policy_version, oracle.policy_hash) != (
+        ledger.policy_version,
+        ledger.policy_hash,
+    ):
+        _fail(
+            findings,
+            GateFailureCategory.POLICY_MISMATCH,
+            f"accepted oracle declares semantic policy {oracle.policy_version!r}/"
+            f"{oracle.policy_hash[:12]}…, projection declares "
+            f"{ledger.policy_version!r}/{ledger.policy_hash[:12]}…",
+        )
+
+    # 3. Population equality against the bound 5c release — the one authority
+    #    that is neither the oracle nor the candidate. This is what makes an
+    #    incomplete production projection fail structurally: a projection that
+    #    classified a handful of leaves is not "mostly complete", it simply is
+    #    not the release's REPRESENTED population.
+    corpus = bound_corpus_from_operational(operational_corpus)
+    represented = set(corpus.leaf_lengths)
+    classified = {s.leaf_id for s in ledger.spans}
+    for leaf_id in sorted(represented - classified):
+        _fail(
+            findings,
+            GateFailureCategory.POPULATION_MISMATCH,
+            f"leaf {leaf_id}: represented by the bound 5c release, absent from the "
+            "accepted classification",
+        )
+    for leaf_id in sorted(classified - represented):
+        _fail(
+            findings,
+            GateFailureCategory.POPULATION_MISMATCH,
+            f"leaf {leaf_id}: classified, but not a represented leaf of the bound "
+            "5c release",
+        )
+
+    # 4. Residue. Classified explicitly rather than read out of the validator's
+    #    findings below, because the publication outcome is typed on these two
+    #    and a typed outcome must not depend on matching a message string.
+    for span in ledger.spans:
+        if span.disposition is SemanticDisposition.UNRESOLVED:
+            _fail(
+                findings,
+                GateFailureCategory.UNRESOLVED_RESIDUE,
+                f"span {span.span_id}: unresolved classification",
+            )
+        if span.review_state is not ReviewState.ACCEPTED:
+            _fail(
+                findings,
+                GateFailureCategory.UNREVIEWED_RESIDUE,
+                f"span {span.span_id}: review state {span.review_state.value}",
+            )
+    accepted_span_ids = {a.span_id for a in ledger.acceptances}
+    for span in ledger.spans:
+        if span.span_id not in accepted_span_ids:
+            _fail(
+                findings,
+                GateFailureCategory.UNREVIEWED_RESIDUE,
+                f"span {span.span_id}: no acceptance record",
+            )
+
+    # 5. Internal honesty of the reconstructed candidate — partition, closed
+    #    reason codes, acceptance evidence, handling, provenance closure,
+    #    reference resolution. Reused, not re-derived.
+    #
+    #    An unclassified leaf is reported twice: once above as a population
+    #    mismatch, and once here as a leaf with no spans. That overlap is
+    #    accepted deliberately. Suppressing either would mean the gate holding
+    #    an opinion about which findings the candidate validator is allowed to
+    #    report, which is how two validators start disagreeing about what
+    #    "covered" means.
+    _fail(
+        findings,
+        GateFailureCategory.SEMANTIC_VALIDATION,
+        *validate_candidate(candidate, corpus),
+    )
+
+    # 6. Exact equality against accepted authority, element by element.
+    _compare_elements(
+        span_payload(ledger.spans),
+        span_payload(oracle.spans),
+        "spans",
+        findings,
+        _CLASSIFICATION_CATEGORIES,
+    )
+    persisted_collections = _comparable_collections(candidate.representation)
+    accepted_collections = _comparable_collections(oracle.representation)
+    for key in sorted(persisted_collections):
+        _compare_elements(
+            persisted_collections[key], accepted_collections[key], key, findings
+        )
+
+    # 7. Accepted per-record obligations.
+    obligations = _check_obligations(candidate, oracle)
+    for outcome in obligations:
+        _fail(
+            findings,
+            GateFailureCategory.UNSATISFIED_OBLIGATION,
+            *(f"record {outcome.record_key}: {f}" for f in outcome.failures),
+        )
+
+    # 8. One identity comparison that proves 2, 3, and 6 together. The
+    #    element diffs above say *what* differs; this says whether the
+    #    projection is the accepted authority at all.
+    expected_uuid = _accepted_identity(oracle)
+    if expected_uuid != projection_uuid:
+        _fail(
+            findings,
+            GateFailureCategory.IDENTITY_MISMATCH,
+            f"accepted authority derives projection {expected_uuid}, persisted "
+            f"state is {projection_uuid}",
+        )
+
+    draft = candidate.representation
+    diagnostics = {
+        "represented_leaves": len(represented),
+        "classified_leaves": len(classified),
+        "accepted_spans": len(ledger.spans),
+        "records": len(draft.records),
+        "components": len(draft.components),
+        "facts": sum(len(c.facts) for c in draft.components),
+        "prose_bindings": len(draft.prose_bindings),
+        "relationships": len(draft.relationships),
+        "references": len(draft.references),
+        "provenance_edges": len(draft.provenance),
+        "obligations": len(obligations),
+    }
+
+    return GateResult(
+        passed=not findings,
+        projection_uuid=projection_uuid,
+        oracle_identity=identity,
+        failures=tuple(findings),
+        obligations=obligations,
+        expected_projection_uuid=expected_uuid,
+        persisted_state_digest=header.persisted_state_digest,
+        diagnostics=diagnostics,
+    )

--- a/src/afterworlds/ingestion/mechanical/oracle.py
+++ b/src/afterworlds/ingestion/mechanical/oracle.py
@@ -1,0 +1,687 @@
+"""The accepted completeness oracle — CRD Issue 5d, Decision 5.
+
+The publication gate compares reconstructed persisted state against *this*, and
+the only property that makes the comparison worth anything is independence: an
+oracle derived from the projection it checks proves nothing but that the code
+is self-consistent.
+
+Independence is structural here, not a convention:
+
+* this module imports no session, no ORM, and nothing from
+  :mod:`persistence`, :mod:`raw_state`, or :mod:`gate`. There is no code path,
+  public or private, that builds an ``AcceptedOracle`` from a persisted
+  projection or from a :class:`ProjectionCandidate`;
+* :func:`load_oracle` reads a committed JSON file and nothing else. Its whole
+  input is bytes on disk that a reviewer accepted and a commit records; and
+* the declared semantic policy comes from the *file*, never from the current
+  :mod:`policy` constants. Reading current code here would let a policy change
+  silently re-bless an oracle nobody re-reviewed — the exact self-attestation
+  this file exists to prevent. When the frozen policy changes, every committed
+  oracle fails its binding check until a reviewer re-accepts it. That is the
+  intended cost.
+
+**What the oracle does not carry.** The represented-leaf population is *not*
+declared here. It is read from the bound CRD Issue 5c release, which is already
+independent accepted authority with its own publication proof. Re-declaring
+28,109 leaf ids in a committed file would add a second place to drift from 5c
+without adding a second opinion.
+
+**What is committed today.** ``oracles/`` holds no production SRD oracle, so
+the production 5c release resolves to no accepted authority and its projection
+cannot be published. Later inactive-content PRs commit the accepted full-corpus
+oracle; this PR builds the machinery that will judge it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.mechanical.accounting import span_payload
+from afterworlds.ingestion.mechanical.canonical import canonical_order
+from afterworlds.ingestion.mechanical.models import (
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ReleaseBinding,
+    representation_payload,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    FactFamily,
+    MalformedFactPayloadError,
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RecordDraft,
+    RecordKind,
+    ReferenceDraft,
+    RelationshipDraft,
+    RelationshipKind,
+    RepresentationDraft,
+    UnknownFactFamilyError,
+    fact_from_payload,
+)
+
+__all__ = [
+    "COMMITTED_ORACLE_DIR",
+    "AcceptedOracle",
+    "OracleLoadError",
+    "RecordObligation",
+    "committed_oracle_for",
+    "derive_obligations",
+    "load_oracle",
+    "obligation_payload",
+    "oracle_identity",
+    "oracle_payload",
+]
+
+#: Committed accepted oracles, one JSON file per published 5c release.
+COMMITTED_ORACLE_DIR = Path(__file__).resolve().parent / "oracles"
+
+
+class OracleLoadError(ValueError):
+    """A committed oracle file that will not load as accepted authority.
+
+    Raised rather than reported: an oracle that cannot be read is not a weaker
+    oracle, it is no oracle, and a gate run against a half-parsed one would
+    compare persisted state to a shape nobody accepted.
+    """
+
+
+@dataclass(frozen=True)
+class RecordObligation:
+    """What a reviewer accepted that one record must actually carry.
+
+    Element-set equality already rejects a projection whose contents differ
+    from the accepted inventory. Obligations exist because equality alone
+    cannot say *why* a projection is wrong, and because they are the accepted
+    claim in reviewable form: "this record is represented by structured
+    authority of these families, and these components remain prose-bound".
+
+    That shape is what makes two specific defects fail by name rather than as
+    an anonymous set difference:
+
+    * **all-prose under-extraction** — a record whose facts were dropped and
+      re-described as prose fails ``structured_fact_families``; and
+    * **reference-only coverage** — a record covered by references alone
+      satisfies no obligation at all, because a reference is not a fact.
+
+    ``prose_bound_components`` names components whose accepted handling is
+    ``PROSE_BOUND`` or ``MIXED``; each must still carry exact governing prose.
+    """
+
+    record_key: str
+    kind: RecordKind
+    structured_fact_families: frozenset[FactFamily]
+    prose_bound_components: frozenset[str]
+
+
+@dataclass(frozen=True)
+class AcceptedOracle:
+    """The complete accepted authority one projection is judged against.
+
+    ``binding`` is the exact 5c release the accepted semantics were reviewed
+    over. A projection bound to any other release is judged by nothing and
+    fails as mismatched rather than being compared anyway.
+    """
+
+    binding: ReleaseBinding
+    policy_version: str
+    policy_hash: str
+    spans: tuple[SemanticSpan, ...]
+    representation: RepresentationDraft
+    obligations: tuple[RecordObligation, ...]
+
+
+#: Handlings whose accepted meaning is carried, wholly or partly, by governing
+#: prose — so the component must still resolve to exact prose.
+_PROSE_BOUND_HANDLINGS = frozenset(
+    {ComponentHandling.PROSE_BOUND, ComponentHandling.MIXED}
+)
+
+
+def derive_obligations(
+    representation: RepresentationDraft,
+) -> tuple[RecordObligation, ...]:
+    """The exact obligations one accepted representation states, one per record.
+
+    The single definition of "what this accepted authority claims about record
+    R", used twice for one reason: :func:`load_oracle` requires a committed
+    file's declared obligations to equal it exactly, and :mod:`gate` evaluates
+    obligations against *persisted* state. Deriving the expectation in one place
+    means an obligation that loads is an obligation the gate can actually
+    satisfy — two hand-written derivations would eventually disagree and produce
+    an oracle nothing can pass.
+
+    Requiring equality does not make obligations redundant. The independence
+    that matters is oracle-versus-projection, and it is untouched; what this
+    forecloses is a committed file whose per-record claim silently understates
+    or overstates the representation it ships with, which would let the gate
+    report satisfied obligations that assert less than the accepted authority.
+    """
+    families: dict[str, set[FactFamily]] = {}
+    prose: dict[str, set[str]] = {}
+    for component in representation.components:
+        for fact in component.facts:
+            family = getattr(fact, "FAMILY", None)
+            if isinstance(family, FactFamily):
+                families.setdefault(component.record_key, set()).add(family)
+        if component.handling in _PROSE_BOUND_HANDLINGS:
+            prose.setdefault(component.record_key, set()).add(component.semantic_key)
+    return tuple(
+        RecordObligation(
+            record_key=record.semantic_key,
+            kind=record.kind,
+            structured_fact_families=frozenset(families.get(record.semantic_key, ())),
+            prose_bound_components=frozenset(prose.get(record.semantic_key, ())),
+        )
+        for record in representation.records
+    )
+
+
+def obligation_payload(obligation: RecordObligation) -> dict[str, object]:
+    """Canonical payload of one accepted per-record obligation."""
+    return {
+        "record_key": obligation.record_key,
+        "kind": obligation.kind.value,
+        "structured_fact_families": sorted(
+            f.value for f in obligation.structured_fact_families
+        ),
+        "prose_bound_components": sorted(obligation.prose_bound_components),
+    }
+
+
+def oracle_payload(oracle: AcceptedOracle) -> dict[str, object]:
+    """Canonical payload of the accepted oracle.
+
+    Reuses the projection's own payload builders for spans and representation,
+    so "the oracle and the projection agree" is a comparison of one canonical
+    form rather than of two hand-written serializations that could drift.
+    """
+    return {
+        "release_binding": {
+            "package_uuid": oracle.binding.package_uuid,
+            "release_version": oracle.binding.release_version,
+            "authoritative_source_hash": oracle.binding.authoritative_source_hash,
+            "transform_config_hash": oracle.binding.transform_config_hash,
+            "bundle_root_hash": oracle.binding.bundle_root_hash,
+            "persisted_corpus_digest": oracle.binding.persisted_corpus_digest,
+        },
+        "semantic_policy_version": oracle.policy_version,
+        "semantic_policy_hash": oracle.policy_hash,
+        "spans": span_payload(oracle.spans),
+        "representation": representation_payload(oracle.representation),
+        "obligations": canonical_order(
+            obligation_payload(o) for o in oracle.obligations
+        ),
+    }
+
+
+def oracle_identity(oracle: AcceptedOracle) -> str:
+    """Content-derived identity of the accepted oracle.
+
+    Recorded in the evidence report and on the published projection, so an
+    audit can name which accepted authority passed the gate — and detect a
+    later oracle edit, because an edited oracle is a different identity.
+    """
+    return hash_obj(oracle_payload(oracle))
+
+
+# ---------------------------------------------------------------------------
+# Committed-file loading
+# ---------------------------------------------------------------------------
+#
+# Strict throughout, in the same spirit as fact reconstruction: a missing key,
+# an unknown enum value, or an extra key is rejected rather than defaulted.
+# An oracle that silently accepts an unrecognised shape would let a typo widen
+# what publication tolerates.
+
+
+def _require(payload: object, keys: tuple[str, ...], where: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise OracleLoadError(
+            f"{where}: expected an object, got {type(payload).__name__}"
+        )
+    supplied = set(payload)
+    if missing := sorted(set(keys) - supplied):
+        raise OracleLoadError(f"{where}: missing {missing}")
+    if extra := sorted(supplied - set(keys)):
+        raise OracleLoadError(f"{where}: unexpected {extra}")
+    return payload
+
+
+def _string(value: object, where: str) -> str:
+    """A JSON string, exactly. No coercion — ``0`` is not ``"0"``."""
+    if type(value) is not str:
+        raise OracleLoadError(
+            f"{where}: expected a string, got {type(value).__name__} {value!r}"
+        )
+    return value
+
+
+def _optional_string(value: object, where: str) -> str | None:
+    """A JSON string or ``null``, for a declared ``str | None`` field."""
+    return None if value is None else _string(value, where)
+
+
+def _offset(value: object, where: str) -> int:
+    """A non-negative JSON integer character offset.
+
+    ``bool`` is rejected explicitly: it is an ``int`` subclass, so ``true``
+    would otherwise load as the offset ``1``. Floats are rejected too — ``0.0``
+    is not the integer the span contract declares.
+
+    Negativity is a *type-domain* violation and belongs here. Ordering, gap-free
+    coverage, and whether a span partitions its leaf belong to the semantic
+    validator, which already owns partition validity; this boundary does not
+    state a second opinion about it.
+    """
+    if type(value) is not int:
+        raise OracleLoadError(
+            f"{where}: expected an integer, got {type(value).__name__} {value!r}"
+        )
+    if value < 0:
+        raise OracleLoadError(
+            f"{where}: character offsets cannot be negative ({value})"
+        )
+    return value
+
+
+def _list(value: object, where: str) -> list[Any]:
+    """A JSON array, exactly. A string is not an array of its characters."""
+    if not isinstance(value, list):
+        raise OracleLoadError(
+            f"{where}: expected an array, got {type(value).__name__} {value!r}"
+        )
+    return value
+
+
+def _string_list(value: object, where: str) -> list[str]:
+    """A JSON array of strings.
+
+    Guards the constructors that would otherwise manufacture accepted authority
+    out of a bare string: ``tuple("abc")`` and ``frozenset("abc")`` both succeed
+    and silently invent three elements.
+    """
+    return [
+        _string(item, f"{where}[{i}]") for i, item in enumerate(_list(value, where))
+    ]
+
+
+def _object_list(value: object, where: str) -> list[dict[str, Any]]:
+    """A JSON array of objects, checked before anything indexes an element."""
+    items = _list(value, where)
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise OracleLoadError(
+                f"{where}[{i}]: expected an object, got {type(item).__name__} {item!r}"
+            )
+    return items
+
+
+def _enum[E: StrEnum](enum_cls: type[E], value: object, where: str) -> E:
+    """Read one closed enum out of a committed file, or reject the file.
+
+    The stored value must be a plain string naming a declared member. No
+    coercion: a number, a null, or a look-alike is a file a reviewer did not
+    write in the accepted shape, and guessing what it meant would be this
+    layer inventing accepted authority.
+    """
+    if type(value) is not str:
+        raise OracleLoadError(
+            f"{where}: expected a string {enum_cls.__name__}, got "
+            f"{type(value).__name__} {value!r}"
+        )
+    try:
+        return enum_cls(value)
+    except ValueError:
+        raise OracleLoadError(
+            f"{where}: {value!r} is not a declared {enum_cls.__name__}"
+        ) from None
+
+
+def _span(payload: object, index: int) -> SemanticSpan:
+    where = f"spans[{index}]"
+    p = _require(
+        payload,
+        (
+            "span_id",
+            "leaf_id",
+            "char_start",
+            "char_end",
+            "disposition",
+            "non_mechanical_reason_code",
+        ),
+        where,
+    )
+    return SemanticSpan(
+        span_id=_string(p["span_id"], f"{where}.span_id"),
+        leaf_id=_string(p["leaf_id"], f"{where}.leaf_id"),
+        char_start=_offset(p["char_start"], f"{where}.char_start"),
+        char_end=_offset(p["char_end"], f"{where}.char_end"),
+        disposition=_enum(SemanticDisposition, p["disposition"], where),
+        # An oracle span is accepted authority by construction: an unaccepted
+        # claim has no business in a committed oracle, so the review state is
+        # not a field a file may set to something else.
+        review_state=ReviewState.ACCEPTED,
+        non_mechanical_reason_code=_optional_string(
+            p["non_mechanical_reason_code"], f"{where}.non_mechanical_reason_code"
+        ),
+    )
+
+
+def _representation(payload: object) -> RepresentationDraft:
+    p = _require(
+        payload,
+        (
+            "records",
+            "components",
+            "prose_bindings",
+            "relationships",
+            "references",
+            "provenance",
+        ),
+        "representation",
+    )
+
+    records = []
+    for i, raw in enumerate(_object_list(p["records"], "representation.records")):
+        where = f"representation.records[{i}]"
+        r = _require(raw, ("semantic_key", "kind", "parent_key"), where)
+        records.append(
+            RecordDraft(
+                semantic_key=_string(r["semantic_key"], f"{where}.semantic_key"),
+                kind=_enum(RecordKind, r["kind"], where),
+                parent_key=_optional_string(r["parent_key"], f"{where}.parent_key"),
+            )
+        )
+
+    components = []
+    for i, raw in enumerate(_object_list(p["components"], "representation.components")):
+        where = f"representation.components[{i}]"
+        c = _require(
+            raw,
+            (
+                "record_key",
+                "semantic_key",
+                "handling",
+                "irreducibility_reason_code",
+                "facts",
+            ),
+            where,
+        )
+        # The fact list is shape-checked here *before* delegation, because the
+        # closed-union parser reads a mapping and a non-object element would
+        # reach it as an unclassified AttributeError rather than this loader's
+        # documented error. Family validation itself stays where it is owned.
+        raw_facts = _object_list(c["facts"], f"{where}.facts")
+        try:
+            facts = tuple(fact_from_payload(f) for f in raw_facts)
+        except (MalformedFactPayloadError, UnknownFactFamilyError) as exc:
+            # Both halves of the closed union's rejection: a payload that will
+            # not rebuild its declared family, and a family outside the union.
+            # The second is a TypeError, so catching ValueError alone would let
+            # an undeclared family escape as an unclassified crash.
+            raise OracleLoadError(f"{where}: {exc}") from exc
+        components.append(
+            ComponentDraft(
+                record_key=_string(c["record_key"], f"{where}.record_key"),
+                semantic_key=_string(c["semantic_key"], f"{where}.semantic_key"),
+                handling=_enum(ComponentHandling, c["handling"], where),
+                irreducibility_reason_code=_optional_string(
+                    c["irreducibility_reason_code"],
+                    f"{where}.irreducibility_reason_code",
+                ),
+                facts=facts,
+            )
+        )
+
+    prose_bindings = []
+    for i, raw in enumerate(
+        _object_list(p["prose_bindings"], "representation.prose_bindings")
+    ):
+        where = f"representation.prose_bindings[{i}]"
+        b = _require(
+            raw,
+            ("record_key", "component_key", "chunk_id", "irreducibility_reason_code"),
+            where,
+        )
+        prose_bindings.append(
+            ProseBindingDraft(
+                record_key=_string(b["record_key"], f"{where}.record_key"),
+                component_key=_string(b["component_key"], f"{where}.component_key"),
+                chunk_id=_string(b["chunk_id"], f"{where}.chunk_id"),
+                irreducibility_reason_code=_string(
+                    b["irreducibility_reason_code"],
+                    f"{where}.irreducibility_reason_code",
+                ),
+            )
+        )
+
+    relationships = []
+    for i, raw in enumerate(
+        _object_list(p["relationships"], "representation.relationships")
+    ):
+        where = f"representation.relationships[{i}]"
+        rel = _require(raw, ("source_record_key", "target_record_key", "kind"), where)
+        relationships.append(
+            RelationshipDraft(
+                source_record_key=_string(
+                    rel["source_record_key"], f"{where}.source_record_key"
+                ),
+                target_record_key=_string(
+                    rel["target_record_key"], f"{where}.target_record_key"
+                ),
+                kind=_enum(RelationshipKind, rel["kind"], where),
+            )
+        )
+
+    references = []
+    reference_fields = (
+        "from_record_key",
+        "from_component_key",
+        "source_text",
+        "scope_key",
+        "target_record_key",
+    )
+    for i, raw in enumerate(_object_list(p["references"], "representation.references")):
+        where = f"representation.references[{i}]"
+        ref = _require(raw, reference_fields, where)
+        references.append(
+            ReferenceDraft(
+                **{k: _string(ref[k], f"{where}.{k}") for k in reference_fields}
+            )
+        )
+
+    provenance = []
+    for i, raw in enumerate(_object_list(p["provenance"], "representation.provenance")):
+        where = f"representation.provenance[{i}]"
+        pr = _require(raw, ("target_kind", "target_key", "span_id", "role"), where)
+        provenance.append(
+            ProvenanceClaim(
+                target_kind=_enum(ProvenanceTargetKind, pr["target_kind"], where),
+                target_key=tuple(_string_list(pr["target_key"], f"{where}.target_key")),
+                span_id=_string(pr["span_id"], f"{where}.span_id"),
+                role=_enum(ProvenanceRole, pr["role"], where),
+            )
+        )
+
+    return RepresentationDraft(
+        records=tuple(records),
+        components=tuple(components),
+        prose_bindings=tuple(prose_bindings),
+        relationships=tuple(relationships),
+        references=tuple(references),
+        provenance=tuple(provenance),
+    )
+
+
+def _obligation(payload: object, index: int) -> RecordObligation:
+    where = f"obligations[{index}]"
+    o = _require(
+        payload,
+        ("record_key", "kind", "structured_fact_families", "prose_bound_components"),
+        where,
+    )
+    return RecordObligation(
+        record_key=_string(o["record_key"], f"{where}.record_key"),
+        kind=_enum(RecordKind, o["kind"], where),
+        structured_fact_families=frozenset(
+            _enum(FactFamily, f, f"{where}.structured_fact_families")
+            for f in _list(
+                o["structured_fact_families"], f"{where}.structured_fact_families"
+            )
+        ),
+        # A bare string here would become a frozenset of its characters, which
+        # is accepted authority invented out of a typo.
+        prose_bound_components=frozenset(
+            _string_list(o["prose_bound_components"], f"{where}.prose_bound_components")
+        ),
+    )
+
+
+def _check_obligations_closed(
+    representation: RepresentationDraft,
+    obligations: tuple[RecordObligation, ...],
+    where: str,
+) -> None:
+    """Reject a committed oracle whose obligation relation is not total and exact.
+
+    Shape validation cannot catch this. A file that parses perfectly but omits
+    an obligation — or all of them — yields an oracle the gate evaluates against
+    an emptier claim than the reviewer accepted, and an otherwise-matching
+    projection then passes with less per-record evidence than ADR-005d
+    Decision 5 requires. So the relation must be *closed*: exactly one
+    obligation per accepted record, each reconciling exactly with what that
+    record's accepted representation states.
+    """
+    accepted = {o.record_key: o for o in derive_obligations(representation)}
+    seen: set[str] = set()
+    for obligation in obligations:
+        if obligation.record_key in seen:
+            raise OracleLoadError(
+                f"{where}: duplicate obligation for record "
+                f"{obligation.record_key!r}"
+            )
+        seen.add(obligation.record_key)
+        expected = accepted.get(obligation.record_key)
+        if expected is None:
+            raise OracleLoadError(
+                f"{where}: obligation targets record {obligation.record_key!r}, "
+                "which the accepted representation does not declare"
+            )
+        if obligation != expected:
+            raise OracleLoadError(
+                f"{where}: obligation for record {obligation.record_key!r} does "
+                f"not reconcile with the accepted representation: declared "
+                f"{obligation_payload(obligation)}, accepted "
+                f"{obligation_payload(expected)}"
+            )
+    if uncovered := sorted(set(accepted) - seen):
+        raise OracleLoadError(
+            f"{where}: accepted records carry no obligation: {uncovered}"
+        )
+
+
+def load_oracle(path: Path) -> AcceptedOracle:
+    """Load one committed accepted oracle from JSON.
+
+    The whole input is the file. Nothing is read from the database, from a
+    candidate, or from the current semantic policy.
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OracleLoadError(f"{path.name}: {exc}") from exc
+
+    p = _require(
+        raw,
+        (
+            "release_binding",
+            "semantic_policy_version",
+            "semantic_policy_hash",
+            "spans",
+            "representation",
+            "obligations",
+        ),
+        path.name,
+    )
+    binding_fields = (
+        "package_uuid",
+        "release_version",
+        "authoritative_source_hash",
+        "transform_config_hash",
+        "bundle_root_hash",
+        "persisted_corpus_digest",
+    )
+    binding = _require(p["release_binding"], binding_fields, "release_binding")
+    representation = _representation(p["representation"])
+    obligations = tuple(
+        _obligation(o, i)
+        for i, o in enumerate(_object_list(p["obligations"], "obligations"))
+    )
+    _check_obligations_closed(representation, obligations, path.name)
+    return AcceptedOracle(
+        binding=ReleaseBinding(
+            **{k: _string(binding[k], f"release_binding.{k}") for k in binding_fields}
+        ),
+        policy_version=_string(p["semantic_policy_version"], "semantic_policy_version"),
+        policy_hash=_string(p["semantic_policy_hash"], "semantic_policy_hash"),
+        spans=tuple(
+            _span(s, i) for i, s in enumerate(_object_list(p["spans"], "spans"))
+        ),
+        representation=representation,
+        obligations=obligations,
+    )
+
+
+def committed_oracle_for(
+    package_uuid: str, release_version: str
+) -> AcceptedOracle | None:
+    """Return the committed oracle for one 5c release, or ``None``.
+
+    Resolves from :data:`COMMITTED_ORACLE_DIR` and nowhere else. There is no
+    directory argument, because an exported helper that accepts one is the same
+    bypass as a publication entry that accepts one: a caller could resolve a
+    self-authored oracle from a writable directory and hand it to the gate as
+    committed authority.
+
+    ``None`` here means "no accepted authority is committed for this release",
+    which callers turn into a typed ``ABSENT`` publication outcome. It is never
+    an empty oracle: an empty oracle would compare equal to an empty projection
+    and publish nothing as if it were everything.
+    """
+    return _resolve_committed_oracle(
+        package_uuid, release_version, COMMITTED_ORACLE_DIR
+    )
+
+
+def _resolve_committed_oracle(
+    package_uuid: str, release_version: str, directory: Path
+) -> AcceptedOracle | None:
+    """Resolution semantics, parameterized by directory for tests only.
+
+    Two committed oracles for one release is a rejection, not a choice. Picking
+    one would make publication depend on filesystem ordering.
+    """
+    matches = [
+        oracle
+        for oracle in (load_oracle(p) for p in sorted(directory.glob("*.json")))
+        if oracle.binding.package_uuid == package_uuid
+        and oracle.binding.release_version == release_version
+    ]
+    if len(matches) > 1:
+        raise OracleLoadError(
+            f"{len(matches)} committed oracles claim release "
+            f"{package_uuid}/{release_version}"
+        )
+    return matches[0] if matches else None

--- a/src/afterworlds/ingestion/mechanical/oracles/README.md
+++ b/src/afterworlds/ingestion/mechanical/oracles/README.md
@@ -1,0 +1,22 @@
+# Committed accepted oracles — CRD Issue 5d
+
+One JSON file per published CRD Issue 5c release, holding the accepted
+meaning-bearing authority the publication gate judges a persisted projection
+against: the exact release binding, the declared semantic policy, the accepted
+span classification, the accepted record/component/fact/prose-binding/
+relationship/reference/provenance inventory, and the accepted per-record
+obligations.
+
+The schema is whatever `oracle.load_oracle` accepts; it rejects a missing key,
+an extra key, and an undeclared enum value rather than defaulting any of them.
+
+**This directory is deliberately empty of production content.** No accepted
+oracle exists for the SRD 5.2.1 release yet, so that release resolves to no
+accepted authority and its mechanical projection cannot be published — which
+is the honest state until the accepted full-corpus authority is reviewed and
+committed by a later CRD Issue 5d content PR.
+
+Files here are review artifacts, not build output. Nothing in `src/` writes to
+this directory, and no oracle may be generated from a candidate or from
+persisted projection state: an oracle derived from the thing it checks proves
+only that the code agrees with itself.

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -110,6 +110,7 @@ __all__ = [
     "persist_draft",
     "reconstruct_candidate",
     "record_persisted_state_digest",
+    "verify_persisted_state",
     "verify_reconstruction",
 ]
 
@@ -618,11 +619,35 @@ def verify_reconstruction(
     *,
     expected_status: str = "draft",
 ) -> tuple[str, ...]:
+    """Verify the persisted projection a build just identified.
+
+    Thin alias for :func:`verify_persisted_state`: the identity is the only
+    thing the verification needs from *identified*, because every value it
+    compares is re-derived from the database. Kept as the build-time spelling
+    so a caller holding an :class:`IdentifiedProjection` need not unwrap it.
+    """
+    return verify_persisted_state(
+        session, identified.projection_uuid, expected_status=expected_status
+    )
+
+
+def verify_persisted_state(
+    session: Session,
+    projection_uuid: str,
+    *,
+    expected_status: str = "draft",
+) -> tuple[str, ...]:
     """Return violations found by rebuilding the projection from the database.
 
     Catches omission (a row that never landed), tamper (a value changed after
     the fact), and stale reuse (a persisted projection whose content no longer
     derives its own identity).
+
+    Takes only the projection's identity, so the publication gate — which has
+    no in-memory build to compare against — verifies persisted state against
+    the database's *own recorded claims*: the header's UUID, payload hash,
+    recorded digest, and stored derived IDs are each re-derived from the rows
+    and must agree.
 
     ``expected_status`` is explicit because the same verification runs before
     publication and, later, against a published projection; hard-coding
@@ -630,7 +655,7 @@ def verify_reconstruction(
     finding.
     """
     findings: list[str] = []
-    uuid_ = identified.projection_uuid
+    uuid_ = projection_uuid
 
     try:
         header = _header(session, uuid_)

--- a/src/afterworlds/ingestion/mechanical/publication.py
+++ b/src/afterworlds/ingestion/mechanical/publication.py
@@ -41,11 +41,13 @@ by discipline:
   A competing projection is rejected as ``ACTIVE_CONFLICT`` with the incumbent
   untouched. Under genuine concurrency the pre-insert observation and the write
   are not one step, so a losing publisher's activation fails at the constraint
-  or the write lock; that is rolled back and the *whole* operation is reattempted
-  once on a clean transaction, where the winner's commit is visible and the
-  ordinary paths return ``ALREADY_PUBLISHED`` or ``ACTIVE_CONFLICT``. The loser
-  never keeps a partially published header, and only activation-contention
-  errors are treated this way — anything else propagates.
+  or the write lock; that is rolled back, then publication waits for the
+  winning activation to become visible within a bounded settlement window. The
+  *whole* operation is re-entered once on a clean transaction only after the
+  winner has committed, and the ordinary paths return ``ALREADY_PUBLISHED`` or
+  ``ACTIVE_CONFLICT``. The loser never keeps a partially published header,
+  and only activation-contention errors are treated this way — anything else
+  propagates.
 
 Every outcome is typed. Nothing here returns ``None``, an empty result, or a
 generic exception to mean "not published" (#137 contract 5).
@@ -55,6 +57,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from time import monotonic, sleep
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, OperationalError
@@ -436,13 +439,49 @@ def _is_activation_race(exc: IntegrityError | OperationalError) -> bool:
     return any(lock in message.lower() for lock in _LOCK_MESSAGES)
 
 
+#: A losing publisher waits only long enough for the transaction that beat it to
+#: make the activation row visible. The wait is bounded so a false-positive lock
+#: classification or a crashed winner cannot hang publication indefinitely.
+_ACTIVATION_SETTLEMENT_TIMEOUT_SECONDS = 1.0
+_ACTIVATION_SETTLEMENT_POLL_SECONDS = 0.01
+
+
+def _wait_for_activation_settlement(
+    session: Session, package_uuid: str
+) -> bool:
+    """Wait boundedly for a winning activation commit to become observable.
+
+    The row is used only as a settlement signal. The caller then re-enters the
+    complete publication path, which derives the typed result through the normal
+    gate and activation checks rather than inferring authority from this read.
+    Each probe ends its read transaction so the next one can observe a commit
+    that happened meanwhile.
+    """
+    deadline = monotonic() + _ACTIVATION_SETTLEMENT_TIMEOUT_SECONDS
+    while True:
+        try:
+            settled = _active_row(session, package_uuid) is not None
+        except OperationalError as exc:
+            session.rollback()
+            if not _is_activation_race(exc):
+                raise
+        else:
+            session.rollback()
+            if settled:
+                return True
+
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return False
+        sleep(min(_ACTIVATION_SETTLEMENT_POLL_SECONDS, remaining))
+
+
 def _publish_projection(
     session: Session,
     projection_uuid: str,
     oracle: AcceptedOracle | None,
     *,
     now: str,
-    reattempted: bool = False,
 ) -> PublicationResult:
     """Gate a persisted projection and, only if it passes, publish it atomically.
 
@@ -467,6 +506,7 @@ def _publish_projection(
     header = _header(session, projection_uuid)
     if header is None or oracle is None:
         return PublicationResult(PublicationOutcome.ABSENT, projection_uuid)
+    package_uuid = header.package_uuid
 
     gate = run_publication_gate(session, projection_uuid, oracle)
     report = build_evidence_report(header, gate)
@@ -532,22 +572,17 @@ def _publish_projection(
         session.commit()
     except (IntegrityError, OperationalError) as exc:
         # The observation above and the write below are not one atomic step, so
-        # a concurrent publisher can commit between them. The database settles
-        # it — that is the point of the activation key — and this turns losing
-        # into a typed outcome instead of a raw driver error.
+        # a concurrent publisher can commit between them. Roll back first, then
+        # wait boundedly for that winning activation to become visible. Only
+        # after settlement do we re-enter the *whole* operation on a clean
+        # transaction: the ordinary paths re-prove authority and return
+        # ALREADY_PUBLISHED or ACTIVE_CONFLICT without a weaker race verifier.
         session.rollback()
-        if reattempted or not _is_activation_race(exc):
+        if not _is_activation_race(exc):
             raise
-        # Re-enter the *whole* operation on a clean transaction rather than
-        # inspecting the active row and inferring a result. The winner's commit
-        # is now visible, so the second pass re-runs the complete committed-oracle
-        # proof and reaches ALREADY_PUBLISHED (same projection, now published) or
-        # ACTIVE_CONFLICT (another projection holds the package) through the
-        # ordinary paths. Bounded to one reattempt by an explicit flag, so it
-        # cannot recurse: a race that recurs on the clean transaction propagates.
-        return _publish_projection(
-            session, projection_uuid, oracle, now=now, reattempted=True
-        )
+        if not _wait_for_activation_settlement(session, package_uuid):
+            raise
+        return _publish_projection(session, projection_uuid, oracle, now=now)
     except Exception:
         session.rollback()
         raise

--- a/src/afterworlds/ingestion/mechanical/publication.py
+++ b/src/afterworlds/ingestion/mechanical/publication.py
@@ -1,0 +1,588 @@
+"""Atomic mechanical-projection publication — CRD Issue 5d, Decision 8.
+
+Completes the lifecycle CRD Issue 5c established and #139 built the first half
+of:
+
+``build → persist draft → reconstruct → prove → gate → atomically publish``
+
+**The supported surface is one function.** :func:`publish_from_committed_oracle`
+resolves the judging authority from the packaged committed-oracle directory
+using the release the persisted header actually binds. Nothing exported here
+accepts an oracle, an oracle directory, or an activation request, because a
+publication API whose caller supplies the authority that judges its own output
+proves only that the caller is self-consistent. Gating and activation are
+private steps of that one operation; tests that need to publish against a
+fixture oracle reach for the private seam deliberately and visibly.
+
+Four properties are load-bearing, and each is enforced by structure rather than
+by discipline:
+
+* **A draft never becomes active before the gate succeeds.** The gate is
+  read-only, so a failing run leaves the database exactly as it found it —
+  there is no partial write to undo. Activation is reachable only from a
+  publication operation that has just completed the full committed-oracle gate,
+  so there is no path that activates on a status column alone.
+* **Published projections are immutable.** Re-running publication re-runs the
+  *complete* gate against reconstructed state and additionally re-derives the
+  evidence report, requiring the recorded payload to be exactly that report, to
+  hash to the recorded hash, and to have been judged by the same oracle. A
+  projection — or its recorded evidence — edited after publication therefore
+  stops being publishable and stops verifying.
+  ``ponytail: enforced at this seam, not by a database trigger — SQLite has no
+  cheap column-level immutability. If direct row edits ever become a real
+  threat model, the upgrade path is an append-only published-state table.``
+* **Concurrent identical builds are idempotent.** Identity is content-derived,
+  so an identical rebuild is the *same* projection UUID; publishing it again
+  returns ``ALREADY_PUBLISHED`` — but only after the full gate re-proves it,
+  never on a status check alone.
+* **Activation cannot split.** ``rp_mech_active_projections`` is keyed by
+  ``package_uuid``, so one active projection per package is a database
+  constraint, and the database — not a process-local lock — is the arbiter.
+  A competing projection is rejected as ``ACTIVE_CONFLICT`` with the incumbent
+  untouched. Under genuine concurrency the pre-insert observation and the write
+  are not one step, so a losing publisher's activation fails at the constraint
+  or the write lock; that is rolled back and the *whole* operation is reattempted
+  once on a clean transaction, where the winner's commit is visible and the
+  ordinary paths return ``ALREADY_PUBLISHED`` or ``ACTIVE_CONFLICT``. The loser
+  never keeps a partially published header, and only activation-contention
+  errors are treated this way — anything else propagates.
+
+Every outcome is typed. Nothing here returns ``None``, an empty result, or a
+generic exception to mean "not published" (#137 contract 5).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.gate import (
+    GateFailureCategory,
+    GateResult,
+    run_publication_gate,
+)
+from afterworlds.ingestion.mechanical.oracle import AcceptedOracle, committed_oracle_for
+from afterworlds.ingestion.mechanical.report import (
+    EVIDENCE_REPORT_SCHEMA_VERSION,
+    EvidenceReport,
+    build_evidence_report,
+    report_hash,
+)
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalActiveProjectionORM,
+    MechanicalProjectionORM,
+)
+
+__all__ = [
+    "ActiveProjection",
+    "PublicationOutcome",
+    "PublicationResult",
+    "publish_from_committed_oracle",
+    "resolve_active_projection",
+]
+
+
+class PublicationOutcome(StrEnum):
+    """The typed result of a publication or activation attempt.
+
+    Deliberately limited to states this stage can actually reach. Runtime
+    binding, selector, and override states (``INVALID_SELECTOR``,
+    ``INVALID_OVERRIDE``, ``INVALID_REFERENCE``, ``AMBIGUOUS``) belong to the
+    runtime authority path and are not declared here as unreachable members.
+    """
+
+    #: The projection passed the gate and is now the package's active authority.
+    PUBLISHED = "published"
+    #: Already published and still proven — an idempotent no-op, not an error.
+    ALREADY_PUBLISHED = "already_published"
+    #: No such projection, or no accepted authority committed for its release.
+    ABSENT = "absent"
+    #: The accepted oracle judges a different release or a different policy.
+    MISMATCHED_RELEASE = "mismatched_release"
+    #: Spans remain proposed or carry no acceptance record.
+    UNREVIEWED = "unreviewed"
+    #: Spans remain classified UNRESOLVED.
+    UNRESOLVED = "unresolved"
+    #: The projection does not exactly match the accepted authority.
+    INCOMPLETE = "incomplete"
+    #: Persisted state no longer derives its own identity or recorded evidence,
+    #: or the 5c release it binds is not an exactly-published, reconstructable
+    #: release. Both are the same finding from an auditor's seat: something the
+    #: decision rests on is not what the record says it is.
+    STALE = "stale"
+    #: Another projection already holds this package's active authority.
+    ACTIVE_CONFLICT = "active_conflict"
+    #: The package has no active mechanical authority.
+    UNPUBLISHED = "unpublished"
+
+
+#: Gate categories mapped to outcomes, most fundamental first. Order is the
+#: contract: a projection whose persisted state does not reconstruct is stale
+#: regardless of what else the gate found, and calling that "incomplete" would
+#: send an auditor looking for missing content instead of tampered rows.
+#:
+#: ``IDENTITY_MISMATCH`` is deliberately absent. It is the roll-up of every
+#: content comparison, so it is present in almost any refusal; treating it as
+#: evidence of tamper would make ``STALE`` swallow the specific reason. It
+#: falls through to ``INCOMPLETE``, which is what "this is not the accepted
+#: authority" actually means.
+_OUTCOME_PRECEDENCE: tuple[
+    tuple[frozenset[GateFailureCategory], PublicationOutcome], ...
+] = (
+    (
+        frozenset(
+            {
+                GateFailureCategory.PERSISTED_STATE,
+                GateFailureCategory.BOUND_RELEASE,
+            }
+        ),
+        PublicationOutcome.STALE,
+    ),
+    (
+        frozenset(
+            {
+                GateFailureCategory.MISMATCHED_RELEASE,
+                GateFailureCategory.POLICY_MISMATCH,
+            }
+        ),
+        PublicationOutcome.MISMATCHED_RELEASE,
+    ),
+    (
+        frozenset({GateFailureCategory.UNRESOLVED_RESIDUE}),
+        PublicationOutcome.UNRESOLVED,
+    ),
+    (
+        frozenset({GateFailureCategory.UNREVIEWED_RESIDUE}),
+        PublicationOutcome.UNREVIEWED,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class PublicationResult:
+    """The complete outcome of one publication or activation attempt.
+
+    ``report`` is present whenever a gate ran, including for refusals: a
+    refused publication is an auditable decision. It is persisted only on
+    success — recording evidence for a projection that was never published
+    would be precisely the partial state atomic publication forbids.
+    """
+
+    outcome: PublicationOutcome
+    projection_uuid: str
+    gate: GateResult | None = None
+    report: EvidenceReport | None = None
+    evidence_report_hash: str | None = None
+
+
+@dataclass(frozen=True)
+class ActiveProjection:
+    """The active mechanical authority of one package, or its typed absence."""
+
+    outcome: PublicationOutcome
+    package_uuid: str
+    projection_uuid: str | None = None
+    activated_at: str | None = None
+
+
+def _outcome_for(gate: GateResult) -> PublicationOutcome:
+    """Classify a failed gate into one typed outcome."""
+    categories = gate.categories()
+    for family, outcome in _OUTCOME_PRECEDENCE:
+        if categories & family:
+            return outcome
+    return PublicationOutcome.INCOMPLETE
+
+
+def _header(session: Session, projection_uuid: str) -> MechanicalProjectionORM | None:
+    return session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == projection_uuid
+        )
+    ).scalar_one_or_none()
+
+
+def _active_row(
+    session: Session, package_uuid: str
+) -> MechanicalActiveProjectionORM | None:
+    return session.execute(
+        select(MechanicalActiveProjectionORM).where(
+            MechanicalActiveProjectionORM.package_uuid == package_uuid
+        )
+    ).scalar_one_or_none()
+
+
+#: Every top-level key :func:`build_evidence_report` produces. A payload missing
+#: any of them is not this schema, whatever its recorded version claims.
+_REQUIRED_REPORT_KEYS = frozenset(
+    {
+        "report_version",
+        "source_release",
+        "mechanical_projection",
+        "accepted_oracle",
+        "gate",
+        "obligations",
+        "drift_diagnostics",
+    }
+)
+
+
+def _recorded_evidence_closure(
+    header: MechanicalProjectionORM,
+) -> tuple[str, ...]:
+    """Is the projection's *recorded* publication evidence internally closed?
+
+    The half of evidence verification that needs nothing but the row itself:
+    the payload is present and is the supported schema, the recorded hash is
+    the hash *of that payload*, and the publication fields that must exist
+    together do.
+
+    The stored hash is never trusted on its own. A hash column identifies a
+    payload; checking only the column and ignoring the payload it identifies
+    means a cleared or edited ``report_payload`` still reports as verified, and
+    the recorded evidence stops being reconstructable from the database while
+    publication keeps claiming it is.
+    """
+    failures: list[str] = []
+    if header.evidence_report_hash is None:
+        failures.append("no recorded evidence_report_hash")
+    if header.oracle_identity is None:
+        failures.append("no recorded judging-oracle identity")
+    if header.published_at is None:
+        failures.append("published projection records no published_at")
+    if header.persisted_state_digest is None:
+        failures.append("no recorded persisted-state digest")
+
+    payload = header.report_payload
+    if payload is None:
+        failures.append("no recorded evidence-report payload")
+    elif (
+        not isinstance(payload, dict)
+        or payload.get("report_version") != EVIDENCE_REPORT_SCHEMA_VERSION
+        or not set(payload) >= _REQUIRED_REPORT_KEYS
+    ):
+        failures.append(
+            "recorded evidence-report payload is not the supported "
+            f"{EVIDENCE_REPORT_SCHEMA_VERSION!r} schema"
+        )
+    elif report_hash(EvidenceReport(payload=payload)) != header.evidence_report_hash:
+        failures.append(
+            "recorded evidence-report payload does not hash to the recorded "
+            "evidence_report_hash"
+        )
+    return tuple(failures)
+
+
+def _recorded_evidence_failures(
+    header: MechanicalProjectionORM,
+    gate: GateResult,
+    report: EvidenceReport,
+    digest: str,
+) -> tuple[str, ...]:
+    """Is the recorded evidence closed *and* still the evidence this state derives?
+
+    Adds the comparisons that need a completed gate run: the persisted payload
+    must be exactly the report freshly derived from the current reconstructed
+    state under the current committed oracle, its hash must be the recorded
+    one, and the judging oracle must be the same authority. A published
+    projection whose state, evidence, or judging authority has drifted is
+    stale — not reusable, and not re-activatable.
+    """
+    failures = list(_recorded_evidence_closure(header))
+    if header.report_payload != report.payload:
+        failures.append(
+            "recorded evidence-report payload is not the report this "
+            "reconstructed state and committed oracle derive"
+        )
+    if header.evidence_report_hash != digest:
+        failures.append(
+            f"recorded evidence_report_hash {header.evidence_report_hash!r} is "
+            f"not the freshly derived {digest!r}"
+        )
+    if header.oracle_identity != gate.oracle_identity:
+        failures.append(
+            f"recorded judging oracle {header.oracle_identity!r} is not the "
+            f"committed oracle {gate.oracle_identity!r}"
+        )
+    return tuple(dict.fromkeys(failures))
+
+
+def resolve_active_projection(session: Session, package_uuid: str) -> ActiveProjection:
+    """Return the package's active mechanical authority.
+
+    ``UNPUBLISHED`` is a typed answer, not ``None`` and not an empty result: a
+    caller that cannot tell "no authority is published" from "the query
+    returned nothing" is one step from treating absence as permission.
+
+    An activation row is not by itself an authority claim. This resolves the
+    projection it names and requires that projection to be published with
+    internally closed recorded evidence; a row pointing at a draft, at another
+    package's projection, or at one whose evidence was cleared or edited
+    resolves to ``STALE``, never to ``PUBLISHED``.
+
+    **The contract this asserts** is recorded-evidence closure, not a re-run of
+    the publication proof. It does not resolve the committed oracle, re-gate
+    reconstructed state, or re-verify the bound 5c release, so two things are
+    deliberately outside what it can detect: evidence edited *consistently*
+    (payload and hash together), and a release retired or edited *after* this
+    projection was published over it. Both are caught by
+    :func:`publish_from_committed_oracle`, which re-runs the complete proof.
+    Re-proof is a publication operation, and revalidating the effective runtime
+    binding on read is CRD Issue 5d PR 3's; this stays a read-only assertion
+    about what the database records.
+    """
+    row = _active_row(session, package_uuid)
+    if row is None:
+        return ActiveProjection(
+            outcome=PublicationOutcome.UNPUBLISHED, package_uuid=package_uuid
+        )
+    header = _header(session, row.projection_uuid)
+    stale = ActiveProjection(
+        outcome=PublicationOutcome.STALE,
+        package_uuid=package_uuid,
+        projection_uuid=row.projection_uuid,
+        activated_at=row.activated_at,
+    )
+    if (
+        header is None
+        or header.package_uuid != package_uuid
+        or header.publication_status != "published"
+        or _recorded_evidence_closure(header)
+    ):
+        return stale
+    return ActiveProjection(
+        outcome=PublicationOutcome.PUBLISHED,
+        package_uuid=package_uuid,
+        projection_uuid=row.projection_uuid,
+        activated_at=row.activated_at,
+    )
+
+
+def _activate_projection(
+    session: Session, projection_uuid: str, *, now: str
+) -> PublicationResult:
+    """Make a just-proven projection its package's active authority.
+
+    Private, and reachable only from :func:`_publish_projection` after the full
+    committed-oracle gate has passed against reconstructed state and the
+    recorded evidence has been verified. It is not a step a caller may perform
+    on its own: ``publication_status``, a non-NULL hash, and the presence of an
+    evidence column are what a successful publication *leaves behind*, not
+    proof that one happened, and a function that activated on them would make a
+    hand-edited or partially migrated header active authority.
+
+    The header checks below are the residue of that ordering, kept as a
+    same-transaction assertion rather than as the gate.
+
+    Flushes rather than commits; :func:`_publish_projection` owns the commit.
+    """
+    header = _header(session, projection_uuid)
+    if header is None:
+        return PublicationResult(PublicationOutcome.ABSENT, projection_uuid)
+    if header.publication_status != "published" or header.evidence_report_hash is None:
+        return PublicationResult(PublicationOutcome.UNPUBLISHED, projection_uuid)
+
+    active = _active_row(session, header.package_uuid)
+    if active is not None:
+        if active.projection_uuid != projection_uuid:
+            return PublicationResult(
+                PublicationOutcome.ACTIVE_CONFLICT,
+                projection_uuid,
+                evidence_report_hash=header.evidence_report_hash,
+            )
+        return PublicationResult(
+            PublicationOutcome.ALREADY_PUBLISHED,
+            projection_uuid,
+            evidence_report_hash=header.evidence_report_hash,
+        )
+
+    session.add(
+        MechanicalActiveProjectionORM(
+            package_uuid=header.package_uuid,
+            projection_uuid=projection_uuid,
+            activated_at=now,
+        )
+    )
+    session.flush()
+    return PublicationResult(
+        PublicationOutcome.PUBLISHED,
+        projection_uuid,
+        evidence_report_hash=header.evidence_report_hash,
+    )
+
+
+#: SQLite's message when a second connection holds the write lock. Matched by
+#: text because the driver exposes no code for it; both spellings occur.
+_LOCK_MESSAGES = ("database is locked", "database table is locked")
+
+
+def _is_activation_race(exc: IntegrityError | OperationalError) -> bool:
+    """Is this the database refusing a *concurrent activation*, specifically?
+
+    Narrow on purpose. A blanket ``except IntegrityError`` would relabel an
+    unrelated constraint violation — a bad FK, a duplicated projection row — as
+    a race and retry it, turning a real defect into a confusing typed outcome.
+    So an integrity error qualifies only when it names the activation table, and
+    an operational error only when it is the write-lock contention this
+    transaction can genuinely lose.
+    """
+    message = str(getattr(exc, "orig", exc))
+    if isinstance(exc, IntegrityError):
+        return MechanicalActiveProjectionORM.__tablename__ in message
+    return any(lock in message.lower() for lock in _LOCK_MESSAGES)
+
+
+def _publish_projection(
+    session: Session,
+    projection_uuid: str,
+    oracle: AcceptedOracle | None,
+    *,
+    now: str,
+    reattempted: bool = False,
+) -> PublicationResult:
+    """Gate a persisted projection and, only if it passes, publish it atomically.
+
+    Private: *oracle* is the authority that judges the projection, so exporting
+    this would restore exactly the bypass removing the oracle-directory
+    parameter closes — a caller able to author the authority its own output is
+    measured against. :func:`publish_from_committed_oracle` is the supported
+    entry, and it resolves the oracle from the committed directory rather than
+    accepting one. Tests reach for this seam directly and visibly, which is a
+    property of the test, not an API a production caller can use by accident.
+
+    Commits on success, which is what makes publication the durability boundary
+    rather than something a caller can forget to finish. On any refusal nothing
+    was written, so there is nothing to roll back; on an unexpected exception
+    after the first write the transaction is rolled back and the exception
+    propagates, so a half-activated package cannot survive.
+
+    *oracle* is ``None`` when no accepted authority is committed for the
+    release. That is ``ABSENT`` — never an empty oracle, which would compare
+    equal to an empty projection and publish nothing as if it were everything.
+    """
+    header = _header(session, projection_uuid)
+    if header is None or oracle is None:
+        return PublicationResult(PublicationOutcome.ABSENT, projection_uuid)
+
+    gate = run_publication_gate(session, projection_uuid, oracle)
+    report = build_evidence_report(header, gate)
+    digest = report_hash(report)
+
+    if not gate.passed:
+        # Read-only up to here: the refusal leaves the database untouched, and
+        # the report goes back to the caller rather than into a row.
+        return PublicationResult(
+            _outcome_for(gate), projection_uuid, gate=gate, report=report
+        )
+
+    try:
+        if header.publication_status == "published":
+            # Idempotent reuse, but only after the full gate above re-proved the
+            # persisted state *and* the recorded evidence proves closed against
+            # the freshly derived report. Reuse is the path an auditor is most
+            # likely to take on trust, so it is the one that must not accept a
+            # stored claim.
+            if _recorded_evidence_failures(header, gate, report, digest):
+                return PublicationResult(
+                    PublicationOutcome.STALE, projection_uuid, gate=gate, report=report
+                )
+            result = _activate_projection(session, projection_uuid, now=now)
+            session.commit()
+            return PublicationResult(
+                (
+                    PublicationOutcome.ALREADY_PUBLISHED
+                    if result.outcome is PublicationOutcome.PUBLISHED
+                    else result.outcome
+                ),
+                projection_uuid,
+                gate=gate,
+                report=report,
+                evidence_report_hash=digest,
+            )
+
+        active = _active_row(session, header.package_uuid)
+        if active is not None and active.projection_uuid != projection_uuid:
+            # The incumbent is left exactly as it is. Publication of a competing
+            # projection is a decision for whoever retires the active one.
+            return PublicationResult(
+                PublicationOutcome.ACTIVE_CONFLICT,
+                projection_uuid,
+                gate=gate,
+                report=report,
+            )
+
+        header.oracle_identity = gate.oracle_identity
+        header.evidence_report_hash = digest
+        header.report_payload = report.payload
+        header.publication_status = "published"
+        header.published_at = now
+        session.flush()
+        activation = _activate_projection(session, projection_uuid, now=now)
+        if activation.outcome is not PublicationOutcome.PUBLISHED:
+            # Unreachable through this path (the conflict was checked above),
+            # but a partially published header must never survive a surprise.
+            session.rollback()
+            return PublicationResult(
+                activation.outcome, projection_uuid, gate=gate, report=report
+            )
+        session.commit()
+    except (IntegrityError, OperationalError) as exc:
+        # The observation above and the write below are not one atomic step, so
+        # a concurrent publisher can commit between them. The database settles
+        # it — that is the point of the activation key — and this turns losing
+        # into a typed outcome instead of a raw driver error.
+        session.rollback()
+        if reattempted or not _is_activation_race(exc):
+            raise
+        # Re-enter the *whole* operation on a clean transaction rather than
+        # inspecting the active row and inferring a result. The winner's commit
+        # is now visible, so the second pass re-runs the complete committed-oracle
+        # proof and reaches ALREADY_PUBLISHED (same projection, now published) or
+        # ACTIVE_CONFLICT (another projection holds the package) through the
+        # ordinary paths. Bounded to one reattempt by an explicit flag, so it
+        # cannot recurse: a race that recurs on the clean transaction propagates.
+        return _publish_projection(
+            session, projection_uuid, oracle, now=now, reattempted=True
+        )
+    except Exception:
+        session.rollback()
+        raise
+
+    return PublicationResult(
+        PublicationOutcome.PUBLISHED,
+        projection_uuid,
+        gate=gate,
+        report=report,
+        evidence_report_hash=digest,
+    )
+
+
+def publish_from_committed_oracle(
+    session: Session, projection_uuid: str, *, now: str
+) -> PublicationResult:
+    """The production publication entry — the only supported one.
+
+    The oracle is resolved from :data:`oracle.COMMITTED_ORACLE_DIR`, the fixed
+    packaged location, using the release the persisted header actually binds.
+    There is deliberately no directory parameter: one would let a caller point
+    publication at a writable directory holding a self-authored oracle that
+    matches its own projection, which is the guarantee this function exists to
+    make — and a guarantee with an override is a default.
+
+    Re-publication and re-activation enter here too, and re-run the complete
+    proof. There is no cheaper door.
+
+    No accepted oracle is committed for the production SRD 5.2.1 release, so
+    this path currently returns ``ABSENT`` for it. That is the honest state:
+    the accepted full-corpus authority has not been reviewed and committed yet,
+    and until it is, nothing over that release can be published.
+    """
+    header = _header(session, projection_uuid)
+    if header is None:
+        return PublicationResult(PublicationOutcome.ABSENT, projection_uuid)
+    oracle = committed_oracle_for(header.package_uuid, header.release_version)
+    return _publish_projection(session, projection_uuid, oracle, now=now)

--- a/src/afterworlds/ingestion/mechanical/publication.py
+++ b/src/afterworlds/ingestion/mechanical/publication.py
@@ -446,9 +446,7 @@ _ACTIVATION_SETTLEMENT_TIMEOUT_SECONDS = 1.0
 _ACTIVATION_SETTLEMENT_POLL_SECONDS = 0.01
 
 
-def _wait_for_activation_settlement(
-    session: Session, package_uuid: str
-) -> bool:
+def _wait_for_activation_settlement(session: Session, package_uuid: str) -> bool:
     """Wait boundedly for a winning activation commit to become observable.
 
     The row is used only as a settlement signal. The caller then re-enters the

--- a/src/afterworlds/ingestion/mechanical/report.py
+++ b/src/afterworlds/ingestion/mechanical/report.py
@@ -1,0 +1,123 @@
+"""Deterministic mechanical-publication evidence report — CRD Issue 5d.
+
+Generated from a completed gate run over reconstructed persisted state, never
+hand-written and never assembled before the state it reports on exists. It
+carries every identity an auditor needs to reproduce the decision:
+
+* the exact 5c source release and the projection built over it;
+* the accepted-oracle identity, so "which authority judged this" is on the
+  record and a later oracle edit is detectable;
+* the reconstructed-state and persisted-proof identities;
+* the gate verdict, its categorized failures, and every obligation with its
+  outcome — satisfied ones included, because a passing gate with no recorded
+  obligations is an assertion rather than evidence; and
+* drift diagnostics, explicitly labelled as such.
+
+It does **not** contain its own hash (nothing can), and it contains no wall
+clock, host, or reviewer identity. That is what makes it reproducible: the same
+committed inputs and the same persisted state produce a byte-identical report,
+and therefore the same report hash, on any host — the CRD Issue 5c determinism
+rule applied to this artifact.
+
+The projection's publication *status* is likewise absent. The report describes
+whether the state is publishable, not what has since been done about it, so a
+projection re-verified after publication reproduces the report hash recorded
+when it was published. Publication relies on that: a recorded hash that no
+longer matches the re-derived one means the evidence and the state have
+diverged.
+
+Counts live under ``drift_diagnostics`` and are named that way deliberately.
+ADR-005d Decision 5 forbids proving completeness with totals; they are here to
+make a regression visible between two releases, and nothing reads them to
+decide anything.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.mechanical.gate import GateResult
+from afterworlds.persistence.orm.mechanical import MechanicalProjectionORM
+
+__all__ = [
+    "EVIDENCE_REPORT_SCHEMA_VERSION",
+    "EvidenceReport",
+    "build_evidence_report",
+    "report_hash",
+]
+
+#: Canonical report shape. Bumped only on an intentional change to the payload's
+#: canonical structure — never for a comment, docstring, or logging edit — so a
+#: shape change is visible in the recorded evidence of every projection
+#: published afterwards, and two reports carrying the same version are directly
+#: comparable.
+EVIDENCE_REPORT_SCHEMA_VERSION = "5d-mechanical-evidence-1"
+
+
+@dataclass(frozen=True)
+class EvidenceReport:
+    """The completed report payload for one publication decision."""
+
+    payload: dict[str, object]
+
+
+def build_evidence_report(
+    header: MechanicalProjectionORM, gate: GateResult
+) -> EvidenceReport:
+    """Build the evidence report for a completed gate run.
+
+    Built for failures as well as successes. A refused publication is a
+    decision that has to be auditable too, and the caller receives the report
+    without it being persisted — recording evidence for a projection that was
+    never published would be exactly the partial state atomic publication
+    forbids.
+    """
+    payload: dict[str, object] = {
+        "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
+        # Exact source release and projection: the two ends of the binding.
+        "source_release": {
+            "package_uuid": header.package_uuid,
+            "release_version": header.release_version,
+            "authoritative_source_hash": header.authoritative_source_hash,
+            "transform_config_hash": header.transform_config_hash,
+            "bundle_root_hash": header.bundle_root_hash,
+            "persisted_corpus_digest": header.persisted_corpus_digest,
+        },
+        "mechanical_projection": {
+            "projection_uuid": header.projection_uuid,
+            "semantic_policy_version": header.semantic_policy_version,
+            "semantic_policy_hash": header.semantic_policy_hash,
+            "payload_hash": header.payload_hash,
+            "persisted_state_digest": gate.persisted_state_digest,
+        },
+        # Which independent authority judged this, and what it derives.
+        "accepted_oracle": {
+            "oracle_identity": gate.oracle_identity,
+            "derived_projection_uuid": gate.expected_projection_uuid,
+        },
+        "gate": {
+            "passed": gate.passed,
+            "failure_categories": sorted(c.value for c in gate.categories()),
+            "failures": [
+                {"category": f.category.value, "detail": f.detail}
+                for f in gate.failures
+            ],
+        },
+        "obligations": [
+            {
+                "record_key": o.record_key,
+                "satisfied": o.satisfied,
+                "failures": list(o.failures),
+            }
+            for o in gate.obligations
+        ],
+        # Regression canaries. Never a pass condition (ADR-005d Decision 5).
+        "drift_diagnostics": dict(sorted(gate.diagnostics.items())),
+    }
+    return EvidenceReport(payload=payload)
+
+
+def report_hash(report: EvidenceReport) -> str:
+    """SHA-256 over the completed report payload."""
+    return hash_obj(report.payload)

--- a/src/afterworlds/ingestion/mechanical/report.py
+++ b/src/afterworlds/ingestion/mechanical/report.py
@@ -16,8 +16,8 @@ carries every identity an auditor needs to reproduce the decision:
 It does **not** contain its own hash (nothing can), and it contains no wall
 clock, host, or reviewer identity. That is what makes it reproducible: the same
 committed inputs and the same persisted state produce a byte-identical report,
-and therefore the same report hash, on any host — the CRD Issue 5c determinism
-rule applied to this artifact.
+and therefore the same report hash, on any host — the deterministic publication
+evidence required by ADR-005d.
 
 The projection's publication *status* is likewise absent. The report describes
 whether the state is publishable, not what has since been done about it, so a

--- a/src/afterworlds/persistence/orm/mechanical.py
+++ b/src/afterworlds/persistence/orm/mechanical.py
@@ -67,6 +67,49 @@ class MechanicalProjectionORM(Base):
     )
     created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
 
+    # Publication evidence (#137 contract 5). All NULL through the draft phase:
+    # the gate runs against reconstructed state, so none of these can exist
+    # before that state does. They are written by one atomic publication and
+    # never by a draft write.
+    oracle_identity: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+    evidence_report_hash: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+    report_payload: Mapped[dict[str, Any] | None] = mapped_column(
+        sa.JSON, nullable=True
+    )
+    published_at: Mapped[str | None] = mapped_column(sa.String(64), nullable=True)
+
+
+class MechanicalActiveProjectionORM(Base):
+    """The one active mechanical projection of a Rules Package.
+
+    ``package_uuid`` is the primary key, so active authority cannot split: the
+    database itself refuses a second active row for a package rather than
+    relying on application code to notice. Competing activation is therefore a
+    typed rejection, not a race whose winner depends on ordering.
+
+    Activation is a separate row rather than a flag on the projection header
+    because "which projection is active" is a property of the *package*. A
+    boolean per projection would let two rows both claim it, which is exactly
+    the split this table forecloses.
+    """
+
+    __tablename__ = "rp_mech_active_projections"
+
+    package_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_corpus_releases.package_uuid", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    projection_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_mech_projections.projection_uuid", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    activated_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
 
 class _ProjectionScoped(Base):
     """Mixin base: every projection-scoped table cascades from its projection."""

--- a/tests/ingestion/conftest.py
+++ b/tests/ingestion/conftest.py
@@ -1,0 +1,101 @@
+"""Ingestion-wide fixtures: the one real CRD Issue 5c release.
+
+Building the production corpus from the committed PDF and finalizing it through
+the genuine persist → reconstruct → digest → gate → publish lifecycle costs
+about two minutes. Both suites that need it — CRD Issue 5c's own tests and CRD
+Issue 5d's production-corpus control — must share one build, so these fixtures
+live here rather than in either subdirectory. Defined in a parent ``conftest``,
+they are a single session-scoped fixture definition; duplicated per directory
+they would be two, and the cost would double.
+
+Everything else stays where it is used. This module holds only what more than
+one subdirectory needs.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+
+from afterworlds.ingestion.corpus.persistence import _finalize_core, finalize_release
+from afterworlds.ingestion.corpus.pipeline import (
+    CandidateRelease,
+    ReleaseArtifacts,
+    build_candidate,
+)
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
+from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PDF_PATH = REPO_ROOT / "docs" / "sources" / "DnD5_5e_SRD_CC_v5_2_1.pdf"
+
+NOW = "2026-07-23T00:00:00Z"
+
+
+def finalize_in_fresh_db(candidate: CandidateRelease, *, core: bool = False):  # type: ignore[no-untyped-def]
+    """Finalize *candidate* against a brand-new, already-committed in-memory DB
+    plus a private, isolated on-disk Chroma store and the deterministic offline
+    embedding function.
+
+    ``core=False`` (default) uses the production ``finalize_release`` (with its
+    completeness guard) — for the full-SRD candidate. ``core=True`` uses the
+    private ``_finalize_core`` seam, which skips the completeness guard so a
+    compact (partial) candidate can still exercise the persist/gate lifecycle.
+    Returns the ``FinalizeResult``; the caller asserts ``published``/``reused``.
+    """
+    eng = create_engine("sqlite://")
+
+    @event.listens_for(eng, "connect")
+    def _fk(dbapi, _rec):  # type: ignore[no-untyped-def]
+        dbapi.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(eng)
+    factory = create_session_factory(eng)
+    sess = factory()
+    chroma_dir = tempfile.mkdtemp(prefix="corpus-chroma-")
+    client = build_isolated_test_chroma_client(chroma_dir)
+    finalize = _finalize_core if core else finalize_release
+    try:
+        result = finalize(
+            sess,
+            candidate,
+            now=NOW,
+            chroma_client=client,
+            retrieval_config=RetrievalMemoryConfig(),
+            embedding_function=DeterministicFakeEmbeddingFunction(),
+        )
+    finally:
+        sess.close()
+        eng.dispose()
+    return result
+
+
+@pytest.fixture(scope="session")
+def full_candidate() -> CandidateRelease:
+    """The real full-SRD pre-persistence candidate, built once for the session.
+
+    This is the primary build (no fixture dependencies), so a test module may
+    safely shadow ``candidate`` with the compact one without recursion.
+    """
+    return build_candidate(PDF_PATH, retrieval_config=RetrievalMemoryConfig())
+
+
+@pytest.fixture(scope="session")
+def full_release(full_candidate: CandidateRelease) -> ReleaseArtifacts:
+    """The real full-SRD corpus release, finalized once for the whole session.
+
+    Goes through the actual publish lifecycle (``finalize_release``) rather than
+    being assembled in memory, so every test that reads from this fixture is
+    implicitly exercising Component K's full acyclic c–g order. Depends on
+    ``full_candidate`` (never shadowed) to keep the shadow-safe dependency
+    chain.
+    """
+    result = finalize_in_fresh_db(full_candidate)
+    assert result.published and result.artifacts is not None, result.gate
+    return result.artifacts

--- a/tests/ingestion/corpus/conftest.py
+++ b/tests/ingestion/corpus/conftest.py
@@ -7,11 +7,16 @@ private, already-committed store, so it exercises the *real* Component K c-g
 lifecycle rather than an in-memory approximation. Adversarial gate/findings
 tests use small synthetic ledgers built by :func:`synthetic_release` and run
 fast.
+
+``full_candidate``, ``full_release``, and ``finalize_in_fresh_db`` live in the
+parent ``tests/ingestion/conftest.py``: the CRD Issue 5d production-corpus
+control needs the same real release, and one session-scoped definition means
+one build rather than two. They are re-exported here so this suite's modules
+keep importing them from ``.conftest``.
 """
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -40,12 +45,7 @@ from afterworlds.ingestion.corpus.pdf_source import (
     ExtractedPage,
     extraction_config,
 )
-from afterworlds.ingestion.corpus.persistence import _finalize_core, finalize_release
-from afterworlds.ingestion.corpus.pipeline import (
-    CandidateRelease,
-    ReleaseArtifacts,
-    build_candidate,
-)
+from afterworlds.ingestion.corpus.pipeline import CandidateRelease, ReleaseArtifacts
 from afterworlds.ingestion.corpus.policy import FROZEN_POLICY, policy_hash
 from afterworlds.ingestion.corpus.reconcile import reconcile
 from afterworlds.ingestion.corpus.transform import build_corpus
@@ -55,11 +55,13 @@ from afterworlds.persistence.orm.base import Base
 from afterworlds.pipeline.retrieval.client import build_isolated_test_chroma_client
 from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 from afterworlds.pipeline.retrieval.embedding import DeterministicFakeEmbeddingFunction
+from tests.ingestion.conftest import (  # noqa: F401  (re-exported for this suite)
+    NOW,
+    PDF_PATH,
+    finalize_in_fresh_db,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-PDF_PATH = REPO_ROOT / "docs" / "sources" / "DnD5_5e_SRD_CC_v5_2_1.pdf"
-
-NOW = "2026-07-23T00:00:00Z"
 
 
 # The six version-canary pages (Component J). A candidate restricted to just
@@ -109,16 +111,6 @@ def _candidate_from_pages(
 
 
 @pytest.fixture(scope="session")
-def full_candidate() -> CandidateRelease:
-    """The real full-SRD pre-persistence candidate, built once for the session.
-
-    This is the primary build (no fixture dependencies), so a test module may
-    safely shadow ``candidate`` with the compact one without recursion.
-    """
-    return build_candidate(PDF_PATH, retrieval_config=RetrievalMemoryConfig())
-
-
-@pytest.fixture(scope="session")
 def candidate(full_candidate: CandidateRelease) -> CandidateRelease:
     """The full-SRD candidate (default). Other corpus test modules consume the
     complete corpus through this name."""
@@ -154,58 +146,6 @@ def fake_embedding() -> DeterministicFakeEmbeddingFunction:
 def chroma_client(tmp_path):  # type: ignore[no-untyped-def]
     """A fully isolated on-disk Chroma client rooted at a per-test tmp dir."""
     return build_isolated_test_chroma_client(str(tmp_path / "chroma"))
-
-
-def finalize_in_fresh_db(candidate: CandidateRelease, *, core: bool = False):  # type: ignore[no-untyped-def]
-    """Finalize *candidate* against a brand-new, already-committed in-memory DB
-    plus a private, isolated on-disk Chroma store and the deterministic offline
-    embedding function.
-
-    ``core=False`` (default) uses the production ``finalize_release`` (with its
-    completeness guard) — for the full-SRD candidate. ``core=True`` uses the
-    private ``_finalize_core`` seam, which skips the completeness guard so a
-    compact (partial) candidate can still exercise the persist/gate lifecycle.
-    Returns the ``FinalizeResult``; the caller asserts ``published``/``reused``.
-    """
-    eng = create_engine("sqlite://")
-
-    @event.listens_for(eng, "connect")
-    def _fk(dbapi, _rec):  # type: ignore[no-untyped-def]
-        dbapi.execute("PRAGMA foreign_keys=ON")
-
-    Base.metadata.create_all(eng)
-    factory = create_session_factory(eng)
-    sess = factory()
-    chroma_dir = tempfile.mkdtemp(prefix="corpus-chroma-")
-    client = build_isolated_test_chroma_client(chroma_dir)
-    finalize = _finalize_core if core else finalize_release
-    try:
-        result = finalize(
-            sess,
-            candidate,
-            now=NOW,
-            chroma_client=client,
-            retrieval_config=RetrievalMemoryConfig(),
-            embedding_function=DeterministicFakeEmbeddingFunction(),
-        )
-    finally:
-        sess.close()
-        eng.dispose()
-    return result
-
-
-@pytest.fixture(scope="session")
-def full_release(full_candidate: CandidateRelease) -> ReleaseArtifacts:
-    """The real full-SRD corpus release, finalized once for the whole session.
-
-    Goes through the actual publish lifecycle (finalize_release) rather than
-    being assembled in memory, so every test that reads from this fixture is
-    implicitly exercising Component K's full acyclic c-g order. Depends on
-    ``full_candidate`` (never shadowed) to keep the shadow-safe dependency chain.
-    """
-    result = finalize_in_fresh_db(full_candidate)
-    assert result.published and result.artifacts is not None, result.gate
-    return result.artifacts
 
 
 @pytest.fixture(scope="session")

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -4,10 +4,71 @@ One small honest candidate: a spell record with a structured descriptor
 component and a prose-bound open-ended clause, plus a scoped creature record —
 the shape the Wish and spell-scoped-creature canaries exercise, small enough
 that each negative control can perturb exactly one thing.
+
+The same content appears twice on purpose, and the duplication is the point:
+
+* :func:`build_candidate` is what a **build** produces from the accepted
+  inputs; and
+* ``data/bounded_oracle.json`` is the committed **accepted authority** stating
+  the same content independently, loaded through the production
+  :func:`load_oracle` path.
+
+Negative controls perturb the candidate or the persisted rows and never the
+oracle, so every one of them is a comparison against authority that did not
+move. :func:`accepted_oracle` builds the equivalent in memory purely so the
+committed file can be checked for drift in one place with a clear message.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.bundle import build_bundle, reconciliation_hash
+from afterworlds.ingestion.corpus.concordance import ConcordanceResult
+from afterworlds.ingestion.corpus.ledger import ledger_hash
+from afterworlds.ingestion.corpus.models import (
+    CorpusBundleMembers,
+    CorpusChunk,
+    Disposition,
+    Leaf,
+    LeafDisposition,
+    LeafType,
+    ProjectionEdge,
+    ReconciliationFindings,
+    ReconciliationMember,
+    SourceLedger,
+)
+from afterworlds.ingestion.corpus.operational import (
+    CORPUS_CONTRACT_VERSION,
+    build_operational_corpus_snapshot,
+    operational_corpus_digest,
+)
+from afterworlds.ingestion.corpus.persistence import (
+    _persist_bundle_rows,
+    _persist_package_and_source,
+    _persist_release_record,
+)
+from afterworlds.ingestion.corpus.policy import (
+    FROZEN_POLICY,
+    policy_hash,
+    policy_payload,
+)
+from afterworlds.ingestion.corpus.report import (
+    EVIDENCE_REPORT_SCHEMA_VERSION as CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
+)
+from afterworlds.ingestion.corpus.report import (
+    EvidenceReport as CorpusEvidenceReport,
+)
+from afterworlds.ingestion.corpus.report import (
+    build_report,
+)
+from afterworlds.ingestion.corpus.report import (
+    report_hash as corpus_report_hash,
+)
 from afterworlds.ingestion.mechanical.accounting import batch_diff_hash, derive_span_id
 from afterworlds.ingestion.mechanical.bound_corpus import (
     BoundCorpusSnapshot,
@@ -22,6 +83,11 @@ from afterworlds.ingestion.mechanical.models import (
     SemanticDiffEntry,
     SemanticDisposition,
     SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.oracle import (
+    AcceptedOracle,
+    RecordObligation,
+    load_oracle,
 )
 from afterworlds.ingestion.mechanical.policy import (
     SEMANTIC_POLICY_VERSION,
@@ -50,6 +116,14 @@ from afterworlds.ingestion.mechanical.representation import (
     reference_target_key,
     relationship_target_key,
 )
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+
+NOW = "2026-07-31T00:00:00Z"
+DATA_DIR = Path(__file__).resolve().parent / "data"
+BOUNDED_ORACLE_PATH = DATA_DIR / "bounded_oracle.json"
 
 SPELL_LEAF = "leaf-spell"
 PROSE_LEAF = "leaf-prose"
@@ -61,6 +135,7 @@ PACKAGE_UUID = "pkg-5c"
 RELEASE_VERSION = "rel-5c"
 WISH_CHUNK = "chunk-wish-0001"
 SECOND_CHUNK = "chunk-wish-0002"
+SPELL_CHUNK = "chunk-wish-spell"
 
 
 def coverage(
@@ -89,6 +164,152 @@ DEFAULT_COVERAGE = (
     coverage(WISH_CHUNK, PROSE_LEAF, 0, 30),
     coverage(SECOND_CHUNK, PROSE_LEAF, 0, 30),
 )
+
+# The persisted 5c fixture is a closed operational corpus: every represented
+# leaf is projected into exactly one content-matching authoritative chunk.
+# ``DEFAULT_COVERAGE`` above remains the deliberately overlapping pure fixture
+# used by chunk-locality unit tests.
+PERSISTED_COVERAGE = (
+    coverage(WISH_CHUNK, PROSE_LEAF, 0, 30),
+    coverage(SECOND_CHUNK, SUPPORT_LEAF, 0, 20),
+    coverage(SPELL_CHUNK, SPELL_LEAF, 0, 40),
+)
+
+
+# ---------------------------------------------------------------------------
+# The bound 5c release, as genuine CRD Issue 5c state
+# ---------------------------------------------------------------------------
+#
+# Stated as real 5c model objects and persisted through 5c's own primitives,
+# because CRD Issue 5d's publication gate now re-derives this release's recorded
+# ledger, reconciliation, and bundle-root proof from the persisted rows. A
+# hand-written release row carrying invented hashes is precisely what that gate
+# exists to refuse, so a fixture built that way would no longer be a *published
+# release* — it would be the forgery the negative controls are about.
+
+SOURCE_DOCUMENT = "D&D SRD 5.2.1"
+AUTHORITATIVE_SOURCE_HASH = "a" * 64
+TRANSFORM_CONFIG_HASH = "b" * 64
+#: Opaque here on purpose: the persisted-corpus digest binds the actual
+#: read-back vector state as well as SQL, so it is an exact recorded value the
+#: 5d gate checks rather than one it can recompute from a session.
+PERSISTED_CORPUS_DIGEST = "d" * 64
+
+BOUND_LEDGER = SourceLedger(
+    source_document=SOURCE_DOCUMENT,
+    source_version="5.2.1",
+    source_sha256=AUTHORITATIVE_SOURCE_HASH,
+    extraction_config={"extractor": "bounded-fixture"},
+    containers=(),
+    leaves=tuple(
+        Leaf(
+            leaf_id=leaf_id,
+            printed_page=1,
+            page_index=0,
+            leaf_type=LeafType.PARAGRAPH,
+            content="x" * length,
+            char_start=0,
+            char_end=length,
+            occurrence_index=index,
+            container_path=(),
+        )
+        for index, (leaf_id, length) in enumerate(sorted(LEAF_LENGTHS.items()))
+    ),
+)
+
+BOUND_MEMBERS = CorpusBundleMembers(
+    chunks=tuple(
+        CorpusChunk(
+            chunk_id=chunk_id,
+            subsystem="spells",
+            content="x" * LEAF_LENGTHS[leaf_id],
+            printed_page=1,
+            section_label=None,
+            container_path=(),
+            source_leaf_ids=(leaf_id,),
+            source_document=SOURCE_DOCUMENT,
+            source_locator_type="page",
+            source_locator_value="p. 1",
+            source_id=PACKAGE_UUID,
+        )
+        for chunk_id, leaf_id in (
+            (WISH_CHUNK, PROSE_LEAF),
+            (SPELL_CHUNK, SPELL_LEAF),
+            (SECOND_CHUNK, SUPPORT_LEAF),
+        )
+    ),
+    derivative_notes=(),
+)
+
+BOUND_RECONCILIATION = ReconciliationMember(
+    policy_version=FROZEN_POLICY.policy_version,
+    policy_hash=policy_hash(FROZEN_POLICY),
+    dispositions=tuple(
+        LeafDisposition(leaf.leaf_id, Disposition.REPRESENTED, None)
+        for leaf in BOUND_LEDGER.leaves
+    ),
+    projections=tuple(
+        ProjectionEdge(
+            projection_id=edge.projection_id,
+            leaf_id=edge.leaf_id,
+            chunk_id=edge.chunk_id,
+            role=edge.role,
+            cover_start=edge.cover_start,
+            cover_end=edge.cover_end,
+        )
+        for edge in PERSISTED_COVERAGE
+    ),
+    findings=ReconciliationFindings((), (), (), (), ()),
+    inventoried_leaves=len(BOUND_LEDGER.leaves),
+    represented_leaves=len(BOUND_LEDGER.leaves),
+    excluded_leaves=0,
+    unresolved_leaves=0,
+)
+
+BOUND_BUNDLE = build_bundle(BOUND_LEDGER, BOUND_MEMBERS, BOUND_RECONCILIATION)
+
+BOUND_TRANSFORM_CONFIG: dict[str, object] = {
+    "reconciliation_policy": policy_payload(FROZEN_POLICY),
+    "evidence_report_schema_version": CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
+}
+
+
+def _build_bound_report(
+    *,
+    ledger: SourceLedger,
+    members: CorpusBundleMembers,
+    recon: ReconciliationMember,
+    bundle_root_hash: str,
+) -> CorpusEvidenceReport:
+    """The 5c evidence report for the bound release, via 5c's own builder."""
+    return build_report(
+        ledger=ledger,
+        members=members,
+        recon=recon,
+        policy=FROZEN_POLICY,
+        authoritative_source_hash=AUTHORITATIVE_SOURCE_HASH,
+        transform_config_hash=TRANSFORM_CONFIG_HASH,
+        transform_config=BOUND_TRANSFORM_CONFIG,
+        bundle_root_hash=bundle_root_hash,
+        ledger_hash_value=ledger_hash(ledger),
+        persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
+        concordance=ConcordanceResult(
+            chunks_checked=len(members.chunks),
+            locator_failures=(),
+            content_failures=(),
+        ),
+        canaries=(),
+        persisted=True,
+    )
+
+
+BOUND_REPORT = _build_bound_report(
+    ledger=BOUND_LEDGER,
+    members=BOUND_MEMBERS,
+    recon=BOUND_RECONCILIATION,
+    bundle_root_hash=BOUND_BUNDLE.bundle_root_hash,
+)
+BOUND_EVIDENCE_REPORT_HASH = corpus_report_hash(BOUND_REPORT)
 
 
 def bound_corpus(
@@ -346,17 +567,195 @@ def build_representation(**overrides: object) -> RepresentationDraft:
     return RepresentationDraft(**fields)  # type: ignore[arg-type]
 
 
+#: The six values a projection binds. ``bundle_root_hash`` is the real bundle
+#: root of the seeded 5c release, not a placeholder: the gate re-derives it from
+#: the persisted rows, so a made-up value would make every bounded projection
+#: fail as bound to a release that does not derive its own proof.
+RELEASE_BINDING = ReleaseBinding(
+    package_uuid=PACKAGE_UUID,
+    release_version=RELEASE_VERSION,
+    authoritative_source_hash=AUTHORITATIVE_SOURCE_HASH,
+    transform_config_hash=TRANSFORM_CONFIG_HASH,
+    bundle_root_hash=BOUND_BUNDLE.bundle_root_hash,
+    persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
+)
+
+
 def build_candidate(**overrides: object) -> ProjectionCandidate:
     ledger = overrides.pop("ledger", None)
     return ProjectionCandidate(
-        binding=ReleaseBinding(
-            package_uuid="pkg-5c",
-            release_version="rel-5c",
-            authoritative_source_hash="a" * 64,
-            transform_config_hash="b" * 64,
-            bundle_root_hash="c" * 64,
-            persisted_corpus_digest="d" * 64,
-        ),
+        binding=RELEASE_BINDING,
         classification=ledger if ledger is not None else build_ledger(),  # type: ignore[arg-type]
         representation=build_representation(**overrides),
     )
+
+
+# ---------------------------------------------------------------------------
+# The accepted authority, and the 5c release it was accepted over
+# ---------------------------------------------------------------------------
+
+
+#: The accepted per-record obligations. ``spell:wish`` must carry structured
+#: spell-descriptor authority *and* keep its open-ended clause prose-bound —
+#: which is what makes all-prose under-extraction and reference-only coverage
+#: fail by name rather than only as an element difference.
+OBLIGATIONS = (
+    RecordObligation(
+        record_key=SPELL_KEY,
+        kind=RecordKind.SPELL,
+        structured_fact_families=frozenset({DESCRIPTOR_FACT.FAMILY}),
+        prose_bound_components=frozenset({OPEN_ENDED_KEY}),
+    ),
+    RecordObligation(
+        record_key=CREATURE_KEY,
+        kind=RecordKind.CREATURE,
+        structured_fact_families=frozenset(),
+        prose_bound_components=frozenset(),
+    ),
+)
+
+
+def accepted_oracle() -> AcceptedOracle:
+    """The accepted authority for the bounded fixture, in memory.
+
+    Exists to check the committed JSON for drift in one place. Tests that gate
+    or publish use :func:`committed_oracle`, which goes through the real
+    committed-file path.
+    """
+    return AcceptedOracle(
+        binding=RELEASE_BINDING,
+        policy_version=SEMANTIC_POLICY_VERSION,
+        policy_hash=semantic_policy_hash(),
+        spans=build_ledger().spans,
+        representation=build_representation(),
+        obligations=OBLIGATIONS,
+    )
+
+
+@pytest.fixture()
+def committed_oracle() -> AcceptedOracle:
+    """The bounded accepted oracle, loaded from its committed JSON file."""
+    return load_oracle(BOUNDED_ORACLE_PATH)
+
+
+def mark_release_published(session: Session) -> None:
+    """Transition the seeded release to published, as ``finalize_release`` does.
+
+    5c's persistence primitives write both rows as drafts, because in 5c the
+    transition to ``published`` is the *last* step of a gate that has already
+    passed. Nothing published a release here, so the fixture states plainly
+    that it is standing in for that step.
+    """
+    for row, extra in (
+        (
+            session.execute(
+                select(CorpusReleaseORM).where(
+                    CorpusReleaseORM.package_uuid == PACKAGE_UUID
+                )
+            ).scalar_one(),
+            {},
+        ),
+        (
+            session.execute(
+                select(RulesPackageORM).where(
+                    RulesPackageORM.rules_package_id == PACKAGE_UUID
+                )
+            ).scalar_one(),
+            {"published_at": NOW},
+        ),
+    ):
+        row.publication_status = "published"
+        for field, value in extra.items():
+            setattr(row, field, value)
+    session.flush()
+
+
+def current_release_binding(session: Session) -> ReleaseBinding:
+    """The six values the persisted 5c release currently records.
+
+    A control that changes the release and then wants to test something *other*
+    than the binding must rebuild its projection against this, because every
+    proof identity a release records moves when its content does — which is the
+    property that makes a forged release detectable in the first place.
+    """
+    release = session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == PACKAGE_UUID)
+    ).scalar_one()
+    assert release.persisted_corpus_digest is not None
+    return ReleaseBinding(
+        package_uuid=release.package_uuid,
+        release_version=release.release_version,
+        authoritative_source_hash=release.authoritative_source_hash,
+        transform_config_hash=release.transform_config_hash,
+        bundle_root_hash=release.bundle_root_hash,
+        persisted_corpus_digest=release.persisted_corpus_digest,
+    )
+
+
+def _seed_bound_release(session: Session) -> None:
+    """Persist the published 5c release the bounded fixture is bound to.
+
+    Written through CRD Issue 5c's own persistence primitives from the genuine
+    5c model objects above: the package, its single authoritative source, the
+    release record the projection FKs, the ``REPRESENTED`` leaves that form the
+    accounting population, and the chunk/projection edges that make exact
+    governing prose resolvable. The publication gate consumes the same rows
+    through 5c's versioned operational snapshot, so the fixture must be a
+    closed operational corpus rather than merely a release-shaped row set.
+    """
+    _persist_package_and_source(session, PACKAGE_UUID, RELEASE_VERSION, now=NOW)
+    _persist_release_record(
+        session,
+        PACKAGE_UUID,
+        release_version=RELEASE_VERSION,
+        authoritative_source_hash=RELEASE_BINDING.authoritative_source_hash,
+        transform_config_hash=RELEASE_BINDING.transform_config_hash,
+        bundle_root_hash=RELEASE_BINDING.bundle_root_hash,
+        evidence_report_hash=BOUND_EVIDENCE_REPORT_HASH,
+        persisted_corpus_digest=RELEASE_BINDING.persisted_corpus_digest,
+        corpus_contract_version=CORPUS_CONTRACT_VERSION,
+        operational_corpus_digest_value=None,
+        ledger_hash=ledger_hash(BOUND_LEDGER),
+        policy_hash=policy_hash(FROZEN_POLICY),
+        reconciliation_hash=reconciliation_hash(BOUND_RECONCILIATION),
+        corpus_report_reference=BOUND_EVIDENCE_REPORT_HASH,
+        transform_config=BOUND_TRANSFORM_CONFIG,
+        report_payload=BOUND_REPORT.payload,
+        now=NOW,
+    )
+    _persist_bundle_rows(
+        session,
+        PACKAGE_UUID,
+        PACKAGE_UUID,
+        ledger=BOUND_LEDGER,
+        recon=BOUND_RECONCILIATION,
+        policy=FROZEN_POLICY,
+        members=BOUND_MEMBERS,
+        now=NOW,
+    )
+    release = session.get(CorpusReleaseORM, PACKAGE_UUID)
+    assert release is not None
+    snapshot = build_operational_corpus_snapshot(
+        session,
+        PACKAGE_UUID,
+        corpus_contract_version=CORPUS_CONTRACT_VERSION,
+        persisted_corpus_digest=RELEASE_BINDING.persisted_corpus_digest,
+    )
+    release.operational_corpus_digest = operational_corpus_digest(snapshot)
+    mark_release_published(session)
+
+
+@pytest.fixture()
+def session(tmp_path) -> Session:  # type: ignore[no-untyped-def]
+    """A fresh database holding the published 5c release, and nothing else.
+
+    Per-test rather than session-scoped: publication commits, so a shared
+    database would let one test's published projection decide another's
+    activation outcome.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'mech.db'}")
+    Base.metadata.create_all(engine)
+    factory = create_session_factory(engine)
+    with factory() as s:
+        _seed_bound_release(s)
+        yield s

--- a/tests/ingestion/mechanical/data/bounded_oracle.json
+++ b/tests/ingestion/mechanical/data/bounded_oracle.json
@@ -1,0 +1,151 @@
+{
+  "release_binding": {
+    "package_uuid": "pkg-5c",
+    "release_version": "rel-5c",
+    "authoritative_source_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "transform_config_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "bundle_root_hash": "07ecf2c0ff0a4071c942c806767edafcbd46ee1b55ee02cfa5515fed5583b807",
+    "persisted_corpus_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "semantic_policy_version": "5d-semantic-policy-1",
+  "semantic_policy_hash": "e6363968d6ee8ec288e6c7e3382907a1afd8bf2aad0b18e153aec439b5aa9454",
+  "spans": [
+    {
+      "span_id": "47d4cc94-8b98-5c55-a6bc-603b83d78766",
+      "leaf_id": "leaf-spell",
+      "char_start": 0,
+      "char_end": 40,
+      "disposition": "substantive",
+      "non_mechanical_reason_code": null
+    },
+    {
+      "span_id": "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
+      "leaf_id": "leaf-prose",
+      "char_start": 0,
+      "char_end": 30,
+      "disposition": "substantive",
+      "non_mechanical_reason_code": null
+    },
+    {
+      "span_id": "bd7c3ee9-737e-5a61-b75e-66d8c15f9f24",
+      "leaf_id": "leaf-support",
+      "char_start": 0,
+      "char_end": 20,
+      "disposition": "supporting_authority",
+      "non_mechanical_reason_code": null
+    }
+  ],
+  "representation": {
+    "records": [
+      {
+        "semantic_key": "spell:wish",
+        "kind": "spell",
+        "parent_key": null
+      },
+      {
+        "semantic_key": "creature:wish-scoped-servant",
+        "kind": "creature",
+        "parent_key": "spell:wish"
+      }
+    ],
+    "components": [
+      {
+        "record_key": "spell:wish",
+        "semantic_key": "descriptor",
+        "handling": "structured",
+        "irreducibility_reason_code": null,
+        "facts": [
+          {
+            "family": "spell_descriptor",
+            "concentration": false,
+            "level": 9,
+            "ritual": false,
+            "school": "conjuration"
+          }
+        ]
+      },
+      {
+        "record_key": "spell:wish",
+        "semantic_key": "open-ended-clause",
+        "handling": "prose_bound",
+        "irreducibility_reason_code": "open_ended_effect",
+        "facts": []
+      }
+    ],
+    "prose_bindings": [
+      {
+        "record_key": "spell:wish",
+        "component_key": "open-ended-clause",
+        "chunk_id": "chunk-wish-0001",
+        "irreducibility_reason_code": "open_ended_effect"
+      }
+    ],
+    "relationships": [
+      {
+        "source_record_key": "creature:wish-scoped-servant",
+        "target_record_key": "spell:wish",
+        "kind": "scoped_within"
+      }
+    ],
+    "references": [],
+    "provenance": [
+      {
+        "target_kind": "fact",
+        "target_key": [
+          "spell:wish",
+          "descriptor",
+          "79b28acf072dd442"
+        ],
+        "span_id": "47d4cc94-8b98-5c55-a6bc-603b83d78766",
+        "role": "primary"
+      },
+      {
+        "target_kind": "prose_binding",
+        "target_key": [
+          "spell:wish",
+          "open-ended-clause",
+          "chunk-wish-0001",
+          "open_ended_effect"
+        ],
+        "span_id": "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
+        "role": "primary"
+      },
+      {
+        "target_kind": "record",
+        "target_key": [
+          "spell:wish"
+        ],
+        "span_id": "bd7c3ee9-737e-5a61-b75e-66d8c15f9f24",
+        "role": "contextual"
+      },
+      {
+        "target_kind": "relationship",
+        "target_key": [
+          "creature:wish-scoped-servant",
+          "spell:wish",
+          "scoped_within"
+        ],
+        "span_id": "47d4cc94-8b98-5c55-a6bc-603b83d78766",
+        "role": "contextual"
+      }
+    ]
+  },
+  "obligations": [
+    {
+      "record_key": "spell:wish",
+      "kind": "spell",
+      "structured_fact_families": [
+        "spell_descriptor"
+      ],
+      "prose_bound_components": [
+        "open-ended-clause"
+      ]
+    },
+    {
+      "record_key": "creature:wish-scoped-servant",
+      "kind": "creature",
+      "structured_fact_families": [],
+      "prose_bound_components": []
+    }
+  ]
+}

--- a/tests/ingestion/mechanical/test_concurrent_publication.py
+++ b/tests/ingestion/mechanical/test_concurrent_publication.py
@@ -114,8 +114,9 @@ def _race(
     keeps the race genuine without inventing a lock ordering the production path
     does not have.
 
-    Each worker trips the barrier at most once, so the bounded reattempt after a
-    rollback runs freely instead of waiting on a spent barrier.
+    Each worker trips the barrier at most once, so the bounded settlement wait
+    and one post-settlement re-entry run freely instead of waiting on a spent
+    barrier.
     """
     barrier = threading.Barrier(len(jobs), timeout=10)
     original = publication._active_row
@@ -238,6 +239,25 @@ def test_concurrent_competing_publication_leaves_the_loser_a_draft(
     assert losing_header.published_at is None
 
 
+def test_settlement_waits_until_a_winning_activation_is_visible(
+    factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An immediate empty read is not evidence that the winner disappeared."""
+    probes: list[int] = []
+
+    def delayed_visibility(session: Session, package_uuid: str) -> Any:
+        probes.append(1)
+        return None if len(probes) < 3 else object()
+
+    monkeypatch.setattr(publication, "_active_row", delayed_visibility)
+    monkeypatch.setattr(publication, "_ACTIVATION_SETTLEMENT_POLL_SECONDS", 0.0)
+    with factory() as session:
+        assert publication._wait_for_activation_settlement(session, "package")
+
+    assert len(probes) == 3
+
+
 def test_an_unrelated_integrity_error_still_propagates(
     factory: sessionmaker[Session],
     committed: AcceptedOracle,
@@ -272,11 +292,11 @@ def test_a_recurring_race_is_not_retried_forever(
     committed: AcceptedOracle,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The reattempt is bounded by construction, not by hoping it converges.
+    """A missing winning activation cannot leave publication waiting forever.
 
-    Activation is made to fail with a genuine activation-table conflict every
-    time. The first failure is reattempted; the second propagates, so a
-    permanently contended package surfaces as an error rather than spinning.
+    Activation is made to fail with a genuine activation-table conflict while
+    no winner ever commits. The bounded settlement window expires and the
+    original error propagates rather than spinning or manufacturing an outcome.
     """
     uuid = _persist(factory, build_candidate())
     calls: list[int] = []
@@ -291,9 +311,10 @@ def test_a_recurring_race_is_not_retried_forever(
         raise conflict
 
     monkeypatch.setattr(publication, "_activate_projection", always_conflict)
+    monkeypatch.setattr(publication, "_ACTIVATION_SETTLEMENT_TIMEOUT_SECONDS", 0.0)
     with factory() as session, pytest.raises(IntegrityError):
         _publish_projection(session, uuid, committed, now=NOW)
 
-    assert len(calls) == 2, "expected exactly one bounded reattempt"
+    assert len(calls) == 1, "no retry is allowed before a winning row is visible"
     assert _active(factory) == []
     assert _header(factory, uuid).publication_status == "draft"

--- a/tests/ingestion/mechanical/test_concurrent_publication.py
+++ b/tests/ingestion/mechanical/test_concurrent_publication.py
@@ -1,0 +1,299 @@
+"""Publication under genuine concurrency — CRD Issue 5d, PR #141 R3.
+
+The activation key makes split authority impossible, but "impossible" is only
+half a contract: the *losing* publisher has to receive a typed outcome, not a
+driver exception. Sequential tests cannot show that, because the losing write
+never happens — one call completes before the next begins.
+
+So these run two workers on separate sessions and separate connections against a
+**file-backed** SQLite database, and coordinate them at the one instant that
+matters: both must be past the pre-insert active-row observation before either
+writes. That is arranged by wrapping that observation with a barrier, so the
+race is structural rather than a hope about timing.
+
+``busy_timeout`` is set to 100 ms deliberately. At SQLite's default a losing
+writer blocks long enough that the winner commits and the loser succeeds
+serially — which looks like a pass while never exercising the contention path
+at all. At zero the lock error is immediate but the winner can lose too. 100 ms
+is short enough to surface contention and long enough that one worker reliably
+wins.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from afterworlds.ingestion.mechanical import publication
+from afterworlds.ingestion.mechanical.oracle import AcceptedOracle, load_oracle
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+    record_persisted_state_digest,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    identify_projection,
+)
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    _publish_projection,
+)
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalActiveProjectionORM,
+    MechanicalProjectionORM,
+)
+from tests.ingestion.mechanical.conftest import (
+    BOUNDED_ORACLE_PATH,
+    NOW,
+    _seed_bound_release,
+    build_candidate,
+)
+from tests.ingestion.mechanical.test_publication import a_different_projection
+
+LATER = "2026-08-02T00:00:00Z"
+
+#: How many times each race runs. A single green pass proves nothing about a
+#: schedule-dependent defect; ten makes an interleaving that only sometimes
+#: loses show up as a failure rather than as luck.
+REPEATS = range(10)
+
+
+@pytest.fixture()
+def factory(tmp_path: Path) -> sessionmaker[Session]:
+    """A file-backed database seeded with the bound 5c release.
+
+    File-backed, not ``sqlite://``: an in-memory database is per-connection, so
+    two workers would silently operate on two different databases and every race
+    would "pass".
+    """
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'race.db'}", connect_args={"timeout": 0.1}
+    )
+    Base.metadata.create_all(engine)
+    made = create_session_factory(engine)
+    with made() as session:
+        _seed_bound_release(session)
+        session.commit()
+    return made
+
+
+def _persist(factory: sessionmaker[Session], candidate: ProjectionCandidate) -> str:
+    identified = identify_projection(candidate)
+    with factory() as session:
+        persist_draft(session, identified, now=NOW)
+        record_persisted_state_digest(session, identified.projection_uuid)
+        session.commit()
+    return identified.projection_uuid
+
+
+def _race(
+    factory: sessionmaker[Session],
+    monkeypatch: pytest.MonkeyPatch,
+    jobs: list[tuple[str, AcceptedOracle]],
+) -> list[Any]:
+    """Run *jobs* concurrently, each on its own session, past a shared barrier.
+
+    The barrier sits on the **pre-insert observation** — the active-row read
+    every publisher performs before deciding to write — so both workers have
+    provably seen the same "no incumbent" state before either writes anything.
+    That is the instant the contract is about.
+
+    It deliberately does *not* sit around activation. SQLite has one writer, so
+    a worker parked mid-transaction holds the write lock; the other would fail
+    its header flush, reattempt, fail again while the first is still parked, and
+    both would deadlock on a barrier that can never fill. Blocking on a read
+    keeps the race genuine without inventing a lock ordering the production path
+    does not have.
+
+    Each worker trips the barrier at most once, so the bounded reattempt after a
+    rollback runs freely instead of waiting on a spent barrier.
+    """
+    barrier = threading.Barrier(len(jobs), timeout=10)
+    original = publication._active_row
+    tripped: set[int] = set()
+    guard = threading.Lock()
+
+    def observe(session: Session, package_uuid: str) -> Any:
+        row = original(session, package_uuid)
+        with guard:
+            first = threading.get_ident() not in tripped
+            tripped.add(threading.get_ident())
+        if first:
+            barrier.wait()
+        return row
+
+    monkeypatch.setattr(publication, "_active_row", observe)
+
+    def work(job: tuple[str, AcceptedOracle]) -> Any:
+        uuid, oracle = job
+        with factory() as session:
+            try:
+                return _publish_projection(session, uuid, oracle, now=NOW)
+            except BaseException as exc:  # returned, so the test can assert on it
+                return exc
+
+    with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+        return list(pool.map(work, jobs))
+
+
+def _active(factory: sessionmaker[Session]) -> list[MechanicalActiveProjectionORM]:
+    with factory() as session:
+        return list(
+            session.execute(select(MechanicalActiveProjectionORM)).scalars().all()
+        )
+
+
+def _header(factory: sessionmaker[Session], uuid: str) -> MechanicalProjectionORM:
+    with factory() as session:
+        return session.execute(
+            select(MechanicalProjectionORM).where(
+                MechanicalProjectionORM.projection_uuid == uuid
+            )
+        ).scalar_one()
+
+
+@pytest.fixture()
+def committed() -> AcceptedOracle:
+    return load_oracle(BOUNDED_ORACLE_PATH)
+
+
+@pytest.mark.parametrize("attempt", REPEATS)
+def test_concurrent_identical_publication_is_published_then_already_published(
+    factory: sessionmaker[Session],
+    committed: AcceptedOracle,
+    monkeypatch: pytest.MonkeyPatch,
+    attempt: int,
+) -> None:
+    """Two workers, one content-derived identity, one active row.
+
+    Identical builds are the *same* projection UUID, so this is the idempotence
+    promise under contention: exactly one worker performs the publication and
+    the other is told it already happened — after re-running the full proof, not
+    by reading a status column.
+    """
+    uuid = _persist(factory, build_candidate())
+    results = _race(factory, monkeypatch, [(uuid, committed), (uuid, committed)])
+
+    for result in results:
+        assert not isinstance(result, BaseException), result
+    outcomes = sorted(r.outcome.value for r in results)
+    assert outcomes == ["already_published", "published"]
+
+    rows = _active(factory)
+    assert len(rows) == 1
+    assert rows[0].projection_uuid == uuid
+    assert _header(factory, uuid).publication_status == "published"
+
+
+@pytest.mark.parametrize("attempt", REPEATS)
+def test_concurrent_competing_publication_leaves_the_loser_a_draft(
+    factory: sessionmaker[Session],
+    committed: AcceptedOracle,
+    monkeypatch: pytest.MonkeyPatch,
+    attempt: int,
+) -> None:
+    """Two different projections for one package: one wins, one is told so.
+
+    Both pass their own gate — the challenger has its own accepted oracle — so
+    nothing about either is wrong. The package can only have one active
+    authority, and the loser must come back as ``ACTIVE_CONFLICT`` holding no
+    publication evidence at all.
+    """
+    incumbent = _persist(factory, build_candidate())
+    with factory() as session:
+        challenger, challenger_oracle = a_different_projection(session, committed)
+        session.commit()
+
+    results = _race(
+        factory,
+        monkeypatch,
+        [(incumbent, committed), (challenger, challenger_oracle)],
+    )
+    for result in results:
+        assert not isinstance(result, BaseException), result
+    by_uuid = {r.projection_uuid: r.outcome for r in results}
+
+    rows = _active(factory)
+    assert len(rows) == 1
+    winner = rows[0].projection_uuid
+    loser = challenger if winner == incumbent else incumbent
+
+    assert by_uuid[winner] is PublicationOutcome.PUBLISHED
+    assert by_uuid[loser] is PublicationOutcome.ACTIVE_CONFLICT
+
+    losing_header = _header(factory, loser)
+    assert losing_header.publication_status == "draft"
+    assert losing_header.evidence_report_hash is None
+    assert losing_header.report_payload is None
+    assert losing_header.oracle_identity is None
+    assert losing_header.published_at is None
+
+
+def test_an_unrelated_integrity_error_still_propagates(
+    factory: sessionmaker[Session],
+    committed: AcceptedOracle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only activation contention is a race; everything else is a defect.
+
+    A blanket ``except IntegrityError`` would relabel an unrelated constraint
+    violation as concurrency and quietly retry it, so this injects one that does
+    not name the activation table and requires it to reach the caller.
+    """
+    uuid = _persist(factory, build_candidate())
+    boom = IntegrityError(
+        "INSERT INTO rp_mech_records ...",
+        {},
+        Exception("UNIQUE constraint failed: rp_mech_records.record_id"),
+    )
+
+    def explode(session: Session, projection_uuid: str, *, now: str) -> Any:
+        raise boom
+
+    monkeypatch.setattr(publication, "_activate_projection", explode)
+    with factory() as session, pytest.raises(IntegrityError):
+        _publish_projection(session, uuid, committed, now=NOW)
+
+    assert _active(factory) == []
+    assert _header(factory, uuid).publication_status == "draft"
+
+
+def test_a_recurring_race_is_not_retried_forever(
+    factory: sessionmaker[Session],
+    committed: AcceptedOracle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reattempt is bounded by construction, not by hoping it converges.
+
+    Activation is made to fail with a genuine activation-table conflict every
+    time. The first failure is reattempted; the second propagates, so a
+    permanently contended package surfaces as an error rather than spinning.
+    """
+    uuid = _persist(factory, build_candidate())
+    calls: list[int] = []
+    conflict = IntegrityError(
+        "INSERT INTO rp_mech_active_projections ...",
+        {},
+        Exception("UNIQUE constraint failed: rp_mech_active_projections.package_uuid"),
+    )
+
+    def always_conflict(session: Session, projection_uuid: str, *, now: str) -> Any:
+        calls.append(1)
+        raise conflict
+
+    monkeypatch.setattr(publication, "_activate_projection", always_conflict)
+    with factory() as session, pytest.raises(IntegrityError):
+        _publish_projection(session, uuid, committed, now=NOW)
+
+    assert len(calls) == 2, "expected exactly one bounded reattempt"
+    assert _active(factory) == []
+    assert _header(factory, uuid).publication_status == "draft"

--- a/tests/ingestion/mechanical/test_gate.py
+++ b/tests/ingestion/mechanical/test_gate.py
@@ -1,0 +1,672 @@
+"""The exact completeness gate — CRD Issue 5d, Decision 5.
+
+The bounded fixture is a *complete* projection of its bound release: three
+represented leaves, all classified, every element declared by the committed
+oracle. That is what makes the negative controls meaningful — each one changes
+exactly one thing about the persisted state, and the accepted authority never
+moves.
+
+Every control asserts a **specific failure category**. Asserting only
+``passed is False`` would pass even if the gate rejected for an unrelated
+reason, which is how a completeness proof rots into a smoke test.
+
+Aggregate totals appear once, and only to prove they are diagnostics: the
+all-prose and duplicated-fact controls both keep a plausible-looking element
+count and are rejected anyway (ADR-005d Decision 5).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.accounting import derive_span_id
+from afterworlds.ingestion.mechanical.gate import (
+    GateFailureCategory,
+    run_publication_gate,
+)
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceRecord,
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.oracle import AcceptedOracle
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+    record_persisted_state_digest,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    identify_projection,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    ReferenceDraft,
+    fact_key,
+)
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+    MechanicalRecordORM,
+    MechanicalSpanORM,
+)
+from tests.ingestion.mechanical.conftest import (
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_FACT_KEY,
+    DESCRIPTOR_KEY,
+    NOW,
+    OPEN_ENDED_KEY,
+    PROSE_SPAN,
+    SPELL_KEY,
+    SPELL_SPAN,
+    SUPPORT_SPAN,
+    build_candidate,
+    build_ledger,
+    build_representation,
+)
+
+
+def persist(session: Session, candidate: ProjectionCandidate | None = None) -> str:
+    """Persist a draft and record its persisted-state proof, as PR #139 does."""
+    identified = identify_projection(
+        build_candidate() if candidate is None else candidate
+    )
+    persist_draft(session, identified, now=NOW)
+    record_persisted_state_digest(session, identified.projection_uuid)
+    return identified.projection_uuid
+
+
+def categories(session: Session, uuid: str, oracle: AcceptedOracle) -> set[str]:
+    result = run_publication_gate(session, uuid, oracle)
+    assert not result.passed
+    return {c.value for c in result.categories()}
+
+
+# ---------------------------------------------------------------------------
+# The complete bounded projection passes
+# ---------------------------------------------------------------------------
+
+
+def test_a_complete_bounded_projection_passes(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    result = run_publication_gate(session, uuid, committed_oracle)
+    assert result.passed, result.failures
+    assert result.expected_projection_uuid == uuid
+    assert result.persisted_state_digest is not None
+    assert all(o.satisfied for o in result.obligations)
+    assert {o.record_key for o in result.obligations} == {
+        "spell:wish",
+        "creature:wish-scoped-servant",
+    }
+
+
+def test_a_passing_gate_records_every_obligation_not_only_failures(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A verdict with no evidence behind it is an assertion, not a proof."""
+    result = run_publication_gate(session, persist(session), committed_oracle)
+    assert [(o.record_key, o.satisfied, o.failures) for o in result.obligations] == [
+        ("spell:wish", True, ()),
+        ("creature:wish-scoped-servant", True, ()),
+    ]
+
+
+def test_the_gate_writes_nothing(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    run_publication_gate(session, uuid, committed_oracle)
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == uuid
+        )
+    ).scalar_one()
+    assert header.publication_status == "draft"
+    assert header.evidence_report_hash is None
+    assert header.oracle_identity is None
+
+
+# ---------------------------------------------------------------------------
+# Omitted authority
+# ---------------------------------------------------------------------------
+
+
+def test_omitted_represented_text_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A leaf the bound 5c release represents but nobody classified.
+
+    Population equality is read from the release, not from the oracle, so this
+    is structural: the projection simply is not over that release's population.
+    """
+    uuid = persist(session)
+    session.execute(
+        MechanicalSpanORM.__table__.delete().where(
+            MechanicalSpanORM.span_id == SUPPORT_SPAN
+        )
+    )
+    session.flush()
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.POPULATION_MISMATCH.value in found
+    assert GateFailureCategory.CLASSIFICATION_MISMATCH.value in found
+
+
+def test_omitted_accepted_obligation_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The accepted prose-bound clause is dropped from the persisted record."""
+    without_clause = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(DESCRIPTOR_FACT,),
+            ),
+        ),
+        prose_bindings=(),
+        provenance=(
+            ProvenanceClaim(
+                ProvenanceTargetKind.FACT,
+                (SPELL_KEY, DESCRIPTOR_KEY, DESCRIPTOR_FACT_KEY),
+                SPELL_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.RECORD,
+                (SPELL_KEY,),
+                PROSE_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.RECORD,
+                (SPELL_KEY,),
+                SUPPORT_SPAN,
+                ProvenanceRole.CONTEXTUAL,
+            ),
+        ),
+        relationships=(),
+    )
+    uuid = persist(
+        session,
+        dataclasses.replace(build_candidate(), representation=without_clause),
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.UNSATISFIED_OBLIGATION.value in found
+    assert GateFailureCategory.MISSING_AUTHORITY.value in found
+
+
+# ---------------------------------------------------------------------------
+# Residue
+# ---------------------------------------------------------------------------
+
+
+def test_a_proposed_span_fails_as_unreviewed(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    row = session.execute(
+        select(MechanicalSpanORM).where(MechanicalSpanORM.span_id == SPELL_SPAN)
+    ).scalar_one()
+    row.review_state = ReviewState.PROPOSED.value
+    session.flush()
+    assert GateFailureCategory.UNREVIEWED_RESIDUE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+def test_a_span_with_no_acceptance_record_fails_as_unreviewed(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Silence is never acceptance, even when the row claims it is accepted."""
+    ledger = build_ledger()
+    unaccepted = dataclasses.replace(
+        ledger,
+        acceptances=tuple(a for a in ledger.acceptances if a.span_id != PROSE_SPAN),
+    )
+    uuid = persist(
+        session,
+        dataclasses.replace(build_candidate(), classification=unaccepted),
+    )
+    assert GateFailureCategory.UNREVIEWED_RESIDUE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+def test_an_unresolved_span_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    row = session.execute(
+        select(MechanicalSpanORM).where(MechanicalSpanORM.span_id == SUPPORT_SPAN)
+    ).scalar_one()
+    row.disposition = SemanticDisposition.UNRESOLVED.value
+    session.flush()
+    assert GateFailureCategory.UNRESOLVED_RESIDUE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+# ---------------------------------------------------------------------------
+# Under-extraction and inflated coverage
+# ---------------------------------------------------------------------------
+
+
+def test_all_prose_under_extraction_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Every component re-described as prose, none of the accepted facts kept.
+
+    The element count barely moves. The obligation is what refuses it: the
+    accepted spell-descriptor authority is not represented by typed facts.
+    """
+    all_prose = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+        )
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), representation=all_prose)
+    )
+    result = run_publication_gate(session, uuid, committed_oracle)
+    assert not result.passed
+    assert GateFailureCategory.UNSATISFIED_OBLIGATION.value in {
+        c.value for c in result.categories()
+    }
+    assert any(
+        "not represented by typed facts" in f
+        for o in result.obligations
+        for f in o.failures
+    )
+
+
+def test_reference_only_coverage_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A record covered by references alone satisfies no obligation.
+
+    References are added and the facts removed, so coverage *looks* present.
+    A reference is not a fact, so the accepted structured authority is absent.
+    """
+    reference = ReferenceDraft(
+        from_record_key=SPELL_KEY,
+        from_component_key=DESCRIPTOR_KEY,
+        source_text="see the descriptor table",
+        scope_key="spell:wish",
+        target_record_key=SPELL_KEY,
+    )
+    reference_only = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+        ),
+        references=(reference,),
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), representation=reference_only)
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.UNSATISFIED_OBLIGATION.value in found
+    assert GateFailureCategory.UNEXPECTED_AUTHORITY.value in found
+
+
+def test_a_duplicated_fact_row_fails_as_duplicate_not_unexpected(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """One accepted fact, persisted twice: coverage inflated, meaning unchanged.
+
+    Multiset comparison is what separates this from carrying something nobody
+    accepted — collapsing the two categories would let inflation hide inside
+    "unexpected".
+    """
+    uuid = persist(session)
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    session.add(
+        MechanicalFactORM(
+            projection_uuid=uuid,
+            fact_id=row.fact_id,
+            record_key=row.record_key,
+            component_key=row.component_key,
+            fact_key=row.fact_key,
+            family=row.family,
+            payload=dict(row.payload),
+        )
+    )
+    session.flush()
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.DUPLICATE_AUTHORITY.value in found
+    assert GateFailureCategory.UNEXPECTED_AUTHORITY.value not in found
+
+
+def test_a_duplicated_provenance_edge_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The same claim recorded twice is one claim, not two."""
+    duplicated = build_representation()
+    uuid = persist(
+        session,
+        dataclasses.replace(
+            build_candidate(),
+            representation=dataclasses.replace(
+                duplicated, provenance=duplicated.provenance + duplicated.provenance[:1]
+            ),
+        ),
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.DUPLICATE_AUTHORITY.value in found
+
+
+def test_an_unexpected_record_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Authority outside the accepted oracle, however plausible it looks."""
+    uuid = persist(session)
+    row = session.execute(select(MechanicalRecordORM)).scalars().first()
+    assert row is not None
+    session.add(
+        MechanicalRecordORM(
+            projection_uuid=uuid,
+            record_id="unexpected-record-id",
+            semantic_key="spell:invented",
+            kind=row.kind,
+            parent_key=None,
+        )
+    )
+    session.flush()
+    assert GateFailureCategory.UNEXPECTED_AUTHORITY.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+# ---------------------------------------------------------------------------
+# Binding, identity, and persisted state
+# ---------------------------------------------------------------------------
+
+
+def test_a_stale_5c_binding_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A projection built over a different source hash of the same release.
+
+    Refused as a bound-release failure rather than as a mismatch against the
+    oracle: the declared binding names no published 5c release at all, which is
+    a stronger statement than "the oracle judges something else" and is decided
+    before any accepted-authority comparison runs.
+    """
+    stale = dataclasses.replace(
+        build_candidate(),
+        binding=dataclasses.replace(
+            build_candidate().binding, authoritative_source_hash="9" * 64
+        ),
+    )
+    uuid = persist(session, stale)
+    assert GateFailureCategory.BOUND_RELEASE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+def test_a_mismatched_release_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """An oracle accepted over a different release judges nothing here."""
+    uuid = persist(session)
+    other = dataclasses.replace(
+        committed_oracle,
+        binding=dataclasses.replace(
+            committed_oracle.binding, release_version="rel-other"
+        ),
+    )
+    assert GateFailureCategory.MISMATCHED_RELEASE.value in categories(
+        session, uuid, other
+    )
+
+
+def test_a_mismatched_semantic_policy_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    older = dataclasses.replace(committed_oracle, policy_version="5d-semantic-policy-0")
+    assert GateFailureCategory.POLICY_MISMATCH.value in categories(session, uuid, older)
+
+
+def test_tampered_persisted_state_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A fact payload edited after the digest was recorded."""
+    uuid = persist(session)
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    payload = dict(row.payload)
+    payload["level"] = 1
+    row.payload = payload
+    session.flush()
+    assert GateFailureCategory.PERSISTED_STATE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+def test_an_altered_derived_identity_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Every semantic value intact; only a stored derived id was rewritten."""
+    uuid = persist(session)
+    row = session.execute(select(MechanicalRecordORM)).scalars().first()
+    assert row is not None
+    row.record_id = "0" * 36
+    session.flush()
+    assert GateFailureCategory.PERSISTED_STATE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+def test_an_unrecorded_persisted_state_digest_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A draft that was never proven cannot be gated into publication."""
+    identified = identify_projection(build_candidate())
+    persist_draft(session, identified, now=NOW)
+    found = categories(session, identified.projection_uuid, committed_oracle)
+    assert GateFailureCategory.PERSISTED_STATE.value in found
+
+
+def test_an_altered_recorded_digest_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == uuid
+        )
+    ).scalar_one()
+    header.persisted_state_digest = "f" * 64
+    session.flush()
+    assert GateFailureCategory.PERSISTED_STATE.value in categories(
+        session, uuid, committed_oracle
+    )
+
+
+def test_an_ambiguous_reference_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Identical wording in one committed scope resolving two ways."""
+    ambiguous = build_representation(
+        references=(
+            ReferenceDraft(
+                SPELL_KEY, DESCRIPTOR_KEY, "the servant", "spell:wish", SPELL_KEY
+            ),
+            ReferenceDraft(
+                SPELL_KEY,
+                DESCRIPTOR_KEY,
+                "the servant",
+                "spell:wish",
+                "creature:wish-scoped-servant",
+            ),
+        )
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), representation=ambiguous)
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.SEMANTIC_VALIDATION.value in found
+
+
+def test_a_missing_projection_is_reported_not_raised(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    result = run_publication_gate(session, "no-such-projection", committed_oracle)
+    assert not result.passed
+    assert result.categories() == {GateFailureCategory.PERSISTED_STATE}
+
+
+# ---------------------------------------------------------------------------
+# Counts are diagnostics, never proof
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_are_reported_but_never_decide(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The all-prose projection keeps the same component and record totals.
+
+    If totals proved anything, this projection would pass. It does not.
+    """
+    honest = run_publication_gate(session, persist(session), committed_oracle)
+    assert honest.diagnostics["represented_leaves"] == 3
+    assert honest.diagnostics["classified_leaves"] == 3
+    assert honest.diagnostics["facts"] == 1
+
+
+def test_a_leaf_classified_outside_the_release_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """5c decides the population; a projection cannot add to it.
+
+    The published release remains untouched; the candidate alone invents a
+    fourth classified leaf. This isolates 5d's population rule without
+    coherently rewriting the 5c release and its integrity metadata.
+    """
+    base = build_ledger()
+    extra = SemanticSpan(
+        span_id=derive_span_id("leaf-outside", 0, 8),
+        leaf_id="leaf-outside",
+        char_start=0,
+        char_end=8,
+        disposition=SemanticDisposition.SUBSTANTIVE,
+        review_state=ReviewState.ACCEPTED,
+    )
+    uuid = persist(
+        session,
+        dataclasses.replace(
+            build_candidate(), classification=build_ledger(base.spans + (extra,))
+        ),
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.POPULATION_MISMATCH.value in found
+
+
+def test_a_dropped_structured_component_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The accepted structured component is gone; the prose-bound one remains.
+
+    (Dropping the prose-bound one instead is
+    ``test_omitted_accepted_obligation_fails``, which must also drop the prose
+    binding — an orphaned binding never reaches the gate, because persisted
+    state that will not reconstruct is rejected before it.)
+    """
+    kept = tuple(
+        c for c in build_representation().components if c.semantic_key != DESCRIPTOR_KEY
+    )
+    representation = dataclasses.replace(
+        build_representation(),
+        components=kept,
+        provenance=tuple(
+            p
+            for p in build_representation().provenance
+            if p.target_kind is not ProvenanceTargetKind.FACT
+        ),
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), representation=representation)
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.MISSING_AUTHORITY.value in found
+    assert GateFailureCategory.UNSATISFIED_OBLIGATION.value in found
+
+
+def test_fact_key_is_content_derived_so_a_changed_fact_is_a_different_element(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    changed = dataclasses.replace(DESCRIPTOR_FACT, level=8)
+    assert fact_key(changed) != DESCRIPTOR_FACT_KEY
+    components = (
+        dataclasses.replace(build_representation().components[0], facts=(changed,)),
+        build_representation().components[1],
+    )
+    representation = dataclasses.replace(
+        build_representation(),
+        components=components,
+        provenance=tuple(
+            (
+                dataclasses.replace(
+                    p, target_key=(SPELL_KEY, DESCRIPTOR_KEY, fact_key(changed))
+                )
+                if p.target_kind is ProvenanceTargetKind.FACT
+                else p
+            )
+            for p in build_representation().provenance
+        ),
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), representation=representation)
+    )
+    found = categories(session, uuid, committed_oracle)
+    assert GateFailureCategory.MISSING_AUTHORITY.value in found
+    assert GateFailureCategory.UNEXPECTED_AUTHORITY.value in found
+
+
+def test_extra_acceptance_evidence_does_not_change_the_verdict(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Reviewer and timestamp are audit metadata, not accepted meaning."""
+    ledger = build_ledger()
+    relabelled = dataclasses.replace(
+        ledger,
+        acceptances=tuple(
+            AcceptanceRecord(a.span_id, a.batch_id, "another-reviewer", a.accepted_at)
+            for a in ledger.acceptances
+        ),
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), classification=relabelled)
+    )
+    assert run_publication_gate(session, uuid, committed_oracle).passed

--- a/tests/ingestion/mechanical/test_oracle.py
+++ b/tests/ingestion/mechanical/test_oracle.py
@@ -1,0 +1,491 @@
+"""The accepted completeness oracle — CRD Issue 5d, Decision 5.
+
+Two things are proven here: that a committed oracle file is read strictly
+enough to be authority, and that the oracle cannot be produced from the thing
+it judges.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from afterworlds.ingestion.mechanical import oracle as oracle_module
+from afterworlds.ingestion.mechanical.oracle import (
+    COMMITTED_ORACLE_DIR,
+    AcceptedOracle,
+    OracleLoadError,
+    _resolve_committed_oracle,
+    derive_obligations,
+    load_oracle,
+    oracle_identity,
+    oracle_payload,
+)
+from tests.ingestion.mechanical.conftest import (
+    BOUNDED_ORACLE_PATH,
+    PACKAGE_UUID,
+    RELEASE_VERSION,
+    accepted_oracle,
+)
+
+
+def _payload() -> dict[str, object]:
+    return json.loads(BOUNDED_ORACLE_PATH.read_text(encoding="utf-8"))
+
+
+def _write(tmp_path: Path, payload: object, name: str = "o.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Self-attestation prevention
+# ---------------------------------------------------------------------------
+
+
+def test_oracle_module_cannot_reach_the_state_it_judges() -> None:
+    """No import path from the oracle to persistence, the ORM, or the gate.
+
+    The structural half of independence: an oracle that could read a persisted
+    projection could be *derived* from one, and a later refactor that adds such
+    an import would silently turn the completeness proof into self-attestation.
+    This fails on the import, before anyone has to notice the semantics.
+    """
+    source = Path(oracle_module.__file__).read_text(encoding="utf-8")
+    imported = {
+        node.module or ""
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom)
+    } | {
+        alias.name
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    forbidden = ("sqlalchemy", "persistence", "raw_state", "gate", "publication", "orm")
+    offending = sorted(m for m in imported if any(f in m for f in forbidden))
+    assert offending == [], f"oracle must not import {offending}"
+
+
+def test_no_committed_oracle_is_generated_into_the_source_tree() -> None:
+    """The committed oracle directory holds no production authority yet.
+
+    The production SRD release therefore resolves to no accepted authority and
+    cannot be published. When a later content PR commits one, this test is the
+    place that says so out loud.
+    """
+    assert sorted(p.name for p in COMMITTED_ORACLE_DIR.glob("*.json")) == []
+
+
+def test_declared_policy_comes_from_the_file_not_current_code(tmp_path: Path) -> None:
+    """A file declaring a different policy loads with *that* policy.
+
+    Substituting the current constants here would let a policy change re-bless
+    an oracle nobody re-reviewed. The gate is what rejects the mismatch; the
+    loader's job is to report honestly what the file says.
+    """
+    payload = _payload()
+    payload["semantic_policy_version"] = "5d-semantic-policy-0"
+    loaded = load_oracle(_write(tmp_path, payload))
+    assert loaded.policy_version == "5d-semantic-policy-0"
+
+
+# ---------------------------------------------------------------------------
+# Committed-file loading
+# ---------------------------------------------------------------------------
+
+
+def test_committed_file_states_the_accepted_authority() -> None:
+    """The committed JSON and the accepted content are the same authority.
+
+    Regenerate ``data/bounded_oracle.json`` when the fixture's accepted content
+    or the frozen semantic policy changes — a policy change legitimately
+    invalidates a committed oracle until it is re-accepted.
+    """
+    assert oracle_payload(load_oracle(BOUNDED_ORACLE_PATH)) == oracle_payload(
+        accepted_oracle()
+    )
+
+
+def test_loaded_oracle_carries_every_accepted_element() -> None:
+    loaded = load_oracle(BOUNDED_ORACLE_PATH)
+    assert isinstance(loaded, AcceptedOracle)
+    assert loaded.binding.package_uuid == PACKAGE_UUID
+    assert len(loaded.spans) == 3
+    assert len(loaded.representation.records) == 2
+    assert len(loaded.representation.provenance) == 4
+    assert {o.record_key for o in loaded.obligations} == {
+        "spell:wish",
+        "creature:wish-scoped-servant",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "fragment"),
+    [
+        (lambda p: p.pop("obligations"), "missing ['obligations']"),
+        (lambda p: p.update(extra=1), "unexpected ['extra']"),
+        (
+            lambda p: p["spans"][0].update(disposition="mostly_substantive"),
+            "not a declared SemanticDisposition",
+        ),
+        (
+            lambda p: p["spans"][0].update(disposition=3),
+            "expected a string SemanticDisposition",
+        ),
+        (
+            lambda p: p["representation"]["records"][0].update(kind="artifact"),
+            "not a declared RecordKind",
+        ),
+        (
+            lambda p: p["representation"]["components"][0]["facts"][0].update(
+                family="vibes"
+            ),
+            "not a member of the closed typed-fact union",
+        ),
+        (
+            lambda p: p["representation"]["components"][0]["facts"][0].pop("level"),
+            "missing ['level']",
+        ),
+        (
+            lambda p: p["obligations"][0].update(
+                structured_fact_families=["telepathy"]
+            ),
+            "not a declared FactFamily",
+        ),
+    ],
+)
+def test_a_malformed_oracle_is_rejected_not_defaulted(
+    tmp_path: Path, mutate, fragment: str  # type: ignore[no-untyped-def]
+) -> None:
+    """Every rejection is a raise, never a quietly narrower oracle.
+
+    An oracle that silently dropped an unreadable element would be *weaker*
+    authority than the one a reviewer accepted, and publication would be judged
+    against the difference.
+    """
+    payload = _payload()
+    mutate(payload)
+    with pytest.raises(OracleLoadError) as exc:
+        load_oracle(_write(tmp_path, payload))
+    assert fragment in str(exc.value)
+
+
+def test_unreadable_file_is_a_load_error(tmp_path: Path) -> None:
+    path = tmp_path / "broken.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(OracleLoadError):
+        load_oracle(path)
+
+
+def test_review_state_is_not_a_field_a_file_may_set(tmp_path: Path) -> None:
+    """A committed oracle is accepted authority by construction."""
+    payload = _payload()
+    payload["spans"][0]["review_state"] = "proposed"
+    with pytest.raises(OracleLoadError) as exc:
+        load_oracle(_write(tmp_path, payload))
+    assert "unexpected ['review_state']" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Release resolution and identity
+# ---------------------------------------------------------------------------
+
+
+def test_release_with_no_committed_oracle_resolves_to_none(tmp_path: Path) -> None:
+    assert _resolve_committed_oracle("other-pkg", "rel-9", tmp_path) is None
+
+
+def test_committed_oracle_resolves_by_exact_release(tmp_path: Path) -> None:
+    _write(tmp_path, _payload(), "bounded.json")
+    resolved = _resolve_committed_oracle(PACKAGE_UUID, RELEASE_VERSION, tmp_path)
+    assert resolved is not None
+    assert resolved.binding.release_version == RELEASE_VERSION
+    assert _resolve_committed_oracle(PACKAGE_UUID, "rel-other", tmp_path) is None
+
+
+def test_two_oracles_for_one_release_is_rejected(tmp_path: Path) -> None:
+    """Picking one would make publication depend on filesystem ordering."""
+    _write(tmp_path, _payload(), "a.json")
+    _write(tmp_path, _payload(), "b.json")
+    with pytest.raises(OracleLoadError) as exc:
+        _resolve_committed_oracle(PACKAGE_UUID, RELEASE_VERSION, tmp_path)
+    assert "2 committed oracles" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Primitive and container types at the JSON boundary
+# ---------------------------------------------------------------------------
+#
+# Key and enum validation was already strict, but a value of the wrong *type*
+# passed straight through: frozen dataclasses do not enforce annotations, so
+# ``"char_start": "0"`` loaded fine and surfaced far away as an unclassified
+# TypeError when the gate compared a string with an integer. Every malformed
+# value must fail here, as OracleLoadError, naming where it was found.
+#
+# Type closure only. Whether spans partition their leaf gap-free is the semantic
+# validator's judgement and is not restated at this boundary — negative offsets
+# are rejected because they are outside the declared domain, not because of a
+# second opinion about partition validity.
+
+
+def _at(payload: dict[str, object], path: str, value: object) -> dict[str, object]:
+    """Set a dotted/indexed *path* inside a payload, returning it."""
+    target: Any = payload
+    parts = path.split(".")
+    for part in parts[:-1]:
+        if part.endswith("]"):
+            name, index = part[:-1].split("[")
+            target = target[name][int(index)] if name else target[int(index)]
+        else:
+            target = target[part]
+    target[parts[-1]] = value
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        # Top-level containers supplied as the wrong shape.
+        pytest.param("spans", "three", id="spans-as-string"),
+        pytest.param("spans", {}, id="spans-as-object"),
+        pytest.param("spans", None, id="spans-as-null"),
+        pytest.param("obligations", "none", id="obligations-as-string"),
+        pytest.param("representation.records", None, id="records-as-null"),
+        pytest.param("representation.components", "c", id="components-as-string"),
+        pytest.param("representation.prose_bindings", 0, id="bindings-as-number"),
+        pytest.param("representation.relationships", {}, id="relationships-as-object"),
+        pytest.param("representation.references", "r", id="references-as-string"),
+        pytest.param("representation.provenance", None, id="provenance-as-null"),
+        # A collection of the right shape holding the wrong element type.
+        pytest.param("spans[0]", "span", id="span-element-as-string"),
+        pytest.param("representation.records[0]", None, id="record-element-as-null"),
+        pytest.param("obligations[0]", 5, id="obligation-element-as-number"),
+        # Release binding and policy strings.
+        pytest.param("release_binding.package_uuid", 5, id="package-uuid-as-number"),
+        pytest.param("release_binding.release_version", None, id="release-as-null"),
+        pytest.param(
+            "release_binding.bundle_root_hash", ["c"], id="bundle-hash-as-array"
+        ),
+        pytest.param("semantic_policy_version", 1, id="policy-version-as-number"),
+        pytest.param("semantic_policy_hash", None, id="policy-hash-as-null"),
+        # Span scalars, including the reported case.
+        pytest.param("spans[0].span_id", 7, id="span-id-as-number"),
+        pytest.param("spans[0].leaf_id", None, id="leaf-id-as-null"),
+        pytest.param("spans[0].char_start", "0", id="char-start-as-string"),
+        pytest.param("spans[0].char_start", True, id="char-start-as-boolean"),
+        pytest.param("spans[0].char_start", 0.0, id="char-start-as-float"),
+        pytest.param("spans[0].char_end", None, id="char-end-as-null"),
+        pytest.param("spans[0].char_start", -1, id="char-start-negative"),
+        pytest.param(
+            "spans[0].non_mechanical_reason_code", 3, id="reason-code-as-number"
+        ),
+        # Record, component, prose-binding, relationship, reference scalars.
+        pytest.param("representation.records[0].semantic_key", 1, id="record-key-num"),
+        pytest.param(
+            "representation.records[0].parent_key", 2, id="parent-key-as-number"
+        ),
+        pytest.param(
+            "representation.components[0].record_key", None, id="component-key-null"
+        ),
+        pytest.param(
+            "representation.components[0].irreducibility_reason_code",
+            4,
+            id="component-reason-as-number",
+        ),
+        pytest.param("representation.components[0].facts", "f", id="facts-as-string"),
+        pytest.param(
+            "representation.components[0].facts[0]", "f", id="fact-element-as-string"
+        ),
+        pytest.param(
+            "representation.prose_bindings[0].chunk_id", 9, id="chunk-id-as-number"
+        ),
+        pytest.param(
+            "representation.prose_bindings[0].irreducibility_reason_code",
+            None,
+            id="binding-reason-as-null",
+        ),
+        pytest.param(
+            "representation.relationships[0].source_record_key",
+            [],
+            id="relationship-source-as-array",
+        ),
+        # Provenance target keys.
+        pytest.param(
+            "representation.provenance[0].target_key",
+            "spell:wish",
+            id="target-key-as-string",
+        ),
+        pytest.param(
+            "representation.provenance[0].target_key", [1], id="target-key-of-numbers"
+        ),
+        pytest.param(
+            "representation.provenance[0].span_id", None, id="provenance-span-null"
+        ),
+        # Obligation collections.
+        pytest.param(
+            "obligations[0].record_key", 1, id="obligation-record-key-as-number"
+        ),
+        pytest.param(
+            "obligations[0].structured_fact_families",
+            "spell_descriptor",
+            id="families-as-string",
+        ),
+        pytest.param(
+            "obligations[0].prose_bound_components",
+            "open-ended-clause",
+            id="prose-components-as-string",
+        ),
+        pytest.param(
+            "obligations[0].prose_bound_components", [7], id="prose-components-numbers"
+        ),
+    ],
+)
+def test_a_wrongly_typed_oracle_value_fails_to_load(
+    tmp_path: Path, path: str, value: object
+) -> None:
+    """Malformed committed authority is an OracleLoadError, never a late crash.
+
+    ``tuple("abc")`` and ``frozenset("abc")`` both succeed on a bare string and
+    invent three elements, so a string supplied where an array is declared would
+    otherwise manufacture accepted authority out of a typo.
+    """
+    with pytest.raises(OracleLoadError) as exc:
+        load_oracle(_write(tmp_path, _at(_payload(), path, value)))
+    assert path.split(".")[0].split("[")[0] in str(exc.value)
+
+
+def test_a_malformed_fact_payload_is_an_oracle_load_error(tmp_path: Path) -> None:
+    """The closed-union parser's own rejections are wrapped, not duplicated."""
+    payload = _payload()
+    facts = payload["representation"]["components"][0]["facts"]  # type: ignore[index]
+    facts[0] = {**facts[0], "family": "not_a_declared_family"}  # type: ignore[index]
+    with pytest.raises(OracleLoadError):
+        load_oracle(_write(tmp_path, payload))
+
+
+# ---------------------------------------------------------------------------
+# The obligation relation must be total and exact
+# ---------------------------------------------------------------------------
+#
+# Shape validation cannot see any of this. Every payload below parses perfectly
+# and describes a real accepted representation; what is wrong is the *relation*
+# between the declared obligations and that representation, which is where a
+# per-record completeness control silently loses its teeth.
+
+SPELL_OBLIGATION = {
+    "record_key": "spell:wish",
+    "kind": "spell",
+    "structured_fact_families": ["spell_descriptor"],
+    "prose_bound_components": ["open-ended-clause"],
+}
+
+
+def _with_obligations(obligations: list[dict[str, object]]) -> dict[str, object]:
+    payload = _payload()
+    payload["obligations"] = obligations
+    return payload
+
+
+def test_the_bounded_oracle_declares_exactly_what_it_represents() -> None:
+    """The committed file's obligations are the derived ones, not a subset."""
+    oracle = load_oracle(BOUNDED_ORACLE_PATH)
+    assert set(oracle.obligations) == set(derive_obligations(oracle.representation))
+
+
+@pytest.mark.parametrize(
+    ("obligations", "expected"),
+    [
+        pytest.param([], "carry no obligation", id="none-at-all"),
+        pytest.param(
+            [SPELL_OBLIGATION],
+            "carry no obligation",
+            id="one-record-uncovered",
+        ),
+        pytest.param(
+            [SPELL_OBLIGATION, SPELL_OBLIGATION],
+            "duplicate obligation",
+            id="duplicate",
+        ),
+        pytest.param(
+            [
+                SPELL_OBLIGATION,
+                {
+                    "record_key": "spell:invented",
+                    "kind": "spell",
+                    "structured_fact_families": [],
+                    "prose_bound_components": [],
+                },
+            ],
+            "does not declare",
+            id="targets-a-nonexistent-record",
+        ),
+        pytest.param(
+            [{**SPELL_OBLIGATION, "kind": "creature"}],
+            "does not reconcile",
+            id="wrong-record-kind",
+        ),
+        pytest.param(
+            [{**SPELL_OBLIGATION, "structured_fact_families": []}],
+            "does not reconcile",
+            id="understated-fact-family",
+        ),
+        pytest.param(
+            [
+                {
+                    **SPELL_OBLIGATION,
+                    "structured_fact_families": ["spell_descriptor", "ability_check"],
+                }
+            ],
+            "does not reconcile",
+            id="overstated-fact-family",
+        ),
+        pytest.param(
+            [{**SPELL_OBLIGATION, "prose_bound_components": []}],
+            "does not reconcile",
+            id="understated-prose-bound-set",
+        ),
+        pytest.param(
+            [{**SPELL_OBLIGATION, "prose_bound_components": ["descriptor"]}],
+            "does not reconcile",
+            id="prose-bound-names-a-structured-component",
+        ),
+        pytest.param(
+            [{**SPELL_OBLIGATION, "prose_bound_components": ["no-such-component"]}],
+            "does not reconcile",
+            id="prose-bound-names-a-nonexistent-component",
+        ),
+    ],
+)
+def test_an_unclosed_obligation_relation_fails_to_load(
+    tmp_path: Path, obligations: list[dict[str, object]], expected: str
+) -> None:
+    """Malformed accepted authority is no oracle, never a weaker one."""
+    with pytest.raises(OracleLoadError) as exc:
+        load_oracle(_write(tmp_path, _with_obligations(obligations)))
+    assert expected in str(exc.value)
+
+
+def test_identity_changes_with_accepted_meaning(tmp_path: Path) -> None:
+    base = load_oracle(BOUNDED_ORACLE_PATH)
+    payload = _payload()
+    payload["representation"]["components"][0]["facts"][0]["level"] = 8
+    assert oracle_identity(load_oracle(_write(tmp_path, payload))) != oracle_identity(
+        base
+    )
+
+
+def test_identity_is_stable_across_authoring_order(tmp_path: Path) -> None:
+    """Two files stating the same authority in different orders are one oracle."""
+    payload = _payload()
+    payload["spans"].reverse()
+    payload["representation"]["records"].reverse()
+    payload["obligations"].reverse()
+    assert oracle_identity(load_oracle(_write(tmp_path, payload))) == oracle_identity(
+        load_oracle(BOUNDED_ORACLE_PATH)
+    )

--- a/tests/ingestion/mechanical/test_packaging.py
+++ b/tests/ingestion/mechanical/test_packaging.py
@@ -1,0 +1,287 @@
+"""Packaging smoke test for committed accepted oracles — CRD Issue 5d, PR #141 R2.
+
+``oracle.committed_oracle_for`` resolves accepted authority from a fixed
+directory inside the installed package. If that directory's JSON is missing from
+the distribution metadata, a source checkout publishes and an installed
+application silently returns ``ABSENT`` for every projection — publication
+failing for a reason that has nothing to do with the oracle.
+
+The directory is deliberately empty of production content today, so the defect
+cannot be caught by shipping the real oracle. Instead this builds a **copy** of
+the source tree carrying one valid sentinel oracle, produces a wheel and an
+sdist from it, installs each, and drives the genuine production resolution and
+publication entry point against the installed copy. Archive listings are checked
+too, but they are not the proof: the defect is runtime resource resolution, so
+the assertion that matters is that ``publish_from_committed_oracle`` reaches the
+packaged oracle instead of reporting ``ABSENT``.
+
+Follows the CRD Issue 5c pattern in ``tests/ingestion/corpus/test_packaging.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ORACLES_REL = "afterworlds/ingestion/mechanical/oracles"
+_PRODUCTION_ORACLES = _REPO_ROOT / "src" / _ORACLES_REL
+
+#: Distinct from every real release so a resolution hit cannot be a coincidence.
+SENTINEL_PACKAGE = "pkg-sentinel-packaging"
+SENTINEL_RELEASE = "rel-sentinel-packaging"
+SENTINEL_FILENAME = "sentinel_packaging_oracle.json"
+
+#: The smallest payload ``load_oracle`` accepts: no spans, no representation, and
+#: therefore no obligations — the derived obligation relation over an empty
+#: record set is empty, so the closed-relation check passes. It exists to be
+#: *found*, not to pass a gate.
+SENTINEL_ORACLE: dict[str, object] = {
+    "release_binding": {
+        "package_uuid": SENTINEL_PACKAGE,
+        "release_version": SENTINEL_RELEASE,
+        "authoritative_source_hash": "a" * 64,
+        "transform_config_hash": "b" * 64,
+        "bundle_root_hash": "c" * 64,
+        "persisted_corpus_digest": "d" * 64,
+    },
+    "semantic_policy_version": "sentinel",
+    "semantic_policy_hash": "e" * 64,
+    "spans": [],
+    "representation": {
+        "records": [],
+        "components": [],
+        "prose_bindings": [],
+        "relationships": [],
+        "references": [],
+        "provenance": [],
+    },
+    "obligations": [],
+}
+
+#: Runs inside the installed distribution, with the repository unimportable. It
+#: exercises the real production path: resolve the committed oracle for the
+#: sentinel release, then call the production publication entry against a header
+#: bound to that release. Without the packaged JSON, ``committed_oracle_for``
+#: returns ``None`` and the entry reports ``ABSENT``; with it, the gate runs and
+#: refuses for a real reason. "Not ABSENT" is therefore the discriminator.
+_PROBE = f"""
+import json
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.mechanical import MechanicalProjectionORM
+from afterworlds.ingestion.mechanical import oracle as oracle_module
+from afterworlds.ingestion.mechanical.oracle import committed_oracle_for
+from afterworlds.ingestion.mechanical.publication import publish_from_committed_oracle
+
+PKG = {SENTINEL_PACKAGE!r}
+REL = {SENTINEL_RELEASE!r}
+NOW = "2026-08-01T00:00:00Z"
+
+resolved = committed_oracle_for(PKG, REL)
+
+engine = create_engine("sqlite://")
+Base.metadata.create_all(engine)
+with Session(engine) as session:
+    session.add(
+        CorpusReleaseORM(
+            package_uuid=PKG,
+            release_version=REL,
+            authoritative_source_hash="a" * 64,
+            transform_config_hash="b" * 64,
+            bundle_root_hash="c" * 64,
+            persisted_corpus_digest="d" * 64,
+            ledger_hash="1" * 64,
+            policy_hash="2" * 64,
+            reconciliation_hash="3" * 64,
+            transform_config={{}},
+            publication_status="published",
+            created_at=NOW,
+        )
+    )
+    session.flush()
+    session.add(
+        MechanicalProjectionORM(
+            projection_uuid="sentinel-projection",
+            package_uuid=PKG,
+            release_version=REL,
+            authoritative_source_hash="a" * 64,
+            transform_config_hash="b" * 64,
+            bundle_root_hash="c" * 64,
+            persisted_corpus_digest="d" * 64,
+            semantic_policy_version="sentinel",
+            semantic_policy_hash="e" * 64,
+            payload_hash="f" * 64,
+            publication_status="draft",
+            created_at=NOW,
+        )
+    )
+    session.flush()
+    outcome = publish_from_committed_oracle(
+        session, "sentinel-projection", now=NOW
+    ).outcome
+
+print(json.dumps({{
+    "module_file": oracle_module.__file__,
+    "oracle_dir": str(oracle_module.COMMITTED_ORACLE_DIR),
+    "resolved": resolved is not None,
+    "resolved_release": None if resolved is None else resolved.binding.release_version,
+    "outcome": outcome.value,
+}}))
+"""
+
+
+def _staged_source_tree(tmp_path: Path) -> Path:
+    """A build-able copy of the project carrying one sentinel oracle.
+
+    A copy rather than the checkout: the sentinel must be present at build time
+    to prove the distribution metadata picks it up, and the real production
+    oracle directory must stay empty of accepted content.
+    """
+    staged = tmp_path / "src-tree"
+    staged.mkdir()
+    for name in ("pyproject.toml", "MANIFEST.in"):
+        shutil.copyfile(_REPO_ROOT / name, staged / name)
+    shutil.copytree(
+        _REPO_ROOT / "src",
+        staged / "src",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    (staged / "src" / _ORACLES_REL / SENTINEL_FILENAME).write_text(
+        json.dumps(SENTINEL_ORACLE, indent=2), encoding="utf-8"
+    )
+    return staged
+
+
+def _build_dists(source: Path, out_dir: Path) -> tuple[Path, Path]:
+    """Build wheel + sdist from *source* using the dev env's build backend."""
+    pytest.importorskip("build")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--no-isolation",
+            "--outdir",
+            str(out_dir),
+            str(source),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"`python -m build --no-isolation` failed (exit {proc.returncode}).\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+    )
+    wheels = list(out_dir.glob("*.whl"))
+    sdists = list(out_dir.glob("*.tar.gz"))
+    assert len(wheels) == 1, wheels
+    assert len(sdists) == 1, sdists
+    return wheels[0], sdists[0]
+
+
+def _install(artifact: Path, target: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--no-build-isolation",
+            "--target",
+            str(target),
+            str(artifact),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _probe_installed(target: Path, cwd: Path) -> dict[str, object]:
+    """Run the production path against the install in *target*.
+
+    ``-S`` skips ``site.py`` so the editable-install finder never registers and
+    cannot shadow the target; the target leads ``PYTHONPATH`` and dependencies
+    resolve from the dev env. ``cwd`` is a neutral tmp dir, so the repository is
+    never importable.
+    """
+    purelib = sysconfig.get_paths()["purelib"]
+    env = {**os.environ, "PYTHONPATH": os.pathsep.join([str(target), purelib])}
+    proc = subprocess.run(
+        [sys.executable, "-S", "-c", _PROBE],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    result: dict[str, object] = json.loads(proc.stdout.strip().splitlines()[-1])
+    # Proof it imported the installed copy, not the source tree.
+    assert str(target) in str(result["module_file"])
+    assert str(_REPO_ROOT / "src") not in str(result["module_file"])
+    return result
+
+
+def test_the_production_oracle_directory_ships_no_accepted_srd_oracle() -> None:
+    """The real directory stays semantically empty until the content PR.
+
+    Guards the sentinel from leaking into the checkout, and restates the claim
+    the PR makes: nothing over the production release can be published yet.
+    """
+    assert _PRODUCTION_ORACLES.is_dir()
+    assert list(_PRODUCTION_ORACLES.glob("*.json")) == []
+
+
+def test_a_packaged_oracle_resolves_and_publishes_from_wheel_and_sdist(
+    tmp_path: Path,
+) -> None:
+    """The production entry reaches a packaged oracle from an installed dist.
+
+    Both artifact types, because they carry package data through different
+    metadata: the wheel through ``[tool.setuptools.package-data]`` and the sdist
+    through ``MANIFEST.in``. A rule missing from either one is a real
+    distribution defect for the accepted-content PR that follows this one.
+    """
+    staged = _staged_source_tree(tmp_path)
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    wheel, sdist = _build_dists(staged, dist)
+
+    # Runtime resolution first, deliberately: it is the property under test, so
+    # it should also be the failure a regression reports. The archive listings
+    # below are a diagnostic that says *where* a runtime failure came from.
+    for label, artifact in (("wheel", wheel), ("sdist", sdist)):
+        target = tmp_path / f"site-{label}"
+        _install(artifact, target)
+        result = _probe_installed(target, tmp_path)
+
+        assert result["resolved"] is True, f"{label}: {result}"
+        assert result["resolved_release"] == SENTINEL_RELEASE, f"{label}: {result}"
+        assert str(target) in str(result["oracle_dir"]), f"{label}: {result}"
+        # The gate refuses this sentinel — it describes no real projection — but
+        # it refuses *having judged it*. ABSENT would mean the installed
+        # application could not see the accepted authority at all, which is the
+        # defect under test.
+        assert result["outcome"] != "absent", f"{label}: {result}"
+
+    sentinel_rel = f"{_ORACLES_REL}/{SENTINEL_FILENAME}"
+    with zipfile.ZipFile(wheel) as zf:
+        assert any(n.endswith(sentinel_rel) for n in zf.namelist()), zf.namelist()
+    with tarfile.open(sdist) as tf:
+        assert any(m.name.endswith(f"src/{sentinel_rel}") for m in tf.getmembers()), [
+            m.name for m in tf.getmembers() if m.name.endswith(".json")
+        ]

--- a/tests/ingestion/mechanical/test_persistence.py
+++ b/tests/ingestion/mechanical/test_persistence.py
@@ -31,9 +31,6 @@ from afterworlds.ingestion.mechanical.representation import (
     RelationshipKind,
     fact_from_payload,
 )
-from afterworlds.persistence.database import create_engine, create_session_factory
-from afterworlds.persistence.orm.base import Base
-from afterworlds.persistence.orm.corpus import CorpusReleaseORM
 from afterworlds.persistence.orm.mechanical import (
     MechanicalBatchDiffORM,
     MechanicalFactORM,
@@ -42,56 +39,15 @@ from afterworlds.persistence.orm.mechanical import (
     MechanicalRecordORM,
     MechanicalSpanORM,
 )
-from afterworlds.persistence.orm.rules_package import RulesPackageORM
 from tests.ingestion.mechanical.conftest import (
     CREATURE_KEY,
+    NOW,
     SCOPED_REFERENCES,
     SPELL_KEY,
     batch_accepted_ledger,
     build_candidate,
     build_representation,
 )
-
-NOW = "2026-07-31T00:00:00Z"
-
-
-@pytest.fixture()
-def session(tmp_path) -> Session:  # type: ignore[no-untyped-def]
-    engine = create_engine(f"sqlite:///{tmp_path / 'mech.db'}")
-    Base.metadata.create_all(engine)
-    factory = create_session_factory(engine)
-    with factory() as s:
-        # The projection FKs a real published 5c release row.
-        s.add(
-            RulesPackageORM(
-                rules_package_id="pkg-5c",
-                name="SRD 5.2.1",
-                system="dnd5e",
-                version="5.2.1",
-                is_enabled=True,
-                publication_status="published",
-                created_at="2026-07-31T00:00:00Z",
-                updated_at="2026-07-31T00:00:00Z",
-            )
-        )
-        s.flush()
-        s.add(
-            CorpusReleaseORM(
-                package_uuid="pkg-5c",
-                release_version="rel-5c",
-                authoritative_source_hash="a" * 64,
-                transform_config_hash="b" * 64,
-                bundle_root_hash="c" * 64,
-                ledger_hash="1" * 64,
-                policy_hash="2" * 64,
-                reconciliation_hash="3" * 64,
-                transform_config={},
-                publication_status="published",
-                created_at=NOW,
-            )
-        )
-        s.flush()
-        yield s
 
 
 def _persist(session: Session):  # type: ignore[no-untyped-def]

--- a/tests/ingestion/mechanical/test_production_release.py
+++ b/tests/ingestion/mechanical/test_production_release.py
@@ -1,0 +1,431 @@
+"""The real CRD Issue 5c release — CRD Issue 5d production control.
+
+Everything else in this suite runs against a bounded fixture. This module runs
+against the *actual* published SRD 5.2.1 corpus: built from the committed PDF,
+finalized through CRD Issue 5c's own persist → reconstruct → digest → gate →
+publish lifecycle, then re-persisted into a private database.
+
+It proves the claim this PR must not overstate — the publication machinery is
+complete and the production mechanical projection is not — and it proves it
+*structurally*.
+
+The projection used here is the strongest possible incomplete one. It is built
+over real leaves of the real release, it is internally honest, its
+persisted-state proof is recorded, and the accepted oracle judging it states
+exactly what it contains, down to deriving the same projection identity. Every
+comparison the gate makes against that oracle passes. It is refused anyway,
+because the release represents leaves it never classified — reported per leaf,
+with no count, threshold, floor, or percentage anywhere in the decision.
+
+Session-scoped 5c fixtures are shared with the CRD Issue 5c suite through
+``tests/ingestion/conftest.py``, so this costs no second corpus build.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.persistence import persist_release
+from afterworlds.ingestion.corpus.pipeline import ReleaseArtifacts
+from afterworlds.ingestion.mechanical.accounting import derive_span_id
+from afterworlds.ingestion.mechanical.bound_corpus import load_bound_corpus
+from afterworlds.ingestion.mechanical.gate import (
+    GateFailureCategory,
+    run_publication_gate,
+)
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceRecord,
+    ClassificationLedger,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.oracle import (
+    AcceptedOracle,
+    committed_oracle_for,
+)
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+    record_persisted_state_digest,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    SEMANTIC_POLICY_VERSION,
+    semantic_policy_hash,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    ReleaseBinding,
+    identify_projection,
+)
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    _publish_projection,
+    publish_from_committed_oracle,
+    resolve_active_projection,
+)
+from afterworlds.ingestion.mechanical.representation import RepresentationDraft
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from tests.ingestion.mechanical.conftest import NOW
+
+#: How many real leaves the incomplete projection classifies. Three, for the
+#: same reason the bounded fixture has three: the point is that it is not the
+#: release's population, not how far short it falls.
+CLASSIFIED_LEAVES = 3
+
+EMPTY_REPRESENTATION = RepresentationDraft(
+    records=(),
+    components=(),
+    prose_bindings=(),
+    relationships=(),
+    references=(),
+    provenance=(),
+)
+
+
+@dataclass(frozen=True)
+class ProductionFixture:
+    """One real release, one incomplete projection over it, and its oracle."""
+
+    session: Session
+    release: ReleaseArtifacts
+    binding: ReleaseBinding
+    projection_uuid: str
+    oracle: AcceptedOracle
+
+
+def _binding(release: ReleaseArtifacts) -> ReleaseBinding:
+    identity = release.release.identity
+    assert identity.persisted_corpus_digest is not None
+    return ReleaseBinding(
+        package_uuid=release.release.package_uuid,
+        release_version=release.release.release_version,
+        authoritative_source_hash=identity.authoritative_source_hash,
+        transform_config_hash=identity.transform_config_hash,
+        bundle_root_hash=identity.bundle_root_hash,
+        persisted_corpus_digest=identity.persisted_corpus_digest,
+    )
+
+
+def _publish_persisted_release(session: Session, pkg: str) -> None:
+    """Transition a re-persisted 5c release to published, as finalize does."""
+    session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+    ).scalar_one().publication_status = "published"
+    package_row = session.execute(
+        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
+    ).scalar_one()
+    package_row.publication_status = "published"
+    package_row.published_at = NOW
+    session.flush()
+
+
+@pytest.fixture(scope="module")
+def production(full_release: ReleaseArtifacts):  # type: ignore[no-untyped-def]
+    """The real release persisted into a private store, plus one draft over it.
+
+    Module-scoped because writing 5c's full persisted state is expensive and
+    nothing in this module publishes successfully — every attempt is refused,
+    so no test can leave state another test would read.
+    """
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as session:
+        persist_release(session, full_release, now=NOW)
+        # ``persist_release`` writes step-c drafts; in 5c the transition to
+        # published is the last step of a gate that has already passed. This
+        # store is a re-persist of an already-finalized release, so the
+        # transition is restated here rather than left implied — the 5d gate
+        # now refuses to publish over a draft 5c release, and it is right to.
+        _publish_persisted_release(session, full_release.release.package_uuid)
+        binding = _binding(full_release)
+        corpus = load_bound_corpus(
+            session, binding.package_uuid, binding.release_version
+        )
+
+        # Real leaves of the real release, classified honestly and completely:
+        # one gap-free span each, non-mechanical under a closed catalog reason,
+        # with explicit acceptance evidence. Nothing about these three claims is
+        # wrong — there are simply tens of thousands more.
+        chosen = sorted(corpus.leaf_lengths)[:CLASSIFIED_LEAVES]
+        spans = tuple(
+            SemanticSpan(
+                span_id=derive_span_id(leaf_id, 0, corpus.leaf_lengths[leaf_id]),
+                leaf_id=leaf_id,
+                char_start=0,
+                char_end=corpus.leaf_lengths[leaf_id],
+                disposition=SemanticDisposition.NON_MECHANICAL,
+                review_state=ReviewState.ACCEPTED,
+                non_mechanical_reason_code="legal_licensing",
+            )
+            for leaf_id in chosen
+        )
+        classification = ClassificationLedger(
+            package_uuid=binding.package_uuid,
+            release_version=binding.release_version,
+            policy_version=SEMANTIC_POLICY_VERSION,
+            policy_hash=semantic_policy_hash(),
+            spans=spans,
+            batches=(),
+            acceptances=tuple(
+                AcceptanceRecord(s.span_id, None, "owner", NOW) for s in spans
+            ),
+        )
+        identified = identify_projection(
+            ProjectionCandidate(
+                binding=binding,
+                classification=classification,
+                representation=EMPTY_REPRESENTATION,
+            )
+        )
+        persist_draft(session, identified, now=NOW)
+        record_persisted_state_digest(session, identified.projection_uuid)
+
+        yield ProductionFixture(
+            session=session,
+            release=full_release,
+            binding=binding,
+            projection_uuid=identified.projection_uuid,
+            # The accepted authority states exactly this content — so every
+            # oracle comparison passes and only the release's own population
+            # can refuse it.
+            oracle=AcceptedOracle(
+                binding=binding,
+                policy_version=SEMANTIC_POLICY_VERSION,
+                policy_hash=semantic_policy_hash(),
+                spans=spans,
+                representation=EMPTY_REPRESENTATION,
+                obligations=(),
+            ),
+        )
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# The release supplies the population
+# ---------------------------------------------------------------------------
+
+
+def test_the_bound_release_supplies_the_accounting_population(
+    production: ProductionFixture,
+) -> None:
+    """Population comes from 5c, not from any CRD Issue 5d input.
+
+    The exact total is a drift canary, not a contract — what matters is that it
+    is tens of thousands of leaves and that it is read from the release.
+    """
+    corpus = load_bound_corpus(
+        production.session,
+        production.binding.package_uuid,
+        production.binding.release_version,
+    )
+    assert len(corpus.leaf_lengths) > 10_000
+    assert corpus.authoritative_chunk_ids
+
+
+# ---------------------------------------------------------------------------
+# The production projection cannot be published
+# ---------------------------------------------------------------------------
+
+
+def test_no_accepted_oracle_is_committed_for_the_production_release(
+    production: ProductionFixture,
+) -> None:
+    """Nothing judges the real SRD release yet, so nothing over it can publish."""
+    assert (
+        committed_oracle_for(
+            production.binding.package_uuid, production.binding.release_version
+        )
+        is None
+    )
+
+
+def test_the_production_path_refuses_the_real_release(
+    production: ProductionFixture,
+) -> None:
+    """``publish_from_committed_oracle`` fails closed on the real release."""
+    result = publish_from_committed_oracle(
+        production.session, production.projection_uuid, now=NOW
+    )
+    assert result.outcome is PublicationOutcome.ABSENT
+    assert (
+        resolve_active_projection(
+            production.session, production.binding.package_uuid
+        ).outcome
+        is PublicationOutcome.UNPUBLISHED
+    )
+
+
+def test_everything_the_projection_claims_is_accepted(
+    production: ProductionFixture,
+) -> None:
+    """The control is not passing for an incidental reason.
+
+    Its persisted state proves out, its accepted oracle derives the very same
+    projection identity, and no comparison against that oracle fails. If any of
+    this stopped holding, the population failure below would no longer be the
+    thing being tested.
+
+    The only two categories present are the uncovered population and the
+    candidate validator's own view of the same leaves — one uncovered leaf,
+    reported by both layers. Nothing about release binding, policy, review
+    residue, missing/unexpected/duplicate authority, obligations, or identity
+    is wrong here.
+    """
+    result = run_publication_gate(
+        production.session, production.projection_uuid, production.oracle
+    )
+    assert result.expected_projection_uuid == production.projection_uuid
+    assert result.persisted_state_digest is not None
+    assert result.categories() == {
+        GateFailureCategory.POPULATION_MISMATCH,
+        GateFailureCategory.SEMANTIC_VALIDATION,
+    }
+    assert all(
+        "no semantic spans" in f.detail
+        for f in result.failures
+        if f.category is GateFailureCategory.SEMANTIC_VALIDATION
+    )
+
+
+def test_the_incomplete_production_projection_fails_the_real_gate(
+    production: ProductionFixture,
+) -> None:
+    """It fails per uncovered leaf, structurally, with no aggregate involved."""
+    result = run_publication_gate(
+        production.session, production.projection_uuid, production.oracle
+    )
+    assert not result.passed
+
+    missing = [
+        f
+        for f in result.failures
+        if f.category is GateFailureCategory.POPULATION_MISMATCH
+    ]
+    assert len(missing) > 10_000
+    assert all(
+        "represented by the bound 5c release, absent from the accepted "
+        "classification" in f.detail
+        for f in missing
+    )
+
+    corpus = load_bound_corpus(
+        production.session,
+        production.binding.package_uuid,
+        production.binding.release_version,
+    )
+    assert len(missing) == len(corpus.leaf_lengths) - CLASSIFIED_LEAVES
+
+
+def test_the_incomplete_production_projection_is_refused_as_incomplete(
+    production: ProductionFixture,
+) -> None:
+    """Typed refusal, nothing written, nothing activated."""
+    result = _publish_projection(
+        production.session, production.projection_uuid, production.oracle, now=NOW
+    )
+    assert result.outcome is PublicationOutcome.INCOMPLETE
+    assert (
+        resolve_active_projection(
+            production.session, production.binding.package_uuid
+        ).outcome
+        is PublicationOutcome.UNPUBLISHED
+    )
+
+
+def test_classifying_more_leaves_does_not_help(
+    production: ProductionFixture,
+) -> None:
+    """Partial progress is not partial success.
+
+    A projection covering nearly the whole release fails exactly as the
+    three-leaf one does. Publication is not a threshold that better coverage
+    eventually crosses (ADR-005d Decision 5).
+    """
+    corpus = load_bound_corpus(
+        production.session,
+        production.binding.package_uuid,
+        production.binding.release_version,
+    )
+    nearly_all = sorted(corpus.leaf_lengths)[:-1]
+    spans = tuple(
+        SemanticSpan(
+            span_id=derive_span_id(leaf_id, 0, corpus.leaf_lengths[leaf_id]),
+            leaf_id=leaf_id,
+            char_start=0,
+            char_end=corpus.leaf_lengths[leaf_id],
+            disposition=SemanticDisposition.NON_MECHANICAL,
+            review_state=ReviewState.ACCEPTED,
+            non_mechanical_reason_code="legal_licensing",
+        )
+        for leaf_id in nearly_all
+    )
+    classification = replace(
+        ClassificationLedger(
+            package_uuid=production.binding.package_uuid,
+            release_version=production.binding.release_version,
+            policy_version=SEMANTIC_POLICY_VERSION,
+            policy_hash=semantic_policy_hash(),
+            spans=spans,
+            batches=(),
+            acceptances=tuple(
+                AcceptanceRecord(s.span_id, None, "owner", NOW) for s in spans
+            ),
+        )
+    )
+    identified = identify_projection(
+        ProjectionCandidate(
+            binding=production.binding,
+            classification=classification,
+            representation=EMPTY_REPRESENTATION,
+        )
+    )
+    persist_draft(production.session, identified, now=NOW)
+    record_persisted_state_digest(production.session, identified.projection_uuid)
+
+    oracle = replace(production.oracle, spans=spans)
+    result = _publish_projection(
+        production.session, identified.projection_uuid, oracle, now=NOW
+    )
+    assert result.outcome is PublicationOutcome.INCOMPLETE
+    assert result.gate is not None
+    assert GateFailureCategory.POPULATION_MISMATCH in result.gate.categories()
+
+
+def test_the_evidence_report_names_the_exact_production_release(
+    production: ProductionFixture,
+) -> None:
+    """A refusal is auditable: the report says what was judged, and by what."""
+    result = _publish_projection(
+        production.session, production.projection_uuid, production.oracle, now=NOW
+    )
+    assert result.report is not None
+    payload = result.report.payload
+    binding = production.binding
+
+    assert payload["source_release"] == {
+        "package_uuid": binding.package_uuid,
+        "release_version": binding.release_version,
+        "authoritative_source_hash": binding.authoritative_source_hash,
+        "transform_config_hash": binding.transform_config_hash,
+        "bundle_root_hash": binding.bundle_root_hash,
+        "persisted_corpus_digest": binding.persisted_corpus_digest,
+    }
+    gate_payload = payload["gate"]
+    assert isinstance(gate_payload, dict)
+    assert gate_payload["passed"] is False
+    assert gate_payload["failure_categories"] == [
+        "population_mismatch",
+        "semantic_validation",
+    ]
+
+    diagnostics = payload["drift_diagnostics"]
+    assert isinstance(diagnostics, dict)
+    assert diagnostics["classified_leaves"] == CLASSIFIED_LEAVES
+    assert diagnostics["represented_leaves"] > 10_000

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -19,8 +19,13 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from afterworlds.ingestion.corpus.operational import (
+    build_operational_corpus_snapshot,
+    operational_corpus_digest,
+)
 from afterworlds.ingestion.mechanical import publication
 from afterworlds.ingestion.mechanical.gate import (
+    SUPPORTED_CORPUS_CONTRACT_VERSIONS,
     GateFailureCategory,
     run_publication_gate,
 )
@@ -664,6 +669,34 @@ def test_an_unpublishable_5c_release_fails_even_when_everything_agrees(
     tamper(session)
     session.flush()
     result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.outcome is PublicationOutcome.STALE
+    assert result.gate is not None
+    assert result.gate.categories() == {GateFailureCategory.BOUND_RELEASE}
+    assert active_rows(session) == []
+
+
+def test_a_future_5c_contract_fails_closed_even_with_a_valid_digest(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """5d compatibility stays pinned when the 5c producer contract advances."""
+    assert frozenset({"5c-operational-1"}) == SUPPORTED_CORPUS_CONTRACT_VERSIONS
+
+    future_contract_version = "5c-operational-2"
+    release = release_row(session)
+    assert release.persisted_corpus_digest is not None
+    release.corpus_contract_version = future_contract_version
+    snapshot = build_operational_corpus_snapshot(
+        session,
+        PACKAGE_UUID,
+        corpus_contract_version=future_contract_version,
+        persisted_corpus_digest=release.persisted_corpus_digest,
+    )
+    release.operational_corpus_digest = operational_corpus_digest(snapshot)
+    session.flush()
+
+    uuid = persist(session)
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+
     assert result.outcome is PublicationOutcome.STALE
     assert result.gate is not None
     assert result.gate.categories() == {GateFailureCategory.BOUND_RELEASE}

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -1,0 +1,888 @@
+"""Atomic publication and activation — CRD Issue 5d, Decision 8.
+
+The four contract properties, each proven by observing the database rather than
+the return value alone: a failed gate leaves no partial active state, published
+projections stop verifying once edited, an identical rebuild is idempotent, and
+a competing projection cannot take a package's active authority.
+
+Publication commits, so every test here gets its own database.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import shutil
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical import publication
+from afterworlds.ingestion.mechanical.gate import (
+    GateFailureCategory,
+    run_publication_gate,
+)
+from afterworlds.ingestion.mechanical.oracle import (
+    AcceptedOracle,
+    committed_oracle_for,
+    oracle_identity,
+)
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+)
+from afterworlds.ingestion.mechanical.projection import identify_projection
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    _activate_projection,
+    _publish_projection,
+    publish_from_committed_oracle,
+    resolve_active_projection,
+)
+from afterworlds.ingestion.mechanical.report import EvidenceReport, report_hash
+from afterworlds.ingestion.mechanical.representation import (
+    ProvenanceTargetKind,
+    fact_key,
+)
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalActiveProjectionORM,
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+)
+from afterworlds.persistence.orm.rules_package import RuleChunkORM, RulesPackageORM
+from tests.ingestion.mechanical.conftest import (
+    BOUNDED_ORACLE_PATH,
+    DESCRIPTOR_FACT,
+    DESCRIPTOR_KEY,
+    NOW,
+    PACKAGE_UUID,
+    SPELL_KEY,
+    build_candidate,
+    build_ledger,
+    build_representation,
+)
+from tests.ingestion.mechanical.test_gate import persist
+
+LATER = "2026-08-01T00:00:00Z"
+
+
+def header(session: Session, uuid: str) -> MechanicalProjectionORM:
+    return session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == uuid
+        )
+    ).scalar_one()
+
+
+def active_rows(session: Session) -> list[MechanicalActiveProjectionORM]:
+    return list(session.execute(select(MechanicalActiveProjectionORM)).scalars().all())
+
+
+def a_different_projection(
+    session: Session, oracle: AcceptedOracle
+) -> tuple[str, AcceptedOracle]:
+    """A second projection over the same package, and the oracle that accepts it.
+
+    Its spell descriptor states a different level, so it is a different
+    projection identity — a genuinely *competing* authority rather than a
+    rebuild. It comes with its own accepted oracle because that is the only way
+    a second projection can pass the gate at all: the gate derives the expected
+    identity from the oracle, so one oracle can bless exactly one projection.
+
+    That is what makes the competing-activation branch reachable. Two committed
+    oracles for one release are rejected at load, but publication takes the
+    oracle it is given, and "someone published against a second accepted
+    authority" is precisely the split the active-projection key exists to stop.
+    """
+    changed = dataclasses.replace(DESCRIPTOR_FACT, level=8)
+    base = build_representation()
+    representation = dataclasses.replace(
+        base,
+        components=(
+            dataclasses.replace(base.components[0], facts=(changed,)),
+            base.components[1],
+        ),
+        provenance=tuple(
+            (
+                dataclasses.replace(
+                    p, target_key=(SPELL_KEY, DESCRIPTOR_KEY, fact_key(changed))
+                )
+                if p.target_kind is ProvenanceTargetKind.FACT
+                else p
+            )
+            for p in base.provenance
+        ),
+    )
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), representation=representation)
+    )
+    return uuid, dataclasses.replace(oracle, representation=representation)
+
+
+# ---------------------------------------------------------------------------
+# The happy path
+# ---------------------------------------------------------------------------
+
+
+def test_a_complete_projection_publishes_and_becomes_active(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+
+    assert result.outcome is PublicationOutcome.PUBLISHED
+    assert result.report is not None
+    assert result.evidence_report_hash == report_hash(result.report)
+
+    row = header(session, uuid)
+    assert row.publication_status == "published"
+    assert row.published_at == NOW
+    assert row.oracle_identity == oracle_identity(committed_oracle)
+    assert row.evidence_report_hash == result.evidence_report_hash
+    assert row.report_payload == result.report.payload
+
+    active = resolve_active_projection(session, PACKAGE_UUID)
+    assert active.outcome is PublicationOutcome.PUBLISHED
+    assert active.projection_uuid == uuid
+    assert active.activated_at == NOW
+
+
+def test_publication_survives_a_new_session(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Publication commits, so it is durable rather than pending in a session."""
+    uuid = persist(session)
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=NOW).outcome
+        is PublicationOutcome.PUBLISHED
+    )
+    session.expunge_all()
+    assert resolve_active_projection(session, PACKAGE_UUID).projection_uuid == uuid
+
+
+# ---------------------------------------------------------------------------
+# A failed gate leaves nothing behind
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_gate_leaves_no_partial_active_state(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    ledger = build_ledger()
+    unaccepted = dataclasses.replace(ledger, acceptances=())
+    uuid = persist(
+        session, dataclasses.replace(build_candidate(), classification=unaccepted)
+    )
+
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.outcome is PublicationOutcome.UNREVIEWED
+
+    row = header(session, uuid)
+    assert row.publication_status == "draft"
+    assert row.published_at is None
+    assert row.evidence_report_hash is None
+    assert row.report_payload is None
+    assert active_rows(session) == []
+    assert (
+        resolve_active_projection(session, PACKAGE_UUID).outcome
+        is PublicationOutcome.UNPUBLISHED
+    )
+
+
+def test_a_failed_gate_still_produces_an_auditable_report(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The refusal is returned as evidence, and is not written anywhere."""
+    uuid = persist(session)
+    session.execute(
+        MechanicalFactORM.__table__.delete().where(
+            MechanicalFactORM.projection_uuid == uuid
+        )
+    )
+    session.flush()
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.report is not None
+    gate = result.report.payload["gate"]
+    assert isinstance(gate, dict)
+    assert gate["passed"] is False
+    assert gate["failures"]
+    assert header(session, uuid).report_payload is None
+
+
+def test_activation_after_a_failed_gate_is_refused(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Activation is fail-closed on its own, not because publication behaved.
+
+    Called directly, with nothing between it and the database — the state a
+    caller who skipped the gate, or ran it and ignored the answer, would be in.
+    """
+    uuid = persist(session)
+    session.execute(
+        MechanicalFactORM.__table__.delete().where(
+            MechanicalFactORM.projection_uuid == uuid
+        )
+    )
+    session.flush()
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=NOW).outcome
+        is not PublicationOutcome.PUBLISHED
+    )
+
+    direct = _activate_projection(session, uuid, now=NOW)
+    assert direct.outcome is PublicationOutcome.UNPUBLISHED
+    assert active_rows(session) == []
+
+
+def test_activation_of_an_unknown_projection_is_absent(session: Session) -> None:
+    assert (
+        _activate_projection(session, "no-such-projection", now=NOW).outcome
+        is PublicationOutcome.ABSENT
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotence and immutability
+# ---------------------------------------------------------------------------
+
+
+def test_publishing_the_same_projection_twice_is_idempotent(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """An identical rebuild is the same content-derived identity.
+
+    The second attempt still runs the complete gate — reuse is never accepted
+    on a status check alone — and leaves the activation record byte-identical.
+    """
+    uuid = persist(session)
+    first = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    before = (
+        active_rows(session)[0].projection_uuid,
+        active_rows(session)[0].activated_at,
+    )
+
+    second = _publish_projection(session, uuid, committed_oracle, now=LATER)
+    assert second.outcome is PublicationOutcome.ALREADY_PUBLISHED
+    assert second.gate is not None and second.gate.passed
+    assert second.evidence_report_hash == first.evidence_report_hash
+
+    assert len(active_rows(session)) == 1
+    assert (
+        active_rows(session)[0].projection_uuid,
+        active_rows(session)[0].activated_at,
+    ) == before
+    assert header(session, uuid).published_at == NOW
+
+
+def test_a_published_projection_edited_afterwards_stops_verifying(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Published projections are immutable: an edit is detected, not absorbed."""
+    uuid = persist(session)
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=NOW).outcome
+        is PublicationOutcome.PUBLISHED
+    )
+
+    row = session.execute(select(MechanicalFactORM)).scalars().one()
+    payload = dict(row.payload)
+    payload["level"] = 1
+    row.payload = payload
+    session.flush()
+
+    again = _publish_projection(session, uuid, committed_oracle, now=LATER)
+    assert again.outcome is PublicationOutcome.STALE
+
+
+def test_a_published_projection_whose_evidence_was_rewritten_is_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Recorded evidence must still be the evidence this state derives."""
+    uuid = persist(session)
+    _publish_projection(session, uuid, committed_oracle, now=NOW)
+    header(session, uuid).evidence_report_hash = "e" * 64
+    session.flush()
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=LATER).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Competing activation
+# ---------------------------------------------------------------------------
+
+
+def test_a_competing_projection_that_passes_its_own_gate_is_still_refused(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The challenger passes a gate — against its own accepted oracle.
+
+    This is the case that actually needs the active-projection key. The
+    challenger is internally honest, proven, and blessed by an oracle that
+    derives its exact identity, so nothing about *it* is wrong. It is refused
+    solely because the package already has active authority, and it is refused
+    before its own header is mutated, so it stays a draft rather than becoming
+    a second published-but-inactive projection.
+    """
+    incumbent = persist(session)
+    assert (
+        _publish_projection(session, incumbent, committed_oracle, now=NOW).outcome
+        is PublicationOutcome.PUBLISHED
+    )
+
+    challenger, challenger_oracle = a_different_projection(session, committed_oracle)
+    assert challenger != incumbent
+    assert run_publication_gate(session, challenger, challenger_oracle).passed
+
+    result = _publish_projection(session, challenger, challenger_oracle, now=LATER)
+    assert result.outcome is PublicationOutcome.ACTIVE_CONFLICT
+
+    assert header(session, challenger).publication_status == "draft"
+    assert header(session, challenger).evidence_report_hash is None
+    assert len(active_rows(session)) == 1
+    assert active_rows(session)[0].projection_uuid == incumbent
+    assert active_rows(session)[0].activated_at == NOW
+
+
+def test_a_competing_projection_judged_by_the_incumbents_oracle_is_incomplete(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """One oracle blesses exactly one projection.
+
+    Judged by the authority that accepted the incumbent, the challenger is not
+    the accepted content and never reaches the activation check at all.
+    """
+    incumbent = persist(session)
+    _publish_projection(session, incumbent, committed_oracle, now=NOW)
+
+    challenger, _ = a_different_projection(session, committed_oracle)
+    result = _publish_projection(session, challenger, committed_oracle, now=LATER)
+    assert result.outcome is PublicationOutcome.INCOMPLETE
+    assert active_rows(session)[0].projection_uuid == incumbent
+
+
+def test_activating_a_second_published_projection_is_an_active_conflict(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The activation seam itself refuses to split, whatever the caller did.
+
+    The challenger is forced into a ``published`` header with recorded evidence
+    — the state a bug, a partial migration, or a hand edit could produce — and
+    activation still refuses, because one active projection per package is a
+    primary key rather than a convention.
+    """
+    incumbent = persist(session)
+    _publish_projection(session, incumbent, committed_oracle, now=NOW)
+
+    challenger, _ = a_different_projection(session, committed_oracle)
+    forced = header(session, challenger)
+    forced.publication_status = "published"
+    forced.evidence_report_hash = "f" * 64
+    session.flush()
+
+    result = _activate_projection(session, challenger, now=LATER)
+    assert result.outcome is PublicationOutcome.ACTIVE_CONFLICT
+    assert len(active_rows(session)) == 1
+    assert active_rows(session)[0].projection_uuid == incumbent
+    assert active_rows(session)[0].activated_at == NOW
+
+
+# ---------------------------------------------------------------------------
+# Typed outcomes, never None
+# ---------------------------------------------------------------------------
+
+
+def test_no_accepted_oracle_is_absent_not_a_pass(session: Session) -> None:
+    """An absent oracle is never an empty one: nothing is published by default."""
+    uuid = persist(session)
+    result = _publish_projection(session, uuid, None, now=NOW)
+    assert result.outcome is PublicationOutcome.ABSENT
+    assert result.gate is None
+    assert active_rows(session) == []
+
+
+def test_the_committed_oracle_path_refuses_a_release_with_no_authority(
+    session: Session,
+) -> None:
+    """The production entry resolves its own oracle and fails closed.
+
+    Nothing is committed for this release, so the projection cannot be
+    published — no caller can supply the authority that judges its own output.
+    """
+    uuid = persist(session)
+    result = publish_from_committed_oracle(session, uuid, now=NOW)
+    assert result.outcome is PublicationOutcome.ABSENT
+    assert active_rows(session) == []
+
+
+def test_publishing_an_unknown_projection_is_absent(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    result = _publish_projection(
+        session, "no-such-projection", committed_oracle, now=NOW
+    )
+    assert result.outcome is PublicationOutcome.ABSENT
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        pytest.param(
+            lambda c: dataclasses.replace(
+                c, binding=dataclasses.replace(c.binding, bundle_root_hash="9" * 64)
+            ),
+            # Not "mismatched release": the declared binding names no published
+            # 5c release at all, which is a statement about the record rather
+            # than about which authority judges it.
+            PublicationOutcome.STALE,
+            id="binding-names-no-published-release",
+        ),
+        pytest.param(
+            lambda c: dataclasses.replace(
+                c,
+                classification=dataclasses.replace(c.classification, acceptances=()),
+            ),
+            PublicationOutcome.UNREVIEWED,
+            id="unreviewed-residue",
+        ),
+    ],
+)
+def test_each_refusal_has_its_own_typed_outcome(
+    session: Session,
+    committed_oracle: AcceptedOracle,
+    mutate,  # type: ignore[no-untyped-def]
+    expected: PublicationOutcome,
+) -> None:
+    """Refusals stay distinguishable rather than collapsing into one failure."""
+    uuid = persist(session, mutate(build_candidate()))
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=NOW).outcome
+        is expected
+    )
+
+
+def test_an_oracle_over_another_release_is_a_mismatched_release(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A well-bound projection judged by authority accepted elsewhere.
+
+    Distinct from a binding that names no published release: here the record is
+    sound and the *authority* is wrong, so the outcome must say so.
+    """
+    uuid = persist(session)
+    elsewhere = dataclasses.replace(
+        committed_oracle,
+        binding=dataclasses.replace(
+            committed_oracle.binding, release_version="rel-other"
+        ),
+    )
+    assert (
+        _publish_projection(session, uuid, elsewhere, now=NOW).outcome
+        is PublicationOutcome.MISMATCHED_RELEASE
+    )
+
+
+def test_an_undrafted_projection_is_never_activated(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A draft with no recorded proof cannot reach publication at all."""
+    identified = identify_projection(build_candidate())
+    persist_draft(session, identified, now=NOW)
+    result = _publish_projection(
+        session, identified.projection_uuid, committed_oracle, now=NOW
+    )
+    assert result.outcome is PublicationOutcome.STALE
+    assert active_rows(session) == []
+
+
+def test_a_projection_in_an_unknown_status_is_refused(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Status no publication path produces is rejected, not interpreted."""
+    uuid = persist(session)
+    header(session, uuid).publication_status = "retired"
+    session.flush()
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.outcome is PublicationOutcome.STALE
+    assert active_rows(session) == []
+
+
+def test_record_digest_is_not_re_recorded_on_the_reuse_path(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Publishing twice must not try to record a proof that already exists."""
+    uuid = persist(session)
+    digest = header(session, uuid).persisted_state_digest
+    _publish_projection(session, uuid, committed_oracle, now=NOW)
+    _publish_projection(session, uuid, committed_oracle, now=LATER)
+    assert header(session, uuid).persisted_state_digest == digest
+
+
+def test_publication_leaves_the_projection_content_untouched(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Activation is package state, so it never changes a projection's proof."""
+    uuid = persist(session)
+    before = header(session, uuid).persisted_state_digest
+    payload_hash = header(session, uuid).payload_hash
+    _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert header(session, uuid).persisted_state_digest == before
+    assert header(session, uuid).payload_hash == payload_hash
+
+
+# ---------------------------------------------------------------------------
+# The supported surface
+# ---------------------------------------------------------------------------
+
+
+def test_no_exported_publication_function_accepts_caller_authority() -> None:
+    """The bypass is closed at the surface, not only on the paths tests take.
+
+    Asserted over the module's public names rather than by calling one of them,
+    because the defect this forecloses is *re-exporting*: a later change that
+    made the gated path optional again would pass every behavioural test here
+    and still hand a caller the authority that judges its own output.
+    """
+    exported = {
+        name: getattr(publication, name)
+        for name in publication.__all__
+        if inspect.isfunction(getattr(publication, name))
+    }
+    assert exported, "nothing exported: the assertion below would be vacuous"
+    for name, function in exported.items():
+        supplied = set(inspect.signature(function).parameters)
+        assert {"oracle", "directory"}.isdisjoint(supplied), name
+
+    # The resolver is the sibling: an exported helper that accepts a directory
+    # is the same bypass one step earlier.
+    assert "directory" not in inspect.signature(committed_oracle_for).parameters
+    assert not hasattr(publication, "publish_projection")
+    assert not hasattr(publication, "activate_projection")
+
+
+def test_the_production_entry_takes_no_oracle_directory(
+    session: Session, tmp_path: Path
+) -> None:
+    """A writable directory holding a self-authored oracle cannot be pointed at.
+
+    The oracle for this fixture release exists on disk and loads, so the only
+    thing between it and a successful publication is that the production entry
+    has no way to be told where to look.
+    """
+    shutil.copyfile(BOUNDED_ORACLE_PATH, tmp_path / "self-authored.json")
+    uuid = persist(session)
+    with pytest.raises(TypeError):
+        publish_from_committed_oracle(  # type: ignore[call-arg]
+            session, uuid, now=NOW, directory=tmp_path
+        )
+    assert (
+        publish_from_committed_oracle(session, uuid, now=NOW).outcome
+        is PublicationOutcome.ABSENT
+    )
+    assert active_rows(session) == []
+
+
+# ---------------------------------------------------------------------------
+# The bound 5c release must be an exactly-published, reconstructable release
+# ---------------------------------------------------------------------------
+
+
+def release_row(session: Session) -> CorpusReleaseORM:
+    return session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == PACKAGE_UUID)
+    ).scalar_one()
+
+
+def package_row(session: Session) -> RulesPackageORM:
+    return session.execute(
+        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == PACKAGE_UUID)
+    ).scalar_one()
+
+
+def a_chunk(session: Session) -> RuleChunkORM:
+    return session.execute(select(RuleChunkORM)).scalars().first()  # type: ignore[return-value]
+
+
+def test_a_fabricated_binding_both_sides_agree_on_still_fails(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The exact defect: two claims agreeing is not authority.
+
+    The projection and the oracle carry the *same* six-value binding, so every
+    comparison the gate makes between them succeeds and the oracle derives this
+    projection's identity. It is refused because no published 5c release
+    records that binding.
+    """
+    forged = dataclasses.replace(
+        build_candidate().binding, persisted_corpus_digest="9" * 64
+    )
+    uuid = persist(session, dataclasses.replace(build_candidate(), binding=forged))
+    agreeing = dataclasses.replace(committed_oracle, binding=forged)
+
+    result = _publish_projection(session, uuid, agreeing, now=NOW)
+    assert result.outcome is PublicationOutcome.STALE
+    assert result.gate is not None
+    assert result.gate.categories() == {GateFailureCategory.BOUND_RELEASE}
+    assert active_rows(session) == []
+
+
+@pytest.mark.parametrize(
+    "tamper",
+    [
+        pytest.param(
+            lambda s: setattr(release_row(s), "publication_status", "draft"),
+            id="release-still-draft",
+        ),
+        pytest.param(
+            lambda s: setattr(package_row(s), "publication_status", "draft"),
+            id="package-not-published",
+        ),
+        pytest.param(
+            lambda s: setattr(package_row(s), "is_enabled", False),
+            id="package-disabled",
+        ),
+        pytest.param(
+            lambda s: setattr(a_chunk(s), "content", a_chunk(s).content + "!"),
+            id="release-content-edited-under-its-recorded-proof",
+        ),
+    ],
+)
+def test_an_unpublishable_5c_release_fails_even_when_everything_agrees(
+    session: Session,
+    committed_oracle: AcceptedOracle,
+    tamper,  # type: ignore[no-untyped-def]
+) -> None:
+    """A projection that would otherwise publish, over a release that must not.
+
+    Each control leaves the projection and the oracle untouched and exactly
+    right, so the only thing refusing publication is the release itself.
+    """
+    uuid = persist(session)
+    tamper(session)
+    session.flush()
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.outcome is PublicationOutcome.STALE
+    assert result.gate is not None
+    assert result.gate.categories() == {GateFailureCategory.BOUND_RELEASE}
+    assert active_rows(session) == []
+
+
+@pytest.mark.parametrize(
+    "diagnostic_edit",
+    [
+        pytest.param(
+            lambda s: setattr(release_row(s), "report_payload", None),
+            id="report-payload",
+        ),
+        pytest.param(
+            lambda s: setattr(release_row(s), "ledger_hash", "9" * 64),
+            id="historical-ledger-hash",
+        ),
+    ],
+)
+def test_5d_does_not_reprove_diagnostic_5c_evidence(
+    session: Session,
+    committed_oracle: AcceptedOracle,
+    diagnostic_edit,  # type: ignore[no-untyped-def]
+) -> None:
+    """The amended trust seam ignores 5c's historical proof genealogy."""
+    uuid = persist(session)
+    diagnostic_edit(session)
+    session.flush()
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.outcome is PublicationOutcome.PUBLISHED
+
+
+# ---------------------------------------------------------------------------
+# Recorded evidence is verified before an already-published projection is reused
+# ---------------------------------------------------------------------------
+
+
+def published(session: Session, oracle: AcceptedOracle) -> str:
+    uuid = persist(session)
+    assert (
+        _publish_projection(session, uuid, oracle, now=NOW).outcome
+        is PublicationOutcome.PUBLISHED
+    )
+    return uuid
+
+
+def test_reuse_with_a_cleared_evidence_payload_is_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The recorded evidence stopped being reconstructable from the database."""
+    uuid = published(session, committed_oracle)
+    header(session, uuid).report_payload = None
+    session.flush()
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=LATER).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+def test_reuse_with_an_edited_payload_under_an_unchanged_hash_is_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """The hash column identifies a payload; it is not a substitute for it."""
+    uuid = published(session, committed_oracle)
+    row = header(session, uuid)
+    edited = dict(row.report_payload or {})
+    edited["drift_diagnostics"] = {"records": 999}
+    row.report_payload = edited
+    session.flush()
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=LATER).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+def test_reuse_with_a_payload_and_hash_edited_together_is_still_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Internal consistency is not the test; deriving the same report is.
+
+    Editing both columns so they agree defeats a rehash-only check. It does not
+    defeat comparing the persisted payload with the report this reconstructed
+    state and this committed oracle actually derive.
+    """
+    uuid = published(session, committed_oracle)
+    row = header(session, uuid)
+    edited = dict(row.report_payload or {})
+    edited["drift_diagnostics"] = {"records": 999}
+    row.report_payload = edited
+    row.evidence_report_hash = report_hash(EvidenceReport(payload=edited))
+    session.flush()
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=LATER).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+def test_reuse_under_a_different_judging_oracle_is_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Which authority passed this projection is part of the evidence."""
+    uuid = published(session, committed_oracle)
+    header(session, uuid).oracle_identity = "f" * 64
+    session.flush()
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=LATER).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+def test_a_hand_marked_published_header_cannot_become_active(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A status column and a non-NULL hash are not publication evidence.
+
+    The state a partial migration or a direct row edit leaves behind: the
+    header claims to be published, and there is no incumbent to collide with.
+    Publication is the only door, and it refuses.
+    """
+    uuid = persist(session)
+    row = header(session, uuid)
+    row.publication_status = "published"
+    row.evidence_report_hash = "e" * 64
+    row.published_at = NOW
+    session.flush()
+
+    assert (
+        _publish_projection(session, uuid, committed_oracle, now=LATER).outcome
+        is PublicationOutcome.STALE
+    )
+    assert active_rows(session) == []
+    assert (
+        resolve_active_projection(session, PACKAGE_UUID).outcome
+        is PublicationOutcome.UNPUBLISHED
+    )
+
+
+@pytest.mark.parametrize(
+    "clear",
+    [
+        pytest.param("evidence_report_hash", id="hash-cleared"),
+        pytest.param("oracle_identity", id="judging-oracle-cleared"),
+        pytest.param("published_at", id="published_at-cleared"),
+        pytest.param("persisted_state_digest", id="persisted-state-proof-cleared"),
+    ],
+)
+def test_a_missing_publication_evidence_field_makes_active_authority_stale(
+    session: Session, committed_oracle: AcceptedOracle, clear: str
+) -> None:
+    """Publication evidence exists as a set; a partial one proves nothing.
+
+    The state a partial migration or an interrupted write leaves behind — some
+    columns populated, one NULL — which reads as published to anything that
+    checks a status and one hash.
+    """
+    uuid = published(session, committed_oracle)
+    setattr(header(session, uuid), clear, None)
+    session.flush()
+    assert (
+        resolve_active_projection(session, PACKAGE_UUID).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+def test_an_obsolete_evidence_schema_makes_active_authority_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """A payload from a superseded report shape is not this schema's evidence."""
+    uuid = published(session, committed_oracle)
+    row = header(session, uuid)
+    superseded = dict(row.report_payload or {})
+    superseded["report_version"] = "5d-mechanical-evidence-0"
+    row.report_payload = superseded
+    row.evidence_report_hash = report_hash(EvidenceReport(payload=superseded))
+    session.flush()
+    assert (
+        resolve_active_projection(session, PACKAGE_UUID).outcome
+        is PublicationOutcome.STALE
+    )
+
+
+def test_the_production_entry_is_absent_for_an_unknown_projection(
+    session: Session,
+) -> None:
+    """It resolves the oracle from the header, so no header is no authority."""
+    assert (
+        publish_from_committed_oracle(session, "no-such-projection", now=NOW).outcome
+        is PublicationOutcome.ABSENT
+    )
+
+
+def test_a_forged_activation_row_is_not_reported_as_valid_authority(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """An activation row is a pointer, not a claim that its target is proven."""
+    uuid = persist(session)
+    session.add(
+        MechanicalActiveProjectionORM(
+            package_uuid=PACKAGE_UUID, projection_uuid=uuid, activated_at=NOW
+        )
+    )
+    session.flush()
+    resolved = resolve_active_projection(session, PACKAGE_UUID)
+    assert resolved.outcome is PublicationOutcome.STALE
+    assert resolved.projection_uuid == uuid
+
+
+def test_an_active_projection_whose_evidence_was_cleared_is_stale(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Resolution asserts recorded-evidence closure, not just row presence."""
+    uuid = published(session, committed_oracle)
+    assert (
+        resolve_active_projection(session, PACKAGE_UUID).outcome
+        is PublicationOutcome.PUBLISHED
+    )
+    header(session, uuid).report_payload = None
+    session.flush()
+    assert (
+        resolve_active_projection(session, PACKAGE_UUID).outcome
+        is PublicationOutcome.STALE
+    )

--- a/tests/ingestion/mechanical/test_raw_state_closure.py
+++ b/tests/ingestion/mechanical/test_raw_state_closure.py
@@ -40,6 +40,7 @@ from afterworlds.persistence.orm.corpus import CorpusReleaseORM
 from afterworlds.persistence.orm.mechanical import (
     MechanicalAcceptanceBatchORM,
     MechanicalAcceptanceORM,
+    MechanicalActiveProjectionORM,
     MechanicalBatchDiffORM,
     MechanicalBatchScopeORM,
     MechanicalComponentORM,
@@ -80,6 +81,11 @@ TABLE_POLICY: dict[type, str] = {
     MechanicalRelationshipORM: "semantic",
     MechanicalReferenceORM: "semantic",
     MechanicalProvenanceORM: "semantic",
+    # Package-scoped, not projection-scoped: which projection a package has
+    # activated is not part of any projection's reconstructed meaning, so it is
+    # deliberately outside the raw row set and the persisted-state digest. A
+    # projection's content must not change when it is activated.
+    MechanicalActiveProjectionORM: "activation",
 }
 
 
@@ -499,7 +505,7 @@ def test_every_scoped_table_is_loaded_into_the_raw_state(session: Session) -> No
     scoped = {
         model.__tablename__  # type: ignore[attr-defined]
         for model, policy in TABLE_POLICY.items()
-        if policy != "header"
+        if policy not in {"header", "activation"}
     }
     # The default batch-reviewed candidate populates every scoped table except
     # references, which the honest fixture leaves empty.

--- a/tests/ingestion/mechanical/test_report.py
+++ b/tests/ingestion/mechanical/test_report.py
@@ -1,0 +1,189 @@
+"""The deterministic evidence report — CRD Issue 5d.
+
+The report is the audit trail for a publication decision, so it has to be
+reproducible from the same inputs and complete enough to re-derive the verdict
+without the database that produced it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.gate import run_publication_gate
+from afterworlds.ingestion.mechanical.oracle import AcceptedOracle, oracle_identity
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    _publish_projection,
+)
+from afterworlds.ingestion.mechanical.report import (
+    EVIDENCE_REPORT_SCHEMA_VERSION,
+    build_evidence_report,
+    report_hash,
+)
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+)
+from tests.ingestion.mechanical.conftest import NOW, build_candidate, build_ledger
+from tests.ingestion.mechanical.test_gate import persist
+
+LATER = "2026-08-01T00:00:00Z"
+
+
+def build(session: Session, uuid: str, oracle: AcceptedOracle):  # type: ignore[no-untyped-def]
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == uuid
+        )
+    ).scalar_one()
+    return build_evidence_report(header, run_publication_gate(session, uuid, oracle))
+
+
+def test_the_report_identifies_everything_needed_to_reproduce_the_decision(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    payload = build(session, uuid, committed_oracle).payload
+
+    assert payload["report_version"] == EVIDENCE_REPORT_SCHEMA_VERSION
+    source = payload["source_release"]
+    assert isinstance(source, dict)
+    assert set(source) == {
+        "package_uuid",
+        "release_version",
+        "authoritative_source_hash",
+        "transform_config_hash",
+        "bundle_root_hash",
+        "persisted_corpus_digest",
+    }
+
+    projection = payload["mechanical_projection"]
+    assert isinstance(projection, dict)
+    assert projection["projection_uuid"] == uuid
+    assert projection["persisted_state_digest"] is not None
+    assert projection["payload_hash"]
+
+    accepted = payload["accepted_oracle"]
+    assert isinstance(accepted, dict)
+    assert accepted["oracle_identity"] == oracle_identity(committed_oracle)
+    assert accepted["derived_projection_uuid"] == uuid
+
+    gate = payload["gate"]
+    assert isinstance(gate, dict)
+    assert gate == {"passed": True, "failure_categories": [], "failures": []}
+    assert payload["obligations"] == [
+        {"record_key": "spell:wish", "satisfied": True, "failures": []},
+        {
+            "record_key": "creature:wish-scoped-servant",
+            "satisfied": True,
+            "failures": [],
+        },
+    ]
+
+
+def test_the_report_is_byte_identical_for_the_same_state(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Same committed inputs, same persisted state, same hash — no wall clock."""
+    uuid = persist(session)
+    first = build(session, uuid, committed_oracle)
+    second = build(session, uuid, committed_oracle)
+    assert first.payload == second.payload
+    assert report_hash(first) == report_hash(second)
+
+
+def test_the_report_hash_survives_publication(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Publication status is not in the payload, so the hash does not move.
+
+    Asserted through ``_publish_projection`` itself, because that is where the
+    property is relied on: the reuse path compares the hash it re-derives from
+    a *published* header against the one recorded when the header was still a
+    draft, and treats a difference as divergence. If the payload carried the
+    status, every republication would look like tamper.
+    """
+    uuid = persist(session)
+    first = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert first.outcome is PublicationOutcome.PUBLISHED
+
+    second = _publish_projection(session, uuid, committed_oracle, now=LATER)
+    assert second.outcome is PublicationOutcome.ALREADY_PUBLISHED
+    assert second.evidence_report_hash == first.evidence_report_hash
+    assert second.report is not None and first.report is not None
+    assert second.report.payload == first.report.payload
+
+
+def test_a_changed_verdict_changes_the_report(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    honest = report_hash(build(session, uuid, committed_oracle))
+    session.execute(
+        MechanicalFactORM.__table__.delete().where(
+            MechanicalFactORM.projection_uuid == uuid
+        )
+    )
+    session.flush()
+    assert report_hash(build(session, uuid, committed_oracle)) != honest
+
+
+def test_a_refusal_reports_categorized_failures_and_failed_obligations(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Structured, not a wall of prose: an auditor can group and count them."""
+    ledger = build_ledger()
+    uuid = persist(
+        session,
+        dataclasses.replace(
+            build_candidate(),
+            classification=dataclasses.replace(ledger, acceptances=()),
+        ),
+    )
+    payload = build(session, uuid, committed_oracle).payload
+    gate = payload["gate"]
+    assert isinstance(gate, dict)
+    assert gate["passed"] is False
+    assert "unreviewed_residue" in gate["failure_categories"]
+    assert all(
+        set(f) == {"category", "detail"} and f["detail"] for f in gate["failures"]
+    )
+
+
+def test_diagnostics_are_named_as_drift_signal(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    """Counts are present and are labelled for what they are.
+
+    ADR-005d Decision 5 forbids proving completeness with totals. They live
+    under ``drift_diagnostics`` and nothing reads them to decide anything.
+    """
+    payload = build(session, persist(session), committed_oracle).payload
+    diagnostics = payload["drift_diagnostics"]
+    assert isinstance(diagnostics, dict)
+    assert diagnostics["represented_leaves"] == 3
+    assert diagnostics["facts"] == 1
+
+    # The verdict carries no totals of its own: it is a pass/fail plus
+    # categorized findings, so no reader can mistake a number for a proof.
+    gate = payload["gate"]
+    assert isinstance(gate, dict)
+    assert set(gate) == {"passed", "failure_categories", "failures"}
+
+
+def test_the_stored_report_is_the_returned_report(
+    session: Session, committed_oracle: AcceptedOracle
+) -> None:
+    uuid = persist(session)
+    result = _publish_projection(session, uuid, committed_oracle, now=NOW)
+    assert result.report is not None
+    header = session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == uuid
+        )
+    ).scalar_one()
+    assert header.report_payload == result.report.payload
+    assert header.evidence_report_hash == report_hash(result.report)

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -257,6 +257,7 @@ class TestRpTablePrefix:
             "rp_mech_relationships",
             "rp_mech_references",
             "rp_mech_provenance",
+            "rp_mech_active_projections",
         }
         actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
         assert (

--- a/tests/services/test_schema_separation_invariant.py
+++ b/tests/services/test_schema_separation_invariant.py
@@ -163,6 +163,7 @@ def test_rules_package_tables_exist_with_rp_prefix() -> None:
         "rp_mech_relationships",
         "rp_mech_references",
         "rp_mech_provenance",
+        "rp_mech_active_projections",
     }
     actual = {name for name in Base.metadata.tables if name.startswith(_RP_PREFIX)}
     assert (


### PR DESCRIPTION
Implements #137 / CRD Issue 5d: complete typed mechanical authority, exact completeness gating, deterministic evidence, and atomic activation.

## Restack

This branch was rebuilt onto the CRD Issue 5c operational correction in #146, which is merged into `main`. No commit from superseded #143 is present.

The former downstream call that reconstructed CRD Issue 5c's evidence report, ledger/policy/reconciliation hashes, and bundle genealogy has been removed. CRD Issue 5d now calls the 5c-owned `load_verified_operational_corpus` seam once, then adapts that already-verified snapshot into its bound-corpus validation view.

## Architecture Notes

No drift from design principles.

- CRD Issue 5d owns an explicit supported corpus-contract set, currently only `5c-operational-1`. A future CRD Issue 5c producer-version bump fails closed until 5d compatibility is deliberately reviewed and updated.
- The downstream boundary verifies the published authoritative SQLite corpus directly. It does not reopen Chroma or reconstruct CRD Issue 5c's diagnostic publication genealogy.
- Deterministic evidence in this PR is 5d-owned publication evidence required by ADR-005d, not a continuation of the prospectively superseded CRD Issue 5c byte-identical-incidental-artifact guarantee.
- This PR is publication infrastructure, not completion of CRD Issue 5d. No accepted production oracle is added; effective runtime binding, override-version, runtime-view, accepted-content, and legacy-removal work remain under #137.

## Binding publication behavior

- exact represented-leaf semantic accounting;
- accepted-oracle comparison independent of the candidate;
- closed typed-fact families and explicit prose-bound handling;
- exact source-subspan provenance and chunk-locality checks;
- deterministic projection identity and persisted-state reconstruction;
- fail-closed publication outcomes;
- atomic one-active-projection activation;
- idempotent and concurrency-safe publication;
- packaged committed-oracle discovery.

## Amended CRD Issue 5c boundary

CRD Issue 5d verifies that the named release:

- exists and is published/enabled;
- matches the six-value release binding;
- exposes a corpus contract in 5d's explicitly supported set;
- has structurally closed authoritative SQLite leaves, chunks, source membership, and projection edges;
- matches its recorded operational corpus digest.

CRD Issue 5d does not reopen Chroma or re-prove CRD Issue 5c's diagnostic evidence report and historical proof graph. Fresh CRD Issue 5c publication and verified reuse retain the live Chroma check implemented through #146.

## Production CRD Issue 5c release exercised

The production control builds and finalizes the committed D&D SRD 5.2.1 source, then verifies CRD Issue 5d's fail-closed publication behavior against this exact release:

- package UUID: `4458fa10-4a66-5e0e-9ecc-ea37530ad2b4`
- release version: `5.2.1-corpus.36b786d8-fa2`
- authoritative source SHA-256: `8974902d109d6e63672d7c490bde9ccf052410503d9cfa768237154fbc5e3d87`
- transform-config SHA-256: `77720c2f3b8c9b88363d48050466fb8e3a26f8476b63145d1b5928ff2581ef3e`
- corpus contract accepted by this transformation: `5c-operational-1`

No accepted oracle exists for that production release, so the production path remains unavailable and fails closed as designed.

## Verification

Current head `34b0e57`:

- focused operational-contract, gate, and publication suites: 79 passed;
- genuine concurrent-publication suite: 23 passed;
- real-SRD production-release suite: 8 passed;
- Black on changed files: passed;
- Ruff on changed files: passed;
- strict mypy on changed source files: passed;
- `git diff --check`: passed.

The immediately preceding head passed 3,074 Python tests with 10 skipped, plus Black, Ruff, strict mypy, pip-audit, and E2E. CI is rerunning on the current head.

Frontend typecheck, lint, formatting, Vitest, and E2E previously passed; `npm audit` alone failed on baseline advisories in `brace-expansion` and `postcss`. This PR changes no frontend dependency or lock file; baseline dependency remediation remains separate from #141.

## PR disposition

- #143 is closed unmerged as superseded by the 2026-08-03 Operational Reliability Amendment.
- #142 remains closed unmerged.
- #144 is merged documentation authority.
- #146 is the merged main-based CRD Issue 5c operational correction.
- #141 remains open and unmerged pending fresh Codex review of this head.
- #137 remains open after this infrastructure PR; CRD Issue 5d is not complete.