### PR TITLE
fix: close the 5c published-release proof boundary

### DIFF
--- a/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
+++ b/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
@@ -1,0 +1,145 @@
+# PR #142 Remediation Log — CRD Issue 5c recorded-evidence schema
+
+Archive of detailed investigation and negative-control evidence for the stacked
+5c recorded-evidence hardening. Kept out of the PR body so that body stays a
+one-screen statement of what changed and why it is separately reviewable.
+
+**Why this PR exists.** PR #141 round 4 produced a fourth consecutive finding in
+the same 5c recorded-evidence verification seam. Its renewed stop condition
+required escalation rather than a fifth local patch, so the hardening is
+delivered here, reviewed on its own, and merged into
+`feature/issue-5d-publication-gate`. It is based on that branch and not on
+`main` because `verify_published_release` and the round-3 report helpers are
+introduced by #141 and do not exist upstream yet.
+
+---
+
+## The finding, and the family behind it
+
+Codex (PR #141, thread on `report.py:158`) is correct. `VERSION_CANARIES`
+defines six required checks; round 3's `verdict_violations` iterated whatever
+`version_canaries` happened to contain and required each present entry to be
+`True`. It never required the map to *be* the canonical population. Once
+`report_payload` and `evidence_report_hash` are edited together, `{}`,
+`{"invented": true}`, or a partial map all satisfy recorded verdict validation,
+and `verify_published_release` accepts evidence recording none of the required
+version checks. `{}` is the sharpest case: `all(...)` over nothing is vacuously
+true.
+
+**Defect family:** *the recorded evidence validator checks required values but
+does not prove the exact population of every closed schema inventory.*
+`version_canaries` is one instance, and the fix is not a canary check.
+
+## Inventory audit — every map classified explicitly
+
+Audited before editing: the top-level report key set, `version_canaries`,
+`findings`, `accounting`, every other nested map, `REQUIRED_REPORT_KEYS`,
+`EVIDENCE_REPORT_SCHEMA_VERSION`, `VERSION_CANARIES`, `build_report`,
+`verdict_violations`, `recorded_success_violations`, `run_gate`,
+`verify_published_release`, fresh finalization, and verified reuse.
+
+| Map | Classification | Population fixed by |
+| --- | --- | --- |
+| top-level report keys | **closed** | `REQUIRED_REPORT_KEYS` |
+| `version_canaries` | **closed, verdict-bearing** | `VERSION_CANARIES` (derived) |
+| `findings` | **closed, verdict-bearing** | `_ZERO_FINDINGS` |
+| `accounting` | **closed, verdict-bearing** | `_ACCOUNTING_KEYS` |
+| `reproduction_target` | **closed, structural** | `build_report` literal |
+| `reconciliation_policy_reference` | **closed, structural** | `build_report` literal |
+| `source_ledger_leaf_totals` | **open** | leaf types occurring in the corpus |
+| `represented_totals` | **open** | leaf types occurring in the corpus |
+| `excluded_totals_by_reason` | **open** | exclusion reasons actually applied |
+| `transform_identity` | **open** | the recorded transform config's own identity payload |
+| `rules_corpus_vector_identity` | **open** | the vector-identity builder |
+
+The open maps are `Counter` results and config passthroughs: a release with no
+table cells legitimately has no `table_cell` total, so demanding an exact
+population would be demanding a particular corpus. That distinction is now
+declared in code — `OPEN_REPORT_MAPS` — rather than left implicit, so nobody
+later "hardens" it into a false failure.
+
+## The correction
+
+One canonical 5c-owned validator, as before; no second canary check anywhere, no
+5d-side check, no parallel validator in `corpus.persistence`, no schema
+framework.
+
+- `CANONICAL_CANARY_NAMES = frozenset(c.name for c in VERSION_CANARIES)` —
+  **derived**, so adding or retiring a canary moves the required population with
+  no second list to remember.
+- `_CLOSED_VERDICT_MAPS` and `_CLOSED_STRUCTURAL_MAPS` declare the closed
+  inventories; `OPEN_REPORT_MAPS` declares the open ones.
+- `_closed_map_violations` reports missing and unexpected entries separately —
+  an omission and a foreign key are different findings.
+- `verdict_violations` now checks **population before values** for the
+  verdict-bearing maps. That runs on both sides of the boundary, which closes
+  the same omission in `build_report`: `all(c.passed for c in ())` was vacuously
+  true, so a report built from a partial canary run would have recorded `"pass"`.
+  It cannot now.
+- `recorded_success_violations` additionally requires the top-level key set to
+  match **exactly** — previously only missing keys were reported, so an
+  edited-and-rehashed payload could carry an unknown field under the same schema
+  version — and closes the two structural maps.
+
+**No schema-version bump.** The canonical payload shape is unchanged; this
+enforces semantics every honestly built report already satisfies. Verified: the
+real full-SRD report and the bounded fixture report both pass unchanged, and
+`EVIDENCE_REPORT_SCHEMA_VERSION` is bound into the transform identity, so a bump
+would mint a new 5c release identity for no shape change.
+
+**Test-fixture consequence.** The bounded mechanical fixture built its report
+with `canaries=()`. That is now refused, correctly, so it supplies the complete
+canonical population via `BOUND_CANARIES`, derived from `VERSION_CANARIES` —
+standing in for a real canary run exactly as the rest of that synthetic release
+stands in for a real corpus. The bounded oracle needed no regeneration: the
+report is not a bundle member and the six binding values are untouched.
+
+## Negative controls
+
+**Canary population** — `tests/ingestion/corpus/test_recorded_evidence.py`:
+`{}`, invented-only, missing one canonical name, canonical plus one invented,
+a canonical canary `False`, a canonical canary non-boolean; and the positive
+control, the exact six all `True`, passing. Plus
+`test_the_canonical_canary_set_is_derived_not_restated`, which holds the
+constant to `VERSION_CANARIES` so a hand-written duplicate cannot creep back.
+
+**Sibling inventories** — `findings` partial and with an extra key; `accounting`
+with an extra key; `reproduction_target` empty and with an extra key;
+`reconciliation_policy_reference` with wrong keys; an unknown top-level key.
+And the counter-control: each of the five open maps accepts an arbitrary
+content-derived key.
+
+**Writing side** —
+`test_build_report_refuses_to_claim_success_over_an_incomplete_canary_run`.
+
+**End-to-end** — the mechanical bound-release matrix gained six cases that
+rewrite the release's recorded report **and rehash it**, so the payload still
+hashes to its recorded hash and all five proof identities are untouched: no
+canaries, invented-only canary, one canonical canary omitted, an invented canary
+added, an incomplete `findings` population, and an unknown top-level key. Each
+returns `STALE` with exactly `{BOUND_RELEASE}` from
+`publish_from_committed_oracle` — publication refused, not merely a validator
+returning a string.
+
+## Verification
+
+`black` clean · `ruff check` clean · `mypy --strict` clean (210 files) ·
+5c corpus + mechanical suites **764 passed** (includes the real-SRD production
+control and the full 5c report/gate/persistence/finalization/reuse suites) ·
+recorded-evidence module **49 passed** · mechanical publication **55 passed** ·
+full default suite **3141 passed, 10 skipped** (93.42%).
+
+No Chroma dependency, no Owner Decision, no ADR or Issue amendment, and nothing
+outside the recorded-evidence schema was touched.
+
+## Further stop condition
+
+If review of this PR finds another omitted closed inventory in the same report
+schema after this audit, the hand-maintained validation is replaced by an
+explicit typed canonical report schema whose construction, hashing, persistence,
+and recorded verification all use one object — not another field-by-field patch.
+
+During this audit no part of `report.py` was found reconstructing the canonical
+schema independently: `build_report` assembles the payload, and the declared
+constants above are the single source for every population check. That is why a
+typed schema object is not yet justified.

--- a/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
+++ b/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
@@ -143,3 +143,157 @@ During this audit no part of `report.py` was found reconstructing the canonical
 schema independently: `build_report` assembles the payload, and the declared
 constants above are the single source for every population check. That is why a
 typed schema object is not yet justified.
+
+---
+
+## Round 2 — the stop condition fired: hand-maintained validation replaced
+
+**Both P1s are valid.**
+
+- `transform_identity` and `rules_corpus_vector_identity` were classified as
+  open. They are not: `extraction_config()`, `transform_identity()`, and
+  `rules_corpus_vector_identity()` all return fixed production schemas. An
+  edited-and-rehashed stored report could replace either identity with `{}` or
+  arbitrary keys and still be accepted, so canonical evidence was removable.
+- The remaining open maps were classified by key-population variability and then
+  given **no runtime enforcement at all**: `OPEN_REPORT_MAPS` was consumed only
+  by tests. `transform_identity="deleted"`, `rules_corpus_vector_identity=None`,
+  and `source_ledger_leaf_totals=[]` all passed. "Open" had come to mean
+  unvalidated rather than variably populated.
+
+Together these invalidate the claim that round 1's hand-maintained sibling audit
+closed the report schema. The PR's explicit stop condition therefore applies: an
+executable typed canonical schema, not another inventory patch.
+
+Four rounds each shut one hole and left the next, and the reason is structural —
+`build_report` held the real shape in a dict literal while the validator held a
+second, partial description of it. Two definitions of one document is the
+defect; the individual omissions were symptoms.
+
+### What replaced it
+
+`report_schema.py`: strict, frozen Pydantic v2 models with `extra="forbid"`.
+`CorpusEvidenceReport` **is** the payload. `build_report` constructs it,
+`report_hash` hashes its canonical dump, SQL persists that same dump,
+reconstruction and `verify_published_release` parse stored bytes back through
+it, and fixtures build it the same way. There is no second rendering.
+
+Modelled explicitly: the top-level document; `TransformIdentity` with nested
+`ExtractorConfig`, `SourceManifestEntry`, and `ComponentBInvocation`;
+`RulesCorpusVectorIdentity`; `ReproductionTarget`; `PolicyReference`;
+`Accounting`; `Findings`. `version_canaries` is a `dict[str, bool]` whose key
+set must equal names derived from `VERSION_CANARIES` — no duplicated list.
+
+`strict=True` is what makes `true` fail an integer field (`bool` is an `int`
+subclass), `"0"` fail an integer, and `0.0` fail an integer. Arrays are declared
+`list` with `strict=False` on those fields only: the identity builders return
+tuples in memory and JSON round-trips them to lists, and both canonicalize to
+the same bytes — so this admits the two encodings of one value while lax mode
+still refuses a bare string.
+
+**Variable-population maps are typed, not untyped.** The three totals maps are
+`dict[str, Count]` with `Count = int >= 0`. The two leaf-total maps additionally
+restrict keys to the `LeafType` universe, derived from the enum: any subset is
+legitimate, an invented type name is not. `excluded_totals_by_reason` keeps free
+string keys deliberately — the frozen policy is not available at parse time, and
+reaching for it would create the second policy definition this refactor exists
+to remove. Reason validity is proven contextually instead.
+
+### Intrinsic versus contextual
+
+The model owns shape, types, closed populations, value domains, and the
+cross-field semantics of a successful verdict. `verify_published_release` now
+owns agreement with the release and with reconstructed state:
+
+- five proof identities against the release row (unchanged);
+- `transform_identity.extractor` against recorded `transform_config.extraction_config`;
+- the rest of the transform identity against recorded `transform_config.transform_identity`;
+- `rules_corpus_vector_identity` against the recorded config;
+- policy reference, leaf totals, represented totals, excluded totals, declared
+  projection count, accounting, and findings all **recomputed** from the
+  reconstructed ledger, reconciliation, and policy.
+
+Not recomputed, and stated as such: concordance and canary results would require
+reopening the authoritative PDF, and the vector half of the persisted-corpus
+digest would require Chroma (Owner Decision 2026-08-01 unchanged). Those are
+verified through their closed successful recorded form.
+
+### `5c-evidence-3` retained — parity proven, not asserted
+
+Run at parent `cfade0d` and at head with identical inputs (`build_candidate`
+over the committed PDF; `build_report` with a fixed placeholder digest; no
+Chroma, no finalize), dumping payload plus every release identity to JSON:
+
+```
+diff parity_parent.json parity_head.json
+→ (no output; files identical)
+```
+
+That covers `report_hash`, `package_uuid`, `release_version`,
+`transform_config_hash`, `bundle_root_hash`, and the complete payload. The typed
+model accepts the honestly generated full-SRD report unmodified and its dump is
+byte-identical to the pre-refactor payload, so the version constant stands and
+no release is reminted. The three identity builders were **not** touched:
+normalizing a tuple in a builder would have moved `transform_config_hash` and
+reminted the package.
+
+### Obsolete machinery removed, not kept beside it
+
+`REQUIRED_REPORT_KEYS`, `_CLOSED_VERDICT_MAPS`, `_CLOSED_STRUCTURAL_MAPS`,
+`OPEN_REPORT_MAPS`, `_closed_map_violations`, `_ZERO_COUNTERS`,
+`_ZERO_FINDINGS`, `_ACCOUNTING_KEYS`, and the standalone `verdict_violations`
+walker are gone. `CANONICAL_CANARY_NAMES` survives because it expresses domain
+semantics and is consumed by the model. Two competing schema definitions were
+the defect; leaving the old validator for defence in depth would have preserved
+it.
+
+### Consequences worth naming
+
+- `EvidenceReport.payload` is the typed object; `EvidenceReport.dump()` is the
+  one serialization. Every 5c consumer was moved onto it.
+- Reconstruction raises `PersistedReportError` on an unparseable stored report,
+  and `_finalize_core`'s reuse path converts that to an ordinary failed result —
+  a parse error never propagates out of publication.
+- The bounded mechanical fixture's `transform_config` carried only a policy, so
+  its report had `transform_identity={"extractor": None}` and no vector
+  identity. It now uses the real production builders. `transform_config_hash` is
+  a fixture constant rather than a hash of that config, so the six binding
+  values are untouched and `bounded_oracle.json` needed no regeneration; only
+  `BOUND_EVIDENCE_REPORT_HASH` moved.
+
+### Controls
+
+`tests/ingestion/corpus/test_recorded_evidence.py` (89) replaces the
+field-by-field inventory tests: malformed identity maps at every nesting level
+(empty, scalar, null, array, extra key, wrong nested shape, incomplete manifest
+entry, wrongly typed component-B invocation, string where an array is declared);
+every variable map as null/string/array/scalar and with boolean, float, string,
+null, negative, and object counts; invented leaf-type names rejected while every
+declared subset is accepted; empty, invented, partial, extended, and
+non-boolean canary populations; missing and extra top-level fields; obsolete
+schema version; invalid status; and the verdict controls. Positive controls: the
+honest report parses, its dump round-trips exactly, and the canary set is
+derived rather than restated.
+
+Mechanical bound-release controls drive the contextual path through real
+publication: each tampered-and-rehashed stored payload returns `STALE` with
+exactly `{BOUND_RELEASE}` rather than an uncaught validation exception.
+
+### Escalation rule now standing
+
+If review finds a report field still constructed, serialized, persisted, or
+verified outside the canonical typed object, that competing path is reported as
+an architectural defect in the typed-schema conversion — not patched locally.
+
+### Verification
+
+`black` clean · `ruff check` clean · `mypy --strict` clean (211 files) ·
+typed-schema module **89 passed** · mechanical suites **521 passed** ·
+5c corpus + production control + packaging **285 passed** · full default suite
+**3181 passed, 10 skipped** (93.43%) · parent-versus-head parity **identical**.
+
+No CI runs on this stacked PR: `.github/workflows/ci.yml` triggers only on
+`pull_request` targeting `main`. Left unchanged deliberately — widening it is a
+repository-workflow decision and a separate infrastructure follow-up after
+Issue 5d, not part of this defect. CI covers the merged result when #141 runs
+against `main`.

--- a/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
+++ b/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
@@ -170,6 +170,58 @@ Four rounds each shut one hole and left the next, and the reason is structural �
 second, partial description of it. Two definitions of one document is the
 defect; the individual omissions were symptoms.
 
+### Why more `_CLOSED_STRUCTURAL_MAPS` entries were rejected
+
+The obvious patch was two more rows in the closed-map table plus a shape loop
+over `OPEN_REPORT_MAPS`. Rejected for three reasons, and the PR's stop condition
+already required the alternative:
+
+1. **It repeats the failure mode.** Rounds 1–4 each added an inventory entry and
+   each left the next omission. The table can only ever describe the fields
+   somebody remembered; the builder's dict literal is what actually defines the
+   document. A fifth entry would have closed `transform_identity` and left its
+   *nested* extractor, manifest, and invocation structures open — which is
+   precisely what Codex would have found next.
+2. **It cannot express nesting.** `_closed_map_violations` compares one key set.
+   Closing `transform_identity` properly needs four levels of key sets and value
+   types; expressing that as constants is a schema language, written badly.
+3. **It leaves two definitions.** The defect named in the stop condition is not
+   any individual omission — it is that `build_report` and the validator each
+   describe the document separately. Adding entries preserves that.
+
+A typed model removes the class of defect rather than its current instance: a
+field that is not on the model does not exist, and one that is on it cannot be
+omitted, retyped, or shadowed.
+
+### Final integration audit
+
+Verified by code search at `05c4e7e`, before requesting review:
+
+| Path | Result |
+| --- | --- |
+| `build_report` | constructs `CorpusEvidenceReport.model_validate` directly — twice, the first only to read the verdict off the assembled document |
+| `EvidenceReport.payload` | typed `CorpusEvidenceReport`; it cannot hold an unparsed dict |
+| `report_hash` | `hash_obj(report.dump())`, nothing else |
+| SQL write | `persist_release` → `artifacts.report.dump()`; `finalize` → `report.dump()` |
+| SQL reconstruction | `_reconstruct_artifacts` → `parse_recorded_report(release_row.report_payload)` |
+| `verify_published_release` | consumes the parsed report for identities, verdict, and recomputation |
+| 5c verified reuse | reaches the same parsed report through `_reconstruct_artifacts` |
+| fixtures | no 5c `EvidenceReport` is built from a raw dict |
+| duplicate key inventories | none remain in 5c |
+| alternate serialization | none; `model_dump` appears only in `dump()` and in the identity comparisons |
+
+Two findings recorded rather than "fixed", because neither is a competing 5c
+schema:
+
+* `mechanical/publication.py::_REQUIRED_REPORT_KEYS` is the **5d** mechanical
+  evidence report's key set — a different document with its own schema and its
+  own hash. Out of scope here; if it deserves the same treatment that is a 5d
+  change, not this one.
+* `_report_schema_ok` survives and still reads the stored dict, because it is a
+  *contextual* check the model cannot make: it compares the report's recorded
+  version with the version recorded in `transform_config`. It duplicates no key
+  list.
+
 ### What replaced it
 
 `report_schema.py`: strict, frozen Pydantic v2 models with `extra="forbid"`.
@@ -225,8 +277,16 @@ over the committed PDF; `build_report` with a fixed placeholder digest; no
 Chroma, no finalize), dumping payload plus every release identity to JSON:
 
 ```
+python parity.py parity_parent.json <PDF>   # at cfade0d
+python parity.py parity_head.json <PDF>     # at 05c4e7e
 diff parity_parent.json parity_head.json
 → (no output; files identical)
+
+report_hash             1b1c26ec4385d034bfb75c8e166ed95f78aa327a74d4b8e95ddb48284079f336
+package_uuid            4458fa10-4a66-5e0e-9ecc-ea37530ad2b4
+release_version         5.2.1-corpus.36b786d8-fa2
+transform_config_hash   77720c2f3b8c9b88363d48050466fb8e3a26f8476b63145d1b5928ff2581ef3e
+bundle_root_hash        03353dfb79790aee7260b9ed96055b7296cd6f70e3e6f97d6cbe0a2484279685
 ```
 
 That covers `report_hash`, `package_uuid`, `release_version`,
@@ -290,7 +350,13 @@ an architectural defect in the typed-schema conversion — not patched locally.
 `black` clean · `ruff check` clean · `mypy --strict` clean (211 files) ·
 typed-schema module **89 passed** · mechanical suites **521 passed** ·
 5c corpus + production control + packaging **285 passed** · full default suite
-**3181 passed, 10 skipped** (93.43%) · parent-versus-head parity **identical**.
+**3181 passed, 10 skipped** (93.43%) · parent-versus-head parity **identical**,
+re-run after the final `_finalize_core` edit and again at the committed head.
+
+No test was skipped, weakened, or xfailed to accommodate the conversion. Two
+existing tests changed because they hashed a deliberately-unparseable payload
+through `EvidenceReport`: both now hash the stored dict with `hash_obj`, which
+is what the verifier itself does, so they assert more precisely than before.
 
 No CI runs on this stacked PR: `.github/workflows/ci.yml` triggers only on
 `pull_request` targeting `main`. Left unchanged deliberately — widening it is a

--- a/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
+++ b/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
@@ -486,3 +486,123 @@ deletion.
 typed-schema module **112 passed** · mechanical suites **521 passed** ·
 5c persistence/quarantine **55 passed** · full default suite **3204 passed,
 10 skipped** (93.43%) · parity **identical**, re-run after the conversion.
+
+---
+
+## Round 4 — boundary classification, recorded before editing
+
+All four findings are valid. Classified, not patched:
+
+1. **The canonical report is not actually an immutable value.** Pydantic
+   `BaseModel` keeps field storage in `__dict__`, so
+   `vars(report)["version_canaries"] = {}` still mutates it, `success_violations()`
+   then reports nothing, and `dump()` and the hash both move. Round 3 froze the
+   *containers* and left the *storage* reachable. Immutability was a property of
+   the values I remembered to wrap, not of the object.
+2. **Contextual comparison still serializes nested report models
+   independently.** `_recorded_identity_violations` calls `model_dump(mode="json")`
+   on three nested values. That is a second report serializer beside
+   `EvidenceReport.dump()`, contradicting the one-serializer boundary this PR
+   claims — the same defect shape as round 3's read-side hash, one level down.
+3. **`verify_published_release` still reconstructs the persisted release proof
+   as a loose collection of individual checks** rather than one closed
+   invariant over the external 5c publication record. Each round has been adding
+   the next remembered field.
+4. **The transform-config-hash and corpus-report-reference findings are existing
+   5c gate invariants the downstream verifier omitted** — `run_gate` already
+   requires both. They are not new product semantics, which is why no ADR or
+   Issue amendment is needed: the implementation is being brought into agreement
+   with publication semantics 5c already defines.
+
+Findings 1 and 2 are one architectural correction (the value and its
+serializer); 3 and 4 are the other (one recorded-release closure). Explicitly
+rejected: an overridden `__dict__`, another mapping proxy, another validator,
+two inline `if`s in the verifier, or swapping the nested `model_dump` calls
+without auditing every serializer.
+
+### Release-row field audit
+
+Every field the 5c published release carries, with one disposition each. Audited
+against `gate.run_gate`, fresh finalization, verified reuse, `CorpusReleaseORM`,
+`RulesPackageORM`, and the report schema before coding.
+
+| Field | Disposition |
+| --- | --- |
+| `publication_status` (release) | recorded-release closure — must be `published` |
+| `publication_status` / `is_enabled` / `published_at` (package) | recorded-release closure |
+| `release_version` | closure (present) + declared-binding comparison |
+| `authoritative_source_hash` | closure (present, equals report) + declared-binding comparison |
+| `transform_config` | closure — object, and `hash_obj(...) == transform_config_hash`; then contextual authority for the report-versus-config identity comparison |
+| `transform_config_hash` | closure (present, equals report, recomputed over the stored config) + declared-binding comparison |
+| `ledger_hash` | closure (present) + recomputed from the reconstructed ledger |
+| `policy_hash` | proven by `_load_policy`'s closed cross-reference chain, which fails closed; closure checks presence only — no duplicate check added |
+| `reconciliation_hash` | closure (present) + recomputed from the reconstructed reconciliation |
+| `bundle_root_hash` | closure (present, equals report) + recomputed via `build_bundle` + declared-binding comparison |
+| `persisted_corpus_digest` | closure (present, equals report) + declared-binding comparison; cross-store half is Owner-authorized recorded identity (2026-08-01), not recomputed |
+| `report_payload` | intrinsic canonical-report validation — the only field parsed rather than compared |
+| `evidence_report_hash` | closure — `report_hash` over the parsed canonical value |
+| `corpus_report_reference` | closure — must equal `evidence_report_hash`, the invariant `run_gate` condition 16 already requires |
+| `created_at` | not authoritative — operational metadata, excluded from every proof identity by design |
+
+Two sibling omissions the audit surfaced beyond the two Codex named, both now in
+the closure: the package's `published_at` (a published package recording no
+publication time), and presence of the identity, report, and reference columns
+as a set rather than individually where they had been assumed.
+
+`policy_hash` is deliberately *not* re-verified in the closure: `_load_policy`
+already validates a closed chain across the policy row, the reconciliation row,
+the release row, and the stored transform configuration, and raises rather than
+returning a violation. Duplicating it would be the two-definitions defect again.
+
+### The fixture had to survive its own proof
+
+`TRANSFORM_CONFIG_HASH` was the fixture constant `"b" * 64`, which is not the
+hash of `BOUND_TRANSFORM_CONFIG`. The closure recomputes it, so the bounded
+release was — accurately — a forgery under the new check. It is now
+`hash_obj(BOUND_TRANSFORM_CONFIG)`. That moved a binding value, so
+`bounded_oracle.json` was regenerated; same shape as the bundle-root correction
+in round 1, and the same lesson: a fixture that cannot pass the proof it is used
+to test was never evidence.
+
+### Controls added
+
+**No mutable backing storage.** Root and all nine nested canonical values:
+`vars()` raises `TypeError`, `__dict__` is absent, and no `BaseModel` is
+reachable. `vars(report)["version_canaries"] = {}` and the nested equivalent
+both raise, with the dump, hash, and verdict asserted unchanged afterwards. Plus
+a control that `build_report` and `parse_recorded_report` return the same type,
+and that the canonical type has no `model_validate`.
+
+**Transform-configuration identity.** Five coordinated-tampering controls —
+extractor, first-party transform identity, vector identity, evidence schema
+version, and the reconciliation-policy portion. Each edits the stored config,
+copies the edited identities into the report, rehashes the report, and leaves
+`transform_config_hash` and package identity untouched, so report and config
+agree perfectly and only recomputing the configuration's own hash catches it.
+
+**Corpus report reference.** Cleared, unrelated hash, and a stale former report
+hash — the reference still names a real report, the previous one. The matching
+case is the honest positive control the whole bounded suite already exercises.
+
+**Canonical serializer.** Existing controls prove write side and read side hash
+the same dump; the identity comparison now slices that one dump, and no nested
+report serializer remains in production.
+
+### Identity parity, re-run after the representation replacement
+
+```
+diff parity_parent.json parity_head4.json
+→ (no output; files identical)
+```
+
+Payload, `report_hash`, `package_uuid`, `release_version`,
+`transform_config_hash`, `bundle_root_hash`, and persisted-corpus digest all as
+at `cfade0d`. Replacing `BaseModel` with slotted dataclasses changed the
+representation, not the document, so `5c-evidence-3` stands.
+
+### Verification (round 4)
+
+`black` clean · `ruff check` clean · `mypy --strict` clean (211 files) ·
+typed-schema module **116 passed** · mechanical publication **64 passed** ·
+mechanical suites **521 passed** · 5c corpus + production control **310 passed**
+· full default suite **3208 passed, 10 skipped** (93.42%).

--- a/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
+++ b/.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md
@@ -363,3 +363,126 @@ No CI runs on this stacked PR: `.github/workflows/ci.yml` triggers only on
 repository-workflow decision and a separate infrastructure follow-up after
 Issue 5d, not part of this defect. CI covers the merged result when #141 runs
 against `main`.
+
+---
+
+## Round 3 — final escalation: the value object was incomplete
+
+**All three P1s are valid, and the final escalation condition fired.** Round 2's
+audit concluded that nothing met that rule. **That conclusion is superseded.**
+The audit asked whether every path *reached* the typed object and answered yes;
+it did not ask whether the object was a *value* — deeply immutable, canonically
+serialized, and the only thing hashed. On that question the honest answer was
+no, and the third finding names it exactly: after parsing the stored payload
+into `CorpusEvidenceReport`, `verify_published_release` still hashed the
+original ORM dictionary. A report was still being verified outside the canonical
+serializer.
+
+**One defect, not three.** `CorpusEvidenceReport` validated a value at entry but
+did not yet *constitute* the single deeply immutable canonical value used for
+construction, serialization, hashing, persistence, and verification. The three
+symptoms are the same boundary being incomplete in three directions:
+
+- a canonical semantic constant (`reproduction_target.python_target`) modelled
+  as an unrestricted string, so an edited-and-rehashed report could record a
+  false reproduction target and pass every check;
+- `ConfigDict(frozen=True)` preventing attribute rebinding while nested `dict`
+  and `list` values stayed mutable — `report.version_canaries.clear()` after
+  parsing left `success_violations()` returning nothing and `dump()` emitting
+  the mutated state without revalidation, reopening the exact schema hole the
+  conversion closed;
+- a second serialization route on the read side.
+
+The reproduction-target and shallow-freeze findings are sibling evidence for the
+third: all three are places where the model is a validator that ran once rather
+than a value that cannot be wrong.
+
+**The correction is a deeply immutable canonical report value**, not more
+validators wrapped around mutable Pydantic containers. Revalidating before
+hashing would have been the fifth iteration of "remember to check" — the class
+of fix this PR exists to stop.
+
+### What replaced it, in three directions
+
+**Deep immutability.** Canonical arrays are `tuple` — source manifest, Component
+B steps, metadata fields — so an element cannot be appended or replaced.
+Content-derived maps and the canary map are validated and then wrapped in a
+`MappingProxyType` over a **copy** of the validated dict: the report owns its
+own value, so a caller mutating the dictionary it passed in cannot reach inside
+the parsed report. The proxy has no `__setitem__`, `__delitem__`, or `clear`.
+Nested models stay frozen; every collection they hold is now immutable too.
+Deliberately not chosen: revalidating before hashing. That is "remember to
+check" again, the class of fix this PR exists to end.
+
+**A canonical constant, bound not defaulted.** `PYTHON_TARGET` moved into the
+schema layer, and `ReproductionTarget` rejects anything else during parsing.
+`"99.0"` now fails intrinsically rather than surviving to a contextual
+comparison that did not exist.
+
+**One serializer, one hash.** `verify_published_release` no longer hashes the
+ORM dictionary. The raw payload is input to `parse_recorded_report` and nothing
+else; the stored hash is then checked with `report_hash` over the parsed value —
+the same call publication makes. `_report_schema_ok` was the last raw-dictionary
+report verifier and now takes the parsed report, so its remaining job is purely
+contextual: comparing the report's version with the one recorded in the stored
+transform configuration.
+
+### Integration audit, re-run
+
+- no production `hash_obj` over a report payload remains (the one match is
+  `mechanical/projection.py`, hashing a projection, unrelated);
+- one `report_hash` implementation, over `EvidenceReport.dump()`;
+- SQL writes, stored verification, and reuse reconstruction all use it;
+- `_report_schema_ok` no longer reads raw report fields;
+- no `dict[...]`/`list[...]` field annotations remain in the schema;
+- no duplicate top-level or nested inventory has returned.
+
+`mechanical/publication.py::_REQUIRED_REPORT_KEYS` remains the 5d mechanical
+report's own key set and is out of scope here, as stated in round 2.
+
+### Controls added
+
+Thirteen mutation attempts — canary `clear`, insert, and delete; totals insert
+of an invented key and of a negative count; totals delete and clear; metadata
+fields assign and append; source manifest assign and append; Component B steps
+append; attribute rebind — each asserting the operation raises **and** that the
+canonical dump and hash are unchanged afterwards. Plus: parsing does not alias
+the caller's dictionaries; the canonical collection types are `MappingProxyType`
+and `tuple`; five non-canonical reproduction targets and an extra-keyed target
+fail; and the read-side hash equals the write-side hash over the same dump.
+
+Existing malformed-shape, identity-map, variable-map, canary-population,
+contextual-tamper, and honest-report controls are retained unchanged.
+
+### Identity parity, re-run after the conversion
+
+```
+diff parity_parent.json parity_head3.json
+→ (no output; files identical)
+```
+
+Same payload, `report_hash`, `package_uuid`, `release_version`,
+`transform_config_hash`, `bundle_root_hash`, and persisted-corpus digest as
+`cfade0d`. Immutability and the bound constant changed how the document is
+*held*, not what it *is*, so `5c-evidence-3` stands.
+
+### One existing test rewritten, and why
+
+`test_report_schema_ok_fails_closed_on_bad_schema` called `_report_schema_ok`
+with raw dictionaries — its whole premise was the raw-dictionary report verifier
+this round removes. It is now
+`test_report_schema_ok_compares_the_parsed_report_with_the_transform_config`,
+passing a parsed report and exercising the one question the model cannot answer:
+agreement with the version recorded in the stored transform configuration. The
+cases it dropped — obsolete, missing, and malformed report versions — did not
+lose coverage; they moved to the parse boundary, where
+`test_recorded_evidence`'s `obsolete-schema-version` control already proves
+them. The docstring says so, so the migration is visible rather than a quiet
+deletion.
+
+### Verification (round 3)
+
+`black` clean · `ruff check` clean · `mypy --strict` clean (211 files) ·
+typed-schema module **112 passed** · mechanical suites **521 passed** ·
+5c persistence/quarantine **55 passed** · full default suite **3204 passed,
+10 skipped** (93.43%) · parity **identical**, re-run after the conversion.

--- a/src/afterworlds/ingestion/corpus/gate.py
+++ b/src/afterworlds/ingestion/corpus/gate.py
@@ -238,9 +238,9 @@ def run_gate(
     # 18. Evidence report postdates persistence and carries the digest.
     if not a.report.persisted:
         f.append("evidence report predates persistence")
-    if not a.report.payload.get("persisted_corpus_digest"):
+    if not a.report.payload.persisted_corpus_digest:
         f.append("evidence report lacks persisted-corpus digest")
-    if a.report.payload.get("prepublication_validation_status") != "pass":
+    if a.report.payload.prepublication_validation_status != "pass":
         f.append("evidence report prepublication status is not pass")
 
     # 19. Accounting equation holds.

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -45,6 +45,7 @@ from afterworlds.ingestion.corpus.bundle import (
 )
 from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
 from afterworlds.ingestion.corpus.gate import PublicationEvidence, run_gate
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CanonicalBundle,
@@ -899,39 +900,135 @@ _REPORT_PROOF_COLUMNS = (
 )
 
 
+def _recorded_release_violations(
+    release: CorpusReleaseORM,
+    package: RulesPackageORM | None,
+    report: CorpusEvidenceReport,
+) -> tuple[str, ...]:
+    """Every invariant the *recorded* 5c publication record must satisfy.
+
+    One closure rather than a growing list of remembered checks. Each review
+    round added the next field somebody noticed was missing — the transform
+    configuration's own hash, then the corpus report reference — and both were
+    invariants ``gate.run_gate`` already required at publication. The downstream
+    seam was re-deriving the release proof from memory instead of stating it.
+
+    Scope is deliberate: this proves what the *rows* must say about each other,
+    needing no corpus reconstruction. Declared-binding equality, the contextual
+    report-versus-config comparison, and everything requiring reconstructed
+    ledger/policy/reconciliation state stay with the verifier's later stages;
+    Chroma stays out entirely (Owner Decision 2026-08-01).
+    """
+    violations: list[str] = []
+
+    if package is None:
+        violations.append(f"no rp_packages row for {release.package_uuid}")
+    elif package.publication_status != "published" or not package.is_enabled:
+        violations.append(
+            f"rp_packages row for {release.package_uuid} is not published and "
+            f"enabled (publication_status={package.publication_status!r}, "
+            f"is_enabled={package.is_enabled})"
+        )
+    elif package.published_at is None:
+        violations.append(
+            f"rp_packages row for {release.package_uuid} is published but "
+            "records no published_at"
+        )
+
+    if release.publication_status != "published":
+        violations.append(
+            f"release {release.package_uuid} is in publication_status "
+            f"{release.publication_status!r}, not 'published'"
+        )
+
+    # The transform configuration is the authority every contextual identity
+    # comparison rests on, so it has to prove it is the configuration whose hash
+    # minted this package before any of them may read it.
+    if not isinstance(release.transform_config, dict):
+        violations.append("recorded transform configuration is not an object")
+    elif hash_obj(release.transform_config) != release.transform_config_hash:
+        violations.append(
+            "recorded transform configuration does not hash to the release's "
+            "recorded transform_config_hash"
+        )
+
+    # The report is hashed through the canonical serializer — the same call
+    # publication makes — never over the row's raw JSON.
+    derived = report_hash(EvidenceReport(payload=report, persisted=True))
+    if derived != release.evidence_report_hash:
+        violations.append(
+            "recorded evidence-report payload does not hash to the recorded "
+            "evidence_report_hash"
+        )
+    # ``run_gate`` condition 16 requires these to be the same value. A cleared or
+    # redirected reference is a release that no longer satisfies its own
+    # publication invariant.
+    if release.corpus_report_reference != release.evidence_report_hash:
+        violations.append(
+            f"corpus_report_reference {release.corpus_report_reference!r} != "
+            f"evidence_report_hash {release.evidence_report_hash!r}"
+        )
+
+    for report_key, column in _REPORT_PROOF_COLUMNS:
+        if getattr(report, report_key) != getattr(release, column):
+            violations.append(
+                f"recorded evidence report states {report_key}="
+                f"{getattr(report, report_key)!r}, release row records "
+                f"{column}={getattr(release, column)!r}"
+            )
+
+    for column in (
+        "release_version",
+        "authoritative_source_hash",
+        "transform_config_hash",
+        "bundle_root_hash",
+        "persisted_corpus_digest",
+        "ledger_hash",
+        "policy_hash",
+        "reconciliation_hash",
+        "evidence_report_hash",
+        "corpus_report_reference",
+    ):
+        if not getattr(release, column):
+            violations.append(f"release {release.package_uuid} records no {column}")
+
+    return tuple(violations)
+
+
 def _recorded_identity_violations(
-    report: CorpusEvidenceReport, transform_config: object
+    report: CorpusEvidenceReport, transform_config: dict[str, Any]
 ) -> tuple[str, ...]:
     """Does the report's recorded identity match the recorded transform config?
 
-    The canonical model proves these maps are complete and correctly shaped; it
+    The canonical value proves these maps are complete and correctly shaped; it
     cannot know whether they describe *this* release. That comparison needs the
-    stored transform configuration, which is the authority the release's
-    ``transform_config_hash`` is taken over — so an identity edited in the
-    report and rehashed no longer agrees with the config that minted the
-    package UUID.
+    stored transform configuration — which the caller has already proven hashes
+    to its recorded identity, so it is authority here rather than another
+    unverified row.
+
+    Every fragment comes from **one** canonical dump. Serializing the nested
+    values independently would be a second rendering of the report, and the two
+    could diverge the moment the canonical dump normalizes anything.
     """
-    if not isinstance(transform_config, dict):
-        return ("recorded transform configuration is not an object",)
+    recorded = report.dump()
+    identity = dict(recorded["transform_identity"])
+    extractor = identity.pop("extractor")
+
     violations: list[str] = []
-    identity = report.transform_identity
-    if identity.extractor.model_dump(mode="json") != transform_config.get(
-        "extraction_config"
-    ):
+    if extractor != transform_config.get("extraction_config"):
         violations.append(
             "recorded evidence report's extractor identity != the release's "
             "recorded transform extraction_config"
         )
-    recorded = transform_config.get("transform_identity")
-    declared = identity.model_dump(mode="json")
-    declared.pop("extractor")
-    if not isinstance(recorded, dict) or declared != _jsonish(recorded):
+    stored_identity = transform_config.get("transform_identity")
+    if not isinstance(stored_identity, dict) or identity != _jsonish(stored_identity):
         violations.append(
             "recorded evidence report's transform identity != the release's "
             "recorded transform_identity"
         )
-    vector = transform_config.get("rules_corpus_vector_identity")
-    if report.rules_corpus_vector_identity.model_dump(mode="json") != _jsonish(vector):
+    if recorded["rules_corpus_vector_identity"] != _jsonish(
+        transform_config.get("rules_corpus_vector_identity")
+    ):
         violations.append(
             "recorded evidence report's rules-corpus vector identity != the "
             "release's recorded rules_corpus_vector_identity"
@@ -1067,23 +1164,9 @@ def verify_published_release(
         # Nothing further is meaningful: there is no authoritative release to
         # compare a declaration with.
         return (f"no rp_corpus_releases row for package {pkg}",)
-    if release.publication_status != "published":
-        violations.append(
-            f"release {pkg} is in publication_status "
-            f"{release.publication_status!r}, not 'published'"
-        )
-
     package_row = session.execute(
         select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
     ).scalar_one_or_none()
-    if package_row is None:
-        violations.append(f"no rp_packages row for {pkg}")
-    elif package_row.publication_status != "published" or not package_row.is_enabled:
-        violations.append(
-            f"rp_packages row for {pkg} is not published and enabled "
-            f"(publication_status={package_row.publication_status!r}, "
-            f"is_enabled={package_row.is_enabled})"
-        )
 
     for field, declared in (
         ("release_version", release_version),
@@ -1129,24 +1212,16 @@ def verify_published_release(
         )
         return tuple(violations)
 
-    # Hashed through the same serializer publication used. Hashing the ORM
-    # dictionary here would be a second representation of the document, and the
-    # two could diverge the moment the canonical dump evolves.
-    if (
-        report_hash(EvidenceReport(payload=report, persisted=True))
-        != release.evidence_report_hash
-    ):
-        violations.append(
-            "recorded evidence-report payload does not hash to the recorded "
-            "evidence_report_hash"
-        )
-    for report_key, column in _REPORT_PROOF_COLUMNS:
-        if getattr(report, report_key) != getattr(release, column):
-            violations.append(
-                f"recorded evidence report states {report_key}="
-                f"{getattr(report, report_key)!r}, release row records "
-                f"{column}={getattr(release, column)!r}"
-            )
+    # The external publication record, as one closed invariant rather than the
+    # checks this function happened to remember.
+    closure = _recorded_release_violations(release, package_row, report)
+    violations.extend(closure)
+    if closure:
+        # Every comparison below reads the transform configuration or the row
+        # identities the closure just refused; continuing would derive noise
+        # from state already known to be untrustworthy.
+        return tuple(violations)
+
     # Identity is necessary but not sufficient. A report edited to "fail" — or to
     # "pass" over summaries that record failures — and rehashed keeps every proof
     # identity intact while recording that publication did not succeed.
@@ -1154,6 +1229,7 @@ def verify_published_release(
         f"recorded evidence report is not a successful 5c verdict: {v}"
         for v in report.success_violations()
     )
+    assert isinstance(release.transform_config, dict)  # proven by the closure
     violations.extend(_recorded_identity_violations(report, release.transform_config))
 
     try:

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -45,7 +45,6 @@ from afterworlds.ingestion.corpus.bundle import (
 )
 from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
 from afterworlds.ingestion.corpus.gate import PublicationEvidence, run_gate
-from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CanonicalBundle,
@@ -683,25 +682,24 @@ def verify_persisted_page_coverage(session: Session, pkg: str) -> tuple[str, ...
     return ()
 
 
-def _report_schema_ok(report_payload: object, transform_config: object) -> bool:
+def _report_schema_ok(report: CorpusEvidenceReport, transform_config: object) -> bool:
     """Reuse-compatibility check for the evidence-report schema (R17).
 
-    Reuse validates the *stored* report against its *stored* hash, so an
-    obsolete-schema report (e.g. the pre-R16 host-dependent ``reproduction_environment``
-    shape) would pass that check and be silently reused. Binding the schema version
-    into the transform identity already gives a differently-schema'd release a
-    different ``package_uuid`` (so it is not matched on the fresh path); this is the
-    fail-closed backstop on the reuse path.
+    The *contextual* half of the schema question, and the only half left here:
+    the canonical model already proves the report declares the supported
+    version, so this compares that version with the one recorded in the stored
+    transform configuration. Binding the schema version into the transform
+    identity already gives a differently-schema'd release a different
+    ``package_uuid``; this is the fail-closed backstop on the reuse path.
 
-    True iff the persisted report's recorded ``report_version`` equals the currently
-    supported :data:`EVIDENCE_REPORT_SCHEMA_VERSION` **and** the persisted transform
-    config records the same version. Missing / obsolete / contradictory / malformed
-    → False.
+    Takes the **parsed** report, never the raw payload: a raw-dictionary report
+    verifier beside the canonical model is the duplication this conversion
+    removed.
     """
-    if not isinstance(report_payload, dict) or not isinstance(transform_config, dict):
+    if not isinstance(transform_config, dict):
         return False
     return (
-        report_payload.get("report_version") == EVIDENCE_REPORT_SCHEMA_VERSION
+        report.report_version == EVIDENCE_REPORT_SCHEMA_VERSION
         and transform_config.get("evidence_report_schema_version")
         == EVIDENCE_REPORT_SCHEMA_VERSION
     )
@@ -1110,17 +1108,10 @@ def verify_published_release(
         # Everything below reads that payload, so continuing would bury the real
         # finding under violations derived from it.
         return tuple(violations)
-    if not _report_schema_ok(payload, release.transform_config):
-        violations.append(
-            "recorded evidence-report schema version "
-            f"(report={payload.get('report_version')!r}) is missing, obsolete, "
-            f"or contradictory vs the supported {EVIDENCE_REPORT_SCHEMA_VERSION!r}"
-        )
-        return tuple(violations)
-
-    # Intrinsic shape, closed populations, and value domains: the canonical
-    # model's, not this function's. A payload that is not this schema cannot be
-    # compared against anything, so it stops here.
+    # Intrinsic shape, closed populations, canonical constants, and value
+    # domains: the canonical model's, not this function's. The raw payload is
+    # input to parsing and nothing else — a report is never verified from the
+    # dictionary it arrived in.
     report, parse_violations = parse_recorded_report(payload)
     if report is None:
         violations.extend(
@@ -1129,7 +1120,22 @@ def verify_published_release(
         )
         return tuple(violations)
 
-    if hash_obj(payload) != release.evidence_report_hash:
+    if not _report_schema_ok(report, release.transform_config):
+        violations.append(
+            "recorded evidence-report schema version "
+            f"(report={report.report_version!r}) is contradictory vs the "
+            f"supported {EVIDENCE_REPORT_SCHEMA_VERSION!r} recorded in the "
+            "release's transform configuration"
+        )
+        return tuple(violations)
+
+    # Hashed through the same serializer publication used. Hashing the ORM
+    # dictionary here would be a second representation of the document, and the
+    # two could diverge the moment the canonical dump evolves.
+    if (
+        report_hash(EvidenceReport(payload=report, persisted=True))
+        != release.evidence_report_hash
+    ):
         violations.append(
             "recorded evidence-report payload does not hash to the recorded "
             "evidence_report_hash"
@@ -1536,7 +1542,7 @@ def _finalize_core(
         )
         page_coverage_violations = verify_persisted_page_coverage(session, pkg)
         schema_ok = _report_schema_ok(
-            artifacts.report.dump(), artifacts.release.transform_config
+            artifacts.report.payload, artifacts.release.transform_config
         )
         if (
             not gate.passed

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -29,6 +29,7 @@ back in the exact order the in-memory payload used.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -44,6 +45,7 @@ from afterworlds.ingestion.corpus.bundle import (
 )
 from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
 from afterworlds.ingestion.corpus.gate import PublicationEvidence, run_gate
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CanonicalBundle,
@@ -77,9 +79,10 @@ from afterworlds.ingestion.corpus.report import (
     EVIDENCE_REPORT_SCHEMA_VERSION,
     EvidenceReport,
     build_report,
-    recorded_success_violations,
+    parse_recorded_report,
     report_hash,
 )
+from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
 from afterworlds.ingestion.corpus.source_completeness import (
     EXPECTED_PAGE_COUNT,
     verify_source_completeness,
@@ -111,6 +114,16 @@ from afterworlds.pipeline.retrieval.embedding import RetrievalEmbeddingFunction
 
 if TYPE_CHECKING:
     from chromadb.api import ClientAPI
+
+
+class PersistedReportError(ValueError):
+    """A stored evidence report that is not the canonical schema.
+
+    Raised rather than reported during reconstruction: a payload that will not
+    parse is not a weaker report, it is not this document, and continuing would
+    build artifacts around a shape nobody published.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Shared row-building primitives
@@ -349,7 +362,7 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
         reconciliation_hash=rel.reconciliation_hash,
         corpus_report_reference=rel.corpus_report_reference,
         transform_config=rel.transform_config,
-        report_payload=artifacts.report.payload,
+        report_payload=artifacts.report.dump(),
         now=now,
     )
     _persist_bundle_rows(
@@ -888,6 +901,127 @@ _REPORT_PROOF_COLUMNS = (
 )
 
 
+def _recorded_identity_violations(
+    report: CorpusEvidenceReport, transform_config: object
+) -> tuple[str, ...]:
+    """Does the report's recorded identity match the recorded transform config?
+
+    The canonical model proves these maps are complete and correctly shaped; it
+    cannot know whether they describe *this* release. That comparison needs the
+    stored transform configuration, which is the authority the release's
+    ``transform_config_hash`` is taken over — so an identity edited in the
+    report and rehashed no longer agrees with the config that minted the
+    package UUID.
+    """
+    if not isinstance(transform_config, dict):
+        return ("recorded transform configuration is not an object",)
+    violations: list[str] = []
+    identity = report.transform_identity
+    if identity.extractor.model_dump(mode="json") != transform_config.get(
+        "extraction_config"
+    ):
+        violations.append(
+            "recorded evidence report's extractor identity != the release's "
+            "recorded transform extraction_config"
+        )
+    recorded = transform_config.get("transform_identity")
+    declared = identity.model_dump(mode="json")
+    declared.pop("extractor")
+    if not isinstance(recorded, dict) or declared != _jsonish(recorded):
+        violations.append(
+            "recorded evidence report's transform identity != the release's "
+            "recorded transform_identity"
+        )
+    vector = transform_config.get("rules_corpus_vector_identity")
+    if report.rules_corpus_vector_identity.model_dump(mode="json") != _jsonish(vector):
+        violations.append(
+            "recorded evidence report's rules-corpus vector identity != the "
+            "release's recorded rules_corpus_vector_identity"
+        )
+    return tuple(violations)
+
+
+def _jsonish(value: object) -> object:
+    """Normalize in-memory tuples to the JSON shape the report round-trips as.
+
+    ``transform_identity()`` returns tuples that JSON renders as arrays, and the
+    two hash identically (:func:`hashing.canonical_bytes`). Comparing the parsed
+    report against the in-memory config therefore needs the same normalization
+    the wire format already applies — not a change to either side.
+    """
+    if isinstance(value, dict):
+        return {k: _jsonish(v) for k, v in value.items()}
+    if isinstance(value, tuple | list):
+        return [_jsonish(v) for v in value]
+    return value
+
+
+def _recomputed_report_violations(
+    report: CorpusEvidenceReport,
+    ledger: SourceLedger,
+    recon: ReconciliationMember,
+    policy: ReconciliationPolicy,
+) -> tuple[str, ...]:
+    """Does the report's arithmetic match the state actually persisted?
+
+    Every summary here is recomputable from reconstructed rows, so a recorded
+    total that was edited and rehashed is caught by *derivation* rather than by
+    a schema rule. What is deliberately not recomputed: the concordance and
+    canary results, which would require reopening the authoritative PDF, and
+    the vector half of the persisted-corpus digest, which would require Chroma
+    (Owner Decision 2026-08-01). Those are verified through their closed
+    successful recorded form instead.
+    """
+    disp_by_leaf = {d.leaf_id: d for d in recon.dispositions}
+    leaf_totals: Counter[str] = Counter()
+    represented: Counter[str] = Counter()
+    excluded: Counter[str] = Counter()
+    for leaf in ledger.leaves:
+        leaf_totals[leaf.leaf_type.value] += 1
+        disposition = disp_by_leaf.get(leaf.leaf_id)
+        if disposition is None:
+            continue
+        if disposition.disposition is Disposition.REPRESENTED:
+            represented[leaf.leaf_type.value] += 1
+        elif (
+            disposition.disposition is Disposition.EXCLUDED
+            and disposition.exclusion_reason_code
+        ):
+            excluded[disposition.exclusion_reason_code] += 1
+
+    expected: dict[str, object] = {
+        "source_ledger_leaf_totals": dict(sorted(leaf_totals.items())),
+        "represented_totals": dict(sorted(represented.items())),
+        "excluded_totals_by_reason": dict(sorted(excluded.items())),
+        "declared_projection_count": len(recon.projections),
+        "unresolved_leaves": recon.unresolved_leaves,
+        "accounting": {
+            "inventoried_leaves": recon.inventoried_leaves,
+            "represented_leaves": recon.represented_leaves,
+            "excluded_leaves": recon.excluded_leaves,
+            "unresolved_leaves": recon.unresolved_leaves,
+        },
+        "findings": {
+            "gaps": len(recon.findings.gaps),
+            "overlaps": len(recon.findings.overlaps),
+            "orphans": len(recon.findings.orphans),
+            "duplications": len(recon.findings.duplications),
+        },
+        "reconciliation_policy_reference": {
+            "policy_version": policy.policy_version,
+            "policy_hash": policy_hash(policy),
+            "applied_policy_hash": recon.policy_hash,
+        },
+    }
+    recorded = report.dump()
+    return tuple(
+        f"recorded evidence report states {field}={recorded[field]!r}, "
+        f"reconstructed 5c state derives {value!r}"
+        for field, value in expected.items()
+        if recorded[field] != value
+    )
+
+
 def verify_published_release(
     session: Session,
     pkg: str,
@@ -984,19 +1118,27 @@ def verify_published_release(
         )
         return tuple(violations)
 
-    if (
-        report_hash(EvidenceReport(payload=payload, persisted=True))
-        != release.evidence_report_hash
-    ):
+    # Intrinsic shape, closed populations, and value domains: the canonical
+    # model's, not this function's. A payload that is not this schema cannot be
+    # compared against anything, so it stops here.
+    report, parse_violations = parse_recorded_report(payload)
+    if report is None:
+        violations.extend(
+            f"recorded evidence report is not the canonical schema: {v}"
+            for v in parse_violations
+        )
+        return tuple(violations)
+
+    if hash_obj(payload) != release.evidence_report_hash:
         violations.append(
             "recorded evidence-report payload does not hash to the recorded "
             "evidence_report_hash"
         )
     for report_key, column in _REPORT_PROOF_COLUMNS:
-        if payload.get(report_key) != getattr(release, column):
+        if getattr(report, report_key) != getattr(release, column):
             violations.append(
                 f"recorded evidence report states {report_key}="
-                f"{payload.get(report_key)!r}, release row records "
+                f"{getattr(report, report_key)!r}, release row records "
                 f"{column}={getattr(release, column)!r}"
             )
     # Identity is necessary but not sufficient. A report edited to "fail" — or to
@@ -1004,8 +1146,9 @@ def verify_published_release(
     # identity intact while recording that publication did not succeed.
     violations.extend(
         f"recorded evidence report is not a successful 5c verdict: {v}"
-        for v in recorded_success_violations(payload)
+        for v in report.success_violations()
     )
+    violations.extend(_recorded_identity_violations(report, release.transform_config))
 
     try:
         policy = _load_policy(session, pkg)
@@ -1044,6 +1187,7 @@ def verify_published_release(
                 f"5c state derives ({recomputed!r})"
             )
 
+    violations.extend(_recomputed_report_violations(report, ledger, recon, policy))
     violations.extend(verify_single_source(session, pkg))
     violations.extend(verify_chunk_runtime_membership(session, pkg))
     return tuple(violations)
@@ -1162,7 +1306,17 @@ def _reconstruct_artifacts(
         reconciliation_hash=release_row.reconciliation_hash,
         corpus_report_reference=release_row.corpus_report_reference,
     )
-    report = EvidenceReport(payload=release_row.report_payload, persisted=True)
+    # The stored payload is parsed back through the canonical model, never
+    # wrapped as-is: reconstruction is a read of unknown-provenance JSON, and a
+    # payload that is not this schema must fail here rather than flow onward as
+    # a report-shaped dict.
+    parsed, parse_violations = parse_recorded_report(release_row.report_payload)
+    if parsed is None:
+        raise PersistedReportError(
+            f"stored evidence report for {pkg} is not the canonical "
+            f"{EVIDENCE_REPORT_SCHEMA_VERSION} schema: {list(parse_violations)}"
+        )
+    report = EvidenceReport(payload=parsed, persisted=True)
     artifacts = ReleaseArtifacts(
         pages=pages,
         ledger=ledger,
@@ -1324,6 +1478,22 @@ def _finalize_core(
                     vector_state=vector_result.state.to_payload(),
                 )
             )
+        except PersistedReportError as exc:
+            # A stored report that is not the canonical schema fails reuse
+            # closed, as an ordinary failed result: publication must never
+            # propagate a parse error to its caller.
+            return FinalizeResult(
+                published=False,
+                reused=False,
+                artifacts=None,
+                gate=GateResult(
+                    passed=False,
+                    failures=(
+                        "persisted evidence-report schema version is not the "
+                        f"supported {EVIDENCE_REPORT_SCHEMA_VERSION!r}: {exc}",
+                    ),
+                ),
+            )
         except PolicyReconstructionError as exc:
             # A missing/malformed/inconsistent persisted policy fails reuse closed
             # (reported as an ordinary failed result, consistent with the other
@@ -1366,7 +1536,7 @@ def _finalize_core(
         )
         page_coverage_violations = verify_persisted_page_coverage(session, pkg)
         schema_ok = _report_schema_ok(
-            artifacts.report.payload, artifacts.release.transform_config
+            artifacts.report.dump(), artifacts.release.transform_config
         )
         if (
             not gate.passed
@@ -1385,7 +1555,7 @@ def _finalize_core(
             if not schema_ok:
                 failures.append(
                     "persisted evidence-report schema version "
-                    f"(report={artifacts.report.payload.get('report_version')!r}) is "
+                    f"(report={artifacts.report.payload.report_version!r}) is "
                     "missing/obsolete/contradictory vs the supported "
                     f"{EVIDENCE_REPORT_SCHEMA_VERSION!r} — refusing to reuse"
                 )
@@ -1551,7 +1721,7 @@ def _finalize_core(
         release_row.evidence_report_hash = report_h
         release_row.persisted_corpus_digest = digest
         release_row.corpus_report_reference = report_h
-        release_row.report_payload = report.payload
+        release_row.report_payload = report.dump()
         session.flush()
 
         gate = run_gate(artifacts, evidence)

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -17,7 +17,11 @@ import platform
 from collections import Counter
 from dataclasses import dataclass
 
-from afterworlds.ingestion.corpus.concordance import CanaryResult, ConcordanceResult
+from afterworlds.ingestion.corpus.concordance import (
+    VERSION_CANARIES,
+    CanaryResult,
+    ConcordanceResult,
+)
 from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.models import (
     CorpusBundleMembers,
@@ -86,6 +90,71 @@ _ACCOUNTING_KEYS = (
     "excluded_leaves",
     "unresolved_leaves",
 )
+#: The canonical version-canary population, derived from the committed canary
+#: definitions rather than restated here. Six names is not a fact this module
+#: gets to hold an opinion about: if a canary is added or retired, the required
+#: population moves with it and no second list has to be remembered.
+CANONICAL_CANARY_NAMES = frozenset(canary.name for canary in VERSION_CANARIES)
+
+# ---------------------------------------------------------------------------
+# Closed inventories versus open diagnostics
+# ---------------------------------------------------------------------------
+#
+# A report carries two kinds of map, and conflating them is how "every value I
+# looked at was fine" gets mistaken for "everything required was there".
+#
+# **Closed**: the key population is fixed by this module or by a committed
+# constant, so a missing key is an omission and an unexpected key is a foreign
+# or tampered payload. Validated by exact set equality.
+#
+# **Open**: the keys derive from the corpus content itself — which leaf types
+# occur, which exclusion reasons were used, what the transform identity
+# records. A release with no table cells legitimately has no ``table_cell``
+# entry, so requiring an exact population would be requiring a particular
+# corpus. Only presence and shape are checked; extra keys are normal.
+
+#: Verdict-bearing closed maps: exact keys *and* success-valued entries.
+_CLOSED_VERDICT_MAPS: dict[str, frozenset[str]] = {
+    "findings": frozenset(_ZERO_FINDINGS),
+    "accounting": frozenset(_ACCOUNTING_KEYS),
+    "version_canaries": CANONICAL_CANARY_NAMES,
+}
+#: Structural closed maps: ``build_report`` fixes their keys, so a recorded
+#: payload carrying different ones was edited after the fact.
+_CLOSED_STRUCTURAL_MAPS: dict[str, frozenset[str]] = {
+    "reproduction_target": frozenset({"python_target"}),
+    "reconciliation_policy_reference": frozenset(
+        {"policy_version", "policy_hash", "applied_policy_hash"}
+    ),
+}
+#: Deliberately open. Named explicitly so the distinction is a decision on the
+#: record rather than an omission someone later "fixes" into a false failure.
+OPEN_REPORT_MAPS = frozenset(
+    {
+        "source_ledger_leaf_totals",
+        "represented_totals",
+        "excluded_totals_by_reason",
+        "transform_identity",
+        "rules_corpus_vector_identity",
+    }
+)
+
+
+def _closed_map_violations(
+    payload: dict[str, object], key: str, required: frozenset[str]
+) -> tuple[str, ...]:
+    """Does *key* hold exactly the canonical population, no more and no less?"""
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        return (f"{key} is missing or not an object",)
+    violations = []
+    if missing := sorted(required - set(value)):
+        violations.append(f"{key} is missing required entries {missing}")
+    if unexpected := sorted(set(value) - required):
+        violations.append(f"{key} carries unrecognised entries {unexpected}")
+    return tuple(violations)
+
+
 #: Every key ``build_report`` produces. A payload missing one is not this shape.
 REQUIRED_REPORT_KEYS = frozenset(
     {
@@ -140,10 +209,14 @@ def verdict_violations(payload: dict[str, object]) -> tuple[str, ...]:
         elif count != 0:
             violations.append(f"{key} is {count}, not 0")
 
+    # Population before values: a map holding only entries that happen to be
+    # present can pass every value check while recording none of the required
+    # ones. ``{}`` is the degenerate case — vacuously "all passed".
+    for key, required in _CLOSED_VERDICT_MAPS.items():
+        violations.extend(_closed_map_violations(payload, key, required))
+
     findings = payload.get("findings")
-    if not isinstance(findings, dict):
-        violations.append("findings is missing or not an object")
-    else:
+    if isinstance(findings, dict):
         for key in _ZERO_FINDINGS:
             found = findings.get(key)
             if type(found) is not int:
@@ -152,9 +225,7 @@ def verdict_violations(payload: dict[str, object]) -> tuple[str, ...]:
                 violations.append(f"findings.{key} is {found}, not 0")
 
     canaries = payload.get("version_canaries")
-    if not isinstance(canaries, dict):
-        violations.append("version_canaries is missing or not an object")
-    else:
+    if isinstance(canaries, dict):
         for name, passed in sorted(canaries.items()):
             if type(passed) is not bool:
                 violations.append(f"version_canaries.{name} is not a boolean")
@@ -162,9 +233,7 @@ def verdict_violations(payload: dict[str, object]) -> tuple[str, ...]:
                 violations.append(f"version canary {name} did not pass")
 
     accounting = payload.get("accounting")
-    if not isinstance(accounting, dict):
-        violations.append("accounting is missing or not an object")
-    else:
+    if isinstance(accounting, dict):
         counts: dict[str, int] = {}
         for key in _ACCOUNTING_KEYS:
             value = accounting.get(key)
@@ -215,8 +284,18 @@ def recorded_success_violations(payload: object) -> tuple[str, ...]:
             f"report_version {payload.get('report_version')!r} is not the supported "
             f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
         )
+    # Exact, not merely complete. Requiring only that the known keys are present
+    # lets an edited-and-rehashed payload carry an unknown field under the same
+    # schema version, which is a different document claiming to be this one.
     if missing := sorted(REQUIRED_REPORT_KEYS - set(payload)):
         violations.append(f"evidence report is missing {missing}")
+    if unexpected := sorted(set(payload) - REQUIRED_REPORT_KEYS):
+        violations.append(
+            f"evidence report carries unrecognised keys {unexpected} under schema "
+            f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
+        )
+    for key, required in _CLOSED_STRUCTURAL_MAPS.items():
+        violations.extend(_closed_map_violations(payload, key, required))
     status = payload.get("prepublication_validation_status")
     if status != "pass":
         violations.append(

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -8,6 +8,10 @@ It contains the authoritative-source/transform/bundle-root/frozen-ledger hashes
 and the persisted-corpus digest — but **not** its own hash — and is **not** a
 bundle member (it contains the bundle root and cannot be covered by it). Its hash
 is computed over the completed report (K step f) and recorded externally.
+
+The payload's shape lives in exactly one place, :mod:`report_schema`. This
+module builds that typed object and hashes its canonical dump; it holds no
+second description of the document.
 """
 
 from __future__ import annotations
@@ -16,12 +20,9 @@ import logging
 import platform
 from collections import Counter
 from dataclasses import dataclass
+from typing import Any
 
-from afterworlds.ingestion.corpus.concordance import (
-    VERSION_CANARIES,
-    CanaryResult,
-    ConcordanceResult,
-)
+from afterworlds.ingestion.corpus.concordance import CanaryResult, ConcordanceResult
 from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.models import (
     CorpusBundleMembers,
@@ -31,6 +32,28 @@ from afterworlds.ingestion.corpus.models import (
     SourceLedger,
 )
 from afterworlds.ingestion.corpus.policy import policy_hash
+from afterworlds.ingestion.corpus.report_schema import (
+    CANONICAL_CANARY_NAMES,
+    EVIDENCE_REPORT_SCHEMA_VERSION,
+    Accounting,
+    CorpusEvidenceReport,
+    Findings,
+    PolicyReference,
+    ReproductionTarget,
+    parse_recorded_report,
+)
+
+__all__ = [
+    "CANONICAL_CANARY_NAMES",
+    "EVIDENCE_REPORT_SCHEMA_VERSION",
+    "PYTHON_TARGET",
+    "CorpusEvidenceReport",
+    "EvidenceReport",
+    "build_report",
+    "parse_recorded_report",
+    "recorded_success_violations",
+    "report_hash",
+]
 
 _log = logging.getLogger(__name__)
 
@@ -40,272 +63,22 @@ _log = logging.getLogger(__name__)
 # identity-bearing payload (PR #134 R16).
 PYTHON_TARGET = "3.12"
 
-# Canonical evidence-report schema version. Bumped across canonical-shape changes:
-# "2" for the R16 host-independent ``reproduction_target`` change; "3" for the R18
-# pre-release clean-baseline change that removed the legacy-reachability status
-# (Issue 5c Rev7 / Issue 18 Rev6 supersede the strict cross-store quarantine
-# contract). This version is bound into ``transform_config_payload`` (hence the
-# transform hash / package UUID / release version), so an evidence-report *schema*
-# change mints a NEW immutable release instead of being reused under a
-# predecessor's identity (R17 mechanism). It is deliberately an *explicit* schema
-# identity rather than a byte-level hash of report.py: only an intentional
-# canonical-shape change should remint, never a comment/docstring/logging edit.
-EVIDENCE_REPORT_SCHEMA_VERSION = "5c-evidence-3"
-
 
 @dataclass(frozen=True)
 class EvidenceReport:
-    """The completed evidence report payload and the flag that it postdates persist."""
+    """The completed evidence report and the flag that it postdates persist.
 
-    payload: dict[str, object]
+    ``payload`` is the typed canonical object, not a dictionary. Anything that
+    hashes, persists, or transmits the report goes through :meth:`dump`, so
+    there is one serialization and no second rendering that could drift.
+    """
+
+    payload: CorpusEvidenceReport
     persisted: bool
 
-
-# ---------------------------------------------------------------------------
-# What a successful publication looks like in the report's own numbers
-# ---------------------------------------------------------------------------
-#
-# One definition, consumed at two boundaries with different trust levels:
-#
-# * :func:`build_report` derives ``prepublication_validation_status`` from it, so
-#   a report cannot be *written* claiming success alongside contradictory
-#   summaries; and
-# * :func:`recorded_success_violations` applies it to a payload read back out of
-#   the database, whose provenance is unknown — JSON round-tripped, possibly
-#   hand-edited, types unproven.
-#
-# ``gate.run_gate`` deliberately keeps its own one-line status check: it holds
-# the freshly built :class:`EvidenceReport` object, with a live ``persisted``
-# flag and typed sub-objects, so it asks a different question of a value it just
-# produced. What must not diverge is the *semantics* below, and it does not.
-
-#: Top-level payload counters that must be zero for a successful verdict.
-_ZERO_COUNTERS = ("unresolved_leaves", "invalid_locators", "concordance_failures")
-#: Reconciliation findings that must all be zero for a successful verdict.
-_ZERO_FINDINGS = ("gaps", "overlaps", "orphans", "duplications")
-#: Accounting keys, and the equation they must satisfy.
-_ACCOUNTING_KEYS = (
-    "inventoried_leaves",
-    "represented_leaves",
-    "excluded_leaves",
-    "unresolved_leaves",
-)
-#: The canonical version-canary population, derived from the committed canary
-#: definitions rather than restated here. Six names is not a fact this module
-#: gets to hold an opinion about: if a canary is added or retired, the required
-#: population moves with it and no second list has to be remembered.
-CANONICAL_CANARY_NAMES = frozenset(canary.name for canary in VERSION_CANARIES)
-
-# ---------------------------------------------------------------------------
-# Closed inventories versus open diagnostics
-# ---------------------------------------------------------------------------
-#
-# A report carries two kinds of map, and conflating them is how "every value I
-# looked at was fine" gets mistaken for "everything required was there".
-#
-# **Closed**: the key population is fixed by this module or by a committed
-# constant, so a missing key is an omission and an unexpected key is a foreign
-# or tampered payload. Validated by exact set equality.
-#
-# **Open**: the keys derive from the corpus content itself — which leaf types
-# occur, which exclusion reasons were used, what the transform identity
-# records. A release with no table cells legitimately has no ``table_cell``
-# entry, so requiring an exact population would be requiring a particular
-# corpus. Only presence and shape are checked; extra keys are normal.
-
-#: Verdict-bearing closed maps: exact keys *and* success-valued entries.
-_CLOSED_VERDICT_MAPS: dict[str, frozenset[str]] = {
-    "findings": frozenset(_ZERO_FINDINGS),
-    "accounting": frozenset(_ACCOUNTING_KEYS),
-    "version_canaries": CANONICAL_CANARY_NAMES,
-}
-#: Structural closed maps: ``build_report`` fixes their keys, so a recorded
-#: payload carrying different ones was edited after the fact.
-_CLOSED_STRUCTURAL_MAPS: dict[str, frozenset[str]] = {
-    "reproduction_target": frozenset({"python_target"}),
-    "reconciliation_policy_reference": frozenset(
-        {"policy_version", "policy_hash", "applied_policy_hash"}
-    ),
-}
-#: Deliberately open. Named explicitly so the distinction is a decision on the
-#: record rather than an omission someone later "fixes" into a false failure.
-OPEN_REPORT_MAPS = frozenset(
-    {
-        "source_ledger_leaf_totals",
-        "represented_totals",
-        "excluded_totals_by_reason",
-        "transform_identity",
-        "rules_corpus_vector_identity",
-    }
-)
-
-
-def _closed_map_violations(
-    payload: dict[str, object], key: str, required: frozenset[str]
-) -> tuple[str, ...]:
-    """Does *key* hold exactly the canonical population, no more and no less?"""
-    value = payload.get(key)
-    if not isinstance(value, dict):
-        return (f"{key} is missing or not an object",)
-    violations = []
-    if missing := sorted(required - set(value)):
-        violations.append(f"{key} is missing required entries {missing}")
-    if unexpected := sorted(set(value) - required):
-        violations.append(f"{key} carries unrecognised entries {unexpected}")
-    return tuple(violations)
-
-
-#: Every key ``build_report`` produces. A payload missing one is not this shape.
-REQUIRED_REPORT_KEYS = frozenset(
-    {
-        "report_version",
-        "authoritative_source_hash",
-        "transform_config_hash",
-        "bundle_root_hash",
-        "frozen_source_ledger_hash",
-        "persisted_corpus_digest",
-        "transform_identity",
-        "rules_corpus_vector_identity",
-        "reproduction_target",
-        "reconciliation_policy_reference",
-        "source_ledger_leaf_totals",
-        "represented_totals",
-        "excluded_totals_by_reason",
-        "unresolved_leaves",
-        "declared_projection_count",
-        "accounting",
-        "findings",
-        "invalid_locators",
-        "concordance_failures",
-        "version_canaries",
-        "prepublication_validation_status",
-    }
-)
-
-
-def _count(payload: dict[str, object], key: str) -> int | None:
-    """A payload counter as an ``int``, or ``None`` if it is not one.
-
-    ``bool`` is excluded explicitly: it is an ``int`` subclass, so ``True``
-    would otherwise read as the count ``1`` and let a hand-edited report satisfy
-    an equation with a boolean.
-    """
-    value = payload.get(key)
-    return value if type(value) is int else None
-
-
-def verdict_violations(payload: dict[str, object]) -> tuple[str, ...]:
-    """Why these report numbers do not state a successful publication.
-
-    Pure over the payload, so it says the same thing about a report being built
-    and a report being read back. Empty exactly when every verdict-bearing
-    summary is present, correctly typed, and success-valued.
-    """
-    violations: list[str] = []
-    for key in _ZERO_COUNTERS:
-        count = _count(payload, key)
-        if count is None:
-            violations.append(f"{key} is missing or not an integer")
-        elif count != 0:
-            violations.append(f"{key} is {count}, not 0")
-
-    # Population before values: a map holding only entries that happen to be
-    # present can pass every value check while recording none of the required
-    # ones. ``{}`` is the degenerate case — vacuously "all passed".
-    for key, required in _CLOSED_VERDICT_MAPS.items():
-        violations.extend(_closed_map_violations(payload, key, required))
-
-    findings = payload.get("findings")
-    if isinstance(findings, dict):
-        for key in _ZERO_FINDINGS:
-            found = findings.get(key)
-            if type(found) is not int:
-                violations.append(f"findings.{key} is missing or not an integer")
-            elif found != 0:
-                violations.append(f"findings.{key} is {found}, not 0")
-
-    canaries = payload.get("version_canaries")
-    if isinstance(canaries, dict):
-        for name, passed in sorted(canaries.items()):
-            if type(passed) is not bool:
-                violations.append(f"version_canaries.{name} is not a boolean")
-            elif not passed:
-                violations.append(f"version canary {name} did not pass")
-
-    accounting = payload.get("accounting")
-    if isinstance(accounting, dict):
-        counts: dict[str, int] = {}
-        for key in _ACCOUNTING_KEYS:
-            value = accounting.get(key)
-            if type(value) is not int:
-                violations.append(f"accounting.{key} is missing or not an integer")
-            else:
-                counts[key] = value
-        if len(counts) == len(_ACCOUNTING_KEYS):
-            if counts["unresolved_leaves"] != 0:
-                violations.append(
-                    f"accounting.unresolved_leaves is "
-                    f"{counts['unresolved_leaves']}, not 0"
-                )
-            if counts["inventoried_leaves"] != (
-                counts["represented_leaves"]
-                + counts["excluded_leaves"]
-                + counts["unresolved_leaves"]
-            ):
-                violations.append("accounting equation does not balance")
-            top_level = _count(payload, "unresolved_leaves")
-            if top_level is not None and top_level != counts["unresolved_leaves"]:
-                violations.append(
-                    "accounting.unresolved_leaves disagrees with the top-level "
-                    "unresolved_leaves"
-                )
-    return tuple(violations)
-
-
-def recorded_success_violations(payload: object) -> tuple[str, ...]:
-    """Is a *recorded* evidence report a well-formed, successful 5c verdict?
-
-    What a downstream consumer needs before treating a stored report as proof
-    that a release published successfully. Identity — that the payload hashes to
-    its recorded hash and states the release's proof identities — is necessary
-    but not sufficient: a report edited to ``"fail"`` and rehashed keeps every
-    identity intact while recording that publication did *not* succeed.
-
-    Deliberately bounded to what the report actually contains. It reconstructs
-    no history, and it does not reopen the vector store (Owner Decision
-    2026-08-01); the recorded digest is verified as an exact recorded value by
-    the caller.
-    """
-    if not isinstance(payload, dict):
-        return (f"evidence report is {type(payload).__name__}, not an object",)
-    violations: list[str] = []
-    if payload.get("report_version") != EVIDENCE_REPORT_SCHEMA_VERSION:
-        violations.append(
-            f"report_version {payload.get('report_version')!r} is not the supported "
-            f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
-        )
-    # Exact, not merely complete. Requiring only that the known keys are present
-    # lets an edited-and-rehashed payload carry an unknown field under the same
-    # schema version, which is a different document claiming to be this one.
-    if missing := sorted(REQUIRED_REPORT_KEYS - set(payload)):
-        violations.append(f"evidence report is missing {missing}")
-    if unexpected := sorted(set(payload) - REQUIRED_REPORT_KEYS):
-        violations.append(
-            f"evidence report carries unrecognised keys {unexpected} under schema "
-            f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
-        )
-    for key, required in _CLOSED_STRUCTURAL_MAPS.items():
-        violations.extend(_closed_map_violations(payload, key, required))
-    status = payload.get("prepublication_validation_status")
-    if status != "pass":
-        violations.append(
-            f"prepublication_validation_status is {status!r}, not 'pass' — the "
-            "recorded evidence states this release did not publish successfully"
-        )
-    # Evaluated even when the status already says "pass": the defect being closed
-    # is a payload that *claims* success while its own summaries record failures.
-    violations.extend(verdict_violations(payload))
-    return tuple(violations)
+    def dump(self) -> dict[str, Any]:
+        """The canonical JSON-compatible payload — hashed and persisted."""
+        return self.payload.dump()
 
 
 def build_report(
@@ -324,7 +97,14 @@ def build_report(
     canaries: tuple[CanaryResult, ...],
     persisted: bool,
 ) -> EvidenceReport:
-    """Build the evidence report after persistence (K step e)."""
+    """Build the evidence report after persistence (K step e).
+
+    Constructs the canonical typed object directly — the model is the shape,
+    not a lint pass over a dictionary. The recorded transform and vector
+    identities are validated on the way in rather than copied through, so a
+    config missing either one fails here instead of producing a report
+    describing a release nobody can verify.
+    """
     leaf_totals = Counter(leaf.leaf_type.value for leaf in ledger.leaves)
     disp_by_leaf = {d.leaf_id: d for d in recon.dispositions}
     represented_totals: Counter[str] = Counter()
@@ -336,7 +116,18 @@ def build_report(
         elif d.disposition is Disposition.EXCLUDED and d.exclusion_reason_code:
             excluded_by_reason[d.exclusion_reason_code] += 1
 
-    payload: dict[str, object] = {
+    # Complete Component B transform identity: extractor config + the first-party
+    # source manifest/hash + deterministic invocation + IR flag (not just
+    # ledger.extraction_config — PR #134 P1). The recorded invocation's steps are
+    # a tuple in memory and a list once JSON round-tripped; both canonicalize to
+    # the same bytes, so normalizing here does not move the hash.
+    recorded_identity = transform_config.get("transform_identity")
+    transform_identity: dict[str, object] = {
+        "extractor": transform_config.get("extraction_config"),
+        **(recorded_identity if isinstance(recorded_identity, dict) else {}),
+    }
+
+    fields: dict[str, Any] = {
         # Canonical schema version, also bound into the transform identity so a
         # schema change remints the release rather than being reused (R17).
         "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
@@ -346,17 +137,7 @@ def build_report(
         "bundle_root_hash": bundle_root_hash,
         "frozen_source_ledger_hash": ledger_hash_value,
         "persisted_corpus_digest": persisted_corpus_digest,
-        # Complete Component B transform identity: extractor config + the
-        # first-party source manifest/hash + deterministic invocation + IR flag
-        # (not just ledger.extraction_config — PR #134 P1).
-        "transform_identity": {
-            "extractor": transform_config.get("extraction_config"),
-            **(
-                transform_config.get("transform_identity", {})  # type: ignore[dict-item]
-                if isinstance(transform_config.get("transform_identity"), dict)
-                else {}
-            ),
-        },
+        "transform_identity": transform_identity,
         # Identity-bearing rules-corpus vector configuration (embedding model +
         # logical schema/ID/metadata contract) bound into the release identity
         # (PR #134 P1); recorded so a model/schema change is on the record.
@@ -371,42 +152,44 @@ def build_report(
         # enters this identity-bearing payload, so the same committed inputs yield a
         # byte-identical evidence report (hence release identity) on every supported
         # host (PR #134 R16). Actual host diagnostics are logged, never hashed.
-        "reproduction_target": {"python_target": PYTHON_TARGET},
-        "reconciliation_policy_reference": {
-            "policy_version": policy.policy_version,
-            "policy_hash": policy_hash(policy),
-            "applied_policy_hash": recon.policy_hash,
-        },
+        "reproduction_target": ReproductionTarget(python_target=PYTHON_TARGET),
+        "reconciliation_policy_reference": PolicyReference(
+            policy_version=policy.policy_version,
+            policy_hash=policy_hash(policy),
+            applied_policy_hash=recon.policy_hash,
+        ),
         # Ledger + reconciliation summary.
         "source_ledger_leaf_totals": dict(sorted(leaf_totals.items())),
         "represented_totals": dict(sorted(represented_totals.items())),
         "excluded_totals_by_reason": dict(sorted(excluded_by_reason.items())),
         "unresolved_leaves": recon.unresolved_leaves,
         "declared_projection_count": len(recon.projections),
-        "accounting": {
-            "inventoried_leaves": recon.inventoried_leaves,
-            "represented_leaves": recon.represented_leaves,
-            "excluded_leaves": recon.excluded_leaves,
-            "unresolved_leaves": recon.unresolved_leaves,
-        },
-        "findings": {
-            "gaps": len(recon.findings.gaps),
-            "overlaps": len(recon.findings.overlaps),
-            "orphans": len(recon.findings.orphans),
-            "duplications": len(recon.findings.duplications),
-        },
+        "accounting": Accounting(
+            inventoried_leaves=recon.inventoried_leaves,
+            represented_leaves=recon.represented_leaves,
+            excluded_leaves=recon.excluded_leaves,
+            unresolved_leaves=recon.unresolved_leaves,
+        ),
+        "findings": Findings(
+            gaps=len(recon.findings.gaps),
+            overlaps=len(recon.findings.overlaps),
+            orphans=len(recon.findings.orphans),
+            duplications=len(recon.findings.duplications),
+        ),
         "invalid_locators": len(concordance.locator_failures),
         "concordance_failures": len(concordance.content_failures),
         "version_canaries": {c.name: c.passed for c in canaries},
     }
-    # The verdict is derived from the payload that has just been assembled, not
-    # from a second predicate over the source objects. One definition (below) of
-    # what a successful publication looks like in the numbers, so a recorded
-    # report claiming "pass" alongside contradictory summaries is impossible to
-    # produce here and detectable everywhere it is read back.
-    payload["prepublication_validation_status"] = (
-        "pass" if persisted and not verdict_violations(payload) else "fail"
+
+    # The verdict is read off the assembled document through the same method a
+    # stored report is measured by, so a report claiming "pass" over
+    # contradictory summaries cannot be produced here — and an incomplete canary
+    # run is refused by the model before the question is even asked.
+    provisional = CorpusEvidenceReport.model_validate(
+        {**fields, "prepublication_validation_status": "fail"}
     )
+    status = "pass" if persisted and not provisional.verdict_violations() else "fail"
+
     # Actual host as an operational diagnostic ONLY — deliberately outside the
     # returned payload, so it never reaches the report hash, the persisted-corpus
     # digest, the package identity, or any publication-gate comparison. Never
@@ -418,9 +201,36 @@ def build_report(
         platform.machine(),
         platform.python_version(),
     )
-    return EvidenceReport(payload=payload, persisted=persisted)
+    return EvidenceReport(
+        payload=CorpusEvidenceReport.model_validate(
+            {**fields, "prepublication_validation_status": status}
+        ),
+        persisted=persisted,
+    )
+
+
+def recorded_success_violations(payload: object) -> tuple[str, ...]:
+    """Is a *recorded* report a well-formed, successful 5c verdict?
+
+    Parse first, then judge. Shape, closed populations, and value domains
+    belong to the typed model; this adds only the verdict question, on a
+    document that has already proven it is this schema.
+
+    Deliberately bounded to what the report contains. It reconstructs no
+    history and does not reopen the vector store (Owner Decision 2026-08-01);
+    agreement with the release row and with reconstructed 5c state is proven
+    contextually by :func:`persistence.verify_published_release`.
+    """
+    parsed, violations = parse_recorded_report(payload)
+    if parsed is None:
+        return violations
+    return parsed.success_violations()
 
 
 def report_hash(report: EvidenceReport) -> str:
-    """Hash the completed evidence report (K step f)."""
-    return hash_obj(report.payload)
+    """Hash the completed evidence report (K step f).
+
+    Over the canonical dump of the typed payload — the same bytes SQL persists,
+    so a stored report always rehashes to the value recorded beside it.
+    """
+    return hash_obj(report.dump())

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -35,6 +35,7 @@ from afterworlds.ingestion.corpus.policy import policy_hash
 from afterworlds.ingestion.corpus.report_schema import (
     CANONICAL_CANARY_NAMES,
     EVIDENCE_REPORT_SCHEMA_VERSION,
+    PYTHON_TARGET,
     Accounting,
     CorpusEvidenceReport,
     Findings,
@@ -56,12 +57,6 @@ __all__ = [
 ]
 
 _log = logging.getLogger(__name__)
-
-# The declared Python target (pyproject ``requires-python``; Python 3.12 only per
-# CLAUDE.md). Recorded as a *declared, host-independent* reproduction target — the
-# actual runtime interpreter/host is a diagnostic and never enters this
-# identity-bearing payload (PR #134 R16).
-PYTHON_TARGET = "3.12"
 
 
 @dataclass(frozen=True)

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -41,6 +41,7 @@ from afterworlds.ingestion.corpus.report_schema import (
     Findings,
     PolicyReference,
     ReproductionTarget,
+    canonical_report,
     parse_recorded_report,
 )
 
@@ -51,6 +52,7 @@ __all__ = [
     "CorpusEvidenceReport",
     "EvidenceReport",
     "build_report",
+    "canonical_report",
     "parse_recorded_report",
     "recorded_success_violations",
     "report_hash",
@@ -180,9 +182,13 @@ def build_report(
     # stored report is measured by, so a report claiming "pass" over
     # contradictory summaries cannot be produced here — and an incomplete canary
     # run is refused by the model before the question is even asked.
-    provisional = CorpusEvidenceReport.model_validate(
+    provisional, provisional_violations = parse_recorded_report(
         {**fields, "prepublication_validation_status": "fail"}
     )
+    if provisional is None:  # pragma: no cover - a build that cannot describe itself
+        raise ValueError(
+            f"evidence report inputs are not canonical: {provisional_violations}"
+        )
     status = "pass" if persisted and not provisional.verdict_violations() else "fail"
 
     # Actual host as an operational diagnostic ONLY — deliberately outside the
@@ -197,7 +203,7 @@ def build_report(
         platform.python_version(),
     )
     return EvidenceReport(
-        payload=CorpusEvidenceReport.model_validate(
+        payload=canonical_report(
             {**fields, "prepublication_validation_status": status}
         ),
         persisted=persisted,

--- a/src/afterworlds/ingestion/corpus/report_schema.py
+++ b/src/afterworlds/ingestion/corpus/report_schema.py
@@ -33,18 +33,20 @@ array.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import fields
 from types import MappingProxyType
 from typing import Annotated, Any
 
 from pydantic import (
     AfterValidator,
-    BaseModel,
     ConfigDict,
     Field,
     PlainSerializer,
+    TypeAdapter,
     ValidationError,
     model_validator,
 )
+from pydantic.dataclasses import dataclass
 from pydantic_core import ErrorDetails
 
 from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
@@ -64,6 +66,7 @@ __all__ = [
     "RulesCorpusVectorIdentity",
     "SourceManifestEntry",
     "TransformIdentity",
+    "canonical_report",
     "parse_recorded_report",
 ]
 
@@ -99,7 +102,32 @@ _LEAF_TYPE_NAMES = frozenset(leaf_type.value for leaf_type in LeafType)
 #: pass. A report recording any other target is not this schema.
 PYTHON_TARGET = "3.12"
 
-Count = Annotated[int, Field(ge=0)]
+#: Closed to unknown fields. Strictness is applied per scalar rather than
+#: globally: a global ``strict=True`` would also demand that every nested value
+#: arrive as an already-constructed instance, which a stored JSON object never
+#: is.
+_CONFIG = ConfigDict(extra="forbid")
+
+
+# Every canonical type below is declared ``frozen=True, slots=True`` with a
+# closed config. ``slots=True`` is the load-bearing word: a frozen Pydantic
+# ``BaseModel`` keeps its fields in ``__dict__``, so
+# ``vars(report)["version_canaries"] = {}`` reached past the freeze, changed the
+# dump, and changed the hash. A slotted dataclass has no instance dictionary at
+# all — ``vars()`` raises and there is no backing store to reach for — so
+# immutability is a property of the type rather than of the values someone
+# remembered to wrap. The decorator is applied directly at each class rather
+# than through a helper so type checkers still see the generated ``__init__``.
+
+#: Strict scalars. ``bool`` is an ``int`` subclass, so without these a JSON
+#: ``true`` would load as the count ``1``; ``"0"`` and ``0.0`` are likewise not
+#: integers, and a number is not a string.
+Str = Annotated[str, Field(strict=True)]
+Bool = Annotated[bool, Field(strict=True)]
+Int = Annotated[int, Field(strict=True)]
+Real = Annotated[float, Field(strict=True)]
+
+Count = Annotated[int, Field(strict=True, ge=0)]
 
 
 def _frozen_mapping[V](value: Mapping[str, V]) -> Mapping[str, V]:
@@ -114,13 +142,13 @@ def _frozen_mapping[V](value: Mapping[str, V]) -> Mapping[str, V]:
 
 #: Content-derived count maps: variable key population, immutable once parsed.
 CountMap = Annotated[
-    Mapping[str, Count],
+    Mapping[Str, Count],
     AfterValidator(_frozen_mapping),
     PlainSerializer(dict, return_type=dict),
 ]
 #: The canary population: closed key set (checked below), immutable values.
 FlagMap = Annotated[
-    Mapping[str, bool],
+    Mapping[Str, Bool],
     AfterValidator(_frozen_mapping),
     PlainSerializer(dict, return_type=dict),
 ]
@@ -129,45 +157,43 @@ FlagMap = Annotated[
 #: return tuples in memory while JSON round-trips them to lists, and both
 #: canonicalize to the same bytes — two encodings of one value. A bare string
 #: is still refused.
-Array = Annotated[tuple[str, ...], Field(strict=False)]
+Array = tuple[Str, ...]
 
 
-class _Canonical(BaseModel):
-    """Frozen, closed, and strict: the three properties this schema needs."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
-
-
-class ExtractorConfig(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class ExtractorConfig:
     """The frozen extraction identity, exactly as ``extraction_config()`` emits."""
 
-    tool: str
-    tool_version: str
-    engine: str
-    engine_version: str
-    use_text_flow: bool
-    keep_blank_chars: bool
-    line_y_tolerance: float
-    geometry_decimals: int
-    reading_order: str
+    tool: Str
+    tool_version: Str
+    engine: Str
+    engine_version: Str
+    use_text_flow: Bool
+    keep_blank_chars: Bool
+    line_y_tolerance: Real
+    geometry_decimals: Int
+    reading_order: Str
 
 
-class SourceManifestEntry(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class SourceManifestEntry:
     """One audited first-party transform module and its content hash."""
 
-    path: str
-    sha256: str
+    path: Str
+    sha256: Str
 
 
-class ComponentBInvocation(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class ComponentBInvocation:
     """The deterministic Component B invocation the transform identity records."""
 
-    entrypoint: str
+    entrypoint: Str
     steps: Array
-    deterministic: bool
+    deterministic: Bool
 
 
-class TransformIdentity(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class TransformIdentity:
     """The complete first-party transform identity carried by the report.
 
     Closed, not content-populated: every key here comes from
@@ -177,28 +203,30 @@ class TransformIdentity(_Canonical):
     """
 
     extractor: ExtractorConfig
-    tool: str
-    tool_version: str
-    source_manifest: Annotated[tuple[SourceManifestEntry, ...], Field(strict=False)]
-    transform_source_hash: str
+    tool: Str
+    tool_version: Str
+    source_manifest: tuple[SourceManifestEntry, ...]
+    transform_source_hash: Str
     component_b_invocation: ComponentBInvocation
-    intermediate_representation_committed: bool
+    intermediate_representation_committed: Bool
 
 
-class RulesCorpusVectorIdentity(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class RulesCorpusVectorIdentity:
     """The identity-bearing rules-corpus vector configuration (ADR-018 D2/D4/D11).
 
     Also closed: ``rules_corpus_vector_identity()`` returns a fixed schema.
     """
 
-    embedding_model_id: str
-    metadata_schema_version: int
+    embedding_model_id: Str
+    metadata_schema_version: Int
     metadata_fields: Array
-    chunk_id_scheme: str
-    collection_name_scheme: str
+    chunk_id_scheme: Str
+    collection_name_scheme: Str
 
 
-class ReproductionTarget(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class ReproductionTarget:
     """The declared, host-independent reproduction target (PR #134 R16).
 
     Bound to :data:`PYTHON_TARGET`, not merely defaulted to it. The field is a
@@ -207,7 +235,7 @@ class ReproductionTarget(_Canonical):
     and possibly not at all.
     """
 
-    python_target: str
+    python_target: Str
 
     @model_validator(mode="after")
     def _canonical_target(self) -> ReproductionTarget:
@@ -219,15 +247,17 @@ class ReproductionTarget(_Canonical):
         return self
 
 
-class PolicyReference(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class PolicyReference:
     """Which reconciliation policy was frozen, and which was actually applied."""
 
-    policy_version: str
-    policy_hash: str
-    applied_policy_hash: str
+    policy_version: Str
+    policy_hash: Str
+    applied_policy_hash: Str
 
 
-class Accounting(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class Accounting:
     """The leaf accounting equation's terms."""
 
     inventoried_leaves: Count
@@ -242,7 +272,8 @@ class Accounting(_Canonical):
         )
 
 
-class Findings(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class Findings:
     """Identity-level reconciliation findings, as counts."""
 
     gaps: Count
@@ -253,21 +284,24 @@ class Findings(_Canonical):
     def nonzero(self) -> tuple[str, ...]:
         return tuple(
             f"findings.{name} is {value}, not 0"
-            for name, value in sorted(self.__dict__.items())
+            for name, value in sorted(
+                (f.name, getattr(self, f.name)) for f in fields(self)
+            )
             if value
         )
 
 
-class CorpusEvidenceReport(_Canonical):
+@dataclass(frozen=True, slots=True, config=_CONFIG)
+class CorpusEvidenceReport:
     """The complete canonical `5c-evidence-3` evidence-report payload."""
 
-    report_version: str
+    report_version: Str
     # Proof identities (never this report's own hash — it cannot contain it).
-    authoritative_source_hash: str
-    transform_config_hash: str
-    bundle_root_hash: str
-    frozen_source_ledger_hash: str
-    persisted_corpus_digest: str
+    authoritative_source_hash: Str
+    transform_config_hash: Str
+    bundle_root_hash: Str
+    frozen_source_ledger_hash: Str
+    persisted_corpus_digest: Str
     # Closed identity structures.
     transform_identity: TransformIdentity
     rules_corpus_vector_identity: RulesCorpusVectorIdentity
@@ -290,7 +324,7 @@ class CorpusEvidenceReport(_Canonical):
     invalid_locators: Count
     concordance_failures: Count
     version_canaries: FlagMap
-    prepublication_validation_status: str
+    prepublication_validation_status: Str
 
     @model_validator(mode="after")
     def _canonical_populations(self) -> CorpusEvidenceReport:
@@ -370,16 +404,33 @@ class CorpusEvidenceReport(_Canonical):
     def dump(self) -> dict[str, Any]:
         """The canonical JSON-compatible payload: hashed, persisted, compared.
 
-        One serialization path. ``report_hash``, the SQL column, and every
-        downstream comparison read this, so there is no second rendering of the
-        document that could drift from the model.
+        The **only** serialization of this document. ``report_hash``, the SQL
+        column, and every contextual comparison read this — including
+        comparisons that need one nested fragment, which slice this dump rather
+        than serializing the nested value separately. A second rendering, even
+        of a fragment, is a second definition waiting to diverge.
         """
-        return self.model_dump(mode="json")
+        dumped: dict[str, Any] = _ADAPTER.dump_python(self, mode="json")
+        return dumped
+
+
+#: The one validator/serializer for the canonical document.
+_ADAPTER: TypeAdapter[CorpusEvidenceReport] = TypeAdapter(CorpusEvidenceReport)
 
 
 def _where(error: ErrorDetails) -> str:
     location = ".".join(str(part) for part in error["loc"]) or "evidence report"
     return f"{location}: {error['msg']}"
+
+
+def canonical_report(payload: object) -> CorpusEvidenceReport:
+    """Build the canonical value, raising on anything that is not this schema.
+
+    The construction-side counterpart to :func:`parse_recorded_report`. A build
+    that cannot describe itself in the canonical shape is a defect here and now,
+    not an auditable finding about someone else's stored bytes.
+    """
+    return _ADAPTER.validate_python(payload)
 
 
 def parse_recorded_report(
@@ -393,6 +444,6 @@ def parse_recorded_report(
     refusals.
     """
     try:
-        return CorpusEvidenceReport.model_validate(payload), ()
+        return _ADAPTER.validate_python(payload), ()
     except ValidationError as exc:
         return None, tuple(_where(error) for error in exc.errors())

--- a/src/afterworlds/ingestion/corpus/report_schema.py
+++ b/src/afterworlds/ingestion/corpus/report_schema.py
@@ -32,9 +32,19 @@ array.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    ValidationError,
+    model_validator,
+)
 from pydantic_core import ErrorDetails
 
 from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
@@ -42,6 +52,7 @@ from afterworlds.ingestion.corpus.models import LeafType
 
 __all__ = [
     "CANONICAL_CANARY_NAMES",
+    "PYTHON_TARGET",
     "EVIDENCE_REPORT_SCHEMA_VERSION",
     "Accounting",
     "ComponentBInvocation",
@@ -82,12 +93,43 @@ CANONICAL_CANARY_NAMES = frozenset(canary.name for canary in VERSION_CANARIES)
 #: Derived from the enum, so the universe cannot drift from the taxonomy.
 _LEAF_TYPE_NAMES = frozenset(leaf_type.value for leaf_type in LeafType)
 
+#: The declared Python target (pyproject ``requires-python``; Python 3.12 only
+#: per CLAUDE.md). Owned here, in the schema layer, because it is a *canonical
+#: semantic constant of the document* — not a default the builder happens to
+#: pass. A report recording any other target is not this schema.
+PYTHON_TARGET = "3.12"
+
 Count = Annotated[int, Field(ge=0)]
-#: Arrays accept a tuple as well as a list. The identity builders return
-#: tuples in memory and JSON round-trips them to lists, and both canonicalize
-#: to the same bytes — so this admits the two encodings of one value without
-#: admitting a *string*, which lax mode still refuses.
-Array = Annotated[list[str], Field(strict=False)]
+
+
+def _frozen_mapping[V](value: Mapping[str, V]) -> Mapping[str, V]:
+    """Copy the validated mapping and hand back a read-only view of the copy.
+
+    Copying matters as much as freezing: a proxy over the caller's dict would
+    still change when the caller does, so the report would not own its own
+    value. The proxy has no ``__setitem__``, ``__delitem__``, or ``clear``.
+    """
+    return MappingProxyType(dict(value))
+
+
+#: Content-derived count maps: variable key population, immutable once parsed.
+CountMap = Annotated[
+    Mapping[str, Count],
+    AfterValidator(_frozen_mapping),
+    PlainSerializer(dict, return_type=dict),
+]
+#: The canary population: closed key set (checked below), immutable values.
+FlagMap = Annotated[
+    Mapping[str, bool],
+    AfterValidator(_frozen_mapping),
+    PlainSerializer(dict, return_type=dict),
+]
+#: Canonical arrays are tuples, so a parsed report cannot be appended to or
+#: have an element replaced. Lax on the way in because the identity builders
+#: return tuples in memory while JSON round-trips them to lists, and both
+#: canonicalize to the same bytes — two encodings of one value. A bare string
+#: is still refused.
+Array = Annotated[tuple[str, ...], Field(strict=False)]
 
 
 class _Canonical(BaseModel):
@@ -137,7 +179,7 @@ class TransformIdentity(_Canonical):
     extractor: ExtractorConfig
     tool: str
     tool_version: str
-    source_manifest: Annotated[list[SourceManifestEntry], Field(strict=False)]
+    source_manifest: Annotated[tuple[SourceManifestEntry, ...], Field(strict=False)]
     transform_source_hash: str
     component_b_invocation: ComponentBInvocation
     intermediate_representation_committed: bool
@@ -157,9 +199,24 @@ class RulesCorpusVectorIdentity(_Canonical):
 
 
 class ReproductionTarget(_Canonical):
-    """The declared, host-independent reproduction target (PR #134 R16)."""
+    """The declared, host-independent reproduction target (PR #134 R16).
+
+    Bound to :data:`PYTHON_TARGET`, not merely defaulted to it. The field is a
+    canonical constant of the schema, so a stored report recording any other
+    target fails intrinsic parsing rather than being compared somewhere later
+    and possibly not at all.
+    """
 
     python_target: str
+
+    @model_validator(mode="after")
+    def _canonical_target(self) -> ReproductionTarget:
+        if self.python_target != PYTHON_TARGET:
+            raise ValueError(
+                f"python_target {self.python_target!r} is not the canonical "
+                f"reproduction target {PYTHON_TARGET!r}"
+            )
+        return self
 
 
 class PolicyReference(_Canonical):
@@ -218,13 +275,13 @@ class CorpusEvidenceReport(_Canonical):
     reconciliation_policy_reference: PolicyReference
     # Content-derived populations: the *key set* varies with the corpus, but the
     # mapping and its value types do not. "Open" never meant "unvalidated".
-    source_ledger_leaf_totals: dict[str, Count]
-    represented_totals: dict[str, Count]
+    source_ledger_leaf_totals: CountMap
+    represented_totals: CountMap
     #: Keys are policy reason codes. Left as free strings here on purpose: the
     #: frozen policy is not available at parse time, and reaching for it would
     #: create a second policy definition. Reason validity is proven
     #: contextually, against the reconstructed policy.
-    excluded_totals_by_reason: dict[str, Count]
+    excluded_totals_by_reason: CountMap
     # Verdict-bearing summaries.
     unresolved_leaves: Count
     declared_projection_count: Count
@@ -232,7 +289,7 @@ class CorpusEvidenceReport(_Canonical):
     findings: Findings
     invalid_locators: Count
     concordance_failures: Count
-    version_canaries: dict[str, bool]
+    version_canaries: FlagMap
     prepublication_validation_status: str
 
     @model_validator(mode="after")

--- a/src/afterworlds/ingestion/corpus/report_schema.py
+++ b/src/afterworlds/ingestion/corpus/report_schema.py
@@ -1,0 +1,341 @@
+"""The canonical evidence-report payload, as one typed object — CRD Issue 5c.
+
+Four review rounds tried to close this schema with constants and loops:
+required-key sets, closed-inventory maps, an "open map" list, a violations
+walker. Each round shut one hole and left the next one — because the builder
+held the real shape in a dict literal while the validator held a second,
+partial description of it. Two definitions of one document is the defect, not
+the individual omissions.
+
+So there is now exactly one definition. :class:`CorpusEvidenceReport` *is* the
+`5c-evidence-3` payload: ``build_report`` constructs it, ``report_hash`` hashes
+its canonical dump, SQL persists that same dump, and a stored report is parsed
+back through it. A field that is not on this model does not exist in the
+schema, and a field on it cannot be omitted, retyped, or shadowed by an extra
+key — ``extra="forbid"`` and ``strict=True`` are doing that work, not a
+hand-maintained inventory.
+
+**Intrinsic versus contextual.** This module owns what the document must be on
+its own: shape, types, closed populations, and the cross-field semantics of a
+successful verdict. It deliberately owns *nothing* about whether the document
+agrees with the release it describes — that comparison needs the release row
+and reconstructed 5c state, and lives in
+:func:`persistence.verify_published_release`.
+
+**Strictness that matters at a JSON boundary.** ``strict=True`` is what makes
+``true`` fail an integer field (``bool`` is an ``int`` subclass), ``"0"`` fail
+an integer, and ``0.0`` fail an integer. Arrays are declared ``list`` rather
+than ``tuple`` because a JSON round-trip produces lists, and hashing is
+unaffected: :func:`hashing.canonical_bytes` renders both as the same JSON
+array.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic_core import ErrorDetails
+
+from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
+from afterworlds.ingestion.corpus.models import LeafType
+
+__all__ = [
+    "CANONICAL_CANARY_NAMES",
+    "EVIDENCE_REPORT_SCHEMA_VERSION",
+    "Accounting",
+    "ComponentBInvocation",
+    "CorpusEvidenceReport",
+    "ExtractorConfig",
+    "Findings",
+    "PolicyReference",
+    "ReproductionTarget",
+    "RulesCorpusVectorIdentity",
+    "SourceManifestEntry",
+    "TransformIdentity",
+    "parse_recorded_report",
+]
+
+# Canonical evidence-report schema version. Bumped across canonical-shape
+# changes: "2" for the R16 host-independent ``reproduction_target`` change; "3"
+# for the R18 pre-release clean-baseline change that removed the
+# legacy-reachability status (Issue 5c Rev7 / Issue 18 Rev6 supersede the strict
+# cross-store quarantine contract). This version is bound into
+# ``transform_config_payload`` (hence the transform hash / package UUID /
+# release version), so an evidence-report *schema* change mints a NEW immutable
+# release instead of being reused under a predecessor's identity (R17
+# mechanism). It is deliberately an *explicit* schema identity rather than a
+# byte-level hash of this module: only an intentional canonical-shape change
+# should remint, never a comment/docstring/annotation edit.
+#
+# Typing this payload did **not** change it. The emitted document and its hash
+# are byte-identical to the untyped implementation, so the version stands.
+EVIDENCE_REPORT_SCHEMA_VERSION = "5c-evidence-3"
+
+#: The canonical version-canary population, derived from the committed canary
+#: definitions. Never a second hand-written list: adding or retiring a canary
+#: moves the required population with it.
+CANONICAL_CANARY_NAMES = frozenset(canary.name for canary in VERSION_CANARIES)
+
+#: Leaf-type totals may cover any *subset* of the taxonomy — a corpus with no
+#: tables legitimately reports no ``table_cell`` — but never a name outside it.
+#: Derived from the enum, so the universe cannot drift from the taxonomy.
+_LEAF_TYPE_NAMES = frozenset(leaf_type.value for leaf_type in LeafType)
+
+Count = Annotated[int, Field(ge=0)]
+#: Arrays accept a tuple as well as a list. The identity builders return
+#: tuples in memory and JSON round-trips them to lists, and both canonicalize
+#: to the same bytes — so this admits the two encodings of one value without
+#: admitting a *string*, which lax mode still refuses.
+Array = Annotated[list[str], Field(strict=False)]
+
+
+class _Canonical(BaseModel):
+    """Frozen, closed, and strict: the three properties this schema needs."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class ExtractorConfig(_Canonical):
+    """The frozen extraction identity, exactly as ``extraction_config()`` emits."""
+
+    tool: str
+    tool_version: str
+    engine: str
+    engine_version: str
+    use_text_flow: bool
+    keep_blank_chars: bool
+    line_y_tolerance: float
+    geometry_decimals: int
+    reading_order: str
+
+
+class SourceManifestEntry(_Canonical):
+    """One audited first-party transform module and its content hash."""
+
+    path: str
+    sha256: str
+
+
+class ComponentBInvocation(_Canonical):
+    """The deterministic Component B invocation the transform identity records."""
+
+    entrypoint: str
+    steps: Array
+    deterministic: bool
+
+
+class TransformIdentity(_Canonical):
+    """The complete first-party transform identity carried by the report.
+
+    Closed, not content-populated: every key here comes from
+    ``extraction_config()`` and ``transform_identity()``, both of which return
+    fixed schemas. Treating it as open let an edited-and-rehashed report replace
+    the whole identity with ``{}``.
+    """
+
+    extractor: ExtractorConfig
+    tool: str
+    tool_version: str
+    source_manifest: Annotated[list[SourceManifestEntry], Field(strict=False)]
+    transform_source_hash: str
+    component_b_invocation: ComponentBInvocation
+    intermediate_representation_committed: bool
+
+
+class RulesCorpusVectorIdentity(_Canonical):
+    """The identity-bearing rules-corpus vector configuration (ADR-018 D2/D4/D11).
+
+    Also closed: ``rules_corpus_vector_identity()`` returns a fixed schema.
+    """
+
+    embedding_model_id: str
+    metadata_schema_version: int
+    metadata_fields: Array
+    chunk_id_scheme: str
+    collection_name_scheme: str
+
+
+class ReproductionTarget(_Canonical):
+    """The declared, host-independent reproduction target (PR #134 R16)."""
+
+    python_target: str
+
+
+class PolicyReference(_Canonical):
+    """Which reconciliation policy was frozen, and which was actually applied."""
+
+    policy_version: str
+    policy_hash: str
+    applied_policy_hash: str
+
+
+class Accounting(_Canonical):
+    """The leaf accounting equation's terms."""
+
+    inventoried_leaves: Count
+    represented_leaves: Count
+    excluded_leaves: Count
+    unresolved_leaves: Count
+
+    @property
+    def balances(self) -> bool:
+        return self.inventoried_leaves == (
+            self.represented_leaves + self.excluded_leaves + self.unresolved_leaves
+        )
+
+
+class Findings(_Canonical):
+    """Identity-level reconciliation findings, as counts."""
+
+    gaps: Count
+    overlaps: Count
+    orphans: Count
+    duplications: Count
+
+    def nonzero(self) -> tuple[str, ...]:
+        return tuple(
+            f"findings.{name} is {value}, not 0"
+            for name, value in sorted(self.__dict__.items())
+            if value
+        )
+
+
+class CorpusEvidenceReport(_Canonical):
+    """The complete canonical `5c-evidence-3` evidence-report payload."""
+
+    report_version: str
+    # Proof identities (never this report's own hash — it cannot contain it).
+    authoritative_source_hash: str
+    transform_config_hash: str
+    bundle_root_hash: str
+    frozen_source_ledger_hash: str
+    persisted_corpus_digest: str
+    # Closed identity structures.
+    transform_identity: TransformIdentity
+    rules_corpus_vector_identity: RulesCorpusVectorIdentity
+    reproduction_target: ReproductionTarget
+    reconciliation_policy_reference: PolicyReference
+    # Content-derived populations: the *key set* varies with the corpus, but the
+    # mapping and its value types do not. "Open" never meant "unvalidated".
+    source_ledger_leaf_totals: dict[str, Count]
+    represented_totals: dict[str, Count]
+    #: Keys are policy reason codes. Left as free strings here on purpose: the
+    #: frozen policy is not available at parse time, and reaching for it would
+    #: create a second policy definition. Reason validity is proven
+    #: contextually, against the reconstructed policy.
+    excluded_totals_by_reason: dict[str, Count]
+    # Verdict-bearing summaries.
+    unresolved_leaves: Count
+    declared_projection_count: Count
+    accounting: Accounting
+    findings: Findings
+    invalid_locators: Count
+    concordance_failures: Count
+    version_canaries: dict[str, bool]
+    prepublication_validation_status: str
+
+    @model_validator(mode="after")
+    def _canonical_populations(self) -> CorpusEvidenceReport:
+        """Closed populations and closed value domains, at parse time."""
+        if self.report_version != EVIDENCE_REPORT_SCHEMA_VERSION:
+            raise ValueError(
+                f"report_version {self.report_version!r} is not the supported "
+                f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
+            )
+        if self.prepublication_validation_status not in ("pass", "fail"):
+            raise ValueError(
+                "prepublication_validation_status must be 'pass' or 'fail', got "
+                f"{self.prepublication_validation_status!r}"
+            )
+        if set(self.version_canaries) != CANONICAL_CANARY_NAMES:
+            missing = sorted(CANONICAL_CANARY_NAMES - set(self.version_canaries))
+            unexpected = sorted(set(self.version_canaries) - CANONICAL_CANARY_NAMES)
+            raise ValueError(
+                "version_canaries is not the canonical population "
+                f"(missing {missing}, unexpected {unexpected})"
+            )
+        for field in ("source_ledger_leaf_totals", "represented_totals"):
+            outside = sorted(set(getattr(self, field)) - _LEAF_TYPE_NAMES)
+            if outside:
+                raise ValueError(
+                    f"{field} names leaf types outside the taxonomy: {outside}"
+                )
+        return self
+
+    def verdict_violations(self) -> tuple[str, ...]:
+        """Why these numbers do not state a successful publication.
+
+        The one definition of success in the report's own terms, read off typed
+        fields. ``build_report`` derives the recorded status from it, so a
+        report cannot be *written* claiming success over contradictory
+        summaries; a stored report is measured against the same rule.
+        """
+        violations: list[str] = []
+        for name in ("unresolved_leaves", "invalid_locators", "concordance_failures"):
+            value: int = getattr(self, name)
+            if value:
+                violations.append(f"{name} is {value}, not 0")
+        violations.extend(self.findings.nonzero())
+        for canary, passed in sorted(self.version_canaries.items()):
+            if not passed:
+                violations.append(f"version canary {canary} did not pass")
+        if self.accounting.unresolved_leaves:
+            violations.append(
+                "accounting.unresolved_leaves is "
+                f"{self.accounting.unresolved_leaves}, not 0"
+            )
+        if not self.accounting.balances:
+            violations.append("accounting equation does not balance")
+        if self.accounting.unresolved_leaves != self.unresolved_leaves:
+            violations.append(
+                "accounting.unresolved_leaves disagrees with the top-level "
+                "unresolved_leaves"
+            )
+        return tuple(violations)
+
+    def success_violations(self) -> tuple[str, ...]:
+        """Why this recorded report is not a successful publication verdict.
+
+        Identity is not sufficiency: a report edited to ``"fail"`` and rehashed
+        keeps every proof identity intact while recording that publication did
+        not succeed.
+        """
+        violations = []
+        if self.prepublication_validation_status != "pass":
+            violations.append(
+                "prepublication_validation_status is "
+                f"{self.prepublication_validation_status!r}, not 'pass' — the "
+                "recorded evidence states this release did not publish successfully"
+            )
+        return (*violations, *self.verdict_violations())
+
+    def dump(self) -> dict[str, Any]:
+        """The canonical JSON-compatible payload: hashed, persisted, compared.
+
+        One serialization path. ``report_hash``, the SQL column, and every
+        downstream comparison read this, so there is no second rendering of the
+        document that could drift from the model.
+        """
+        return self.model_dump(mode="json")
+
+
+def _where(error: ErrorDetails) -> str:
+    location = ".".join(str(part) for part in error["loc"]) or "evidence report"
+    return f"{location}: {error['msg']}"
+
+
+def parse_recorded_report(
+    payload: object,
+) -> tuple[CorpusEvidenceReport | None, tuple[str, ...]]:
+    """Parse a stored payload, returning violations rather than raising.
+
+    A recorded report has unknown provenance — JSON round-tripped, possibly
+    hand-edited — so a malformed one is an auditable finding, not an exception
+    escaping into the publication path. Callers turn these strings into typed
+    refusals.
+    """
+    try:
+        return CorpusEvidenceReport.model_validate(payload), ()
+    except ValidationError as exc:
+        return None, tuple(_where(error) for error in exc.errors())

--- a/tests/ingestion/corpus/test_ledger_pipeline.py
+++ b/tests/ingestion/corpus/test_ledger_pipeline.py
@@ -169,7 +169,7 @@ def test_clean_regeneration_is_byte_for_byte_deterministic(release):
 
 
 def test_evidence_report_carries_proof_hashes_but_not_its_own(release):
-    payload = release.report.payload
+    payload = release.report.dump()
     assert "persisted_corpus_digest" in payload
     assert payload["bundle_root_hash"] == release.release.identity.bundle_root_hash
     # The report never contains its own hash.
@@ -180,7 +180,7 @@ def test_evidence_report_records_complete_transform_identity(release):
     """PR #134 P1: the report records the full Component B identity — extractor
     config + first-party source manifest/hash + deterministic invocation + IR
     flag — not just ledger.extraction_config."""
-    ti = release.report.payload["transform_identity"]
+    ti = release.report.dump()["transform_identity"]
     assert isinstance(ti, dict)
     assert ti["extractor"]  # extractor config present
     assert ti["source_manifest"]  # first-party source manifest present
@@ -224,7 +224,7 @@ def test_evidence_report_identity_is_host_independent(release, monkeypatch):
         monkeypatch.setattr(report_mod.platform, "machine", lambda: machine)
         monkeypatch.setattr(report_mod.platform, "python_version", lambda: pyver)
         r = _rebuild_report(release)
-        return r.payload, report_hash(r)
+        return r.dump(), report_hash(r)
 
     p1, h1 = build_under("Linux", "x86_64", "3.12.1")
     p2, h2 = build_under("Windows", "AMD64", "3.12.9")

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -923,7 +923,7 @@ def test_reuse_rejects_obsolete_evidence_report_schema(
     published release (recomputing the stored hash so the gate's hash check passes,
     isolating the schema backstop) and assert the reuse attempt surfaces the schema
     failure and does not reuse."""
-    from afterworlds.ingestion.corpus.report import EvidenceReport, report_hash
+    from afterworlds.ingestion.corpus.hashing import hash_obj
 
     first = _finalize(
         session, candidate, chroma_client, retrieval_config, fake_embedding
@@ -939,9 +939,9 @@ def test_reuse_rejects_obsolete_evidence_report_schema(
     row.report_payload = payload
     # Keep the stored hash consistent with the tampered payload so the gate's
     # evidence_report_hash check passes — this isolates the schema backstop.
-    row.evidence_report_hash = report_hash(
-        EvidenceReport(payload=payload, persisted=True)
-    )
+    # Hashed as stored: the payload is deliberately an obsolete shape, so it
+    # cannot be round-tripped through the canonical model first.
+    row.evidence_report_hash = hash_obj(payload)
     session.commit()
 
     result = _finalize(

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -888,29 +888,33 @@ def test_completeness_rejects_page_corruption_and_leaves_no_state(
 #  see test_migration_0018_deletes_incomplete_package_and_dependent_rows.)
 
 
-def test_report_schema_ok_fails_closed_on_bad_schema():
-    """R17 unit: ``_report_schema_ok`` is the reuse-path backstop for the evidence-
-    report schema. Current + matching (report AND transform config) → True;
-    obsolete, contradictory, missing, or malformed → False (fail closed)."""
+def test_report_schema_ok_compares_the_parsed_report_with_the_transform_config():
+    """R17 unit: the reuse-path schema backstop, now purely contextual.
+
+    ``_report_schema_ok`` used to re-verify a raw report dictionary. It takes
+    the parsed canonical report instead, so a report object cannot exist with an
+    obsolete, missing, or malformed version — the model rejects those at the
+    parse boundary, covered by ``test_recorded_evidence``'s
+    ``obsolete-schema-version`` control. What remains here is the one question
+    the model cannot answer: does the report's version agree with the version
+    recorded in the stored transform configuration?
+    """
     from afterworlds.ingestion.corpus.persistence import _report_schema_ok
     from afterworlds.ingestion.corpus.report import EVIDENCE_REPORT_SCHEMA_VERSION as V
+    from afterworlds.ingestion.corpus.report import parse_recorded_report
+    from tests.ingestion.corpus.test_recorded_evidence import payload
 
-    assert _report_schema_ok(
-        {"report_version": V}, {"evidence_report_schema_version": V}
-    )
-    # obsolete pre-R16 report version
-    assert not _report_schema_ok(
-        {"report_version": "5c-evidence-1"}, {"evidence_report_schema_version": V}
-    )
+    report, violations = parse_recorded_report(payload())
+    assert report is not None, violations
+
+    assert _report_schema_ok(report, {"evidence_report_schema_version": V})
     # contradictory: report current, transform config stale or absent
-    assert not _report_schema_ok({"report_version": V}, {})
+    assert not _report_schema_ok(report, {})
     assert not _report_schema_ok(
-        {"report_version": V}, {"evidence_report_schema_version": "5c-evidence-1"}
+        report, {"evidence_report_schema_version": "5c-evidence-1"}
     )
-    # missing report version
-    assert not _report_schema_ok({}, {"evidence_report_schema_version": V})
-    # malformed payloads
-    assert not _report_schema_ok(None, {"evidence_report_schema_version": V})
+    # malformed transform configuration
+    assert not _report_schema_ok(report, None)
     assert not _report_schema_ok({"report_version": V}, None)
 
 

--- a/tests/ingestion/corpus/test_recorded_evidence.py
+++ b/tests/ingestion/corpus/test_recorded_evidence.py
@@ -1,37 +1,49 @@
-"""A recorded evidence report as a *successful* verdict — Issue 5c, PR #141 R3.
+"""The canonical evidence-report schema as one typed object — Issue 5c, PR #142.
 
-Identity is not sufficiency. A report edited to ``"fail"`` and rehashed keeps
-its five proof identities intact and still hashes to its recorded hash, so a
-downstream consumer that checks only identity accepts a release whose own
-evidence records that publication did not succeed.
+Four rounds of hand-maintained validation each shut one hole and left the next,
+because the builder held the real shape in a dict literal and the validator held
+a second, partial description of it. These tests exercise the replacement: one
+typed model that *is* the `5c-evidence-3` payload.
 
-``recorded_success_violations`` is the one definition of what success looks like
-in the report's own numbers. ``build_report`` derives
-``prepublication_validation_status`` from the same predicate, so a contradictory
-report cannot be *written* here either — these controls therefore describe an
-edited or foreign payload, which is exactly the provenance a recorded report
-has when it is read back.
+Two boundaries, tested separately:
+
+* **intrinsic** — what the document must be on its own: shape, types, closed
+  populations, value domains, and the cross-field semantics of a successful
+  verdict. Owned by :mod:`report_schema` and covered here;
+* **contextual** — whether the document agrees with the release it describes.
+  Owned by ``verify_published_release`` and covered by the mechanical
+  bound-release controls, which drive it through real publication.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
 
 from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
+from afterworlds.ingestion.corpus.models import LeafType
+from afterworlds.ingestion.corpus.pdf_source import extraction_config
 from afterworlds.ingestion.corpus.report import (
     CANONICAL_CANARY_NAMES,
     EVIDENCE_REPORT_SCHEMA_VERSION,
-    OPEN_REPORT_MAPS,
-    REQUIRED_REPORT_KEYS,
+    parse_recorded_report,
     recorded_success_violations,
-    verdict_violations,
 )
+from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
+from afterworlds.ingestion.corpus.transform_identity import transform_identity
+from afterworlds.models.retrieval import rules_corpus_vector_identity
 
 
 def payload(**overrides: Any) -> dict[str, Any]:
-    """An honest successful report payload, with *overrides* applied."""
+    """An honest successful report payload, with *overrides* applied.
+
+    Built from the real production identity builders and round-tripped through
+    JSON, so it is the shape a stored report actually has — not a hand-written
+    approximation that could drift from what ``build_report`` emits.
+    """
+    identity = transform_identity()
     base: dict[str, Any] = {
         "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
         "authoritative_source_hash": "a" * 64,
@@ -39,8 +51,8 @@ def payload(**overrides: Any) -> dict[str, Any]:
         "bundle_root_hash": "c" * 64,
         "frozen_source_ledger_hash": "d" * 64,
         "persisted_corpus_digest": "e" * 64,
-        "transform_identity": {"extractor": {}},
-        "rules_corpus_vector_identity": {"embedding_model_id": "m"},
+        "transform_identity": {"extractor": extraction_config(), **identity},
+        "rules_corpus_vector_identity": rules_corpus_vector_identity("model-x"),
         "reproduction_target": {"python_target": "3.12"},
         "reconciliation_policy_reference": {
             "policy_version": "v",
@@ -64,27 +76,270 @@ def payload(**overrides: Any) -> dict[str, Any]:
         "version_canaries": dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
         "prepublication_validation_status": "pass",
     }
-    base.update(overrides)
-    return base
+    stored: dict[str, Any] = json.loads(json.dumps(base))
+    stored.update(overrides)
+    return stored
 
 
-def test_the_fixture_matches_the_declared_report_shape() -> None:
-    """Guards this module from drifting away from what build_report produces."""
-    assert set(payload()) == REQUIRED_REPORT_KEYS
-
-
-def test_an_honest_successful_report_is_accepted() -> None:
-    assert recorded_success_violations(payload()) == ()
-    assert verdict_violations(payload()) == ()
+def at(path: str, value: object) -> dict[str, Any]:
+    """A payload with one dotted *path* replaced."""
+    document = payload()
+    target: Any = document
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[part]
+    target[parts[-1]] = value
+    return document
 
 
 # ---------------------------------------------------------------------------
-# The verdict itself
+# Positive controls
+# ---------------------------------------------------------------------------
+
+
+def test_an_honest_successful_report_parses_and_passes() -> None:
+    parsed, violations = parse_recorded_report(payload())
+    assert violations == ()
+    assert parsed is not None
+    assert parsed.success_violations() == ()
+    assert recorded_success_violations(payload()) == ()
+
+
+def test_the_typed_dump_round_trips_exactly() -> None:
+    """One serialization: what parses out is what would be hashed and stored."""
+    parsed, _ = parse_recorded_report(payload())
+    assert parsed is not None
+    assert parsed.dump() == payload()
+
+
+def test_the_canonical_canary_set_is_derived_not_restated() -> None:
+    assert frozenset(c.name for c in VERSION_CANARIES) == CANONICAL_CANARY_NAMES
+    assert len(CANONICAL_CANARY_NAMES) == 6
+
+
+# ---------------------------------------------------------------------------
+# The closed identity maps — the two fields wrongly classified as open
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        pytest.param("transform_identity", {}, id="transform-identity-empty"),
+        pytest.param("transform_identity", "deleted", id="transform-identity-scalar"),
+        pytest.param("transform_identity", None, id="transform-identity-null"),
+        pytest.param("transform_identity", [], id="transform-identity-array"),
+        pytest.param("transform_identity.tool", 7, id="identity-scalar-wrong-type"),
+        pytest.param("transform_identity.extractor", {}, id="extractor-empty"),
+        pytest.param("transform_identity.extractor", None, id="extractor-null"),
+        pytest.param(
+            "transform_identity.extractor.tool_version",
+            3,
+            id="extractor-field-wrong-type",
+        ),
+        pytest.param(
+            "transform_identity.source_manifest",
+            [{"path": "x"}],
+            id="manifest-entry-incomplete",
+        ),
+        pytest.param(
+            "transform_identity.source_manifest",
+            [{"path": "x", "sha256": "y", "extra": 1}],
+            id="manifest-entry-extra-key",
+        ),
+        pytest.param(
+            "transform_identity.source_manifest",
+            [{"path": 1, "sha256": "y"}],
+            id="manifest-entry-wrong-type",
+        ),
+        pytest.param(
+            "transform_identity.source_manifest", "modules", id="manifest-as-string"
+        ),
+        pytest.param(
+            "transform_identity.component_b_invocation",
+            {"entrypoint": "x"},
+            id="component-b-incomplete",
+        ),
+        pytest.param(
+            "transform_identity.component_b_invocation.deterministic",
+            "yes",
+            id="component-b-wrong-type",
+        ),
+        pytest.param(
+            "transform_identity.component_b_invocation.steps",
+            "a0",
+            id="component-b-steps-as-string",
+        ),
+        pytest.param("rules_corpus_vector_identity", {}, id="vector-identity-empty"),
+        pytest.param("rules_corpus_vector_identity", None, id="vector-identity-null"),
+        pytest.param(
+            "rules_corpus_vector_identity", "gone", id="vector-identity-scalar"
+        ),
+        pytest.param(
+            "rules_corpus_vector_identity.metadata_fields",
+            [1, 2],
+            id="vector-fields-wrong-element-type",
+        ),
+        pytest.param(
+            "rules_corpus_vector_identity.metadata_schema_version",
+            "1",
+            id="vector-schema-version-as-string",
+        ),
+    ],
+)
+def test_a_malformed_identity_map_fails_to_parse(path: str, value: object) -> None:
+    """These are fixed production schemas, not content-populated maps.
+
+    Calling them open let an edited-and-rehashed report replace canonical
+    evidence with ``{}`` — the omission that ended the hand-maintained approach.
+    """
+    parsed, violations = parse_recorded_report(at(path, value))
+    assert parsed is None
+    assert violations
+
+
+def test_an_extra_key_inside_a_closed_identity_map_fails() -> None:
+    document = payload()
+    document["transform_identity"]["smuggled"] = 1
+    assert parse_recorded_report(document)[0] is None
+
+
+# ---------------------------------------------------------------------------
+# Variable-population maps: variable keys, never absent structure
+# ---------------------------------------------------------------------------
+
+
+VARIABLE_MAPS = (
+    "source_ledger_leaf_totals",
+    "represented_totals",
+    "excluded_totals_by_reason",
+)
+
+
+@pytest.mark.parametrize("field", VARIABLE_MAPS)
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(None, id="null"),
+        pytest.param("none", id="string"),
+        pytest.param([], id="array"),
+        pytest.param(3, id="scalar"),
+    ],
+)
+def test_a_variable_map_supplied_as_a_non_object_fails(
+    field: str, value: object
+) -> None:
+    """ "Open" meant a variable key population, never absent structure."""
+    assert parse_recorded_report(at(field, value))[0] is None
+
+
+@pytest.mark.parametrize("field", VARIABLE_MAPS)
+@pytest.mark.parametrize(
+    "count",
+    [
+        pytest.param(True, id="boolean"),
+        pytest.param(1.5, id="float"),
+        pytest.param("1", id="string"),
+        pytest.param(None, id="null"),
+        pytest.param(-1, id="negative"),
+        pytest.param({"nested": 1}, id="object"),
+    ],
+)
+def test_a_variable_map_with_a_non_count_value_fails(field: str, count: object) -> None:
+    key = "reason" if field == "excluded_totals_by_reason" else "paragraph"
+    assert parse_recorded_report(at(field, {key: count}))[0] is None
+
+
+@pytest.mark.parametrize("field", ["source_ledger_leaf_totals", "represented_totals"])
+def test_a_leaf_total_outside_the_taxonomy_fails(field: str) -> None:
+    """The key universe is derived from ``LeafType``, so it cannot be invented.
+
+    Any *subset* is legitimate — a corpus with no tables reports no
+    ``table_cell`` — but a name the taxonomy does not define is not a leaf type.
+    """
+    assert parse_recorded_report(at(field, {"invented_type": 1}))[0] is None
+    every = {leaf_type.value: 1 for leaf_type in LeafType}
+    assert parse_recorded_report(at(field, every))[0] is not None
+
+
+def test_excluded_reason_keys_stay_free_strings() -> None:
+    """Reason validity is contextual, against the reconstructed policy.
+
+    Deriving the universe here would need the frozen policy at parse time and
+    would create the second policy definition this refactor exists to avoid.
+    """
+    assert parse_recorded_report(at("excluded_totals_by_reason", {"any": 1}))[0]
+
+
+# ---------------------------------------------------------------------------
+# Top-level shape, counters, and the canary population
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_top_level_field_fails() -> None:
+    assert parse_recorded_report(payload(smuggled="value"))[0] is None
+
+
+def test_a_missing_top_level_field_fails() -> None:
+    document = payload()
+    del document["findings"]
+    assert parse_recorded_report(document)[0] is None
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        pytest.param("unresolved_leaves", True, id="counter-boolean"),
+        pytest.param("unresolved_leaves", "0", id="counter-string"),
+        pytest.param("invalid_locators", 1.0, id="counter-float"),
+        pytest.param("concordance_failures", None, id="counter-null"),
+        pytest.param("declared_projection_count", -1, id="counter-negative"),
+        pytest.param("accounting.inventoried_leaves", "10", id="accounting-string"),
+        pytest.param("findings.gaps", True, id="finding-boolean"),
+        pytest.param("report_version", "5c-evidence-2", id="obsolete-schema-version"),
+        pytest.param("prepublication_validation_status", "maybe", id="bad-status"),
+        pytest.param("reproduction_target", {}, id="reproduction-target-empty"),
+        pytest.param(
+            "reconciliation_policy_reference",
+            {"policy_version": "v"},
+            id="policy-reference-incomplete",
+        ),
+    ],
+)
+def test_a_wrongly_typed_or_domain_invalid_field_fails(
+    path: str, value: object
+) -> None:
+    assert parse_recorded_report(at(path, value))[0] is None
+
+
+@pytest.mark.parametrize(
+    "canaries",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"invented": True}, id="invented-only"),
+        pytest.param(
+            dict.fromkeys(sorted(CANONICAL_CANARY_NAMES)[1:], True), id="missing-one"
+        ),
+        pytest.param(
+            {**dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True), "invented": True},
+            id="canonical-plus-invented",
+        ),
+        pytest.param(
+            {**dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True), "exhaustion": "y"},
+            id="non-boolean-value",
+        ),
+    ],
+)
+def test_a_non_canonical_canary_population_fails(canaries: dict[str, Any]) -> None:
+    assert parse_recorded_report(payload(version_canaries=canaries))[0] is None
+
+
+# ---------------------------------------------------------------------------
+# The verdict, on a document that has already proven its shape
 # ---------------------------------------------------------------------------
 
 
 def test_a_failed_verdict_is_rejected_however_well_formed() -> None:
-    """The control the finding names: status edited to 'fail', nothing else."""
     violations = recorded_success_violations(
         payload(prepublication_validation_status="fail")
     )
@@ -102,18 +357,6 @@ def test_a_failed_verdict_is_rejected_however_well_formed() -> None:
             id="findings-gap",
         ),
         pytest.param(
-            {"findings": {"gaps": 0, "overlaps": 2, "orphans": 0, "duplications": 0}},
-            id="findings-overlap",
-        ),
-        pytest.param(
-            {"findings": {"gaps": 0, "overlaps": 0, "orphans": 1, "duplications": 0}},
-            id="findings-orphan",
-        ),
-        pytest.param(
-            {"findings": {"gaps": 0, "overlaps": 0, "orphans": 0, "duplications": 4}},
-            id="findings-duplication",
-        ),
-        pytest.param(
             {
                 "version_canaries": {
                     **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
@@ -125,41 +368,24 @@ def test_a_failed_verdict_is_rejected_however_well_formed() -> None:
         pytest.param(
             {
                 "accounting": {
-                    "inventoried_leaves": 10,
-                    "represented_leaves": 8,
-                    "excluded_leaves": 2,
-                    "unresolved_leaves": 5,
-                }
-            },
-            id="accounting-unresolved",
-        ),
-        pytest.param(
-            {
-                "accounting": {
                     "inventoried_leaves": 99,
                     "represented_leaves": 8,
                     "excluded_leaves": 2,
                     "unresolved_leaves": 0,
                 }
             },
-            id="accounting-equation-unbalanced",
+            id="accounting-unbalanced",
         ),
     ],
 )
 def test_a_pass_verdict_over_contradictory_summaries_is_rejected(
     override: dict[str, Any],
 ) -> None:
-    """ "pass" is not a licence to ignore the numbers underneath it.
-
-    Each payload keeps the status at ``"pass"`` and makes exactly one
-    success-bearing summary say otherwise. A verdict that survives its own
-    contradicting evidence is not a verdict.
-    """
+    """A "pass" is not a licence to ignore the numbers underneath it."""
     assert recorded_success_violations(payload(**override)) != ()
 
 
-def test_a_disagreeing_accounting_total_is_rejected() -> None:
-    """The duplicated unresolved count must agree with the top-level one."""
+def test_the_accounting_total_must_agree_with_the_top_level_count() -> None:
     contradictory = payload(
         unresolved_leaves=0,
         accounting={
@@ -169,186 +395,30 @@ def test_a_disagreeing_accounting_total_is_rejected() -> None:
             "unresolved_leaves": 1,
         },
     )
-    violations = recorded_success_violations(contradictory)
-    assert any("disagrees with the top-level" in v for v in violations)
-
-
-# ---------------------------------------------------------------------------
-# Shape and type closure
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "override",
-    [
-        pytest.param({"unresolved_leaves": "0"}, id="counter-as-string"),
-        pytest.param({"unresolved_leaves": True}, id="counter-as-boolean"),
-        pytest.param({"invalid_locators": None}, id="counter-as-null"),
-        pytest.param({"findings": "none"}, id="findings-as-string"),
-        pytest.param({"findings": {"gaps": "0"}}, id="finding-as-string"),
-        pytest.param({"version_canaries": []}, id="canaries-as-array"),
-        pytest.param(
-            {
-                "version_canaries": {
-                    **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
-                    "exhaustion": "yes",
-                }
-            },
-            id="canary-as-string",
-        ),
-        pytest.param({"accounting": None}, id="accounting-as-null"),
-        pytest.param(
-            {"accounting": {"inventoried_leaves": 10}}, id="accounting-incomplete"
-        ),
-    ],
-)
-def test_a_wrongly_typed_verdict_field_is_rejected(override: dict[str, Any]) -> None:
-    """A verdict cannot rest on a field whose type was never checked.
-
-    ``True`` is called out separately: it is an ``int`` subclass, so a boolean
-    would otherwise read as the count ``1`` and could satisfy an equation.
-    """
-    assert recorded_success_violations(payload(**override)) != ()
-
-
-def test_a_missing_verdict_field_is_rejected() -> None:
-    incomplete = payload()
-    del incomplete["findings"]
-    violations = recorded_success_violations(incomplete)
-    assert any("missing" in v for v in violations)
+    assert any(
+        "disagrees with the top-level" in v
+        for v in recorded_success_violations(contradictory)
+    )
 
 
 @pytest.mark.parametrize(
     "value", [None, "report", 7, [], pytest.param({}, id="empty-object")]
 )
 def test_a_payload_that_is_not_this_report_is_rejected(value: object) -> None:
+    parsed, violations = parse_recorded_report(value)
+    assert parsed is None
+    assert violations
     assert recorded_success_violations(value) != ()
 
 
-def test_an_obsolete_schema_version_is_rejected() -> None:
-    violations = recorded_success_violations(payload(report_version="5c-evidence-2"))
-    assert any("not the supported" in v for v in violations)
+def test_parsing_reports_violations_rather_than_raising() -> None:
+    """A malformed stored report is an auditable finding, not an exception.
 
-
-# ---------------------------------------------------------------------------
-# Closed inventories: the exact population, not merely the entries present
-# ---------------------------------------------------------------------------
-#
-# The omission this closes: iterating whatever a map happens to contain and
-# requiring each entry to be valid says nothing about the entries that are
-# *absent*. An empty map is vacuously "all passed".
-
-
-def test_the_canonical_canary_set_is_derived_not_restated() -> None:
-    """The required population follows the committed definitions.
-
-    A second hand-written list of six names would drift the first time a canary
-    is added or retired, and drift silently in the safe-looking direction.
+    Publication has to refuse it with a typed outcome, so the parse boundary
+    never lets a ``ValidationError`` escape toward the caller.
     """
-    assert frozenset(c.name for c in VERSION_CANARIES) == CANONICAL_CANARY_NAMES
-    assert len(CANONICAL_CANARY_NAMES) == 6
-
-
-@pytest.mark.parametrize(
-    "canaries",
-    [
-        pytest.param({}, id="empty"),
-        pytest.param({"invented": True}, id="invented-only"),
-        pytest.param(
-            {n: True for n in sorted(CANONICAL_CANARY_NAMES)[1:]},
-            id="missing-one-canonical",
-        ),
-        pytest.param(
-            {
-                **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
-                "invented": True,
-            },
-            id="canonical-plus-invented",
-        ),
-    ],
-)
-def test_a_version_canary_population_that_is_not_canonical_is_rejected(
-    canaries: dict[str, Any],
-) -> None:
-    assert recorded_success_violations(payload(version_canaries=canaries)) != ()
-
-
-def test_the_exact_canonical_canary_population_passes() -> None:
-    """The positive control, so the rule above is not simply "reject"."""
-    exact = dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True)
-    assert recorded_success_violations(payload(version_canaries=exact)) == ()
-
-
-@pytest.mark.parametrize(
-    ("key", "value"),
-    [
-        pytest.param("findings", {"gaps": 0, "overlaps": 0}, id="findings-partial"),
-        pytest.param(
-            "findings",
-            {
-                "gaps": 0,
-                "overlaps": 0,
-                "orphans": 0,
-                "duplications": 0,
-                "invented": 0,
-            },
-            id="findings-extra",
-        ),
-        pytest.param(
-            "accounting",
-            {
-                "inventoried_leaves": 10,
-                "represented_leaves": 8,
-                "excluded_leaves": 2,
-                "unresolved_leaves": 0,
-                "invented": 0,
-            },
-            id="accounting-extra",
-        ),
-        pytest.param(
-            "reproduction_target",
-            {"python_target": "3.12", "host": "ci"},
-            id="repro-extra",
-        ),
-        pytest.param("reproduction_target", {}, id="repro-empty"),
-        pytest.param(
-            "reconciliation_policy_reference",
-            {"policy_version": "v", "invented": 1},
-            id="policy-reference-wrong-keys",
-        ),
-    ],
-)
-def test_a_closed_sibling_map_with_the_wrong_population_is_rejected(
-    key: str, value: dict[str, Any]
-) -> None:
-    """Every closed inventory, not only the one the finding landed on."""
-    assert recorded_success_violations(payload(**{key: value})) != ()
-
-
-def test_an_unknown_top_level_key_is_rejected() -> None:
-    """A rehashed payload cannot smuggle a field in under the same schema."""
-    violations = recorded_success_violations(payload(smuggled="value"))
-    assert any("unrecognised keys" in v for v in violations)
-
-
-@pytest.mark.parametrize("key", sorted(OPEN_REPORT_MAPS))
-def test_an_open_diagnostic_map_may_carry_content_derived_keys(key: str) -> None:
-    """Open maps stay open: their keys come from the corpus, not from code.
-
-    A release with no table cells legitimately has no ``table_cell`` total.
-    Requiring an exact population here would be requiring a particular corpus,
-    which is why the closed/open split is declared rather than assumed.
-    """
-    assert recorded_success_violations(payload(**{key: {"anything_at_all": 1}})) == ()
-
-
-def test_build_report_refuses_to_claim_success_over_an_incomplete_canary_run() -> None:
-    """The same omission existed on the writing side, and is closed with it.
-
-    ``all(c.passed for c in ())`` is vacuously true, so a report built from a
-    partial canary run would have recorded ``"pass"``. It cannot now.
-    """
-    partial = payload(
-        version_canaries={n: True for n in sorted(CANONICAL_CANARY_NAMES)[:3]}
-    )
-    assert verdict_violations(partial) != ()
+    parsed, violations = parse_recorded_report({"report_version": 1})
+    assert parsed is None
+    assert all(isinstance(v, str) for v in violations)
+    with pytest.raises(Exception, match="validation error"):
+        CorpusEvidenceReport.model_validate({"report_version": 1})

--- a/tests/ingestion/corpus/test_recorded_evidence.py
+++ b/tests/ingestion/corpus/test_recorded_evidence.py
@@ -18,18 +18,24 @@ Two boundaries, tested separately:
 from __future__ import annotations
 
 import json
+from types import MappingProxyType
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.models import LeafType
 from afterworlds.ingestion.corpus.pdf_source import extraction_config
 from afterworlds.ingestion.corpus.report import (
     CANONICAL_CANARY_NAMES,
     EVIDENCE_REPORT_SCHEMA_VERSION,
+    PYTHON_TARGET,
+    EvidenceReport,
     parse_recorded_report,
     recorded_success_violations,
+    report_hash,
 )
 from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
 from afterworlds.ingestion.corpus.transform_identity import transform_identity
@@ -422,3 +428,163 @@ def test_parsing_reports_violations_rather_than_raising() -> None:
     assert all(isinstance(v, str) for v in violations)
     with pytest.raises(Exception, match="validation error"):
         CorpusEvidenceReport.model_validate({"report_version": 1})
+
+
+# ---------------------------------------------------------------------------
+# The report is a value: deeply immutable, canonically serialized
+# ---------------------------------------------------------------------------
+#
+# ``frozen=True`` only stops attribute rebinding. Nested dicts and lists stayed
+# mutable, so a holder could clear the canary map after parsing and ``dump()``
+# would serialize the invalid state without revalidation — reopening the exact
+# hole the typed conversion closed. A validator that ran once is not a value.
+
+
+def parsed() -> CorpusEvidenceReport:
+    report, violations = parse_recorded_report(payload())
+    assert report is not None, violations
+    return report
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda r: r.version_canaries.clear(), id="canaries-clear"),
+        pytest.param(
+            lambda r: r.version_canaries.__setitem__("invented", True),
+            id="canaries-insert",
+        ),
+        pytest.param(
+            lambda r: r.version_canaries.__delitem__("exhaustion"),
+            id="canaries-delete",
+        ),
+        pytest.param(
+            lambda r: r.source_ledger_leaf_totals.__setitem__("invented", 1),
+            id="leaf-totals-insert-invented",
+        ),
+        pytest.param(
+            lambda r: r.source_ledger_leaf_totals.__setitem__("paragraph", -5),
+            id="leaf-totals-insert-negative",
+        ),
+        pytest.param(
+            lambda r: r.represented_totals.__delitem__("paragraph"),
+            id="represented-totals-delete",
+        ),
+        pytest.param(
+            lambda r: r.excluded_totals_by_reason.clear(),
+            id="excluded-totals-clear",
+        ),
+        pytest.param(
+            lambda r: r.rules_corpus_vector_identity.metadata_fields.__setitem__(
+                0, "x"
+            ),
+            id="metadata-fields-assign",
+        ),
+        pytest.param(
+            lambda r: r.rules_corpus_vector_identity.metadata_fields.append("x"),
+            id="metadata-fields-append",
+        ),
+        pytest.param(
+            lambda r: r.transform_identity.source_manifest.append(None),
+            id="source-manifest-append",
+        ),
+        pytest.param(
+            lambda r: r.transform_identity.source_manifest.__setitem__(0, None),
+            id="source-manifest-assign",
+        ),
+        pytest.param(
+            lambda r: r.transform_identity.component_b_invocation.steps.append("x"),
+            id="component-b-steps-append",
+        ),
+        pytest.param(
+            lambda r: setattr(r, "unresolved_leaves", 9), id="attribute-rebind"
+        ),
+    ],
+)
+def test_a_parsed_report_cannot_be_mutated(mutate: Any) -> None:
+    """Every reachable collection refuses mutation, and nothing moves.
+
+    The dump and hash are recorded first and re-checked after, so this proves
+    the report is unchanged rather than merely that an exception was raised.
+    """
+    report = parsed()
+    before_dump = report.dump()
+    before_hash = report_hash(EvidenceReport(payload=report, persisted=True))
+
+    with pytest.raises((AttributeError, TypeError, ValidationError)):
+        mutate(report)
+
+    assert report.dump() == before_dump
+    assert report_hash(EvidenceReport(payload=report, persisted=True)) == before_hash
+
+
+def test_the_report_does_not_alias_the_callers_dictionaries() -> None:
+    """Parsing copies. A proxy over the caller's dict is still the caller's."""
+    document = payload()
+    report = parse_recorded_report(document)[0]
+    assert report is not None
+    document["version_canaries"]["invented"] = True
+    document["source_ledger_leaf_totals"]["paragraph"] = 999
+    assert "invented" not in report.version_canaries
+    assert report.source_ledger_leaf_totals["paragraph"] == 10
+
+
+def test_canonical_collections_are_immutable_types() -> None:
+    report = parsed()
+    assert isinstance(report.version_canaries, MappingProxyType)
+    assert isinstance(report.source_ledger_leaf_totals, MappingProxyType)
+    assert isinstance(report.transform_identity.source_manifest, tuple)
+    assert isinstance(report.transform_identity.component_b_invocation.steps, tuple)
+    assert isinstance(report.rules_corpus_vector_identity.metadata_fields, tuple)
+
+
+# ---------------------------------------------------------------------------
+# The reproduction target is a canonical constant, not a free string
+# ---------------------------------------------------------------------------
+
+
+def test_the_honest_reproduction_target_passes() -> None:
+    assert parsed().reproduction_target.python_target == PYTHON_TARGET
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param("99.0", id="false-target"),
+        pytest.param("", id="empty"),
+        pytest.param(None, id="null"),
+        pytest.param(3.12, id="number"),
+        pytest.param("3.13", id="near-miss"),
+    ],
+)
+def test_a_non_canonical_reproduction_target_fails(target: object) -> None:
+    """Bound, not defaulted: a report recording another target is not this schema."""
+    assert (
+        parse_recorded_report(at("reproduction_target.python_target", target))[0]
+        is None
+    )
+
+
+def test_an_extra_key_in_the_reproduction_target_fails() -> None:
+    document = payload()
+    document["reproduction_target"]["host"] = "ci"
+    assert parse_recorded_report(document)[0] is None
+
+
+# ---------------------------------------------------------------------------
+# One serializer, one hash
+# ---------------------------------------------------------------------------
+
+
+def test_the_canonical_hash_is_over_the_model_dump() -> None:
+    """Read side and write side hash the same representation.
+
+    An honest stored payload therefore rehashes to the value publication
+    recorded, without the raw dictionary ever being the thing hashed.
+    """
+    document = payload()
+    report = parse_recorded_report(document)[0]
+    assert report is not None
+    wrapped = EvidenceReport(payload=report, persisted=True)
+    assert wrapped.dump() == report.dump() == document
+    assert report_hash(wrapped) == hash_obj(report.dump())

--- a/tests/ingestion/corpus/test_recorded_evidence.py
+++ b/tests/ingestion/corpus/test_recorded_evidence.py
@@ -22,7 +22,7 @@ from types import MappingProxyType
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
 from afterworlds.ingestion.corpus.hashing import hash_obj
@@ -33,6 +33,7 @@ from afterworlds.ingestion.corpus.report import (
     EVIDENCE_REPORT_SCHEMA_VERSION,
     PYTHON_TARGET,
     EvidenceReport,
+    canonical_report,
     parse_recorded_report,
     recorded_success_violations,
     report_hash,
@@ -426,8 +427,10 @@ def test_parsing_reports_violations_rather_than_raising() -> None:
     parsed, violations = parse_recorded_report({"report_version": 1})
     assert parsed is None
     assert all(isinstance(v, str) for v in violations)
-    with pytest.raises(Exception, match="validation error"):
-        CorpusEvidenceReport.model_validate({"report_version": 1})
+    # The construction-side constructor does raise: a build that cannot describe
+    # itself canonically is a defect here and now, not an auditable finding.
+    with pytest.raises(ValidationError):
+        canonical_report({"report_version": 1})
 
 
 # ---------------------------------------------------------------------------
@@ -588,3 +591,71 @@ def test_the_canonical_hash_is_over_the_model_dump() -> None:
     wrapped = EvidenceReport(payload=report, persisted=True)
     assert wrapped.dump() == report.dump() == document
     assert report_hash(wrapped) == hash_obj(report.dump())
+
+
+# ---------------------------------------------------------------------------
+# No mutable backing storage anywhere in the canonical tree
+# ---------------------------------------------------------------------------
+#
+# Round 3 froze the containers and left the *storage* reachable: a frozen
+# Pydantic BaseModel keeps its fields in ``__dict__``, so
+# ``vars(report)["version_canaries"] = {}`` reached past the freeze, made
+# ``success_violations()`` return nothing, and moved both the dump and the hash.
+# Slotted dataclasses have no instance dictionary to reach for.
+
+
+def canonical_values(report: CorpusEvidenceReport) -> list[tuple[str, Any]]:
+    """The report and every nested canonical value inside it."""
+    identity = report.transform_identity
+    return [
+        ("report", report),
+        ("transform_identity", identity),
+        ("extractor", identity.extractor),
+        ("component_b_invocation", identity.component_b_invocation),
+        ("source_manifest[0]", identity.source_manifest[0]),
+        ("rules_corpus_vector_identity", report.rules_corpus_vector_identity),
+        ("reproduction_target", report.reproduction_target),
+        ("reconciliation_policy_reference", report.reconciliation_policy_reference),
+        ("accounting", report.accounting),
+        ("findings", report.findings),
+    ]
+
+
+def test_no_canonical_value_exposes_backing_storage() -> None:
+    """``vars()`` must be unavailable, not merely unhelpful."""
+    for name, value in canonical_values(parsed()):
+        assert not hasattr(value, "__dict__"), name
+        with pytest.raises(TypeError):
+            vars(value)
+
+
+def test_no_pydantic_base_model_is_reachable_from_the_report() -> None:
+    """Pydantic validates at ingress; it does not hold the canonical value."""
+    for name, value in canonical_values(parsed()):
+        assert not isinstance(value, BaseModel), name
+
+
+def test_the_backing_store_cannot_be_replaced_through_vars() -> None:
+    """The exact attack the finding names, on the root and on a nested value.
+
+    Impossible because ``vars()`` itself is unavailable — not because something
+    downstream happens to revalidate afterwards.
+    """
+    report = parsed()
+    before_dump = report.dump()
+    before_hash = report_hash(EvidenceReport(payload=report, persisted=True))
+
+    with pytest.raises(TypeError):
+        vars(report)["version_canaries"] = {}
+    with pytest.raises(TypeError):
+        vars(report.transform_identity)["extractor"] = {}
+
+    assert report.dump() == before_dump
+    assert report_hash(EvidenceReport(payload=report, persisted=True)) == before_hash
+    assert report.success_violations() == ()
+
+
+def test_build_report_and_parse_return_the_same_canonical_type() -> None:
+    """One runtime type, whether the report was built or read back."""
+    assert isinstance(parsed(), CorpusEvidenceReport)
+    assert not hasattr(CorpusEvidenceReport, "model_validate")

--- a/tests/ingestion/corpus/test_recorded_evidence.py
+++ b/tests/ingestion/corpus/test_recorded_evidence.py
@@ -19,8 +19,11 @@ from typing import Any
 
 import pytest
 
+from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
 from afterworlds.ingestion.corpus.report import (
+    CANONICAL_CANARY_NAMES,
     EVIDENCE_REPORT_SCHEMA_VERSION,
+    OPEN_REPORT_MAPS,
     REQUIRED_REPORT_KEYS,
     recorded_success_violations,
     verdict_violations,
@@ -39,7 +42,11 @@ def payload(**overrides: Any) -> dict[str, Any]:
         "transform_identity": {"extractor": {}},
         "rules_corpus_vector_identity": {"embedding_model_id": "m"},
         "reproduction_target": {"python_target": "3.12"},
-        "reconciliation_policy_reference": {"policy_version": "v"},
+        "reconciliation_policy_reference": {
+            "policy_version": "v",
+            "policy_hash": "f" * 64,
+            "applied_policy_hash": "f" * 64,
+        },
         "source_ledger_leaf_totals": {"paragraph": 10},
         "represented_totals": {"paragraph": 8},
         "excluded_totals_by_reason": {"running_header_footer": 2},
@@ -54,7 +61,7 @@ def payload(**overrides: Any) -> dict[str, Any]:
         "findings": {"gaps": 0, "overlaps": 0, "orphans": 0, "duplications": 0},
         "invalid_locators": 0,
         "concordance_failures": 0,
-        "version_canaries": {"wish": True, "true-polymorph": True},
+        "version_canaries": dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
         "prepublication_validation_status": "pass",
     }
     base.update(overrides)
@@ -107,7 +114,12 @@ def test_a_failed_verdict_is_rejected_however_well_formed() -> None:
             id="findings-duplication",
         ),
         pytest.param(
-            {"version_canaries": {"wish": True, "true-polymorph": False}},
+            {
+                "version_canaries": {
+                    **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
+                    "counterspell": False,
+                }
+            },
             id="failed-canary",
         ),
         pytest.param(
@@ -175,7 +187,15 @@ def test_a_disagreeing_accounting_total_is_rejected() -> None:
         pytest.param({"findings": "none"}, id="findings-as-string"),
         pytest.param({"findings": {"gaps": "0"}}, id="finding-as-string"),
         pytest.param({"version_canaries": []}, id="canaries-as-array"),
-        pytest.param({"version_canaries": {"wish": "yes"}}, id="canary-as-string"),
+        pytest.param(
+            {
+                "version_canaries": {
+                    **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
+                    "exhaustion": "yes",
+                }
+            },
+            id="canary-as-string",
+        ),
         pytest.param({"accounting": None}, id="accounting-as-null"),
         pytest.param(
             {"accounting": {"inventoried_leaves": 10}}, id="accounting-incomplete"
@@ -208,3 +228,127 @@ def test_a_payload_that_is_not_this_report_is_rejected(value: object) -> None:
 def test_an_obsolete_schema_version_is_rejected() -> None:
     violations = recorded_success_violations(payload(report_version="5c-evidence-2"))
     assert any("not the supported" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Closed inventories: the exact population, not merely the entries present
+# ---------------------------------------------------------------------------
+#
+# The omission this closes: iterating whatever a map happens to contain and
+# requiring each entry to be valid says nothing about the entries that are
+# *absent*. An empty map is vacuously "all passed".
+
+
+def test_the_canonical_canary_set_is_derived_not_restated() -> None:
+    """The required population follows the committed definitions.
+
+    A second hand-written list of six names would drift the first time a canary
+    is added or retired, and drift silently in the safe-looking direction.
+    """
+    assert frozenset(c.name for c in VERSION_CANARIES) == CANONICAL_CANARY_NAMES
+    assert len(CANONICAL_CANARY_NAMES) == 6
+
+
+@pytest.mark.parametrize(
+    "canaries",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"invented": True}, id="invented-only"),
+        pytest.param(
+            {n: True for n in sorted(CANONICAL_CANARY_NAMES)[1:]},
+            id="missing-one-canonical",
+        ),
+        pytest.param(
+            {
+                **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
+                "invented": True,
+            },
+            id="canonical-plus-invented",
+        ),
+    ],
+)
+def test_a_version_canary_population_that_is_not_canonical_is_rejected(
+    canaries: dict[str, Any],
+) -> None:
+    assert recorded_success_violations(payload(version_canaries=canaries)) != ()
+
+
+def test_the_exact_canonical_canary_population_passes() -> None:
+    """The positive control, so the rule above is not simply "reject"."""
+    exact = dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True)
+    assert recorded_success_violations(payload(version_canaries=exact)) == ()
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        pytest.param("findings", {"gaps": 0, "overlaps": 0}, id="findings-partial"),
+        pytest.param(
+            "findings",
+            {
+                "gaps": 0,
+                "overlaps": 0,
+                "orphans": 0,
+                "duplications": 0,
+                "invented": 0,
+            },
+            id="findings-extra",
+        ),
+        pytest.param(
+            "accounting",
+            {
+                "inventoried_leaves": 10,
+                "represented_leaves": 8,
+                "excluded_leaves": 2,
+                "unresolved_leaves": 0,
+                "invented": 0,
+            },
+            id="accounting-extra",
+        ),
+        pytest.param(
+            "reproduction_target",
+            {"python_target": "3.12", "host": "ci"},
+            id="repro-extra",
+        ),
+        pytest.param("reproduction_target", {}, id="repro-empty"),
+        pytest.param(
+            "reconciliation_policy_reference",
+            {"policy_version": "v", "invented": 1},
+            id="policy-reference-wrong-keys",
+        ),
+    ],
+)
+def test_a_closed_sibling_map_with_the_wrong_population_is_rejected(
+    key: str, value: dict[str, Any]
+) -> None:
+    """Every closed inventory, not only the one the finding landed on."""
+    assert recorded_success_violations(payload(**{key: value})) != ()
+
+
+def test_an_unknown_top_level_key_is_rejected() -> None:
+    """A rehashed payload cannot smuggle a field in under the same schema."""
+    violations = recorded_success_violations(payload(smuggled="value"))
+    assert any("unrecognised keys" in v for v in violations)
+
+
+@pytest.mark.parametrize("key", sorted(OPEN_REPORT_MAPS))
+def test_an_open_diagnostic_map_may_carry_content_derived_keys(key: str) -> None:
+    """Open maps stay open: their keys come from the corpus, not from code.
+
+    A release with no table cells legitimately has no ``table_cell`` total.
+    Requiring an exact population here would be requiring a particular corpus,
+    which is why the closed/open split is declared rather than assumed.
+    """
+    assert recorded_success_violations(payload(**{key: {"anything_at_all": 1}})) == ()
+
+
+def test_build_report_refuses_to_claim_success_over_an_incomplete_canary_run() -> None:
+    """The same omission existed on the writing side, and is closed with it.
+
+    ``all(c.passed for c in ())`` is vacuously true, so a report built from a
+    partial canary run would have recorded ``"pass"``. It cannot now.
+    """
+    partial = payload(
+        version_canaries={n: True for n in sorted(CANONICAL_CANARY_NAMES)[:3]}
+    )
+    assert verdict_violations(partial) != ()

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -28,7 +28,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.corpus.bundle import build_bundle, reconciliation_hash
-from afterworlds.ingestion.corpus.concordance import ConcordanceResult
+from afterworlds.ingestion.corpus.concordance import (
+    VERSION_CANARIES,
+    CanaryResult,
+    ConcordanceResult,
+)
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CorpusBundleMembers,
@@ -261,6 +265,19 @@ BOUND_TRANSFORM_CONFIG: dict[str, object] = {
 }
 
 
+#: Derived from the committed canary definitions, never a second list of names.
+BOUND_CANARIES = tuple(
+    CanaryResult(
+        name=canary.name,
+        printed_page=canary.printed_page,
+        passed=True,
+        missing=(),
+        unexpected=(),
+    )
+    for canary in VERSION_CANARIES
+)
+
+
 def _build_bound_report(
     *,
     ledger: SourceLedger,
@@ -285,7 +302,11 @@ def _build_bound_report(
             locator_failures=(),
             content_failures=(),
         ),
-        canaries=(),
+        # The complete canonical canary population, standing in for a real
+        # canary run exactly as the rest of this release stands in for a real
+        # corpus. An empty tuple would now be refused, and rightly: a report
+        # cannot claim a successful verdict over version checks that never ran.
+        canaries=BOUND_CANARIES,
         persisted=True,
     )
 

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -33,6 +33,7 @@ from afterworlds.ingestion.corpus.concordance import (
     CanaryResult,
     ConcordanceResult,
 )
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CorpusBundleMembers,
@@ -184,8 +185,28 @@ DEFAULT_COVERAGE = (
 # release* — it would be the forgery the negative controls are about.
 
 SOURCE_DOCUMENT = "D&D SRD 5.2.1"
+#: The real production identity builders, not hand-written stand-ins. The typed
+#: evidence-report schema requires the complete transform and vector identities,
+#: and a fixture that invented their shape would be asserting a schema nobody
+#: publishes. ``transform_config_hash`` is the fixture constant above rather than
+#: a hash of this config, so the six binding values — and the committed oracle —
+#: are unaffected.
+BOUND_TRANSFORM_CONFIG: dict[str, object] = {
+    "reconciliation_policy": policy_payload(FROZEN_POLICY),
+    "evidence_report_schema_version": CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
+    "extraction_config": extraction_config(),
+    "transform_identity": transform_identity(),
+    "rules_corpus_vector_identity": rules_corpus_vector_identity(
+        RetrievalMemoryConfig().embedding_model_id
+    ),
+}
+
 AUTHORITATIVE_SOURCE_HASH = "a" * 64
-TRANSFORM_CONFIG_HASH = "b" * 64
+#: Derived, not invented. The recorded-release closure requires the stored
+#: transform configuration to hash to its recorded identity — a fixture stating
+#: a hash its own config does not produce is the forgery that check exists to
+#: catch, so this fixture has to survive its own proof.
+TRANSFORM_CONFIG_HASH = hash_obj(BOUND_TRANSFORM_CONFIG)
 #: Opaque here on purpose: the persisted-corpus digest binds the actual
 #: read-back vector state as well as SQL, so it is an exact recorded value the
 #: 5d gate checks rather than one it can recompute from a session.
@@ -262,23 +283,6 @@ BOUND_RECONCILIATION = ReconciliationMember(
 )
 
 BOUND_BUNDLE = build_bundle(BOUND_LEDGER, BOUND_MEMBERS, BOUND_RECONCILIATION)
-
-#: The real production identity builders, not hand-written stand-ins. The typed
-#: evidence-report schema requires the complete transform and vector identities,
-#: and a fixture that invented their shape would be asserting a schema nobody
-#: publishes. ``transform_config_hash`` is the fixture constant above rather than
-#: a hash of this config, so the six binding values — and the committed oracle —
-#: are unaffected.
-BOUND_TRANSFORM_CONFIG: dict[str, object] = {
-    "reconciliation_policy": policy_payload(FROZEN_POLICY),
-    "evidence_report_schema_version": CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
-    "extraction_config": extraction_config(),
-    "transform_identity": transform_identity(),
-    "rules_corpus_vector_identity": rules_corpus_vector_identity(
-        RetrievalMemoryConfig().embedding_model_id
-    ),
-}
-
 
 #: Derived from the committed canary definitions, never a second list of names.
 BOUND_CANARIES = tuple(

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -46,6 +46,7 @@ from afterworlds.ingestion.corpus.models import (
     ReconciliationMember,
     SourceLedger,
 )
+from afterworlds.ingestion.corpus.pdf_source import extraction_config
 from afterworlds.ingestion.corpus.persistence import (
     _load_ledger,
     _load_members,
@@ -72,6 +73,7 @@ from afterworlds.ingestion.corpus.report import (
 from afterworlds.ingestion.corpus.report import (
     report_hash as corpus_report_hash,
 )
+from afterworlds.ingestion.corpus.transform_identity import transform_identity
 from afterworlds.ingestion.mechanical.accounting import batch_diff_hash, derive_span_id
 from afterworlds.ingestion.mechanical.bound_corpus import (
     BoundCorpusSnapshot,
@@ -119,10 +121,12 @@ from afterworlds.ingestion.mechanical.representation import (
     reference_target_key,
     relationship_target_key,
 )
+from afterworlds.models.retrieval import rules_corpus_vector_identity
 from afterworlds.persistence.database import create_engine, create_session_factory
 from afterworlds.persistence.orm.base import Base
 from afterworlds.persistence.orm.corpus import CorpusReleaseORM
 from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 
 NOW = "2026-07-31T00:00:00Z"
 DATA_DIR = Path(__file__).resolve().parent / "data"
@@ -259,9 +263,20 @@ BOUND_RECONCILIATION = ReconciliationMember(
 
 BOUND_BUNDLE = build_bundle(BOUND_LEDGER, BOUND_MEMBERS, BOUND_RECONCILIATION)
 
+#: The real production identity builders, not hand-written stand-ins. The typed
+#: evidence-report schema requires the complete transform and vector identities,
+#: and a fixture that invented their shape would be asserting a schema nobody
+#: publishes. ``transform_config_hash`` is the fixture constant above rather than
+#: a hash of this config, so the six binding values — and the committed oracle —
+#: are unaffected.
 BOUND_TRANSFORM_CONFIG: dict[str, object] = {
     "reconciliation_policy": policy_payload(FROZEN_POLICY),
     "evidence_report_schema_version": CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
+    "extraction_config": extraction_config(),
+    "transform_identity": transform_identity(),
+    "rules_corpus_vector_identity": rules_corpus_vector_identity(
+        RetrievalMemoryConfig().embedding_model_id
+    ),
 }
 
 
@@ -727,7 +742,7 @@ def rerecord_release_proof(session: Session) -> None:
         recon=recon,
         bundle_root_hash=bundle.bundle_root_hash,
     )
-    release.report_payload = report.payload
+    release.report_payload = report.dump()
     release.evidence_report_hash = corpus_report_hash(report)
     release.corpus_report_reference = release.evidence_report_hash
     session.flush()
@@ -760,7 +775,7 @@ def _seed_bound_release(session: Session) -> None:
         reconciliation_hash=reconciliation_hash(BOUND_RECONCILIATION),
         corpus_report_reference=BOUND_EVIDENCE_REPORT_HASH,
         transform_config=BOUND_TRANSFORM_CONFIG,
-        report_payload=BOUND_REPORT.payload,
+        report_payload=BOUND_REPORT.dump(),
         now=NOW,
     )
     _persist_bundle_rows(

--- a/tests/ingestion/mechanical/data/bounded_oracle.json
+++ b/tests/ingestion/mechanical/data/bounded_oracle.json
@@ -3,7 +3,7 @@
     "package_uuid": "pkg-5c",
     "release_version": "rel-5c",
     "authoritative_source_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "transform_config_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "transform_config_hash": "fcb76c3ece157bad3095c32f1a9006fcb6d91cf3d2f56635cc6b41ae8d79a6c7",
     "bundle_root_hash": "5f4471769d7ebf6650c3d07ba0093803b3032e71c4ebd5a4039da0aac372bbfd",
     "persisted_corpus_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
   },

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -19,16 +19,10 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.report import (
     CANONICAL_CANARY_NAMES,
-    REQUIRED_REPORT_KEYS,
     recorded_success_violations,
-)
-from afterworlds.ingestion.corpus.report import (
-    EvidenceReport as CorpusEvidenceReport,
-)
-from afterworlds.ingestion.corpus.report import (
-    report_hash as corpus_report_hash,
 )
 from afterworlds.ingestion.mechanical import publication
 from afterworlds.ingestion.mechanical.gate import (
@@ -629,21 +623,20 @@ def _rewrite_release_report(session: Session, **overrides: object) -> None:
     payload = dict(release.report_payload or {})
     payload.update(overrides)
     release.report_payload = payload
-    release.evidence_report_hash = corpus_report_hash(
-        CorpusEvidenceReport(payload=payload, persisted=True)
-    )
+    # Hashed as stored, exactly as the verifier rehashes it — the payload is
+    # deliberately no longer parseable in some of these cases, so it cannot be
+    # round-tripped through the canonical model first.
+    release.evidence_report_hash = hash_obj(payload)
     release.corpus_report_reference = release.evidence_report_hash
 
 
 def test_the_bounded_release_report_is_a_successful_5c_verdict() -> None:
     """The fixture's report is a real ``build_report`` output, and it passes.
 
-    Also a drift guard: if ``build_report`` gains or renames a key without
-    ``REQUIRED_REPORT_KEYS`` following, this fails rather than quietly letting
-    the recorded-verdict check stop covering the new field.
+    Its stored form re-parses through the canonical model, so the fixture
+    exercises the same construct → dump → persist → parse path production does.
     """
-    assert set(BOUND_REPORT.payload) == REQUIRED_REPORT_KEYS
-    assert recorded_success_violations(BOUND_REPORT.payload) == ()
+    assert recorded_success_violations(BOUND_REPORT.dump()) == ()
 
 
 def test_a_fabricated_binding_both_sides_agree_on_still_fails(

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -10,6 +10,7 @@ Publication commits, so every test here gets its own database.
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import inspect
 import shutil
@@ -630,6 +631,69 @@ def _rewrite_release_report(session: Session, **overrides: object) -> None:
     release.corpus_report_reference = release.evidence_report_hash
 
 
+def _stale_report_reference(session: Session) -> None:
+    """The reference still names a real report — the previous one."""
+    release = release_row(session)
+    stale = release.evidence_report_hash
+    _rewrite_release_report(session, declared_projection_count=99)
+    release_row(session).corpus_report_reference = stale
+
+
+def _coordinated_transform_edit(session: Session, mutate) -> None:  # type: ignore[no-untyped-def]
+    """Edit the stored transform config *and* copy it into the rehashed report.
+
+    The coordinated attack the closure exists to refuse: report and config agree
+    with each other perfectly, and ``transform_config_hash`` and the package
+    identity are left untouched — so only recomputing the configuration's own
+    hash catches it.
+    """
+    release = release_row(session)
+    config = copy.deepcopy(dict(release.transform_config))
+    mutate(config)
+    release.transform_config = config
+    payload = dict(release.report_payload or {})
+    payload["transform_identity"] = {
+        "extractor": config.get("extraction_config"),
+        **(config.get("transform_identity") or {}),
+    }
+    payload["rules_corpus_vector_identity"] = config.get("rules_corpus_vector_identity")
+    release.report_payload = payload
+    release.evidence_report_hash = hash_obj(payload)
+    release.corpus_report_reference = release.evidence_report_hash
+
+
+def _tamper_extractor_identity(session: Session) -> None:
+    _coordinated_transform_edit(
+        session, lambda c: c["extraction_config"].update(tool="forged")
+    )
+
+
+def _tamper_transform_identity(session: Session) -> None:
+    _coordinated_transform_edit(
+        session,
+        lambda c: c["transform_identity"].update(transform_source_hash="9" * 64),
+    )
+
+
+def _tamper_vector_identity(session: Session) -> None:
+    _coordinated_transform_edit(
+        session,
+        lambda c: c["rules_corpus_vector_identity"].update(embedding_model_id="forged"),
+    )
+
+
+def _tamper_evidence_schema_version(session: Session) -> None:
+    _coordinated_transform_edit(
+        session, lambda c: c.update(evidence_report_schema_version="5c-evidence-1")
+    )
+
+
+def _tamper_policy_portion(session: Session) -> None:
+    _coordinated_transform_edit(
+        session, lambda c: c["reconciliation_policy"].update(policy_version="forged")
+    )
+
+
 def test_the_bounded_release_report_is_a_successful_5c_verdict() -> None:
     """The fixture's report is a real ``build_report`` output, and it passes.
 
@@ -747,6 +811,33 @@ def test_a_fabricated_binding_both_sides_agree_on_still_fails(
             lambda s: _rewrite_release_report(s, smuggled_field="value"),
             id="release-evidence-carries-an-unknown-top-level-key",
         ),
+        # The recorded-release closure: row-level invariants the 5c gate already
+        # requires, which the downstream seam used to omit.
+        pytest.param(
+            lambda s: setattr(release_row(s), "corpus_report_reference", None),
+            id="release-report-reference-cleared",
+        ),
+        pytest.param(
+            lambda s: setattr(release_row(s), "corpus_report_reference", "9" * 64),
+            id="release-report-reference-unrelated-hash",
+        ),
+        pytest.param(
+            _stale_report_reference,
+            id="release-report-reference-stale-former-hash",
+        ),
+        pytest.param(
+            lambda s: setattr(package_row(s), "published_at", None),
+            id="package-records-no-published-at",
+        ),
+        pytest.param(
+            _tamper_extractor_identity, id="transform-config-extractor-edited"
+        ),
+        pytest.param(_tamper_transform_identity, id="transform-config-identity-edited"),
+        pytest.param(_tamper_vector_identity, id="transform-config-vector-edited"),
+        pytest.param(
+            _tamper_evidence_schema_version, id="transform-config-schema-version-edited"
+        ),
+        pytest.param(_tamper_policy_portion, id="transform-config-policy-edited"),
     ],
 )
 def test_an_unpublishable_5c_release_fails_even_when_everything_agrees(

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.corpus.report import (
+    CANONICAL_CANARY_NAMES,
     REQUIRED_REPORT_KEYS,
     recorded_success_violations,
 )
@@ -715,6 +716,43 @@ def test_a_fabricated_binding_both_sides_agree_on_still_fails(
         pytest.param(
             lambda s: _rewrite_release_report(s, concordance_failures=1),
             id="release-evidence-claims-pass-over-concordance-failures",
+        ),
+        # Closed-inventory population: an entry-by-entry check passes on all of
+        # these, because every entry that *is* present is valid.
+        pytest.param(
+            lambda s: _rewrite_release_report(s, version_canaries={}),
+            id="release-evidence-records-no-version-canaries",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(s, version_canaries={"invented": True}),
+            id="release-evidence-records-only-an-invented-canary",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(
+                s,
+                version_canaries=dict.fromkeys(
+                    sorted(CANONICAL_CANARY_NAMES)[1:], True
+                ),
+            ),
+            id="release-evidence-omits-one-canonical-canary",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(
+                s,
+                version_canaries={
+                    **dict.fromkeys(sorted(CANONICAL_CANARY_NAMES), True),
+                    "invented": True,
+                },
+            ),
+            id="release-evidence-adds-an-invented-canary",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(s, findings={"gaps": 0, "overlaps": 0}),
+            id="release-evidence-findings-population-incomplete",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(s, smuggled_field="value"),
+            id="release-evidence-carries-an-unknown-top-level-key",
         ),
     ],
 )


### PR DESCRIPTION
Stacked on **#141**. Base branch is `feature/issue-5d-publication-gate`, not `main`: the downstream verification seam this closes is introduced by #141 and does not exist upstream. Review of #141 is paused until this merges into it.

## What went wrong, and why it kept going wrong

PR #141 produced four consecutive findings in the same 5c recorded-evidence seam; this PR produced four more across three rounds. Every one had the same shape: **two competing representations of one document, and an incomplete downstream proof of the release that document describes.**

`build_report` held the real shape in a dict literal while a hand-maintained validator held a second, partial description — a required-key set, closed-inventory maps, an "open map" list. Each round closed one omission and left the next. Replacing that with a typed model narrowed the problem but did not end it: the model validated at ingress while its storage stayed reachable through `__dict__`, nested values were serialized independently of the canonical dump, and the verifier re-derived the release proof from whichever fields had been remembered so far.

## What the code does now

**One canonical value.** Every canonical type is a frozen, slotted Pydantic dataclass. There is no `__dict__` at the root or any nested value — `vars()` raises — so there is no backing store to reach past the freeze. Arrays are tuples; content-derived maps are `MappingProxyType` over copies the report owns. Pydantic validates at ingress; it does not hold the value.

**Raw JSON only at the parser boundary.** Stored bytes enter through `parse_recorded_report` and nowhere else. `build_report` and `parse_recorded_report` return the same runtime type.

**One serializer.** `dump()` is the only serialization. `report_hash` hashes it, SQL persists it, stored-hash verification recomputes through it, and contextual comparisons *slice* it rather than serializing nested values separately.

**One recorded-release closure.** `_recorded_release_violations` owns the external 5c publication-row invariants: package published, enabled, and carrying `published_at`; release published; transform configuration an object that hashes to its recorded `transform_config_hash`; the report hashing to `evidence_report_hash`; `corpus_report_reference == evidence_report_hash`; report proof identities equal to their columns. The last two are invariants `run_gate` already required — this brings the downstream seam into agreement with 5c publication semantics, which is why no ADR or Issue amendment applies.

**Reconstruction owns live proof.** Ledger, policy, reconciliation, bundle root, source and chunk membership, and every recomputable report summary are derived from persisted rows. Chroma stays outside downstream 5d verification under the existing Owner Decision (2026-08-01).

## `5c-evidence-3` retained — parity measured

```
diff parity_parent.json parity_head4.json
→ (no output; files identical)
```

Parent `cfade0d` versus head over identical deterministic inputs, covering the complete payload, `report_hash`, `package_uuid`, `release_version`, `transform_config_hash`, `bundle_root_hash`, and the persisted-corpus digest. Typing, freezing, and replacing the runtime representation changed how the document is *held*, never what it *is*.

## Test evidence

`black`, `ruff`, `mypy --strict` (211 files) clean. Typed-schema **116**; mechanical publication **64**; mechanical suites **521**; 5c corpus and production control **310**; full default suite **3208 passed, 10 skipped**, 93.42%.

Controls include: `vars()` unavailable on the root and all nine nested values, with dump and hash asserted unchanged after every attempted mutation; five coordinated transform-configuration tampering cases where report and config agree perfectly and only recomputing the config's own hash catches it; cleared, unrelated, and stale `corpus_report_reference`; the full malformed-shape, identity-map, variable-map, canary-population, and contextual-tamper matrices. Each malformed stored payload is refused end-to-end through mechanical publication as `STALE` / `BOUND_RELEASE`, never an uncaught exception.

**CI:** none runs on this stacked PR — `.github/workflows/ci.yml` triggers only on `pull_request` targeting `main`. Unchanged deliberately; a post-5d infrastructure follow-up. CI covers the merged result when #141 runs against `main`.

## Architecture Notes

**No drift from design principles.** Repeated review exposed two competing report representations and an incomplete downstream release proof; the canonical report is now a deeply immutable value with no mutable backing storage, one serializer owns hashing, persistence, and comparison, and one recorded-release closure owns the external 5c publication-row invariants that `run_gate` already required. Measured parity preserves `5c-evidence-3` and every release identity.

Chronology, the release-row field audit, and the negative-control inventory: `.claude/review-notes/pr-142-issue-5c-recorded-evidence-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
