### PR TITLE
fix: establish the 5c published-release proof boundary

### DIFF
--- a/.claude/review-notes/pr-143-issue-5c-release-proof-plan.md
+++ b/.claude/review-notes/pr-143-issue-5c-release-proof-plan.md
@@ -1,0 +1,172 @@
+# CRD Issue 5c — published-release proof boundary: construction plan
+
+Replacement for PR #142, which was frozen and closed as superseded. #142 is
+retained as a defect catalogue, a source of adversarial controls, and the record
+of two rejected representations. Its implementation history is deliberately not
+transplanted: this branch starts from `feature/issue-5d-publication-gate` at
+`b35386c` and builds the boundary once.
+
+This is a construction plan, not a chronology.
+
+## Why a replacement rather than a fifth remediation round
+
+Four rounds on #142 replaced the representation and then the closure, and the
+same defect family escaped every replacement:
+
+| Round | Representation / closure | Escape |
+| --- | --- | --- |
+| 1–2 | Hand-maintained key inventories beside a dict-literal builder | Two definitions of one document; each round shut one omission |
+| 3 | Frozen Pydantic `BaseModel` | `vars(report)["version_canaries"] = {}` reached past the freeze |
+| 4 | Frozen **slotted** Pydantic dataclass | `object.__setattr__(report, "version_canaries", {})` overwrites slot storage |
+| 4 | Recorded-release closure at one seam | `finalize_release` reuse never calls it; the audit's unit was the release *row*, not the package/release *pair* |
+
+Both representations were *conventionally* frozen — immutability enforced by a
+setter that a lower-level setter bypasses. Both closures were a function one
+caller happened to call. The corrections below are structural in the first case
+and shared in the second.
+
+## Boundary A — canonical report authority
+
+**Representation: a tuple-based immutable value tree.** Every canonical type is
+a `NamedTuple`; arrays are tuples; maps are `Pairs`, a `tuple` subclass holding
+sorted `(key, value)` pairs.
+
+Spike results (`object.__setattr__` on an existing field, on a novel field,
+`setattr`, `vars`):
+
+| Candidate | `object.__setattr__` | `vars()` | `__dict__` |
+| --- | --- | --- | --- |
+| Pydantic frozen `BaseModel` | writes | writes | present |
+| Pydantic frozen + slotted dataclass (#142 head) | **writes** | raises | absent |
+| `NamedTuple` | raises | raises | absent |
+| `tuple` subclass | raises | raises | absent |
+
+A `NamedTuple` stores its values in the tuple itself. There is no instance
+dictionary and no slot descriptor, so there is nothing for the base setter to
+write — immutability is a property of the storage rather than of a guard.
+
+`Pairs` is chosen over `MappingProxyType` for the same reason. A proxy is a view
+onto a real dict, which remains reachable through `gc.get_referents`; a pair
+tuple has no backing dict at all. This is the difference between "no mutable
+dictionary is *exposed*" and the required "no mutable dictionary is
+*reachable*".
+
+**One parser.** A single `TypeAdapter` over the value tree. Pydantic validates
+ingress and never holds the value: strict per-scalar aliases (`true` is not an
+integer, `"0"` is not an integer), `BeforeValidator` requiring a JSON *object*
+at every node (pydantic's native `NamedTuple` handling would otherwise accept a
+positional array), `AfterValidator` for closed populations, the canonical
+`report_version`, and the canonical `python_target`. Extra, missing, and
+wrongly-typed keys are refused by the adapter.
+
+**One construction path.** `build_report` assembles a plain dict and hands it to
+`canonical_report(...)`. A `NamedTuple` constructor runs no validators, so
+direct construction of the canonical types is never a production path; a
+build-time negative control asserts a non-canonical canary population, an
+unsupported `report_version`, and a non-canonical `python_target` each fail at
+*build* time, not only at parse time.
+
+**One serializer.** `CorpusEvidenceReport.dump()` walks the tree and reads field
+names off `NamedTuple._asdict()` and `Pairs`, so the serializer cannot drift from
+the declaration. It is the only rendering: `report_hash`, the SQL column, stored-
+hash verification, contextual comparison, and reuse reconstruction all read it.
+
+**New hazard this representation introduces.** `json.dumps` raised `TypeError`
+on a dataclass but *succeeds* on a `NamedTuple`, emitting a positional array —
+so `canonical_bytes(report)` would silently mint a wrong-but-plausible hash. A
+control asserts `report_hash` equals `sha256_hex(canonical_bytes(report.dump()))`
+and that the raw object's canonical bytes differ from the payload's, so any
+accidental direct serialization fails loudly.
+
+## Boundary B — published-release authority
+
+**One 5c-owned seam:** `load_published_release(session, pkg)`, returning the
+proven package/release pair or the violations that refuse it. Its unit is the
+**pair**, not either row — that is precisely what the #142 field audit got wrong.
+
+Invariants stated in the seam:
+
+- package row exists; is `published`; is enabled; has `published_at`
+- release row exists; is `published`
+- `package.version == release.release_version`
+- identity, report, and reference columns present as a set
+- `hash_obj(release.transform_config) == release.transform_config_hash`
+- canonical report hashes to `evidence_report_hash`
+- `corpus_report_reference == evidence_report_hash`
+- report proof identities equal their release columns
+- report schema version agrees with the recorded transform configuration
+
+Reconstruction keeps what it already owns and the seam does not duplicate:
+ledger, policy, reconciliation, bundle, source, chunk membership, page coverage,
+and every recomputable report total.
+
+**Every caller of the seam:**
+
+| Caller | Site | Why |
+| --- | --- | --- |
+| `verify_published_release` | `persistence.py` — downstream 5d entry, called by `mechanical/gate.py:run_gate` step 0 | Proves the pair before comparing 5d's six declared values against it |
+| `_finalize_core` verified reuse | `persistence.py` reuse branch, replacing the `package_state_ok` inline check | A release refused downstream must not be returned as `published=True, reused=True` |
+| `_finalize_core` fresh publication | `persistence.py`, after the status writes and before `session.commit()` | The same row-level invariants gate a *fresh* success; failing rolls back rather than committing a release the seam would later refuse |
+
+Three call sites, one definition. `policy_hash` is deliberately not re-verified
+in the seam: `_load_policy` already validates a closed cross-reference chain
+across the policy, reconciliation, and release rows and fails closed, and a
+second statement of it would reintroduce the two-definitions defect.
+
+## Package / release field disposition
+
+`rp_packages` (for `rules_package_id == pkg`):
+
+| Field | Disposition |
+| --- | --- |
+| `rules_package_id` | Seam — the lookup key; absence is a violation |
+| `version` | **Seam — must equal `release.release_version`** (the #142 omission) |
+| `publication_status` | Seam — must be `published` |
+| `is_enabled` | Seam — must be true |
+| `published_at` | Seam — must be present |
+| `name`, `system` | Not proof-bearing; fixed descriptive values, no identity binds them |
+| `created_at`, `updated_at` | Wall-clock; excluded from every hashed artifact by construction |
+
+`rp_corpus_releases` (for `package_uuid == pkg`):
+
+| Field | Disposition |
+| --- | --- |
+| `package_uuid` | Seam — the lookup key |
+| `release_version` | Seam — must equal `package.version`; also a 5d declared value |
+| `publication_status` | Seam — must be `published` |
+| `authoritative_source_hash` | Seam — must equal the report's identity; also a 5d declared value |
+| `transform_config` | Seam — must be an object hashing to `transform_config_hash` |
+| `transform_config_hash` | Seam — recomputed from `transform_config`, and equal to the report's |
+| `ledger_hash` | Reconstruction — recomputed from persisted leaves |
+| `policy_hash` | Reconstruction — `_load_policy` proves the closed chain and fails closed |
+| `reconciliation_hash` | Reconstruction — recomputed from persisted reconciliation |
+| `bundle_root_hash` | Both — seam compares the report's; reconstruction recomputes the bundle |
+| `persisted_corpus_digest` | Seam (recorded equality only) — its cross-store half is provable solely by `finalize_release`, which holds a Chroma client; unchanged by the 2026-08-01 Owner Decision |
+| `report_payload` | Seam — parsed by the one parser; unparseable is a refusal, not an exception |
+| `evidence_report_hash` | Seam — the canonical report must hash to it |
+| `corpus_report_reference` | Seam — must equal `evidence_report_hash` |
+| `created_at` | Wall-clock; excluded from hashed artifacts |
+
+## Identity parity
+
+Compared against clean base `b35386c` — the untyped dict-based report — from an
+explicit worktree at that commit, on identical deterministic inputs. Unchanged
+canonical payload, `evidence_report_hash`, `transform_config_hash`,
+`package_uuid`, `release_version`, `bundle_root_hash`, `persisted_corpus_digest`,
+and every other release identity. `5c-evidence-3` is retained only if that
+comparison is empty.
+
+The bounded mechanical fixture declared `transform_config_hash = "b" * 64`,
+which is not the hash of its own configuration — it was a synthetic constant
+chosen before any check recomputed it, so nothing had ever required it to be
+honestly derived. It is derived here and `bounded_oracle.json` regenerated,
+because a fixture that cannot pass the proof it is used to test is not evidence.
+
+## Scope
+
+Unchanged: 5c digest identity semantics, the payload's canonical shape, the
+2026-08-01 Owner Decision on the persisted-corpus digest (Chroma is not
+reopened), and CI workflow configuration. No Owner Decision, ADR amendment,
+Issue amendment, or schema-version decision is required — every invariant above
+is one `run_gate` already defines; the implementation is being brought into
+agreement with it.

--- a/.claude/review-notes/pr-143-issue-5c-release-proof-plan.md
+++ b/.claude/review-notes/pr-143-issue-5c-release-proof-plan.md
@@ -230,3 +230,174 @@ reopened), and CI workflow configuration. No Owner Decision, ADR amendment,
 Issue amendment, or schema-version decision is required — every invariant above
 is one `run_gate` already defines; the implementation is being brought into
 agreement with it.
+
+---
+
+# Round 1 — boundary reassessment
+
+Two P1 findings, both valid, both firing this PR's standing condition. They are
+not patched where they were reported: the accepted construction plan above is
+revised first, because each names a boundary that was drawn in the wrong place
+rather than a check that was left out.
+
+**The tuple tree held.** `CorpusEvidenceReport` and every nested value remain
+structurally immutable; no finding reaches them. That is worth stating plainly,
+because it means the representation decision was right and the mistake was in
+what the boundary was drawn *around*.
+
+**Boundary A was drawn around the payload; the authority was the wrapper.**
+`build_report` returns `EvidenceReport`, a frozen dataclass holding the
+canonical value, and everything that matters consumes *that* —
+`report_hash`, SQL persistence, the gate. So
+`object.__setattr__(report, "payload", forged)` replaces the whole document
+after construction. Making the payload unforgeable while the object carrying it
+to the hash function stays writable protects the wrong thing. The correction is
+to delete the wrapper, not to freeze a second one.
+
+The wrapper also carried `persisted`, a caller-supplied boolean outside the
+hashed payload that gate condition 18 trusted as proof the report postdates
+persistence. `build_report`'s `persisted` parameter is the same trust one layer
+down: it is the sole input deciding whether the hashed
+`prepublication_validation_status` may be `"pass"`, and the single production
+call site passes a hardcoded `True` under a comment arguing that this particular
+caller is trustworthy. Both go.
+
+**Boundary B was drawn around recorded-row closure; published authority is
+more.** `load_published_release` proves the package/release rows are internally
+coherent and then stops. It never asks whether the report *describes the
+persisted corpus*. Rewrite `declared_projection_count`, the totals, and the
+accounting to different but internally consistent values, rehash, and update the
+reference: the pair is accepted, and neither downstream reconstruction nor the
+reuse gate compares those fields with the reconstructed ledger and
+reconciliation. The name overclaims what the function proves, which is how the
+gap survived a field audit.
+
+**Authority disposition.** Neither finding requires an Owner Decision, ADR
+amendment, Issue amendment, or schema-version change. Both are invariants
+already implied by `run_gate` and by Component K's ordering; the implementation
+is being brought into agreement with them. Removing a non-payload wrapper and a
+non-payload constructor parameter must not move a single byte of the canonical
+document — if parity is non-empty afterwards, that is a behavioural change to
+report and not a fixture to adjust.
+
+## Revised Boundary A — the canonical report is the authority
+
+`build_report(...) -> CorpusEvidenceReport` and
+`report_hash(report: CorpusEvidenceReport)`. No wrapper type remains in
+production; `ReleaseArtifacts.report` carries the canonical value. Construction,
+hashing, persistence, parsing, stored-hash verification, contextual comparison,
+gate evaluation, and reuse reconstruction all consume it directly.
+
+The name `EvidenceReport` is kept in `report.py` as a runtime alias of the
+canonical class — `EvidenceReport is CorpusEvidenceReport` — so that
+`pipeline.py`, whose bytes are bound into the transform identity, stays
+byte-identical. It is vocabulary, not a type: no `payload`, no `persisted`, no
+second serializer, nothing to construct or unwrap.
+
+No runtime type guard is added at the hash boundary. A guard is the shape the
+last two rounds killed: the answer is that there is no wrapper type to pass, so
+the control asserts the *absence* of the production type rather than the
+rejection of imposters.
+
+**Where "postdates persistence" is now structurally enforced,** replacing the
+deleted `report.persisted` check:
+
+1. `persisted_corpus_digest` is a required argument to `build_report` and cannot
+   be computed before persistence — it digests reconstructed SQL rows and the
+   read-back vector state. A pre-persistence caller has nothing to pass.
+2. `ReleaseArtifacts` — the only thing `run_gate` accepts — has exactly two
+   construction sites, both in `persistence.py`: the fresh path after the digest
+   is computed, and reconstruction from an already-proven published release.
+   None in tests.
+3. `PublicationEvidence.sql_persist_ok` is derived from comparing reconstructed
+   rows against the candidate, never defaulted.
+
+Gate condition 18 keeps its other two checks: the report carries a
+persisted-corpus digest, and its recorded status is `"pass"`.
+
+## Revised Boundary B — row closure is a prerequisite, not authority
+
+Two named concepts instead of one overclaiming name:
+
+- **`load_recorded_release_pair`** — recorded-row closure only. Existence,
+  statuses, enablement, `published_at`, version equality, required
+  post-persistence fields, transform-config hash, report parse and hash, report
+  reference, proof-column equality, schema version, self-contained verdict.
+  Necessary, explicitly not sufficient.
+- **`load_verified_published_release`** — the one published-authority seam:
+  recorded closure, then policy/ledger/reconciliation/members/source
+  reconstruction, reconstruction identity checks, report-versus-reconstructed-
+  state verification, and membership verification. Returns the proven state
+  bundle, so callers do not reconstruct a second independent copy.
+
+**One report-context verifier.** `report_state_violations(report, *, release,
+transform_config, ledger, reconciliation, policy, members)` is the single
+definition of "the report agrees with the persisted corpus". It takes one
+`report.dump()` and never serializes a nested fragment independently. The
+summary fields are recomputed through the same derivation `build_report` uses
+rather than a second implementation of how totals are counted.
+
+Called from the seam (reuse, downstream) and from `run_gate` (fresh publication,
+which has no seam call before the rows exist). Reuse runs both and may report a
+violation twice; that redundancy is accepted deliberately rather than resolved
+by giving one of them its own copy of the comparison.
+
+**Recorded-only fields.** Concordance against the authoritative PDF, canary
+execution, and the live vector half of the persisted-corpus digest are not
+recomputable from SQL alone. They keep their existing treatment — required in
+closed successful recorded form under the 2026-08-01 Owner Decision — while
+fresh publication and reuse, which hold pages and vector state, continue to
+rerun the real checks.
+
+A drift guard makes the completeness claim executable rather than asserted: the
+21 declared fields partition exactly into 10 recomputed from reconstructed
+state, 5 compared against release columns, and 6 that are neither, with no
+remainder. A field added to the document and not routed anywhere fails that
+test rather than silently ceasing to be compared.
+
+## Exact identity parity, and the intermediate implementation that lost it
+
+The first implementation of this round edited `pipeline.py` for one reason: to
+retype `ReleaseArtifacts.report` from the deleted wrapper to
+`CorpusEvidenceReport`. `pipeline.py` is one of the eleven modules whose source
+bytes are bound into the transform identity, so that annotation change reminted
+`transform_source_hash`, `transform_config_hash`, `package_uuid`,
+`release_version`, `bundle_root_hash`, and `report_hash`.
+
+That remint was a whole-file-hash side effect, not a transform change.
+`pipeline.py` is audited because `build_candidate` owns the candidate-affecting
+steps a0–b; `ReleaseArtifacts.report` is post-persistence plumbing for steps
+c–g. No candidate corpus, canonical bundle member, or report schema moved — the
+canonical payload was byte-identical throughout, which was proven by restoring
+`pipeline.py` alone and observing an empty diff.
+
+**The architecture was adjusted rather than the identity accepted.**
+`EvidenceReport` is retained in `report.py` as a runtime alias of
+`CorpusEvidenceReport` — the same class object, not a wrapper, adapter, or
+second report type. It has no `payload` member and no `persisted` member,
+introduces no alternate serializer, and cannot be constructed as anything other
+than the canonical report. `pipeline.py` is byte-identical to `b35386c` and was
+not reformatted, re-annotated, or re-imported.
+
+The intermediate reminting head was never pushed.
+
+**Verified after the amendment:**
+
+- `git diff --exit-code b35386c -- src/afterworlds/ingestion/corpus/pipeline.py`
+  is clean, and a direct SHA-256 over newline-normalized bytes matches
+  (`f0af4fdb…`, the same value the base manifest records);
+- all **eleven** `TRANSFORM_SOURCE_MODULES` entries hash identically to
+  `b35386c`, and `transform_source_hash` is `6332f201…` as before;
+- full parity `diff` against `b35386c` is **empty** — canonical payload,
+  `report_hash`, `transform_config_hash`, `package_uuid`, `release_version`,
+  and `bundle_root_hash`;
+- `bounded_oracle.json` is back to its pre-remint committed value, and the
+  fixture derives the same hash.
+
+Modules outside the manifest — `report.py`, `report_schema.py`, `persistence.py`,
+`gate.py` — changed substantially and do not move transform identity, which is
+the intended separation: verification and post-persistence code is not
+candidate-affecting.
+
+**`5c-evidence-3` is retained.** It versions the canonical shape, which is
+unchanged, and every release identity is now exactly as it was.

--- a/.claude/review-notes/pr-143-issue-5c-release-proof-plan.md
+++ b/.claude/review-notes/pr-143-issue-5c-release-proof-plan.md
@@ -67,7 +67,7 @@ unsupported `report_version`, and a non-canonical `python_target` each fail at
 *build* time, not only at parse time.
 
 **One serializer.** `CorpusEvidenceReport.dump()` walks the tree and reads field
-names off `NamedTuple._asdict()` and `Pairs`, so the serializer cannot drift from
+names off `NamedTuple._fields` and renders `Pairs` as objects, so it cannot drift from
 the declaration. It is the only rendering: `report_hash`, the SQL column, stored-
 hash verification, contextual comparison, and reuse reconstruction all read it.
 
@@ -161,6 +161,66 @@ which is not the hash of its own configuration — it was a synthetic constant
 chosen before any check recomputed it, so nothing had ever required it to be
 honestly derived. It is derived here and `bounded_oracle.json` regenerated,
 because a fixture that cannot pass the proof it is used to test is not evidence.
+
+## What was built
+
+Both boundaries as planned, with three findings worth recording because the
+construction changed them.
+
+**The serializer could not come from Pydantic.** `TypeAdapter.dump_python` over
+a `NamedTuple` emits a *positional array*, not an object, so the canonical
+payload had to be rendered by a small recursive walk. It reads field names off
+`NamedTuple._fields`, so there is still one declaration — but the same fact
+creates a hazard the dataclass did not have: `json.dumps` *succeeds* on a
+`NamedTuple`. `canonical_bytes(report)` therefore mints a wrong-but-plausible
+hash instead of raising, and a control asserts the raw object's bytes differ
+from the payload's.
+
+**Positional input had to be refused explicitly.** Pydantic's native
+`NamedTuple` handling accepts a sequence, so a stored report could have arrived
+as a JSON array and parsed. `BeforeValidator(_object_only)` is applied at the
+root and at every nested node.
+
+**Reuse proves the pair before reconstructing, not after.** The plan said reuse
+must call the seam; putting the call after `_reconstruct_artifacts` — where the
+old inline package check lived — meant artifacts were assembled around rows
+nothing had accepted yet, and `_reconstruct_artifacts` asserted on the
+post-persistence columns rather than refusing. The seam now runs first, and
+those `assert`s are a `PersistedReportError` (an `assert` disappears under `-O`).
+
+Two invariants proved to belong intrinsically to the document rather than
+contextually, so they moved onto their own fields: the canonical
+`report_version` and the canonical `python_target`. `_report_schema_ok` keeps
+only the genuinely contextual half — agreement with the persisted transform
+configuration, which the document cannot know about itself.
+
+**Fresh publication needed fault injection, not a positive assertion.** Both
+other callers can be driven by editing rows after publication; the fresh path
+has to be made to write a bad pair while it runs, or its refusal branch never
+executes. A monkeypatched `_persist_package_and_source` writes a package version
+the release does not carry, and the control asserts the refusal *and* that no
+published package or release row survives — the rollback, not just the verdict.
+
+Two `PersistedReportError` raises inside `_reconstruct_artifacts` became
+unreachable once reuse proved the pair first. They are kept as backstops and
+marked `# pragma: no cover`, because assembling artifacts around a half-written
+or unparseable release would produce something that looks whole. The
+`PolicyReconstructionError` half of the surrounding `except` stays live: the
+seam does not call `_load_policy`, so a deleted policy row still lands there.
+
+## Verification
+
+Parity against clean base `b35386c`, identical deterministic inputs, generated
+before any edit and again at the final head: `diff` produced **no output**
+across the complete payload, `report_hash`, `package_uuid`, `release_version`,
+`transform_config_hash`, `bundle_root_hash`, and the persisted-corpus digest.
+`5c-evidence-3` therefore stands.
+
+Black, Ruff, and `mypy --strict` (211 source files) clean. 75 tests in the
+typed-schema module, 24 in the new published-release seam module; 875 across
+ingestion. Coverage on the changed modules: `report_schema.py` 100%,
+`report.py` 100%, `persistence.py` 99% — its three remaining lines are
+pre-existing, `delete_release` among them.
 
 ## Scope
 

--- a/src/afterworlds/ingestion/corpus/gate.py
+++ b/src/afterworlds/ingestion/corpus/gate.py
@@ -38,7 +38,7 @@ from afterworlds.ingestion.corpus.policy import (
     policy_hash,
     policy_payload,
 )
-from afterworlds.ingestion.corpus.report import report_hash
+from afterworlds.ingestion.corpus.report import report_hash, report_state_violations
 
 
 @dataclass(frozen=True)
@@ -236,12 +236,40 @@ def run_gate(
         f.append("persisted_corpus_digest mismatch (tampered persisted state)")
 
     # 18. Evidence report postdates persistence and carries the digest.
-    if not a.report.persisted:
-        f.append("evidence report predates persistence")
-    if not a.report.payload.persisted_corpus_digest:
+    #     The former `if not a.report.persisted` check is gone: that flag lived
+    #     on a wrapper outside the hashed payload and was set by the caller, so
+    #     it asserted the ordering rather than proving it. The ordering is now
+    #     structural — `persisted_corpus_digest` is a required argument to
+    #     `build_report`, and condition 17 above recomputes it over the
+    #     reconstructed SQL rows and the actual read-back vector state — so a
+    #     digest invented before persistence fails there rather than being
+    #     trusted here. `ReleaseArtifacts` is constructed in exactly two places,
+    #     both in `persistence`, both from reconstructed state.
+    if not a.report.persisted_corpus_digest:
         f.append("evidence report lacks persisted-corpus digest")
-    if a.report.payload.prepublication_validation_status != "pass":
+    if a.report.prepublication_validation_status != "pass":
         f.append("evidence report prepublication status is not pass")
+
+    # 18b. The report describes THIS corpus, not merely a coherent one. Shared
+    #      with the published-authority seam so there is one definition of
+    #      report-versus-state agreement; the gate needs its own call because a
+    #      fresh publication has no proven release to load yet.
+    f.extend(
+        report_state_violations(
+            a.report,
+            identities={
+                "authoritative_source_hash": ident.authoritative_source_hash,
+                "transform_config_hash": ident.transform_config_hash,
+                "bundle_root_hash": ident.bundle_root_hash,
+                "frozen_source_ledger_hash": rel.ledger_hash,
+                "persisted_corpus_digest": ident.persisted_corpus_digest,
+            },
+            transform_config=tconfig if isinstance(tconfig, dict) else {},
+            ledger=ledger,
+            reconciliation=recon,
+            policy=policy,
+        )
+    )
 
     # 19. Accounting equation holds.
     if recon.inventoried_leaves != (

--- a/src/afterworlds/ingestion/corpus/gate.py
+++ b/src/afterworlds/ingestion/corpus/gate.py
@@ -238,9 +238,9 @@ def run_gate(
     # 18. Evidence report postdates persistence and carries the digest.
     if not a.report.persisted:
         f.append("evidence report predates persistence")
-    if not a.report.payload.get("persisted_corpus_digest"):
+    if not a.report.payload.persisted_corpus_digest:
         f.append("evidence report lacks persisted-corpus digest")
-    if a.report.payload.get("prepublication_validation_status") != "pass":
+    if a.report.payload.prepublication_validation_status != "pass":
         f.append("evidence report prepublication status is not pass")
 
     # 19. Accounting equation holds.

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -76,9 +76,11 @@ from afterworlds.ingestion.corpus.policy import (
 )
 from afterworlds.ingestion.corpus.report import (
     EVIDENCE_REPORT_SCHEMA_VERSION,
-    EvidenceReport,
+    REPORT_PROOF_COLUMNS,
     build_report,
+    recorded_identities,
     report_hash,
+    report_state_violations,
 )
 from afterworlds.ingestion.corpus.report_schema import (
     CorpusEvidenceReport,
@@ -876,31 +878,48 @@ def verify_persisted_digest(
     )
 
 
-#: What a downstream consumer must be able to prove about a release before it
-#: may treat that release as authority. Each entry is
-#: ``(evidence-report key, rp_corpus_releases column)``: the recorded report and
-#: the recorded release row must state the same proof identity, or one of them
-#: has been edited since publication.
-_REPORT_PROOF_COLUMNS = (
-    ("authoritative_source_hash", "authoritative_source_hash"),
-    ("transform_config_hash", "transform_config_hash"),
-    ("bundle_root_hash", "bundle_root_hash"),
-    ("frozen_source_ledger_hash", "ledger_hash"),
-    ("persisted_corpus_digest", "persisted_corpus_digest"),
-)
-
-
-class PersistedReportError(ValueError):
-    """A stored evidence report is not the canonical `5c-evidence-3` schema."""
-
-
 @dataclass(frozen=True)
-class PublishedRelease:
-    """A package/release pair proven to be an exactly-published 5c release."""
+class RecordedReleasePair:
+    """A package/release pair whose *recorded rows* are internally closed.
+
+    Necessary authority, explicitly not sufficient. Nothing here has asked
+    whether the report describes the persisted corpus — see
+    :class:`VerifiedPublishedRelease`, which is what a lifecycle may act on.
+    """
 
     package: RulesPackageORM
     release: CorpusReleaseORM
     report: CorpusEvidenceReport
+
+
+@dataclass(frozen=True)
+class VerifiedPublishedRelease:
+    """A published 5c release proven against the state it claims to describe.
+
+    Carries the reconstruction it was proven from, so a caller that needs the
+    ledger, reconciliation, policy, members, or sources uses the copy that was
+    verified rather than loading a second, independently-trusted one.
+    """
+
+    package: RulesPackageORM
+    release: CorpusReleaseORM
+    report: CorpusEvidenceReport
+    #: The release row as a typed record, with the post-persistence columns
+    #: already narrowed — proving the pair is what establishes they are present,
+    #: so no consumer re-derives that.
+    record: ReleaseRecord
+    policy: ReconciliationPolicy
+    ledger: SourceLedger
+    reconciliation: ReconciliationMember
+    members: CorpusBundleMembers
+    sources: tuple[PersistedSource, ...]
+    #: The membership checks as *measured*, not as assumed. Both are empty
+    #: whenever this object exists — the seam refuses otherwise — but a caller
+    #: assembling publication evidence must report what was computed rather than
+    #: a constant justified by an invariant held somewhere else. Gate condition
+    #: 20 requires real operation evidence, never a default.
+    chunk_membership_violations: tuple[str, ...]
+    source_violations: tuple[str, ...]
 
 
 #: Columns that are NULL through the draft phase and set exactly once by
@@ -915,32 +934,28 @@ _POST_PERSISTENCE_COLUMNS = (
 )
 
 
-def load_published_release(
+def load_recorded_release_pair(
     session: Session, pkg: str
-) -> tuple[PublishedRelease | None, tuple[str, ...]]:
-    """Load and prove the published package/release pair for *pkg*.
+) -> tuple[RecordedReleasePair | None, tuple[str, ...]]:
+    """Prove the *recorded rows* for *pkg* are an internally closed published pair.
 
-    The one 5c-owned statement of what a published release *is*, in terms of its
-    own persisted rows. Every lifecycle operation that treats a release as
-    published calls this: downstream :func:`verify_published_release`,
-    :func:`finalize_release` verified reuse, and fresh finalization before it
-    commits. A release refused here cannot be reused, consumed, or freshly
-    published — which is the property that a check living at one caller could
-    not give.
+    Narrowly named on purpose. Its predecessor was called
+    ``load_published_release`` and was treated as published authority, which it
+    is not: everything it proves is a relationship *among recorded values*. A
+    report whose summaries were rewritten to different but internally successful
+    values, rehashed, and re-referenced satisfies every line below.
+    :func:`load_verified_published_release` is the seam a lifecycle may act on.
 
     Its unit is the **pair**, not either row. Both rows are written from one
     derived value at publication, ``RulesPackageService`` exposes the package's
     version while 5d binds the release's, so a mismatch between them leaves two
     public versions for one supposedly closed release.
 
-    Deliberately *not* re-proven here, because it is already proven elsewhere and
-    a second statement is a second definition: ``policy_hash``, whose closed
+    Deliberately *not* re-proven here: ``policy_hash``, whose closed
     cross-reference chain across the policy, reconciliation, and release rows is
-    validated by :func:`_load_policy`, which fails closed; and everything
-    recomputable from persisted rows (ledger, reconciliation, bundle root,
-    source and chunk membership), which belongs to reconstruction.
+    validated by :func:`_load_policy`, which fails closed.
 
-    Returns the proven pair, or ``None`` and the violations that refuse it.
+    Returns the closed pair, or ``None`` and the violations that refuse it.
     """
     violations: list[str] = []
     release = session.execute(
@@ -1006,9 +1021,7 @@ def load_published_release(
         )
         return None, tuple(violations)
 
-    if report_hash(EvidenceReport(payload=report, persisted=True)) != (
-        release.evidence_report_hash
-    ):
+    if report_hash(report) != release.evidence_report_hash:
         violations.append(
             "recorded evidence-report payload does not hash to the recorded "
             "evidence_report_hash"
@@ -1025,7 +1038,7 @@ def load_published_release(
             f"the supported {EVIDENCE_REPORT_SCHEMA_VERSION!r}"
         )
     recorded = report.dump()
-    for report_key, column in _REPORT_PROOF_COLUMNS:
+    for report_key, column in REPORT_PROOF_COLUMNS:
         if recorded[report_key] != getattr(release, column):
             violations.append(
                 f"recorded evidence report states {report_key}="
@@ -1042,7 +1055,137 @@ def load_published_release(
 
     if violations:
         return None, tuple(violations)
-    return PublishedRelease(package=package, release=release, report=report), ()
+    return RecordedReleasePair(package=package, release=release, report=report), ()
+
+
+def load_verified_published_release(
+    session: Session, pkg: str
+) -> tuple[VerifiedPublishedRelease | None, tuple[str, ...]]:
+    """The one 5c-owned seam for "this release is published authority".
+
+    Recorded-row closure is a prerequisite, not the answer. This adds the two
+    things that make a release *authority* rather than merely coherent: the
+    persisted rows reconstruct, and the evidence report describes **that**
+    reconstruction. Without the second, a coherently rewritten set of totals,
+    accounting, and projection counts is accepted — every recorded value agrees
+    with every other recorded value, and none of them is checked against the
+    corpus they claim to summarize.
+
+    Stages, in order, each refusing before the next can derive noise from state
+    already known untrustworthy:
+
+    1. :func:`load_recorded_release_pair` — the recorded rows are closed;
+    2. policy, ledger, reconciliation, member, and source reconstruction;
+    3. reconstruction identity checks — ledger, reconciliation, and bundle-root
+       hashes are what the rows actually derive;
+    4. :func:`report_state_violations` — every SQL-reconstructable report claim
+       agrees with the reconstruction;
+    5. single-source and chunk-runtime membership.
+
+    Every lifecycle that treats a release as published calls this: downstream
+    :func:`verify_published_release`, :func:`finalize_release` verified reuse,
+    and fresh finalization before it commits. It returns the reconstruction it
+    proved, so a caller uses the copy that was verified rather than loading a
+    second, independently-trusted one.
+    """
+    pair, violations = load_recorded_release_pair(session, pkg)
+    if pair is None:
+        return None, violations
+
+    try:
+        policy = _load_policy(session, pkg)
+        ledger = _load_ledger(session, pkg)
+        recon = _load_reconciliation(session, pkg, policy)
+        members = _load_members(session, pkg, ledger)
+        sources = _load_sources(session, pkg)
+    except (PolicyReconstructionError, SQLAlchemyError, KeyError, ValueError) as exc:
+        # Deliberately broad: this runs over rows that may have been partially
+        # migrated or edited directly, and every way that can fail — a missing
+        # row, an unreadable enum, a findings key that is gone — means the same
+        # thing, that the release does not reconstruct.
+        return None, (f"release {pkg} does not reconstruct from persisted rows: {exc}",)
+
+    release = pair.release
+    found: list[str] = []
+    # ``_load_policy`` already fails closed on a policy_hash that disagrees with
+    # the policy row, the reconciliation row, or the release row, so the policy
+    # identity is proven by having got here at all.
+    for label, recomputed, was in (
+        ("ledger_hash", ledger_hash(ledger), release.ledger_hash),
+        (
+            "reconciliation_hash",
+            reconciliation_hash(recon),
+            release.reconciliation_hash,
+        ),
+        (
+            "bundle_root_hash",
+            build_bundle(ledger, members, recon).bundle_root_hash,
+            release.bundle_root_hash,
+        ),
+    ):
+        if recomputed != was:
+            found.append(
+                f"recorded {label} {was!r} is not what the reconstructed "
+                f"5c state derives ({recomputed!r})"
+            )
+
+    found.extend(
+        report_state_violations(
+            pair.report,
+            identities=recorded_identities(release),
+            transform_config=release.transform_config,
+            ledger=ledger,
+            reconciliation=recon,
+            policy=policy,
+        )
+    )
+    source_violations = verify_single_source(session, pkg)
+    membership_violations = verify_chunk_runtime_membership(session, pkg)
+    found.extend(source_violations)
+    found.extend(membership_violations)
+
+    if found:
+        return None, tuple(found)
+
+    evidence_hash = release.evidence_report_hash
+    digest = release.persisted_corpus_digest
+    reference = release.corpus_report_reference
+    if (
+        evidence_hash is None or digest is None or reference is None
+    ):  # pragma: no cover - recorded closure already required all three
+        return None, (f"release {pkg} is missing post-persistence columns",)
+
+    return (
+        VerifiedPublishedRelease(
+            package=pair.package,
+            release=release,
+            report=pair.report,
+            record=ReleaseRecord(
+                package_uuid=pkg,
+                release_version=release.release_version,
+                identity=ReleaseIdentity(
+                    authoritative_source_hash=release.authoritative_source_hash,
+                    transform_config_hash=release.transform_config_hash,
+                    bundle_root_hash=release.bundle_root_hash,
+                    evidence_report_hash=evidence_hash,
+                    persisted_corpus_digest=digest,
+                ),
+                transform_config=release.transform_config,
+                ledger_hash=release.ledger_hash,
+                policy_hash=release.policy_hash,
+                reconciliation_hash=release.reconciliation_hash,
+                corpus_report_reference=reference,
+            ),
+            policy=policy,
+            ledger=ledger,
+            reconciliation=recon,
+            members=members,
+            sources=sources,
+            chunk_membership_violations=membership_violations,
+            source_violations=source_violations,
+        ),
+        (),
+    )
 
 
 def verify_published_release(
@@ -1065,19 +1208,21 @@ def verify_published_release(
     already here; 5d calls it rather than re-deriving a second opinion about
     what a published 5c release is.
 
-    Three stages, in order. :func:`load_published_release` proves the persisted
-    package/release **pair** is an exactly-published release in its own terms;
-    the five declared values (plus *pkg* itself) must then equal that proven
-    row; and the ledger, reconciliation, and bundle-root identities must be
-    exactly what the persisted rows reconstruct to.
+    Two stages, in order. :func:`load_verified_published_release` proves the
+    release is published authority — recorded rows closed, persisted rows
+    reconstructing, and the evidence report describing that reconstruction — and
+    only then are 5d's five declared values (plus *pkg* itself) compared against
+    it.
 
-    The order is the point. Comparing a declaration against a row that has not
-    been proven is comparing two claims, and deriving further findings from a
-    refused pair buries the real one — so a failed pair returns immediately.
+    The order is the point, and getting it wrong is what this seam is for.
+    Comparing a declaration against rows that have not been proven compares two
+    claims; deriving further findings from a refused release buries the real
+    one. So a failed proof returns immediately, and the declared binding is
+    never measured against anything but already-proven authority.
 
     **What this cannot re-prove.** ``persisted_corpus_digest`` binds the actual
     read-back *vector* logical state as well as SQL (Component A), so it is not
-    recomputable from a session alone. It is verified here as an exact recorded
+    recomputable from a session alone. It is verified as an exact recorded
     value, cross-checked against the recorded evidence report, and its
     cross-store half remains proven by :func:`finalize_release`, which is the
     only path that may set it. Re-proving that half needs a Chroma client and
@@ -1085,9 +1230,9 @@ def verify_published_release(
 
     Returns the violations, empty iff the release is publishable authority.
     """
-    proven, pair_violations = load_published_release(session, pkg)
+    proven, refusals = load_verified_published_release(session, pkg)
     if proven is None:
-        return pair_violations
+        return refusals
     release = proven.release
 
     violations: list[str] = []
@@ -1104,46 +1249,6 @@ def verify_published_release(
                 f"declared {field} {declared!r} is not the authoritative "
                 f"release's {recorded!r}"
             )
-
-    try:
-        policy = _load_policy(session, pkg)
-        ledger = _load_ledger(session, pkg)
-        recon = _load_reconciliation(session, pkg, policy)
-        members = _load_members(session, pkg, ledger)
-    except (PolicyReconstructionError, SQLAlchemyError, KeyError, ValueError) as exc:
-        # Deliberately broad: this runs over rows that may have been partially
-        # migrated or edited directly, and every way that can fail — a missing
-        # row, an unreadable enum, a findings key that is gone — means the same
-        # thing, that the release does not reconstruct.
-        violations.append(
-            f"release {pkg} does not reconstruct from persisted rows: {exc}"
-        )
-        return tuple(violations)
-
-    # ``_load_policy`` already fails closed on a policy_hash that disagrees with
-    # the policy row, the reconciliation row, or the release row, so the policy
-    # identity is proven by having got here at all.
-    for label, recomputed, recorded in (
-        ("ledger_hash", ledger_hash(ledger), release.ledger_hash),
-        (
-            "reconciliation_hash",
-            reconciliation_hash(recon),
-            release.reconciliation_hash,
-        ),
-        (
-            "bundle_root_hash",
-            build_bundle(ledger, members, recon).bundle_root_hash,
-            release.bundle_root_hash,
-        ),
-    ):
-        if recomputed != recorded:
-            violations.append(
-                f"recorded {label} {recorded!r} is not what the reconstructed "
-                f"5c state derives ({recomputed!r})"
-            )
-
-    violations.extend(verify_single_source(session, pkg))
-    violations.extend(verify_chunk_runtime_membership(session, pkg))
     return tuple(violations)
 
 
@@ -1207,103 +1312,40 @@ class FinalizeResult:
 
 
 def _reconstruct_artifacts(
-    session: Session,
-    pkg: str,
+    proven: VerifiedPublishedRelease,
     *,
     pages: list[ExtractedPage],
     bundle: CanonicalBundle,
     vector_state: dict[str, object],
-) -> tuple[ReleaseArtifacts, tuple[str, ...], tuple[str, ...]]:
-    """Load a fully-persisted release's DB-grounded artifacts + its chunk-runtime
-    membership and single-source violations (used by both the fresh-publish and
-    the idempotent-reuse path).
+) -> ReleaseArtifacts:
+    """Assemble a published release's artifacts from *already-proven* state.
 
-    The applied policy is reconstructed and validated from the persisted rows
-    (:func:`_load_policy`), never a caller policy — so a tampered persisted policy
-    fails closed here (PR #134 P1). ``vector_state`` is the actual read-back
-    vector logical state; it is carried on the artifacts so the gate recomputes
-    the persisted-corpus digest over the real cross-store state (Component A /
-    K step c).
+    Takes the reconstruction :func:`load_verified_published_release` produced
+    rather than loading its own. That is the point: the predecessor re-read
+    every row itself, so the artifacts a caller went on to gate were assembled
+    from a second, independently-trusted copy of state that something else had
+    proven. The applied policy, ledger, reconciliation, members, and sources
+    here are the ones the proof ran against.
+
+    ``vector_state`` is the actual read-back vector logical state; it is carried
+    on the artifacts so the gate recomputes the persisted-corpus digest over the
+    real cross-store state (Component A / K step c). Concordance and canaries
+    are re-run for real here because this caller holds the pages.
     """
-    release_row = session.execute(
-        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
-    ).scalar_one()
-    policy = _load_policy(session, pkg)
-    ledger = _load_ledger(session, pkg)
-    recon = _load_reconciliation(session, pkg, policy)
-    members = _load_members(session, pkg, ledger)
-    sources = _load_sources(session, pkg)
-    membership_violations = verify_chunk_runtime_membership(session, pkg)
-    source_violations = verify_single_source(session, pkg)
-    concordance = check_concordance(members.chunks, pages)
-    canaries = check_canaries(pages)
-
-    # Backstops, not the enforcement point. Every caller proves the pair through
-    # ``load_published_release`` before reconstructing, so neither raise below is
-    # reachable today; they stay because assembling artifacts around a
-    # half-written or unparseable release would produce something that *looks*
-    # whole, and because a bare ``assert`` here would vanish under ``-O``.
-    evidence_report_hash = release_row.evidence_report_hash
-    corpus_digest = release_row.persisted_corpus_digest
-    report_reference = release_row.corpus_report_reference
-    if (
-        evidence_report_hash is None
-        or corpus_digest is None
-        or report_reference is None
-        or release_row.report_payload is None
-    ):  # pragma: no cover - unreachable while every caller proves the pair
-        absent = [
-            column
-            for column in _POST_PERSISTENCE_COLUMNS
-            if getattr(release_row, column) is None
-        ]
-        raise PersistedReportError(
-            f"release {pkg} is missing post-persistence columns {absent}"
-        )
-
-    identity = ReleaseIdentity(
-        authoritative_source_hash=release_row.authoritative_source_hash,
-        transform_config_hash=release_row.transform_config_hash,
-        bundle_root_hash=release_row.bundle_root_hash,
-        evidence_report_hash=evidence_report_hash,
-        persisted_corpus_digest=corpus_digest,
-    )
-    release_record = ReleaseRecord(
-        package_uuid=pkg,
-        release_version=release_row.release_version,
-        identity=identity,
-        transform_config=release_row.transform_config,
-        ledger_hash=release_row.ledger_hash,
-        policy_hash=release_row.policy_hash,
-        reconciliation_hash=release_row.reconciliation_hash,
-        corpus_report_reference=report_reference,
-    )
-    parsed, report_violations = parse_recorded_report(release_row.report_payload)
-    if parsed is None:  # pragma: no cover - the seam already refused this
-        # Reconstruction cannot proceed on a stored report that is not this
-        # schema: every artifact below would be assembled around an unparseable
-        # document. Raised rather than returned so no caller can mistake a
-        # partially reconstructed release for a whole one.
-        raise PersistedReportError(
-            f"persisted evidence report for {pkg} is not the canonical schema: "
-            f"{list(report_violations)}"
-        )
-    report = EvidenceReport(payload=parsed, persisted=True)
-    artifacts = ReleaseArtifacts(
+    return ReleaseArtifacts(
         pages=pages,
-        ledger=ledger,
-        members=members,
-        reconciliation=recon,
-        policy=policy,
+        ledger=proven.ledger,
+        members=proven.members,
+        reconciliation=proven.reconciliation,
+        policy=proven.policy,
         bundle=bundle,
-        report=report,
-        release=release_record,
-        concordance=concordance,
-        canaries=canaries,
-        sources=sources,
+        report=proven.report,
+        release=proven.record,
+        concordance=check_concordance(proven.members.chunks, pages),
+        canaries=check_canaries(pages),
+        sources=proven.sources,
         vector_state=vector_state,
     )
-    return artifacts, membership_violations, source_violations
 
 
 def finalize_release(
@@ -1434,24 +1476,24 @@ def _finalize_core(
                     ),
                 ),
             )
-        # Reuse path. The published pair is proven first, through the *same*
-        # seam a downstream consumer uses, so a release that 5d verification
-        # refuses can never be handed back as a successful reuse. Its
-        # predecessor checked the package row's status and enablement inline
-        # after reconstruction, which left every other row-level publication
-        # invariant — published_at, the package/release version pair, the
-        # recorded transform hash, the report reference — proven at one caller
-        # and not the other, and reconstructed artifacts assembled around rows
-        # nothing had yet accepted.
-        _, pair_violations = load_published_release(session, pkg)
-        if pair_violations:
+        # Reuse path. Published authority is established first, through the
+        # *same* full seam a downstream consumer uses, so a release that 5d
+        # verification refuses can never be handed back as a successful reuse —
+        # including one whose report was coherently rewritten to describe a
+        # corpus other than the persisted one. A missing/malformed/inconsistent
+        # persisted policy, an unparseable stored report, and a release that
+        # does not reconstruct all arrive here as ordinary refusals rather than
+        # exceptions, and are never republished on a caller/default policy
+        # (PR #134 P1).
+        proven, refusals = load_verified_published_release(session, pkg)
+        if proven is None:
             return FinalizeResult(
                 published=False,
                 reused=False,
                 artifacts=None,
                 gate=GateResult(
                     passed=False,
-                    failures=tuple(f"{v} — refusing to reuse" for v in pair_violations),
+                    failures=tuple(f"{v} — refusing to reuse" for v in refusals),
                 ),
             )
         # Verify the existing vectors against SQL ground truth WITHOUT rewriting
@@ -1460,31 +1502,18 @@ def _finalize_core(
         vector_result = verify_only(
             session, pkg, chroma_client, retrieval_config, embedding_function
         )
-        try:
-            artifacts, membership_violations, source_violations = (
-                _reconstruct_artifacts(
-                    session,
-                    pkg,
-                    pages=candidate.pages,
-                    bundle=candidate.bundle,
-                    vector_state=vector_result.state.to_payload(),
-                )
-            )
-        except (PolicyReconstructionError, PersistedReportError) as exc:
-            # A missing/malformed/inconsistent persisted policy — or a stored
-            # report that is not the canonical schema — fails reuse closed
-            # (reported as an ordinary failed result, consistent with the other
-            # reuse-rejection cases) — never republished on a caller/default
-            # policy (PR #134 P1).
-            return FinalizeResult(
-                published=False,
-                reused=False,
-                artifacts=None,
-                gate=GateResult(
-                    passed=False,
-                    failures=(f"persisted release does not reconstruct: {exc}",),
-                ),
-            )
+        artifacts = _reconstruct_artifacts(
+            proven,
+            pages=candidate.pages,
+            bundle=candidate.bundle,
+            vector_state=vector_result.state.to_payload(),
+        )
+        # Measured, never defaulted (gate condition 20). The seam already
+        # computed both membership checks against the same reconstruction and
+        # refused unless they were empty, so these are carried rather than
+        # recomputed — but they are the values it actually measured, not
+        # constants standing in for an invariant proven elsewhere.
+        membership_violations = proven.chunk_membership_violations
         sql_persist_ok = (
             len(artifacts.ledger.leaves) == len(candidate.ledger.leaves)
             and len(artifacts.members.chunks) == len(candidate.members.chunks)
@@ -1494,7 +1523,7 @@ def _finalize_core(
             sql_persist_ok=sql_persist_ok,
             vector_write_ok=vector_result.ok,
             chunk_membership_violations=len(membership_violations),
-            source_membership_violations=len(source_violations),
+            source_membership_violations=len(proven.source_violations),
             vector_verification_failures=vector_result.failures,
         )
         # Re-run the *full* gate against the reconstructed existing release —
@@ -1611,7 +1640,6 @@ def _finalize_core(
             persisted_corpus_digest=digest,
             concordance=concordance,
             canaries=canaries,
-            persisted=True,  # legitimate: computed from the reconstruction above
         )
         report_h = report_hash(report)
 
@@ -1683,12 +1711,12 @@ def _finalize_core(
             package_row.updated_at = now
             release_row.publication_status = "published"
             session.flush()
-            # A fresh publication must satisfy the same row-level invariants a
-            # consumer will later demand of it — proven here, on the rows as
-            # written, while the transaction can still be rolled back. Without
-            # this, the only thing standing between a malformed write and a
-            # committed release was that no reader had looked yet.
-            _, pair_violations = load_published_release(session, pkg)
+            # A fresh publication must satisfy everything a consumer will later
+            # demand of it — the *same* full seam, on the rows as written, while
+            # the transaction can still be rolled back. Without this, the only
+            # thing standing between a malformed write and a committed release
+            # was that no reader had looked yet.
+            _, pair_violations = load_verified_published_release(session, pkg)
             if pair_violations:
                 session.rollback()
                 cleanup_armed = False

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -44,6 +44,7 @@ from afterworlds.ingestion.corpus.bundle import (
 )
 from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
 from afterworlds.ingestion.corpus.gate import PublicationEvidence, run_gate
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CanonicalBundle,
@@ -77,8 +78,11 @@ from afterworlds.ingestion.corpus.report import (
     EVIDENCE_REPORT_SCHEMA_VERSION,
     EvidenceReport,
     build_report,
-    recorded_success_violations,
     report_hash,
+)
+from afterworlds.ingestion.corpus.report_schema import (
+    CorpusEvidenceReport,
+    parse_recorded_report,
 )
 from afterworlds.ingestion.corpus.source_completeness import (
     EXPECTED_PAGE_COUNT,
@@ -349,7 +353,7 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
         reconciliation_hash=rel.reconciliation_hash,
         corpus_report_reference=rel.corpus_report_reference,
         transform_config=rel.transform_config,
-        report_payload=artifacts.report.payload,
+        report_payload=artifacts.report.dump(),
         now=now,
     )
     _persist_bundle_rows(
@@ -670,8 +674,8 @@ def verify_persisted_page_coverage(session: Session, pkg: str) -> tuple[str, ...
     return ()
 
 
-def _report_schema_ok(report_payload: object, transform_config: object) -> bool:
-    """Reuse-compatibility check for the evidence-report schema (R17).
+def _report_schema_ok(report: CorpusEvidenceReport, transform_config: object) -> bool:
+    """Does the parsed report's schema version agree with the recorded transform?
 
     Reuse validates the *stored* report against its *stored* hash, so an
     obsolete-schema report (e.g. the pre-R16 host-dependent ``reproduction_environment``
@@ -680,15 +684,13 @@ def _report_schema_ok(report_payload: object, transform_config: object) -> bool:
     different ``package_uuid`` (so it is not matched on the fresh path); this is the
     fail-closed backstop on the reuse path.
 
-    True iff the persisted report's recorded ``report_version`` equals the currently
-    supported :data:`EVIDENCE_REPORT_SCHEMA_VERSION` **and** the persisted transform
-    config records the same version. Missing / obsolete / contradictory / malformed
-    → False.
+    The report's *own* version is already proven by having parsed at all — the
+    schema refuses any other value — so what remains is agreement with the
+    persisted transform configuration, which is a contextual question.
     """
-    if not isinstance(report_payload, dict) or not isinstance(transform_config, dict):
-        return False
     return (
-        report_payload.get("report_version") == EVIDENCE_REPORT_SCHEMA_VERSION
+        report.report_version == EVIDENCE_REPORT_SCHEMA_VERSION
+        and isinstance(transform_config, dict)
         and transform_config.get("evidence_report_schema_version")
         == EVIDENCE_REPORT_SCHEMA_VERSION
     )
@@ -888,6 +890,161 @@ _REPORT_PROOF_COLUMNS = (
 )
 
 
+class PersistedReportError(ValueError):
+    """A stored evidence report is not the canonical `5c-evidence-3` schema."""
+
+
+@dataclass(frozen=True)
+class PublishedRelease:
+    """A package/release pair proven to be an exactly-published 5c release."""
+
+    package: RulesPackageORM
+    release: CorpusReleaseORM
+    report: CorpusEvidenceReport
+
+
+#: Columns that are NULL through the draft phase and set exactly once by
+#: :func:`finalize_release` from actual persisted state. A published release
+#: missing any of them was never completed, so they are required as a *set*
+#: rather than discovered one at a time by whichever check happens to read one.
+_POST_PERSISTENCE_COLUMNS = (
+    "evidence_report_hash",
+    "persisted_corpus_digest",
+    "corpus_report_reference",
+    "report_payload",
+)
+
+
+def load_published_release(
+    session: Session, pkg: str
+) -> tuple[PublishedRelease | None, tuple[str, ...]]:
+    """Load and prove the published package/release pair for *pkg*.
+
+    The one 5c-owned statement of what a published release *is*, in terms of its
+    own persisted rows. Every lifecycle operation that treats a release as
+    published calls this: downstream :func:`verify_published_release`,
+    :func:`finalize_release` verified reuse, and fresh finalization before it
+    commits. A release refused here cannot be reused, consumed, or freshly
+    published — which is the property that a check living at one caller could
+    not give.
+
+    Its unit is the **pair**, not either row. Both rows are written from one
+    derived value at publication, ``RulesPackageService`` exposes the package's
+    version while 5d binds the release's, so a mismatch between them leaves two
+    public versions for one supposedly closed release.
+
+    Deliberately *not* re-proven here, because it is already proven elsewhere and
+    a second statement is a second definition: ``policy_hash``, whose closed
+    cross-reference chain across the policy, reconciliation, and release rows is
+    validated by :func:`_load_policy`, which fails closed; and everything
+    recomputable from persisted rows (ledger, reconciliation, bundle root,
+    source and chunk membership), which belongs to reconstruction.
+
+    Returns the proven pair, or ``None`` and the violations that refuse it.
+    """
+    violations: list[str] = []
+    release = session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+    ).scalar_one_or_none()
+    package = session.execute(
+        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
+    ).scalar_one_or_none()
+    if release is None:
+        violations.append(f"no rp_corpus_releases row for package {pkg}")
+    if package is None:
+        violations.append(f"no rp_packages row for {pkg}")
+    if release is None or package is None:
+        # Nothing below is meaningful without both halves of the pair.
+        return None, tuple(violations)
+
+    if release.publication_status != "published":
+        violations.append(
+            f"release {pkg} is in publication_status "
+            f"{release.publication_status!r}, not 'published'"
+        )
+    if package.publication_status != "published" or not package.is_enabled:
+        violations.append(
+            f"rp_packages row for {pkg} is not published and enabled "
+            f"(publication_status={package.publication_status!r}, "
+            f"is_enabled={package.is_enabled})"
+        )
+    if package.published_at is None:
+        violations.append(
+            f"rp_packages row for {pkg} records no published_at, so it was never "
+            "carried through a completed publication"
+        )
+    if package.version != release.release_version:
+        violations.append(
+            f"rp_packages version {package.version!r} is not the release's "
+            f"release_version {release.release_version!r}"
+        )
+
+    absent = [
+        column
+        for column in _POST_PERSISTENCE_COLUMNS
+        if getattr(release, column) is None
+    ]
+    if absent:
+        violations.append(
+            f"release {pkg} is missing post-persistence columns {absent}, so it "
+            "carries no completed publication evidence"
+        )
+        # Every check below reads one of them.
+        return None, tuple(violations)
+
+    if hash_obj(release.transform_config) != release.transform_config_hash:
+        violations.append(
+            "recorded transform configuration does not hash to the recorded "
+            f"transform_config_hash {release.transform_config_hash!r}"
+        )
+
+    report, parse_violations = parse_recorded_report(release.report_payload)
+    if report is None:
+        violations.extend(
+            f"recorded evidence report is not the canonical schema: {v}"
+            for v in parse_violations
+        )
+        return None, tuple(violations)
+
+    if report_hash(EvidenceReport(payload=report, persisted=True)) != (
+        release.evidence_report_hash
+    ):
+        violations.append(
+            "recorded evidence-report payload does not hash to the recorded "
+            "evidence_report_hash"
+        )
+    if release.corpus_report_reference != release.evidence_report_hash:
+        violations.append(
+            f"corpus_report_reference {release.corpus_report_reference!r} is not "
+            f"the recorded evidence_report_hash {release.evidence_report_hash!r}"
+        )
+    if not _report_schema_ok(report, release.transform_config):
+        violations.append(
+            "recorded evidence-report schema version "
+            f"(report={report.report_version!r}) is obsolete or contradictory vs "
+            f"the supported {EVIDENCE_REPORT_SCHEMA_VERSION!r}"
+        )
+    recorded = report.dump()
+    for report_key, column in _REPORT_PROOF_COLUMNS:
+        if recorded[report_key] != getattr(release, column):
+            violations.append(
+                f"recorded evidence report states {report_key}="
+                f"{recorded[report_key]!r}, release row records "
+                f"{column}={getattr(release, column)!r}"
+            )
+    # Identity is necessary but not sufficient. A report edited to "fail" — or to
+    # "pass" over summaries that record failures — and rehashed keeps every proof
+    # identity intact while recording that publication did not succeed.
+    violations.extend(
+        f"recorded evidence report is not a successful 5c verdict: {v}"
+        for v in report.success_violations()
+    )
+
+    if violations:
+        return None, tuple(violations)
+    return PublishedRelease(package=package, release=release, report=report), ()
+
+
 def verify_published_release(
     session: Session,
     pkg: str,
@@ -908,14 +1065,15 @@ def verify_published_release(
     already here; 5d calls it rather than re-deriving a second opinion about
     what a published 5c release is.
 
-    The five declared values (plus *pkg* itself) must equal the authoritative
-    ``rp_corpus_releases`` row, that row must be published under a
-    published/enabled ``rp_packages`` row, its recorded evidence report must
-    still hash to its recorded hash, state the same proof identities as the row,
-    **and record a successful publication verdict**
-    (:func:`report.recorded_success_violations`), and the ledger, reconciliation,
-    and bundle-root identities must be exactly what the persisted rows
-    reconstruct to.
+    Three stages, in order. :func:`load_published_release` proves the persisted
+    package/release **pair** is an exactly-published release in its own terms;
+    the five declared values (plus *pkg* itself) must then equal that proven
+    row; and the ledger, reconciliation, and bundle-root identities must be
+    exactly what the persisted rows reconstruct to.
+
+    The order is the point. Comparing a declaration against a row that has not
+    been proven is comparing two claims, and deriving further findings from a
+    refused pair buries the real one — so a failed pair returns immediately.
 
     **What this cannot re-prove.** ``persisted_corpus_digest`` binds the actual
     read-back *vector* logical state as well as SQL (Component A), so it is not
@@ -927,32 +1085,12 @@ def verify_published_release(
 
     Returns the violations, empty iff the release is publishable authority.
     """
+    proven, pair_violations = load_published_release(session, pkg)
+    if proven is None:
+        return pair_violations
+    release = proven.release
+
     violations: list[str] = []
-    release = session.execute(
-        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
-    ).scalar_one_or_none()
-    if release is None:
-        # Nothing further is meaningful: there is no authoritative release to
-        # compare a declaration with.
-        return (f"no rp_corpus_releases row for package {pkg}",)
-    if release.publication_status != "published":
-        violations.append(
-            f"release {pkg} is in publication_status "
-            f"{release.publication_status!r}, not 'published'"
-        )
-
-    package_row = session.execute(
-        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
-    ).scalar_one_or_none()
-    if package_row is None:
-        violations.append(f"no rp_packages row for {pkg}")
-    elif package_row.publication_status != "published" or not package_row.is_enabled:
-        violations.append(
-            f"rp_packages row for {pkg} is not published and enabled "
-            f"(publication_status={package_row.publication_status!r}, "
-            f"is_enabled={package_row.is_enabled})"
-        )
-
     for field, declared in (
         ("release_version", release_version),
         ("authoritative_source_hash", authoritative_source_hash),
@@ -966,46 +1104,6 @@ def verify_published_release(
                 f"declared {field} {declared!r} is not the authoritative "
                 f"release's {recorded!r}"
             )
-
-    payload = release.report_payload
-    if release.evidence_report_hash is None or payload is None:
-        violations.append(
-            f"release {pkg} carries no recorded evidence report "
-            "(hash and/or payload absent)"
-        )
-        # Everything below reads that payload, so continuing would bury the real
-        # finding under violations derived from it.
-        return tuple(violations)
-    if not _report_schema_ok(payload, release.transform_config):
-        violations.append(
-            "recorded evidence-report schema version "
-            f"(report={payload.get('report_version')!r}) is missing, obsolete, "
-            f"or contradictory vs the supported {EVIDENCE_REPORT_SCHEMA_VERSION!r}"
-        )
-        return tuple(violations)
-
-    if (
-        report_hash(EvidenceReport(payload=payload, persisted=True))
-        != release.evidence_report_hash
-    ):
-        violations.append(
-            "recorded evidence-report payload does not hash to the recorded "
-            "evidence_report_hash"
-        )
-    for report_key, column in _REPORT_PROOF_COLUMNS:
-        if payload.get(report_key) != getattr(release, column):
-            violations.append(
-                f"recorded evidence report states {report_key}="
-                f"{payload.get(report_key)!r}, release row records "
-                f"{column}={getattr(release, column)!r}"
-            )
-    # Identity is necessary but not sufficient. A report edited to "fail" — or to
-    # "pass" over summaries that record failures — and rehashed keeps every proof
-    # identity intact while recording that publication did not succeed.
-    violations.extend(
-        f"recorded evidence report is not a successful 5c verdict: {v}"
-        for v in recorded_success_violations(payload)
-    )
 
     try:
         policy = _load_policy(session, pkg)
@@ -1140,17 +1238,35 @@ def _reconstruct_artifacts(
     concordance = check_concordance(members.chunks, pages)
     canaries = check_canaries(pages)
 
-    assert release_row.evidence_report_hash is not None
-    assert release_row.persisted_corpus_digest is not None
-    assert release_row.corpus_report_reference is not None
-    assert release_row.report_payload is not None
+    # Backstops, not the enforcement point. Every caller proves the pair through
+    # ``load_published_release`` before reconstructing, so neither raise below is
+    # reachable today; they stay because assembling artifacts around a
+    # half-written or unparseable release would produce something that *looks*
+    # whole, and because a bare ``assert`` here would vanish under ``-O``.
+    evidence_report_hash = release_row.evidence_report_hash
+    corpus_digest = release_row.persisted_corpus_digest
+    report_reference = release_row.corpus_report_reference
+    if (
+        evidence_report_hash is None
+        or corpus_digest is None
+        or report_reference is None
+        or release_row.report_payload is None
+    ):  # pragma: no cover - unreachable while every caller proves the pair
+        absent = [
+            column
+            for column in _POST_PERSISTENCE_COLUMNS
+            if getattr(release_row, column) is None
+        ]
+        raise PersistedReportError(
+            f"release {pkg} is missing post-persistence columns {absent}"
+        )
 
     identity = ReleaseIdentity(
         authoritative_source_hash=release_row.authoritative_source_hash,
         transform_config_hash=release_row.transform_config_hash,
         bundle_root_hash=release_row.bundle_root_hash,
-        evidence_report_hash=release_row.evidence_report_hash,
-        persisted_corpus_digest=release_row.persisted_corpus_digest,
+        evidence_report_hash=evidence_report_hash,
+        persisted_corpus_digest=corpus_digest,
     )
     release_record = ReleaseRecord(
         package_uuid=pkg,
@@ -1160,9 +1276,19 @@ def _reconstruct_artifacts(
         ledger_hash=release_row.ledger_hash,
         policy_hash=release_row.policy_hash,
         reconciliation_hash=release_row.reconciliation_hash,
-        corpus_report_reference=release_row.corpus_report_reference,
+        corpus_report_reference=report_reference,
     )
-    report = EvidenceReport(payload=release_row.report_payload, persisted=True)
+    parsed, report_violations = parse_recorded_report(release_row.report_payload)
+    if parsed is None:  # pragma: no cover - the seam already refused this
+        # Reconstruction cannot proceed on a stored report that is not this
+        # schema: every artifact below would be assembled around an unparseable
+        # document. Raised rather than returned so no caller can mistake a
+        # partially reconstructed release for a whole one.
+        raise PersistedReportError(
+            f"persisted evidence report for {pkg} is not the canonical schema: "
+            f"{list(report_violations)}"
+        )
+    report = EvidenceReport(payload=parsed, persisted=True)
     artifacts = ReleaseArtifacts(
         pages=pages,
         ledger=ledger,
@@ -1308,9 +1434,29 @@ def _finalize_core(
                     ),
                 ),
             )
-        # Reuse path: verify the existing vectors against SQL ground truth
-        # WITHOUT rewriting them, so a missing/stale/tampered collection cannot
-        # be silently rebuilt into a false "successful reuse".
+        # Reuse path. The published pair is proven first, through the *same*
+        # seam a downstream consumer uses, so a release that 5d verification
+        # refuses can never be handed back as a successful reuse. Its
+        # predecessor checked the package row's status and enablement inline
+        # after reconstruction, which left every other row-level publication
+        # invariant — published_at, the package/release version pair, the
+        # recorded transform hash, the report reference — proven at one caller
+        # and not the other, and reconstructed artifacts assembled around rows
+        # nothing had yet accepted.
+        _, pair_violations = load_published_release(session, pkg)
+        if pair_violations:
+            return FinalizeResult(
+                published=False,
+                reused=False,
+                artifacts=None,
+                gate=GateResult(
+                    passed=False,
+                    failures=tuple(f"{v} — refusing to reuse" for v in pair_violations),
+                ),
+            )
+        # Verify the existing vectors against SQL ground truth WITHOUT rewriting
+        # them, so a missing/stale/tampered collection cannot be silently
+        # rebuilt into a false "successful reuse".
         vector_result = verify_only(
             session, pkg, chroma_client, retrieval_config, embedding_function
         )
@@ -1324,8 +1470,9 @@ def _finalize_core(
                     vector_state=vector_result.state.to_payload(),
                 )
             )
-        except PolicyReconstructionError as exc:
-            # A missing/malformed/inconsistent persisted policy fails reuse closed
+        except (PolicyReconstructionError, PersistedReportError) as exc:
+            # A missing/malformed/inconsistent persisted policy — or a stored
+            # report that is not the canonical schema — fails reuse closed
             # (reported as an ordinary failed result, consistent with the other
             # reuse-rejection cases) — never republished on a caller/default
             # policy (PR #134 P1).
@@ -1335,7 +1482,7 @@ def _finalize_core(
                 artifacts=None,
                 gate=GateResult(
                     passed=False,
-                    failures=(f"persisted reconciliation policy invalid: {exc}",),
+                    failures=(f"persisted release does not reconstruct: {exc}",),
                 ),
             )
         sql_persist_ok = (
@@ -1356,39 +1503,10 @@ def _finalize_core(
         # reconciliation hash), live legacy state, or actual vector state no
         # longer satisfy publication.
         gate = run_gate(artifacts, evidence)
-        package_row = session.execute(
-            select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
-        ).scalar_one_or_none()
-        package_state_ok = (
-            package_row is not None
-            and package_row.is_enabled
-            and package_row.publication_status == "published"
-        )
         page_coverage_violations = verify_persisted_page_coverage(session, pkg)
-        schema_ok = _report_schema_ok(
-            artifacts.report.payload, artifacts.release.transform_config
-        )
-        if (
-            not gate.passed
-            or not package_state_ok
-            or page_coverage_violations
-            or not schema_ok
-        ):
+        if not gate.passed or page_coverage_violations:
             failures = list(gate.failures)
-            if not package_state_ok:
-                failures.append(
-                    f"rp_packages row for {pkg} is missing or not in a "
-                    "published+enabled state consistent with its published "
-                    "rp_corpus_releases row"
-                )
             failures.extend(page_coverage_violations)
-            if not schema_ok:
-                failures.append(
-                    "persisted evidence-report schema version "
-                    f"(report={artifacts.report.payload.get('report_version')!r}) is "
-                    "missing/obsolete/contradictory vs the supported "
-                    f"{EVIDENCE_REPORT_SCHEMA_VERSION!r} — refusing to reuse"
-                )
             return FinalizeResult(
                 published=False,
                 reused=False,
@@ -1551,7 +1669,7 @@ def _finalize_core(
         release_row.evidence_report_hash = report_h
         release_row.persisted_corpus_digest = digest
         release_row.corpus_report_reference = report_h
-        release_row.report_payload = report.payload
+        release_row.report_payload = report.dump()
         session.flush()
 
         gate = run_gate(artifacts, evidence)
@@ -1564,6 +1682,28 @@ def _finalize_core(
             package_row.published_at = now
             package_row.updated_at = now
             release_row.publication_status = "published"
+            session.flush()
+            # A fresh publication must satisfy the same row-level invariants a
+            # consumer will later demand of it — proven here, on the rows as
+            # written, while the transaction can still be rolled back. Without
+            # this, the only thing standing between a malformed write and a
+            # committed release was that no reader had looked yet.
+            _, pair_violations = load_published_release(session, pkg)
+            if pair_violations:
+                session.rollback()
+                cleanup_armed = False
+                cleanup_vector_collection(chroma_client, pkg)
+                return FinalizeResult(
+                    published=False,
+                    reused=False,
+                    artifacts=None,
+                    gate=GateResult(
+                        passed=False,
+                        failures=tuple(
+                            f"{v} — refusing to publish" for v in pair_violations
+                        ),
+                    ),
+                )
             session.commit()
             # Publication is durable in both stores — only now is it safe to
             # disarm compensation.

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -8,6 +8,10 @@ It contains the authoritative-source/transform/bundle-root/frozen-ledger hashes
 and the persisted-corpus digest — but **not** its own hash — and is **not** a
 bundle member (it contains the bundle root and cannot be covered by it). Its hash
 is computed over the completed report (K step f) and recorded externally.
+
+The document itself is defined once, in :mod:`report_schema`. This module
+assembles its inputs and hands them to the one parser; it holds no second
+description of the payload's shape.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ import logging
 import platform
 from collections import Counter
 from dataclasses import dataclass
+from typing import Any
 
 from afterworlds.ingestion.corpus.concordance import CanaryResult, ConcordanceResult
 from afterworlds.ingestion.corpus.hashing import hash_obj
@@ -27,206 +32,36 @@ from afterworlds.ingestion.corpus.models import (
     SourceLedger,
 )
 from afterworlds.ingestion.corpus.policy import policy_hash
+from afterworlds.ingestion.corpus.report_schema import (
+    EVIDENCE_REPORT_SCHEMA_VERSION,
+    PYTHON_TARGET,
+    CorpusEvidenceReport,
+    canonical_report,
+    parse_recorded_report,
+)
 
 _log = logging.getLogger(__name__)
 
-# The declared Python target (pyproject ``requires-python``; Python 3.12 only per
-# CLAUDE.md). Recorded as a *declared, host-independent* reproduction target — the
-# actual runtime interpreter/host is a diagnostic and never enters this
-# identity-bearing payload (PR #134 R16).
-PYTHON_TARGET = "3.12"
-
-# Canonical evidence-report schema version. Bumped across canonical-shape changes:
-# "2" for the R16 host-independent ``reproduction_target`` change; "3" for the R18
-# pre-release clean-baseline change that removed the legacy-reachability status
-# (Issue 5c Rev7 / Issue 18 Rev6 supersede the strict cross-store quarantine
-# contract). This version is bound into ``transform_config_payload`` (hence the
-# transform hash / package UUID / release version), so an evidence-report *schema*
-# change mints a NEW immutable release instead of being reused under a
-# predecessor's identity (R17 mechanism). It is deliberately an *explicit* schema
-# identity rather than a byte-level hash of report.py: only an intentional
-# canonical-shape change should remint, never a comment/docstring/logging edit.
-EVIDENCE_REPORT_SCHEMA_VERSION = "5c-evidence-3"
+__all__ = [
+    "EVIDENCE_REPORT_SCHEMA_VERSION",
+    "PYTHON_TARGET",
+    "EvidenceReport",
+    "build_report",
+    "recorded_success_violations",
+    "report_hash",
+]
 
 
 @dataclass(frozen=True)
 class EvidenceReport:
-    """The completed evidence report payload and the flag that it postdates persist."""
+    """The completed evidence report and the flag that it postdates persist."""
 
-    payload: dict[str, object]
+    payload: CorpusEvidenceReport
     persisted: bool
 
-
-# ---------------------------------------------------------------------------
-# What a successful publication looks like in the report's own numbers
-# ---------------------------------------------------------------------------
-#
-# One definition, consumed at two boundaries with different trust levels:
-#
-# * :func:`build_report` derives ``prepublication_validation_status`` from it, so
-#   a report cannot be *written* claiming success alongside contradictory
-#   summaries; and
-# * :func:`recorded_success_violations` applies it to a payload read back out of
-#   the database, whose provenance is unknown — JSON round-tripped, possibly
-#   hand-edited, types unproven.
-#
-# ``gate.run_gate`` deliberately keeps its own one-line status check: it holds
-# the freshly built :class:`EvidenceReport` object, with a live ``persisted``
-# flag and typed sub-objects, so it asks a different question of a value it just
-# produced. What must not diverge is the *semantics* below, and it does not.
-
-#: Top-level payload counters that must be zero for a successful verdict.
-_ZERO_COUNTERS = ("unresolved_leaves", "invalid_locators", "concordance_failures")
-#: Reconciliation findings that must all be zero for a successful verdict.
-_ZERO_FINDINGS = ("gaps", "overlaps", "orphans", "duplications")
-#: Accounting keys, and the equation they must satisfy.
-_ACCOUNTING_KEYS = (
-    "inventoried_leaves",
-    "represented_leaves",
-    "excluded_leaves",
-    "unresolved_leaves",
-)
-#: Every key ``build_report`` produces. A payload missing one is not this shape.
-REQUIRED_REPORT_KEYS = frozenset(
-    {
-        "report_version",
-        "authoritative_source_hash",
-        "transform_config_hash",
-        "bundle_root_hash",
-        "frozen_source_ledger_hash",
-        "persisted_corpus_digest",
-        "transform_identity",
-        "rules_corpus_vector_identity",
-        "reproduction_target",
-        "reconciliation_policy_reference",
-        "source_ledger_leaf_totals",
-        "represented_totals",
-        "excluded_totals_by_reason",
-        "unresolved_leaves",
-        "declared_projection_count",
-        "accounting",
-        "findings",
-        "invalid_locators",
-        "concordance_failures",
-        "version_canaries",
-        "prepublication_validation_status",
-    }
-)
-
-
-def _count(payload: dict[str, object], key: str) -> int | None:
-    """A payload counter as an ``int``, or ``None`` if it is not one.
-
-    ``bool`` is excluded explicitly: it is an ``int`` subclass, so ``True``
-    would otherwise read as the count ``1`` and let a hand-edited report satisfy
-    an equation with a boolean.
-    """
-    value = payload.get(key)
-    return value if type(value) is int else None
-
-
-def verdict_violations(payload: dict[str, object]) -> tuple[str, ...]:
-    """Why these report numbers do not state a successful publication.
-
-    Pure over the payload, so it says the same thing about a report being built
-    and a report being read back. Empty exactly when every verdict-bearing
-    summary is present, correctly typed, and success-valued.
-    """
-    violations: list[str] = []
-    for key in _ZERO_COUNTERS:
-        count = _count(payload, key)
-        if count is None:
-            violations.append(f"{key} is missing or not an integer")
-        elif count != 0:
-            violations.append(f"{key} is {count}, not 0")
-
-    findings = payload.get("findings")
-    if not isinstance(findings, dict):
-        violations.append("findings is missing or not an object")
-    else:
-        for key in _ZERO_FINDINGS:
-            found = findings.get(key)
-            if type(found) is not int:
-                violations.append(f"findings.{key} is missing or not an integer")
-            elif found != 0:
-                violations.append(f"findings.{key} is {found}, not 0")
-
-    canaries = payload.get("version_canaries")
-    if not isinstance(canaries, dict):
-        violations.append("version_canaries is missing or not an object")
-    else:
-        for name, passed in sorted(canaries.items()):
-            if type(passed) is not bool:
-                violations.append(f"version_canaries.{name} is not a boolean")
-            elif not passed:
-                violations.append(f"version canary {name} did not pass")
-
-    accounting = payload.get("accounting")
-    if not isinstance(accounting, dict):
-        violations.append("accounting is missing or not an object")
-    else:
-        counts: dict[str, int] = {}
-        for key in _ACCOUNTING_KEYS:
-            value = accounting.get(key)
-            if type(value) is not int:
-                violations.append(f"accounting.{key} is missing or not an integer")
-            else:
-                counts[key] = value
-        if len(counts) == len(_ACCOUNTING_KEYS):
-            if counts["unresolved_leaves"] != 0:
-                violations.append(
-                    f"accounting.unresolved_leaves is "
-                    f"{counts['unresolved_leaves']}, not 0"
-                )
-            if counts["inventoried_leaves"] != (
-                counts["represented_leaves"]
-                + counts["excluded_leaves"]
-                + counts["unresolved_leaves"]
-            ):
-                violations.append("accounting equation does not balance")
-            top_level = _count(payload, "unresolved_leaves")
-            if top_level is not None and top_level != counts["unresolved_leaves"]:
-                violations.append(
-                    "accounting.unresolved_leaves disagrees with the top-level "
-                    "unresolved_leaves"
-                )
-    return tuple(violations)
-
-
-def recorded_success_violations(payload: object) -> tuple[str, ...]:
-    """Is a *recorded* evidence report a well-formed, successful 5c verdict?
-
-    What a downstream consumer needs before treating a stored report as proof
-    that a release published successfully. Identity — that the payload hashes to
-    its recorded hash and states the release's proof identities — is necessary
-    but not sufficient: a report edited to ``"fail"`` and rehashed keeps every
-    identity intact while recording that publication did *not* succeed.
-
-    Deliberately bounded to what the report actually contains. It reconstructs
-    no history, and it does not reopen the vector store (Owner Decision
-    2026-08-01); the recorded digest is verified as an exact recorded value by
-    the caller.
-    """
-    if not isinstance(payload, dict):
-        return (f"evidence report is {type(payload).__name__}, not an object",)
-    violations: list[str] = []
-    if payload.get("report_version") != EVIDENCE_REPORT_SCHEMA_VERSION:
-        violations.append(
-            f"report_version {payload.get('report_version')!r} is not the supported "
-            f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
-        )
-    if missing := sorted(REQUIRED_REPORT_KEYS - set(payload)):
-        violations.append(f"evidence report is missing {missing}")
-    status = payload.get("prepublication_validation_status")
-    if status != "pass":
-        violations.append(
-            f"prepublication_validation_status is {status!r}, not 'pass' — the "
-            "recorded evidence states this release did not publish successfully"
-        )
-    # Evaluated even when the status already says "pass": the defect being closed
-    # is a payload that *claims* success while its own summaries record failures.
-    violations.extend(verdict_violations(payload))
-    return tuple(violations)
+    def dump(self) -> dict[str, Any]:
+        """The canonical payload, through the document's one serializer."""
+        return self.payload.dump()
 
 
 def build_report(
@@ -257,7 +92,8 @@ def build_report(
         elif d.disposition is Disposition.EXCLUDED and d.exclusion_reason_code:
             excluded_by_reason[d.exclusion_reason_code] += 1
 
-    payload: dict[str, object] = {
+    identity = transform_config.get("transform_identity")
+    fields: dict[str, object] = {
         # Canonical schema version, also bound into the transform identity so a
         # schema change remints the release rather than being reused (R17).
         "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
@@ -272,11 +108,7 @@ def build_report(
         # (not just ledger.extraction_config — PR #134 P1).
         "transform_identity": {
             "extractor": transform_config.get("extraction_config"),
-            **(
-                transform_config.get("transform_identity", {})  # type: ignore[dict-item]
-                if isinstance(transform_config.get("transform_identity"), dict)
-                else {}
-            ),
+            **(identity if isinstance(identity, dict) else {}),
         },
         # Identity-bearing rules-corpus vector configuration (embedding model +
         # logical schema/ID/metadata contract) bound into the release identity
@@ -320,14 +152,17 @@ def build_report(
         "concordance_failures": len(concordance.content_failures),
         "version_canaries": {c.name: c.passed for c in canaries},
     }
-    # The verdict is derived from the payload that has just been assembled, not
-    # from a second predicate over the source objects. One definition (below) of
-    # what a successful publication looks like in the numbers, so a recorded
-    # report claiming "pass" alongside contradictory summaries is impossible to
-    # produce here and detectable everywhere it is read back.
-    payload["prepublication_validation_status"] = (
-        "pass" if persisted and not verdict_violations(payload) else "fail"
+
+    # The verdict is read off the assembled document through the same method a
+    # stored report is measured by, so a report claiming "pass" over
+    # contradictory summaries cannot be produced here — and an incomplete canary
+    # run, an unsupported schema version, or a non-canonical reproduction target
+    # is refused by the parser before the question is even asked.
+    provisional = canonical_report(
+        {**fields, "prepublication_validation_status": "fail"}
     )
+    status = "pass" if persisted and not provisional.verdict_violations() else "fail"
+
     # Actual host as an operational diagnostic ONLY — deliberately outside the
     # returned payload, so it never reaches the report hash, the persisted-corpus
     # digest, the package identity, or any publication-gate comparison. Never
@@ -339,9 +174,36 @@ def build_report(
         platform.machine(),
         platform.python_version(),
     )
-    return EvidenceReport(payload=payload, persisted=persisted)
+    return EvidenceReport(
+        payload=canonical_report(
+            {**fields, "prepublication_validation_status": status}
+        ),
+        persisted=persisted,
+    )
+
+
+def recorded_success_violations(payload: object) -> tuple[str, ...]:
+    """Is a *recorded* report a well-formed, successful 5c verdict?
+
+    Parse first, then judge. Shape, closed populations, and value domains belong
+    to the typed document; this adds only the verdict question, on something that
+    has already proven it is this schema.
+
+    Deliberately bounded to what the report contains. It reconstructs no history
+    and does not reopen the vector store (Owner Decision 2026-08-01); agreement
+    with the release row and with reconstructed 5c state is proven contextually
+    by :func:`persistence.verify_published_release`.
+    """
+    parsed, violations = parse_recorded_report(payload)
+    if parsed is None:
+        return violations
+    return parsed.success_violations()
 
 
 def report_hash(report: EvidenceReport) -> str:
-    """Hash the completed evidence report (K step f)."""
-    return hash_obj(report.payload)
+    """Hash the completed evidence report (K step f).
+
+    Over the canonical dump of the typed payload — the same bytes SQL persists,
+    so a stored report always rehashes to the value recorded beside it.
+    """
+    return hash_obj(report.dump())

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -19,11 +19,10 @@ from __future__ import annotations
 import logging
 import platform
 from collections import Counter
-from dataclasses import dataclass
-from typing import Any
+from collections.abc import Mapping
 
 from afterworlds.ingestion.corpus.concordance import CanaryResult, ConcordanceResult
-from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.corpus.hashing import canonical_bytes, hash_obj
 from afterworlds.ingestion.corpus.models import (
     CorpusBundleMembers,
     Disposition,
@@ -42,45 +41,50 @@ from afterworlds.ingestion.corpus.report_schema import (
 
 _log = logging.getLogger(__name__)
 
+#: Compatibility vocabulary, not a second type. ``EvidenceReport`` *is*
+#: :class:`CorpusEvidenceReport` — the same class object, so there is nothing to
+#: construct, nothing to unwrap, no ``payload`` to substitute and no ``persisted``
+#: flag to trust. The name is retained for one concrete reason: ``pipeline.py``
+#: imports it, and ``pipeline.py`` is one of the eleven modules whose source
+#: bytes are bound into the transform identity. Retyping an annotation there
+#: would remint the package UUID and release version over a post-persistence
+#: plumbing edit that changes no candidate corpus, no bundle member, and no
+#: report schema — an avoidable whole-file-hash side effect, not a transform
+#: change. The alias keeps the audited source byte-identical while leaving
+#: exactly one report representation in the system.
+EvidenceReport = CorpusEvidenceReport
+
 __all__ = [
     "EVIDENCE_REPORT_SCHEMA_VERSION",
     "PYTHON_TARGET",
+    "REPORT_PROOF_COLUMNS",
     "EvidenceReport",
     "build_report",
+    "recorded_identities",
     "recorded_success_violations",
     "report_hash",
+    "report_state_violations",
+    "state_derived_fields",
 ]
 
 
-@dataclass(frozen=True)
-class EvidenceReport:
-    """The completed evidence report and the flag that it postdates persist."""
-
-    payload: CorpusEvidenceReport
-    persisted: bool
-
-    def dump(self) -> dict[str, Any]:
-        """The canonical payload, through the document's one serializer."""
-        return self.payload.dump()
-
-
-def build_report(
+def state_derived_fields(
     *,
     ledger: SourceLedger,
-    members: CorpusBundleMembers,
     recon: ReconciliationMember,
     policy: ReconciliationPolicy,
-    authoritative_source_hash: str,
-    transform_config_hash: str,
     transform_config: dict[str, object],
-    bundle_root_hash: str,
-    ledger_hash_value: str,
-    persisted_corpus_digest: str,
-    concordance: ConcordanceResult,
-    canaries: tuple[CanaryResult, ...],
-    persisted: bool,
-) -> EvidenceReport:
-    """Build the evidence report after persistence (K step e)."""
+) -> dict[str, object]:
+    """The report claims that are a pure function of reconstructed 5c state.
+
+    One definition, used twice and never reimplemented: :func:`build_report`
+    emits these fields, and :func:`report_state_violations` recomputes them from
+    the persisted rows and compares. Writing the comparison as "what would this
+    report say if it were built from this state" means a field added to the
+    document is checked contextually the moment it is derived here — the defect
+    that let coherently rewritten totals pass was a *second*, shorter list of
+    what to compare.
+    """
     leaf_totals = Counter(leaf.leaf_type.value for leaf in ledger.leaves)
     disp_by_leaf = {d.leaf_id: d for d in recon.dispositions}
     represented_totals: Counter[str] = Counter()
@@ -93,16 +97,7 @@ def build_report(
             excluded_by_reason[d.exclusion_reason_code] += 1
 
     identity = transform_config.get("transform_identity")
-    fields: dict[str, object] = {
-        # Canonical schema version, also bound into the transform identity so a
-        # schema change remints the release rather than being reused (R17).
-        "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
-        # Proof hashes (NOT this report's own hash).
-        "authoritative_source_hash": authoritative_source_hash,
-        "transform_config_hash": transform_config_hash,
-        "bundle_root_hash": bundle_root_hash,
-        "frozen_source_ledger_hash": ledger_hash_value,
-        "persisted_corpus_digest": persisted_corpus_digest,
+    return {
         # Complete Component B transform identity: extractor config + the
         # first-party source manifest/hash + deterministic invocation + IR flag
         # (not just ledger.extraction_config — PR #134 P1).
@@ -116,15 +111,6 @@ def build_report(
         "rules_corpus_vector_identity": transform_config.get(
             "rules_corpus_vector_identity"
         ),
-        # The *declared* environment needed to reproduce the transform (Component
-        # B): the Python target here, plus the exact pinned extractor/parser/tool
-        # versions and deterministic invocation already carried by
-        # ``transform_identity`` above. This is host-independent by construction —
-        # no runtime host name, OS, architecture, absolute path, timestamp, or PID
-        # enters this identity-bearing payload, so the same committed inputs yield a
-        # byte-identical evidence report (hence release identity) on every supported
-        # host (PR #134 R16). Actual host diagnostics are logged, never hashed.
-        "reproduction_target": {"python_target": PYTHON_TARGET},
         "reconciliation_policy_reference": {
             "policy_version": policy.policy_version,
             "policy_hash": policy_hash(policy),
@@ -148,6 +134,147 @@ def build_report(
             "orphans": len(recon.findings.orphans),
             "duplications": len(recon.findings.duplications),
         },
+    }
+
+
+#: ``(report key, release column)`` for the proof identities a published release
+#: records in both places. The report's own hash is deliberately absent: a
+#: document cannot contain its own digest.
+#:
+#: One list, read two ways. :func:`recorded_identities` uses it to lift the
+#: values off a ``rp_corpus_releases`` row; the publication gate, which holds
+#: in-memory models that spread the same five values across a
+#: :class:`ReleaseIdentity` and a :class:`ReleaseRecord`, states them directly.
+#: The *comparison* and the key set stay here either way.
+REPORT_PROOF_COLUMNS = (
+    ("authoritative_source_hash", "authoritative_source_hash"),
+    ("transform_config_hash", "transform_config_hash"),
+    ("bundle_root_hash", "bundle_root_hash"),
+    ("frozen_source_ledger_hash", "ledger_hash"),
+    ("persisted_corpus_digest", "persisted_corpus_digest"),
+)
+
+
+def recorded_identities(release: object) -> dict[str, object]:
+    """The five proof identities as a persisted release row records them."""
+    return {key: getattr(release, column) for key, column in REPORT_PROOF_COLUMNS}
+
+
+def report_state_violations(
+    report: CorpusEvidenceReport,
+    *,
+    identities: Mapping[str, object],
+    transform_config: dict[str, object],
+    ledger: SourceLedger,
+    reconciliation: ReconciliationMember,
+    policy: ReconciliationPolicy,
+) -> tuple[str, ...]:
+    """Does this report describe *this* persisted corpus?
+
+    The single definition of report-versus-state agreement, shared by the
+    published-authority seam and the publication gate. Parsing proves a report
+    is well-formed and self-consistent; hashing proves it has not been edited
+    since it was recorded. Neither asks whether its summaries are true of the
+    rows beside it — so a report whose ``declared_projection_count``, totals, and
+    accounting are rewritten to different but internally successful values,
+    rehashed, and re-referenced was accepted as published authority.
+
+    Every SQL-reconstructable claim is recomputed through
+    :func:`state_derived_fields` and compared, alongside the five proof
+    identities against their release columns. Comparison is over canonical
+    bytes, because the same logical value arrives as tuples in memory and lists
+    out of a JSON column.
+
+    Deliberately silent about the three claims SQL cannot recompute —
+    concordance, canary execution, and the live vector half of the
+    persisted-corpus digest. Those keep their recorded-successful-form treatment
+    under the 2026-08-01 Owner Decision, and are re-run for real by the paths
+    that hold pages and vector state.
+
+    ``identities`` maps report key to the value the release records for it —
+    :func:`recorded_identities` builds it from a persisted row.
+    """
+    violations: list[str] = []
+    recorded = report.dump()
+    expected = state_derived_fields(
+        ledger=ledger,
+        recon=reconciliation,
+        policy=policy,
+        transform_config=transform_config,
+    )
+    for key, want in sorted(expected.items()):
+        if canonical_bytes(recorded[key]) != canonical_bytes(want):
+            violations.append(
+                f"recorded evidence report states {key}={recorded[key]!r}, the "
+                f"reconstructed 5c state derives {want!r}"
+            )
+    for key, declared in sorted(identities.items()):
+        if recorded[key] != declared:
+            violations.append(
+                f"recorded evidence report states {key}={recorded[key]!r}, the "
+                f"release records {declared!r}"
+            )
+    return tuple(violations)
+
+
+def build_report(
+    *,
+    ledger: SourceLedger,
+    members: CorpusBundleMembers,
+    recon: ReconciliationMember,
+    policy: ReconciliationPolicy,
+    authoritative_source_hash: str,
+    transform_config_hash: str,
+    transform_config: dict[str, object],
+    bundle_root_hash: str,
+    ledger_hash_value: str,
+    persisted_corpus_digest: str,
+    concordance: ConcordanceResult,
+    canaries: tuple[CanaryResult, ...],
+) -> CorpusEvidenceReport:
+    """Build the evidence report after persistence (K step e).
+
+    Returns the canonical document itself. There is no completed-report wrapper:
+    one existed, holding the payload beside a caller-supplied ``persisted``
+    flag, and it was the hash-bearing authority every consumer actually read —
+    so ``object.__setattr__(report, "payload", forged)`` replaced the whole
+    document after construction while the tuple tree inside stayed immutable.
+
+    That the report postdates persistence is now structural rather than
+    declared. ``persisted_corpus_digest`` is a required argument, and gate
+    condition 17 *recomputes* it over the reconstructed SQL rows and the actual
+    read-back vector state — so a value invented before persistence fails there
+    rather than being taken on trust (a caller can pass any string here; what it
+    cannot do is pass one that survives the gate). :class:`ReleaseArtifacts` —
+    the only thing ``run_gate`` accepts — is constructed in exactly two places,
+    both in :mod:`persistence`, and both hold reconstructed state.
+    """
+    fields: dict[str, object] = {
+        # Canonical schema version, also bound into the transform identity so a
+        # schema change remints the release rather than being reused (R17).
+        "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
+        # Proof hashes (NOT this report's own hash).
+        "authoritative_source_hash": authoritative_source_hash,
+        "transform_config_hash": transform_config_hash,
+        "bundle_root_hash": bundle_root_hash,
+        "frozen_source_ledger_hash": ledger_hash_value,
+        "persisted_corpus_digest": persisted_corpus_digest,
+        # The *declared* environment needed to reproduce the transform (Component
+        # B): the Python target here, plus the exact pinned extractor/parser/tool
+        # versions and deterministic invocation already carried by
+        # ``transform_identity`` below. This is host-independent by construction —
+        # no runtime host name, OS, architecture, absolute path, timestamp, or PID
+        # enters this identity-bearing payload, so the same committed inputs yield a
+        # byte-identical evidence report (hence release identity) on every supported
+        # host (PR #134 R16). Actual host diagnostics are logged, never hashed.
+        "reproduction_target": {"python_target": PYTHON_TARGET},
+        **state_derived_fields(
+            ledger=ledger, recon=recon, policy=policy, transform_config=transform_config
+        ),
+        # The three claims SQL alone cannot recompute: concordance is measured
+        # against the authoritative PDF and canaries are executed against its
+        # pages, so both are recorded evidence rather than reconstructable state
+        # (Owner Decision 2026-08-01).
         "invalid_locators": len(concordance.locator_failures),
         "concordance_failures": len(concordance.content_failures),
         "version_canaries": {c.name: c.passed for c in canaries},
@@ -161,7 +288,7 @@ def build_report(
     provisional = canonical_report(
         {**fields, "prepublication_validation_status": "fail"}
     )
-    status = "pass" if persisted and not provisional.verdict_violations() else "fail"
+    status = "fail" if provisional.verdict_violations() else "pass"
 
     # Actual host as an operational diagnostic ONLY — deliberately outside the
     # returned payload, so it never reaches the report hash, the persisted-corpus
@@ -174,12 +301,7 @@ def build_report(
         platform.machine(),
         platform.python_version(),
     )
-    return EvidenceReport(
-        payload=canonical_report(
-            {**fields, "prepublication_validation_status": status}
-        ),
-        persisted=persisted,
-    )
+    return canonical_report({**fields, "prepublication_validation_status": status})
 
 
 def recorded_success_violations(payload: object) -> tuple[str, ...]:
@@ -200,10 +322,12 @@ def recorded_success_violations(payload: object) -> tuple[str, ...]:
     return parsed.success_violations()
 
 
-def report_hash(report: EvidenceReport) -> str:
+def report_hash(report: CorpusEvidenceReport) -> str:
     """Hash the completed evidence report (K step f).
 
-    Over the canonical dump of the typed payload — the same bytes SQL persists,
-    so a stored report always rehashes to the value recorded beside it.
+    Over the canonical dump of the document itself — the same bytes SQL
+    persists, so a stored report always rehashes to the value recorded beside
+    it. Takes the canonical value rather than a container holding one: there is
+    no other report type to pass, which is why nothing here checks for one.
     """
     return hash_obj(report.dump())

--- a/src/afterworlds/ingestion/corpus/report_schema.py
+++ b/src/afterworlds/ingestion/corpus/report_schema.py
@@ -1,0 +1,477 @@
+"""The canonical evidence-report payload, as one structurally immutable value.
+
+CRD Issue 5c. This module owns the `5c-evidence-3` document: what it is, how a
+stored one is parsed, and how it is rendered. There is exactly one definition —
+:class:`CorpusEvidenceReport` *is* the payload. ``build_report`` produces it,
+``report_hash`` hashes its dump, SQL persists that same dump, and a stored report
+is parsed back through it. A field not declared here does not exist in the
+schema, and a declared field cannot be omitted, retyped, or shadowed by an extra
+key.
+
+**Structural immutability, not a freeze.** Every canonical type is a
+:class:`typing.NamedTuple` and every container is a tuple, because two
+*conventionally* frozen representations were defeated in review by writing
+underneath their guards: a frozen Pydantic ``BaseModel`` through
+``vars(report)[...] = {}``, and a frozen **slotted** dataclass through
+``object.__setattr__(report, ...)`` — slots remove ``__dict__`` but the
+inherited base setter still writes slot storage. A ``NamedTuple`` keeps its
+values in the tuple itself: no instance dictionary, no slot descriptor, nothing
+for any setter to reach. Immutability is a property of the storage rather than
+of a guard someone remembered to apply.
+
+Maps are :class:`Pairs`, a tuple of sorted key/value pairs, for the same reason.
+A ``MappingProxyType`` is a *view* onto a real dictionary that stays reachable
+through ``gc.get_referents``; a pair tuple has no backing dictionary at all.
+
+**Pydantic validates ingress and never holds the value.** One
+:class:`~pydantic.TypeAdapter` parses raw JSON into the tree — strict scalars,
+objects required at every node, closed populations. Nothing downstream holds a
+Pydantic instance.
+
+**Intrinsic versus contextual.** This module owns what the document must be on
+its own: shape, types, closed populations, and the cross-field semantics of a
+successful verdict. It owns *nothing* about whether the document agrees with the
+release it describes — that comparison needs the release row and reconstructed
+5c state, and lives in :mod:`persistence`.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, NamedTuple
+
+from pydantic import (
+    AfterValidator,
+    BeforeValidator,
+    Field,
+    TypeAdapter,
+    ValidationError,
+)
+from pydantic_core import ErrorDetails
+
+from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
+from afterworlds.ingestion.corpus.models import LeafType
+
+__all__ = [
+    "CANONICAL_CANARY_NAMES",
+    "EVIDENCE_REPORT_SCHEMA_VERSION",
+    "PYTHON_TARGET",
+    "Accounting",
+    "ComponentBInvocation",
+    "CorpusEvidenceReport",
+    "ExtractorConfig",
+    "Findings",
+    "Pairs",
+    "PolicyReference",
+    "ReproductionTarget",
+    "RulesCorpusVectorIdentity",
+    "SourceManifestEntry",
+    "TransformIdentity",
+    "canonical_report",
+    "parse_recorded_report",
+]
+
+# Canonical evidence-report schema version. Bumped across canonical-shape
+# changes: "2" for the R16 host-independent ``reproduction_target`` change; "3"
+# for the R18 pre-release clean-baseline change that removed the
+# legacy-reachability status (Issue 5c Rev7 / Issue 18 Rev6 supersede the strict
+# cross-store quarantine contract). This version is bound into
+# ``transform_config_payload`` (hence the transform hash / package UUID /
+# release version), so an evidence-report *schema* change mints a NEW immutable
+# release instead of being reused under a predecessor's identity (R17
+# mechanism). It is deliberately an *explicit* schema identity rather than a
+# byte-level hash of this module: only an intentional canonical-shape change
+# should remint, never a comment/docstring/annotation edit.
+#
+# Typing this payload did **not** change it. The emitted document and its hash
+# are byte-identical to the untyped implementation, so the version stands.
+EVIDENCE_REPORT_SCHEMA_VERSION = "5c-evidence-3"
+
+#: The declared Python target (pyproject ``requires-python``; Python 3.12 only
+#: per CLAUDE.md). Owned here, in the schema layer, because it is a *canonical
+#: semantic constant of the document* — not a default the builder happens to
+#: pass. A report recording any other target is not this schema.
+PYTHON_TARGET = "3.12"
+
+#: The canonical version-canary population, derived from the committed canary
+#: definitions. Never a second hand-written list: adding or retiring a canary
+#: moves the required population with it.
+CANONICAL_CANARY_NAMES = frozenset(canary.name for canary in VERSION_CANARIES)
+
+#: Leaf-type totals may cover any *subset* of the taxonomy — a corpus with no
+#: tables legitimately reports no ``table_cell`` — but never a name outside it.
+#: Derived from the enum, so the universe cannot drift from the taxonomy.
+_LEAF_TYPE_NAMES = frozenset(leaf_type.value for leaf_type in LeafType)
+
+
+class Pairs(tuple[tuple[str, Any], ...]):
+    """A canonical JSON object, stored as sorted ``(key, value)`` pairs.
+
+    A distinct type rather than a naming convention: :func:`_json` renders a
+    ``Pairs`` as an object and every other tuple as an array, so an *empty* map
+    still serializes to ``{}`` instead of being guessed at from its contents.
+    """
+
+    __slots__ = ()
+
+
+def _object_only(value: object) -> object:
+    """Refuse anything but a JSON object at a node that declares one.
+
+    Pydantic's native ``NamedTuple`` handling accepts a positional sequence, so
+    without this a stored report could arrive as a JSON *array* and parse.
+    """
+    if not isinstance(value, dict):
+        raise ValueError(f"expected a JSON object, got {type(value).__name__}")
+    return value
+
+
+def _sorted_pairs(value: object) -> object:
+    """A JSON object as sorted pairs, ready for per-entry validation."""
+    if not isinstance(value, dict):
+        raise ValueError(f"expected a JSON object, got {type(value).__name__}")
+    return tuple(sorted(value.items()))
+
+
+#: Applied at every node declaring a nested object.
+_OBJ = BeforeValidator(_object_only)
+
+#: Strict scalars. ``bool`` is an ``int`` subclass, so without these a JSON
+#: ``true`` would load as the count ``1``; ``"0"`` and ``0.0`` are likewise not
+#: integers, and a number is not a string.
+Str = Annotated[str, Field(strict=True)]
+Bool = Annotated[bool, Field(strict=True)]
+Int = Annotated[int, Field(strict=True)]
+Real = Annotated[float, Field(strict=True)]
+
+Count = Annotated[int, Field(strict=True, ge=0)]
+
+#: Content-derived count maps: variable key population, closed value domain.
+CountMap = Annotated[
+    tuple[tuple[Str, Count], ...],
+    BeforeValidator(_sorted_pairs),
+    AfterValidator(Pairs),
+]
+#: Boolean maps — the canary population.
+FlagMap = Annotated[
+    tuple[tuple[Str, Bool], ...],
+    BeforeValidator(_sorted_pairs),
+    AfterValidator(Pairs),
+]
+#: Canonical arrays are tuples, so a parsed report cannot be appended to or have
+#: an element replaced. Lax about list-versus-tuple on the way in because the
+#: identity builders return tuples in memory while JSON round-trips them to
+#: lists, and both canonicalize to the same bytes. A bare string is still
+#: refused.
+Array = tuple[Str, ...]
+
+
+def _supported_version(value: str) -> str:
+    if value != EVIDENCE_REPORT_SCHEMA_VERSION:
+        raise ValueError(
+            f"report_version {value!r} is not the supported "
+            f"{EVIDENCE_REPORT_SCHEMA_VERSION!r}"
+        )
+    return value
+
+
+def _validation_status(value: str) -> str:
+    if value not in ("pass", "fail"):
+        raise ValueError(
+            f"prepublication_validation_status must be 'pass' or 'fail', got {value!r}"
+        )
+    return value
+
+
+def _canonical_python_target(value: str) -> str:
+    if value != PYTHON_TARGET:
+        raise ValueError(
+            f"python_target {value!r} is not the canonical reproduction target "
+            f"{PYTHON_TARGET!r}"
+        )
+    return value
+
+
+def _canonical_canaries(value: Pairs) -> Pairs:
+    names = {name for name, _ in value}
+    if names != CANONICAL_CANARY_NAMES:
+        raise ValueError(
+            "version_canaries is not the canonical population (missing "
+            f"{sorted(CANONICAL_CANARY_NAMES - names)}, unexpected "
+            f"{sorted(names - CANONICAL_CANARY_NAMES)})"
+        )
+    return value
+
+
+def _leaf_type_keys(value: Pairs) -> Pairs:
+    outside = sorted({name for name, _ in value} - _LEAF_TYPE_NAMES)
+    if outside:
+        raise ValueError(f"names leaf types outside the taxonomy: {outside}")
+    return value
+
+
+class ExtractorConfig(NamedTuple):
+    """The frozen extraction identity, exactly as ``extraction_config()`` emits."""
+
+    tool: Str
+    tool_version: Str
+    engine: Str
+    engine_version: Str
+    use_text_flow: Bool
+    keep_blank_chars: Bool
+    line_y_tolerance: Real
+    geometry_decimals: Int
+    reading_order: Str
+
+
+class SourceManifestEntry(NamedTuple):
+    """One audited first-party transform module and its content hash."""
+
+    path: Str
+    sha256: Str
+
+
+class ComponentBInvocation(NamedTuple):
+    """The deterministic Component B invocation the transform identity records."""
+
+    entrypoint: Str
+    steps: Array
+    deterministic: Bool
+
+
+class TransformIdentity(NamedTuple):
+    """The complete first-party transform identity carried by the report.
+
+    Closed, not content-populated: every key comes from ``extraction_config()``
+    and ``transform_identity()``, both of which return fixed schemas. Treating it
+    as open let an edited-and-rehashed report replace the whole identity with
+    ``{}``.
+    """
+
+    extractor: Annotated[ExtractorConfig, _OBJ]
+    tool: Str
+    tool_version: Str
+    source_manifest: tuple[Annotated[SourceManifestEntry, _OBJ], ...]
+    transform_source_hash: Str
+    component_b_invocation: Annotated[ComponentBInvocation, _OBJ]
+    intermediate_representation_committed: Bool
+
+
+class RulesCorpusVectorIdentity(NamedTuple):
+    """The identity-bearing rules-corpus vector configuration (ADR-018 D2/D4/D11).
+
+    Also closed: ``rules_corpus_vector_identity()`` returns a fixed schema.
+    """
+
+    embedding_model_id: Str
+    metadata_schema_version: Int
+    metadata_fields: Array
+    chunk_id_scheme: Str
+    collection_name_scheme: Str
+
+
+class ReproductionTarget(NamedTuple):
+    """The declared, host-independent reproduction target (PR #134 R16).
+
+    Bound to :data:`PYTHON_TARGET` on the field itself, not merely defaulted to
+    it by the builder. A stored report recording any other target fails
+    intrinsic parsing rather than being compared somewhere later and possibly
+    not at all.
+    """
+
+    python_target: Annotated[Str, AfterValidator(_canonical_python_target)]
+
+
+class PolicyReference(NamedTuple):
+    """Which reconciliation policy was frozen, and which was actually applied."""
+
+    policy_version: Str
+    policy_hash: Str
+    applied_policy_hash: Str
+
+
+class Accounting(NamedTuple):
+    """The leaf accounting equation's terms."""
+
+    inventoried_leaves: Count
+    represented_leaves: Count
+    excluded_leaves: Count
+    unresolved_leaves: Count
+
+    @property
+    def balances(self) -> bool:
+        return self.inventoried_leaves == (
+            self.represented_leaves + self.excluded_leaves + self.unresolved_leaves
+        )
+
+
+class Findings(NamedTuple):
+    """Identity-level reconciliation findings, as counts."""
+
+    gaps: Count
+    overlaps: Count
+    orphans: Count
+    duplications: Count
+
+    def nonzero(self) -> tuple[str, ...]:
+        return tuple(
+            f"findings.{name} is {value}, not 0"
+            for name, value in sorted(self._asdict().items())
+            if value
+        )
+
+
+class CorpusEvidenceReport(NamedTuple):
+    """The complete canonical `5c-evidence-3` evidence-report payload."""
+
+    report_version: Annotated[Str, AfterValidator(_supported_version)]
+    # Proof identities (never this report's own hash — it cannot contain it).
+    authoritative_source_hash: Str
+    transform_config_hash: Str
+    bundle_root_hash: Str
+    frozen_source_ledger_hash: Str
+    persisted_corpus_digest: Str
+    # Closed identity structures.
+    transform_identity: Annotated[TransformIdentity, _OBJ]
+    rules_corpus_vector_identity: Annotated[RulesCorpusVectorIdentity, _OBJ]
+    reproduction_target: Annotated[ReproductionTarget, _OBJ]
+    reconciliation_policy_reference: Annotated[PolicyReference, _OBJ]
+    # Content-derived populations: the *key set* varies with the corpus, but the
+    # mapping and its value types do not. "Open" never meant "unvalidated".
+    source_ledger_leaf_totals: Annotated[CountMap, AfterValidator(_leaf_type_keys)]
+    represented_totals: Annotated[CountMap, AfterValidator(_leaf_type_keys)]
+    #: Keys are policy reason codes. Left as free strings here on purpose: the
+    #: frozen policy is not available at parse time, and reaching for it would
+    #: create a second policy definition. Reason validity is proven contextually,
+    #: against the reconstructed policy.
+    excluded_totals_by_reason: CountMap
+    # Verdict-bearing summaries.
+    unresolved_leaves: Count
+    declared_projection_count: Count
+    accounting: Annotated[Accounting, _OBJ]
+    findings: Annotated[Findings, _OBJ]
+    invalid_locators: Count
+    concordance_failures: Count
+    version_canaries: Annotated[FlagMap, AfterValidator(_canonical_canaries)]
+    prepublication_validation_status: Annotated[Str, AfterValidator(_validation_status)]
+
+    def verdict_violations(self) -> tuple[str, ...]:
+        """Why these numbers do not state a successful publication.
+
+        The one definition of success in the report's own terms, read off typed
+        fields. ``build_report`` derives the recorded status from it, so a report
+        cannot be *written* claiming success over contradictory summaries; a
+        stored report is measured against the same rule.
+        """
+        violations: list[str] = []
+        for name in ("unresolved_leaves", "invalid_locators", "concordance_failures"):
+            value: int = getattr(self, name)
+            if value:
+                violations.append(f"{name} is {value}, not 0")
+        violations.extend(self.findings.nonzero())
+        # Sorted explicitly: the parser sorts the pairs, but violation order is
+        # asserted in tests and must not depend on that staying true.
+        for canary, passed in sorted(self.version_canaries):
+            if not passed:
+                violations.append(f"version canary {canary} did not pass")
+        if self.accounting.unresolved_leaves:
+            violations.append(
+                "accounting.unresolved_leaves is "
+                f"{self.accounting.unresolved_leaves}, not 0"
+            )
+        if not self.accounting.balances:
+            violations.append("accounting equation does not balance")
+        if self.accounting.unresolved_leaves != self.unresolved_leaves:
+            violations.append(
+                "accounting.unresolved_leaves disagrees with the top-level "
+                "unresolved_leaves"
+            )
+        return tuple(violations)
+
+    def success_violations(self) -> tuple[str, ...]:
+        """Why this recorded report is not a successful publication verdict.
+
+        Identity is not sufficiency: a report edited to ``"fail"`` and rehashed
+        keeps every proof identity intact while recording that publication did
+        not succeed.
+        """
+        violations = []
+        if self.prepublication_validation_status != "pass":
+            violations.append(
+                "prepublication_validation_status is "
+                f"{self.prepublication_validation_status!r}, not 'pass' — the "
+                "recorded evidence states this release did not publish successfully"
+            )
+        return (*violations, *self.verdict_violations())
+
+    def dump(self) -> dict[str, Any]:
+        """The canonical JSON-compatible payload: hashed, persisted, compared.
+
+        The **only** serialization of this document. ``report_hash``, the SQL
+        column, and every contextual comparison read this — including
+        comparisons that need one nested fragment, which slice this dump rather
+        than serializing the nested value separately.
+
+        Note what this replaces rather than merely wraps: a ``NamedTuple`` *is*
+        JSON-serializable by ``json.dumps``, as a positional **array**. So
+        ``canonical_bytes(report)`` succeeds and mints a wrong-but-plausible
+        hash. Every hash, column, and comparison goes through this method, and a
+        control asserts the raw object's canonical bytes differ from the
+        payload's so an accidental direct serialization fails loudly.
+        """
+        rendered: dict[str, Any] = _json(self)
+        return rendered
+
+
+def _json(value: object) -> Any:
+    """Render the immutable value tree as canonical JSON-compatible data.
+
+    Field names come off the ``NamedTuple`` itself, so the serializer cannot
+    drift from the declaration the way a hand-maintained key list did.
+    """
+    if isinstance(value, Pairs):
+        return {key: _json(item) for key, item in value}
+    if isinstance(value, tuple):
+        names: tuple[str, ...] | None = getattr(value, "_fields", None)
+        if names is not None:
+            return {name: _json(item) for name, item in zip(names, value, strict=True)}
+        return [_json(item) for item in value]
+    return value
+
+
+#: The one parser for the canonical document.
+_ADAPTER: TypeAdapter[CorpusEvidenceReport] = TypeAdapter(
+    Annotated[CorpusEvidenceReport, _OBJ]
+)
+
+
+def _where(error: ErrorDetails) -> str:
+    location = ".".join(str(part) for part in error["loc"]) or "evidence report"
+    return f"{location}: {error['msg']}"
+
+
+def canonical_report(payload: object) -> CorpusEvidenceReport:
+    """Build the canonical value, raising on anything that is not this schema.
+
+    The construction-side counterpart to :func:`parse_recorded_report`, and the
+    *only* way production code makes one of these: a ``NamedTuple`` constructor
+    runs no validators, so direct construction is never a production path. A
+    build that cannot describe itself in the canonical shape is a defect here
+    and now, not an auditable finding about someone else's stored bytes.
+    """
+    return _ADAPTER.validate_python(payload)
+
+
+def parse_recorded_report(
+    payload: object,
+) -> tuple[CorpusEvidenceReport | None, tuple[str, ...]]:
+    """Parse a stored payload, returning violations rather than raising.
+
+    A recorded report has unknown provenance — JSON round-tripped, possibly
+    hand-edited — so a malformed one is an auditable finding, not an exception
+    escaping into the publication path. Callers turn these strings into typed
+    refusals.
+    """
+    try:
+        return _ADAPTER.validate_python(payload), ()
+    except ValidationError as exc:
+        return None, tuple(_where(error) for error in exc.errors())

--- a/tests/ingestion/corpus/test_gate.py
+++ b/tests/ingestion/corpus/test_gate.py
@@ -144,12 +144,19 @@ def test_gate_fails_when_reconciliation_hash_substituted(release):
     assert any("reconciliation" in f for f in result.failures)
 
 
-def test_gate_fails_when_report_predates_persistence(release):
-    report = dataclasses.replace(release.report, persisted=False)
+def test_gate_fails_when_the_report_lacks_a_persisted_corpus_digest(release):
+    """The structural replacement for the deleted ``report.persisted`` check.
+
+    That flag lived on a wrapper outside the hashed payload and was supplied by
+    the caller, so it asserted the post-persistence ordering rather than proving
+    it. What proves it now is that ``persisted_corpus_digest`` cannot be
+    computed before persistence — so a report without one did not come from a
+    persisted release, whatever it claims."""
+    report = release.report._replace(persisted_corpus_digest="")
     broken = dataclasses.replace(release, report=report)
     result = run_gate(broken, _evidence())
     assert not result.passed
-    assert any("predates persistence" in f for f in result.failures)
+    assert any("lacks persisted-corpus digest" in f for f in result.failures)
 
 
 def test_gate_fails_when_sql_or_vector_persist_incomplete(release):

--- a/tests/ingestion/corpus/test_ledger_pipeline.py
+++ b/tests/ingestion/corpus/test_ledger_pipeline.py
@@ -191,7 +191,7 @@ def test_evidence_report_records_complete_transform_identity(release):
     assert ti["intermediate_representation_committed"] is False
 
 
-def _rebuild_report(a, persisted=True, **overrides):
+def _rebuild_report(a, **overrides):
     """Rebuild the evidence report from a release's inputs (R16 F2 host test)."""
     from afterworlds.ingestion.corpus.report import build_report
 
@@ -208,10 +208,40 @@ def _rebuild_report(a, persisted=True, **overrides):
         persisted_corpus_digest=a.release.identity.persisted_corpus_digest,
         concordance=a.concordance,
         canaries=a.canaries,
-        persisted=persisted,
     )
     kwargs.update(overrides)
     return build_report(**kwargs)
+
+
+def test_the_gate_and_persistence_consume_the_canonical_report_directly(release):
+    """No indirection between the artifacts and the hashed document.
+
+    ``ReleaseArtifacts.report`` is the canonical value itself, so the gate reads
+    its fields and persistence stores its dump without unwrapping anything.
+    Asserted on a real finalized release rather than on annotations."""
+    from afterworlds.ingestion.corpus.report import EvidenceReport, report_hash
+    from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
+
+    assert EvidenceReport is CorpusEvidenceReport
+    assert type(release.report) is CorpusEvidenceReport
+    assert not hasattr(release.report, "payload")
+    assert release.report.prepublication_validation_status == "pass"
+    assert report_hash(release.report) == release.release.identity.evidence_report_hash
+
+
+def test_build_report_returns_the_canonical_value_itself(release):
+    """No completed-report wrapper stands between construction and hashing.
+
+    The wrapper this replaces was the hash-bearing authority every consumer
+    read, so replacing its ``payload`` after construction replaced the whole
+    document. ``build_report`` now returns the structurally immutable value, and
+    ``report_hash`` takes that value."""
+    from afterworlds.ingestion.corpus.report import report_hash
+    from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
+
+    built = _rebuild_report(release)
+    assert isinstance(built, CorpusEvidenceReport)
+    assert report_hash(built) == release.release.identity.evidence_report_hash
 
 
 def test_a_report_that_cannot_describe_itself_fails_at_build_time(release):

--- a/tests/ingestion/corpus/test_ledger_pipeline.py
+++ b/tests/ingestion/corpus/test_ledger_pipeline.py
@@ -8,6 +8,8 @@ containers, heading coverage, and multi-unit segmentation.
 
 from __future__ import annotations
 
+import pytest
+
 from afterworlds.ingestion.corpus.bundle import reconciliation_hash
 from afterworlds.ingestion.corpus.concordance import check_canaries, check_concordance
 from afterworlds.ingestion.corpus.ledger import build_ledger, ledger_hash
@@ -169,7 +171,7 @@ def test_clean_regeneration_is_byte_for_byte_deterministic(release):
 
 
 def test_evidence_report_carries_proof_hashes_but_not_its_own(release):
-    payload = release.report.payload
+    payload = release.report.dump()
     assert "persisted_corpus_digest" in payload
     assert payload["bundle_root_hash"] == release.release.identity.bundle_root_hash
     # The report never contains its own hash.
@@ -180,7 +182,7 @@ def test_evidence_report_records_complete_transform_identity(release):
     """PR #134 P1: the report records the full Component B identity — extractor
     config + first-party source manifest/hash + deterministic invocation + IR
     flag — not just ledger.extraction_config."""
-    ti = release.report.payload["transform_identity"]
+    ti = release.report.dump()["transform_identity"]
     assert isinstance(ti, dict)
     assert ti["extractor"]  # extractor config present
     assert ti["source_manifest"]  # first-party source manifest present
@@ -189,11 +191,11 @@ def test_evidence_report_records_complete_transform_identity(release):
     assert ti["intermediate_representation_committed"] is False
 
 
-def _rebuild_report(a, persisted=True):
+def _rebuild_report(a, persisted=True, **overrides):
     """Rebuild the evidence report from a release's inputs (R16 F2 host test)."""
     from afterworlds.ingestion.corpus.report import build_report
 
-    return build_report(
+    kwargs = dict(
         ledger=a.ledger,
         members=a.members,
         recon=a.reconciliation,
@@ -208,6 +210,22 @@ def _rebuild_report(a, persisted=True):
         canaries=a.canaries,
         persisted=persisted,
     )
+    kwargs.update(overrides)
+    return build_report(**kwargs)
+
+
+def test_a_report_that_cannot_describe_itself_fails_at_build_time(release):
+    """The construction side goes through the one parser too.
+
+    A NamedTuple constructor runs no validators, so `build_report` assembling
+    the payload as a plain dict and handing it to `canonical_report` is what
+    makes construction a validated path at all. Without it, an incomplete canary
+    run would be *written* into a release rather than caught when someone later
+    read it back."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _rebuild_report(release, canaries=release.canaries[1:])
 
 
 def test_evidence_report_identity_is_host_independent(release, monkeypatch):
@@ -224,7 +242,7 @@ def test_evidence_report_identity_is_host_independent(release, monkeypatch):
         monkeypatch.setattr(report_mod.platform, "machine", lambda: machine)
         monkeypatch.setattr(report_mod.platform, "python_version", lambda: pyver)
         r = _rebuild_report(release)
-        return r.payload, report_hash(r)
+        return r.dump(), report_hash(r)
 
     p1, h1 = build_under("Linux", "x86_64", "3.12.1")
     p2, h2 = build_under("Windows", "AMD64", "3.12.9")

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -901,7 +901,7 @@ def test_report_schema_ok_fails_closed_on_a_contradictory_transform_config(relea
     from afterworlds.ingestion.corpus.persistence import _report_schema_ok
     from afterworlds.ingestion.corpus.report import EVIDENCE_REPORT_SCHEMA_VERSION as V
 
-    report = release.report.payload
+    report = release.report
     assert _report_schema_ok(report, {"evidence_report_schema_version": V})
     # contradictory: report current, transform config stale, absent, or not an
     # object at all.

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -526,7 +526,7 @@ def test_reuse_fails_closed_on_deleted_policy_row(
     )
     assert not result.published and not result.reused
     assert result.gate is not None
-    assert any("policy" in f for f in result.gate.failures)
+    assert any("does not reconstruct" in f for f in result.gate.failures)
 
 
 # --- Pre-release clean baseline: obsolete SRD artifact retired (R18) ----------
@@ -888,30 +888,28 @@ def test_completeness_rejects_page_corruption_and_leaves_no_state(
 #  see test_migration_0018_deletes_incomplete_package_and_dependent_rows.)
 
 
-def test_report_schema_ok_fails_closed_on_bad_schema():
+def test_report_schema_ok_fails_closed_on_a_contradictory_transform_config(release):
     """R17 unit: ``_report_schema_ok`` is the reuse-path backstop for the evidence-
-    report schema. Current + matching (report AND transform config) → True;
-    obsolete, contradictory, missing, or malformed → False (fail closed)."""
+    report schema.
+
+    It now takes a *parsed* report, so the cases this test used to cover with raw
+    dictionaries — a missing ``report_version``, an obsolete one, a non-object
+    payload — no longer reach it: the parser refuses them, and
+    ``test_recorded_evidence`` owns those controls. What remains here is the
+    genuinely contextual half: agreement with the persisted transform
+    configuration, which the document cannot know about itself."""
     from afterworlds.ingestion.corpus.persistence import _report_schema_ok
     from afterworlds.ingestion.corpus.report import EVIDENCE_REPORT_SCHEMA_VERSION as V
 
-    assert _report_schema_ok(
-        {"report_version": V}, {"evidence_report_schema_version": V}
-    )
-    # obsolete pre-R16 report version
+    report = release.report.payload
+    assert _report_schema_ok(report, {"evidence_report_schema_version": V})
+    # contradictory: report current, transform config stale, absent, or not an
+    # object at all.
+    assert not _report_schema_ok(report, {})
     assert not _report_schema_ok(
-        {"report_version": "5c-evidence-1"}, {"evidence_report_schema_version": V}
+        report, {"evidence_report_schema_version": "5c-evidence-1"}
     )
-    # contradictory: report current, transform config stale or absent
-    assert not _report_schema_ok({"report_version": V}, {})
-    assert not _report_schema_ok(
-        {"report_version": V}, {"evidence_report_schema_version": "5c-evidence-1"}
-    )
-    # missing report version
-    assert not _report_schema_ok({}, {"evidence_report_schema_version": V})
-    # malformed payloads
-    assert not _report_schema_ok(None, {"evidence_report_schema_version": V})
-    assert not _report_schema_ok({"report_version": V}, None)
+    assert not _report_schema_ok(report, None)
 
 
 def test_reuse_rejects_obsolete_evidence_report_schema(
@@ -923,7 +921,7 @@ def test_reuse_rejects_obsolete_evidence_report_schema(
     published release (recomputing the stored hash so the gate's hash check passes,
     isolating the schema backstop) and assert the reuse attempt surfaces the schema
     failure and does not reuse."""
-    from afterworlds.ingestion.corpus.report import EvidenceReport, report_hash
+    from afterworlds.ingestion.corpus.hashing import hash_obj
 
     first = _finalize(
         session, candidate, chroma_client, retrieval_config, fake_embedding
@@ -939,9 +937,10 @@ def test_reuse_rejects_obsolete_evidence_report_schema(
     row.report_payload = payload
     # Keep the stored hash consistent with the tampered payload so the gate's
     # evidence_report_hash check passes — this isolates the schema backstop.
-    row.evidence_report_hash = report_hash(
-        EvidenceReport(payload=payload, persisted=True)
-    )
+    # Hashed as raw stored bytes: an obsolete-schema payload is by definition
+    # not something the canonical serializer can render.
+    row.evidence_report_hash = hash_obj(payload)
+    row.corpus_report_reference = row.evidence_report_hash
     session.commit()
 
     result = _finalize(
@@ -949,7 +948,10 @@ def test_reuse_rejects_obsolete_evidence_report_schema(
     )
     assert not result.published and not result.reused
     assert result.gate is not None
-    assert any("schema version" in f for f in result.gate.failures)
+    # Refused at the parse boundary now: an obsolete ``report_version`` is not
+    # this schema, so reconstruction fails closed before the contextual schema
+    # comparison is reached. Either way the release is not reused.
+    assert any("report_version" in f for f in result.gate.failures)
 
 
 def test_repeated_finalize_is_idempotent_and_does_not_mutate(

--- a/tests/ingestion/corpus/test_published_release_seam.py
+++ b/tests/ingestion/corpus/test_published_release_seam.py
@@ -1,0 +1,407 @@
+"""One published-release seam, and every lifecycle path that must use it.
+
+CRD Issue 5c. The defect these controls close is not a missing check but a
+missing *shared* one: ``verify_published_release`` accumulated row-level
+publication invariants one review round at a time while ``finalize_release``'s
+verified-reuse path checked the package row's status inline and nothing else. So
+a release that downstream 5d verification refused was still handed back as
+``published=True, reused=True`` — two authorities on one published release.
+
+Every control below therefore asserts the *same* tampering is refused by **both**
+paths, and the parametrisation is the point: a new invariant added to the seam
+is automatically demanded of reuse and of downstream consumption, and cannot be
+added to one of them alone.
+
+The seam's unit is the package/release **pair**. An earlier field-by-field audit
+of ``rp_corpus_releases`` alone missed ``rp_packages.version``, because a
+cross-row equality has no single row to be filed under.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+import afterworlds.ingestion.corpus.persistence as persistence
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.corpus.persistence import (
+    _finalize_core,
+    load_published_release,
+    verify_published_release,
+)
+from afterworlds.persistence.orm.corpus import (
+    CorpusReleaseORM,
+    ReconciliationPolicyORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+
+_NOW = "2026-07-23T00:00:00Z"
+_LATER = "2026-07-24T00:00:00Z"
+
+Tamper = Callable[[Session, str], None]
+
+
+def release_row(session: Session, pkg: str) -> CorpusReleaseORM:
+    return session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+    ).scalar_one()
+
+
+def package_row(session: Session, pkg: str) -> RulesPackageORM:
+    return session.execute(
+        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
+    ).scalar_one()
+
+
+@pytest.fixture()
+def published(  # type: ignore[no-untyped-def]
+    session, compact_candidate, chroma_client, retrieval_config, fake_embedding
+):
+    """An honestly published compact release, and the tools to re-drive it."""
+    first = _finalize_core(
+        session,
+        compact_candidate,
+        now=_NOW,
+        chroma_client=chroma_client,
+        retrieval_config=retrieval_config,
+        embedding_function=fake_embedding,
+    )
+    assert first.published and not first.reused and first.artifacts is not None
+    return first, compact_candidate, chroma_client, retrieval_config, fake_embedding
+
+
+def downstream(session: Session, first) -> tuple[str, ...]:  # type: ignore[no-untyped-def]
+    """What a 5d consumer sees, declaring exactly what the release recorded."""
+    identity = first.artifacts.release.identity
+    return verify_published_release(
+        session,
+        first.artifacts.release.package_uuid,
+        release_version=first.artifacts.release.release_version,
+        authoritative_source_hash=identity.authoritative_source_hash,
+        transform_config_hash=identity.transform_config_hash,
+        bundle_root_hash=identity.bundle_root_hash,
+        corpus_digest=identity.persisted_corpus_digest,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The positive control: one honest release, both paths, same semantics
+# ---------------------------------------------------------------------------
+
+
+def test_an_honest_release_passes_the_seam_and_downstream(session, published) -> None:  # type: ignore[no-untyped-def]
+    first, *_ = published
+    pkg = first.artifacts.release.package_uuid
+
+    proven, violations = load_published_release(session, pkg)
+    assert violations == ()
+    assert proven is not None
+    assert proven.package.version == proven.release.release_version
+    assert proven.report.prepublication_validation_status == "pass"
+
+    assert downstream(session, first) == ()
+
+
+def test_honest_fresh_publication_and_honest_reuse_share_these_semantics(  # type: ignore[no-untyped-def]
+    session, full_candidate, chroma_client, retrieval_config, fake_embedding
+) -> None:
+    """Both lifecycle outcomes pass the same seam, on the complete corpus.
+
+    The full candidate rather than the compact one because verified reuse also
+    demands complete persisted page coverage, which a six-page fixture cannot
+    satisfy — the compact controls below are therefore asserted on the specific
+    pair refusal rather than on reuse failing for any reason at all.
+    """
+    first = _finalize_core(
+        session,
+        full_candidate,
+        now=_NOW,
+        chroma_client=chroma_client,
+        retrieval_config=retrieval_config,
+        embedding_function=fake_embedding,
+    )
+    assert first.published and not first.reused
+    assert load_published_release(session, full_candidate.package_uuid)[1] == ()
+    assert downstream(session, first) == ()
+
+    second = _finalize_core(
+        session,
+        full_candidate,
+        now=_LATER,
+        chroma_client=chroma_client,
+        retrieval_config=retrieval_config,
+        embedding_function=fake_embedding,
+    )
+    assert second.published and second.reused
+    assert load_published_release(session, full_candidate.package_uuid)[1] == ()
+
+
+def test_an_honest_fresh_publication_leaves_rows_that_satisfy_the_seam(  # type: ignore[no-untyped-def]
+    session, published
+) -> None:
+    """The committed rows prove themselves, with no later repair."""
+    first, *_ = published
+    assert (
+        load_published_release(session, first.artifacts.release.package_uuid)[1] == ()
+    )
+
+
+def test_a_fresh_publication_the_seam_refuses_is_rolled_back_not_committed(  # type: ignore[no-untyped-def]
+    session,
+    compact_candidate,
+    chroma_client,
+    retrieval_config,
+    fake_embedding,
+    monkeypatch,
+) -> None:
+    """Fault injection on the *fresh* path, which no other control reaches.
+
+    Both other callers can be driven by editing rows after publication; a fresh
+    publication has to be made to write a bad pair while it runs. Here the
+    package row is given a version the release does not carry — the exact
+    invariant a field-by-field audit of the release row could not surface —
+    after the draft rows are persisted and before the gate.
+
+    The refusal is only half the property. The other half is that nothing was
+    committed: a fresh publication the seam declines must leave no published
+    package or release behind, which is why the row assertions matter more than
+    the failure text.
+    """
+    original = persistence._persist_package_and_source
+
+    def forge_package_version(session_, pkg, release_version, *, now):  # type: ignore[no-untyped-def]
+        source_id = original(session_, pkg, release_version, now=now)
+        package_row(session_, pkg).version = "forged-version"
+        session_.flush()
+        return source_id
+
+    monkeypatch.setattr(
+        persistence, "_persist_package_and_source", forge_package_version
+    )
+
+    result = _finalize_core(
+        session,
+        compact_candidate,
+        now=_NOW,
+        chroma_client=chroma_client,
+        retrieval_config=retrieval_config,
+        embedding_function=fake_embedding,
+    )
+    assert not result.published and not result.reused
+    assert result.gate is not None
+    assert any("refusing to publish" in f for f in result.gate.failures)
+    assert any("is not the release's" in f for f in result.gate.failures)
+
+    pkg = compact_candidate.package_uuid
+    assert (
+        session.execute(
+            select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+        ).scalar_one_or_none()
+        is None
+    )
+    assert (
+        session.execute(
+            select(RulesPackageORM).where(RulesPackageORM.rules_package_id == pkg)
+        ).scalar_one_or_none()
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Every row-level invariant, refused by both paths
+# ---------------------------------------------------------------------------
+
+
+def _coordinated_transform_edit(session: Session, pkg: str) -> None:
+    """Edit the stored transform configuration and keep everything agreeing.
+
+    Nothing else moves: the recorded ``transform_config_hash``, the report, and
+    the package identity are all untouched and mutually consistent. Only
+    recomputing the configuration's own hash catches it.
+    """
+    release = release_row(session, pkg)
+    config = dict(release.transform_config)
+    config["evidence_report_schema_version"] = "forged"
+    release.transform_config = config
+
+
+def _stale_report_reference(session: Session, pkg: str) -> None:
+    """The reference names a real report — the one before this one."""
+    release = release_row(session, pkg)
+    payload = dict(release.report_payload or {})
+    stale = release.evidence_report_hash
+    payload["declared_projection_count"] = 99
+    release.report_payload = payload
+    release.evidence_report_hash = hash_obj(payload)
+    release.corpus_report_reference = stale
+
+
+TAMPERS: list[tuple[str, Tamper]] = [
+    (
+        "package-published_at-cleared",
+        lambda s, p: setattr(package_row(s, p), "published_at", None),
+    ),
+    (
+        "package-not-published",
+        lambda s, p: setattr(package_row(s, p), "publication_status", "draft"),
+    ),
+    (
+        "package-disabled",
+        lambda s, p: setattr(package_row(s, p), "is_enabled", False),
+    ),
+    (
+        "package-version-edited-away-from-the-release",
+        lambda s, p: setattr(package_row(s, p), "version", "forged-version"),
+    ),
+    (
+        "release-not-published",
+        lambda s, p: setattr(release_row(s, p), "publication_status", "draft"),
+    ),
+    (
+        "transform-config-does-not-hash-to-its-recorded-hash",
+        _coordinated_transform_edit,
+    ),
+    (
+        "report-payload-cleared",
+        lambda s, p: setattr(release_row(s, p), "report_payload", None),
+    ),
+    (
+        "evidence-report-hash-cleared",
+        lambda s, p: setattr(release_row(s, p), "evidence_report_hash", None),
+    ),
+    (
+        "persisted-corpus-digest-cleared",
+        lambda s, p: setattr(release_row(s, p), "persisted_corpus_digest", None),
+    ),
+    (
+        "report-reference-cleared",
+        lambda s, p: setattr(release_row(s, p), "corpus_report_reference", None),
+    ),
+    (
+        "report-reference-names-an-unrelated-report",
+        lambda s, p: setattr(release_row(s, p), "corpus_report_reference", "9" * 64),
+    ),
+    ("report-reference-names-the-previous-report", _stale_report_reference),
+    (
+        "report-does-not-hash-to-its-recorded-hash",
+        lambda s, p: setattr(
+            release_row(s, p),
+            "report_payload",
+            {**(release_row(s, p).report_payload or {}), "invalid_locators": 7},
+        ),
+    ),
+    (
+        "report-identity-disagrees-with-its-release-column",
+        lambda s, p: _rehashed(s, p, bundle_root_hash="9" * 64),
+    ),
+    (
+        "report-records-a-failed-verdict",
+        lambda s, p: _rehashed(s, p, prepublication_validation_status="fail"),
+    ),
+    (
+        "report-claims-pass-over-unresolved-leaves",
+        lambda s, p: _rehashed(s, p, unresolved_leaves=3),
+    ),
+]
+
+
+def _rehashed(session: Session, pkg: str, **overrides: object) -> None:
+    """Edit the recorded report *and* rehash it, so identity alone accepts it."""
+    release = release_row(session, pkg)
+    payload = dict(release.report_payload or {})
+    payload.update(overrides)
+    release.report_payload = payload
+    release.evidence_report_hash = hash_obj(payload)
+    release.corpus_report_reference = release.evidence_report_hash
+
+
+@pytest.mark.parametrize("tamper", [pytest.param(t, id=label) for label, t in TAMPERS])
+def test_a_refused_release_is_refused_by_downstream_consumption_and_by_reuse(
+    session,  # type: ignore[no-untyped-def]
+    published,  # type: ignore[no-untyped-def]
+    tamper: Tamper,
+) -> None:
+    """One tampering, both paths — the property a per-caller check cannot give.
+
+    The reuse half is the finding this module exists for: before the seam, a
+    release rejected here was still returned as ``published=True, reused=True``.
+    """
+    first, candidate, chroma_client, retrieval_config, fake_embedding = published
+    pkg = first.artifacts.release.package_uuid
+
+    tamper(session, pkg)
+    session.commit()
+
+    assert load_published_release(session, pkg)[0] is None
+    assert downstream(session, first) != ()
+
+    second = _finalize_core(
+        session,
+        candidate,
+        now=_LATER,
+        chroma_client=chroma_client,
+        retrieval_config=retrieval_config,
+        embedding_function=fake_embedding,
+    )
+    assert not second.published
+    assert not second.reused
+    assert second.gate is not None
+    # Asserted on the *pair* refusal specifically, not merely on reuse failing:
+    # the compact fixture cannot satisfy full page coverage either, so "reuse
+    # returned False" alone would be true no matter what this control did. A
+    # release row edited out of ``published`` never reaches the reuse branch —
+    # the older non-published-row guard refuses to touch it at all, which is the
+    # same fail-closed answer one step earlier.
+    assert any(
+        "refusing to reuse" in f or "refusing to mutate" in f
+        for f in second.gate.failures
+    )
+
+
+def test_the_seam_returns_the_pair_it_proved(session, published) -> None:  # type: ignore[no-untyped-def]
+    """Callers get the proven rows, so nothing re-reads them unproven."""
+    first, *_ = published
+    pkg = first.artifacts.release.package_uuid
+    proven, _ = load_published_release(session, pkg)
+    assert proven is not None
+    assert proven.release.package_uuid == pkg
+    assert proven.package.rules_package_id == pkg
+    assert proven.report.dump() == release_row(session, pkg).report_payload
+
+
+def test_a_proven_pair_that_no_longer_reconstructs_is_still_refused_downstream(  # type: ignore[no-untyped-def]
+    session, published
+) -> None:
+    """The seam and reconstruction own different halves, and both must hold.
+
+    Deleting the frozen policy row leaves the pair perfectly self-consistent —
+    every column, hash, and recorded identity still agrees — so the seam passes
+    it. What fails is the half the seam deliberately does not restate:
+    reconstruction from the persisted rows.
+    """
+    first, *_ = published
+    pkg = first.artifacts.release.package_uuid
+    session.execute(
+        delete(ReconciliationPolicyORM).where(
+            ReconciliationPolicyORM.package_uuid == pkg
+        )
+    )
+    session.flush()
+
+    assert load_published_release(session, pkg)[1] == ()
+    violations = downstream(session, first)
+    assert any("does not reconstruct from persisted rows" in v for v in violations)
+
+
+def test_an_absent_release_is_refused_without_deriving_further_findings(
+    session,  # type: ignore[no-untyped-def]
+) -> None:
+    """A missing pair yields the real finding, not a cascade derived from it."""
+    proven, violations = load_published_release(session, "no-such-package")
+    assert proven is None
+    assert len(violations) == 2
+    assert any("rp_corpus_releases" in v for v in violations)
+    assert any("rp_packages" in v for v in violations)

--- a/tests/ingestion/corpus/test_published_release_seam.py
+++ b/tests/ingestion/corpus/test_published_release_seam.py
@@ -29,7 +29,8 @@ import afterworlds.ingestion.corpus.persistence as persistence
 from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.persistence import (
     _finalize_core,
-    load_published_release,
+    load_recorded_release_pair,
+    load_verified_published_release,
     verify_published_release,
 )
 from afterworlds.persistence.orm.corpus import (
@@ -96,7 +97,7 @@ def test_an_honest_release_passes_the_seam_and_downstream(session, published) ->
     first, *_ = published
     pkg = first.artifacts.release.package_uuid
 
-    proven, violations = load_published_release(session, pkg)
+    proven, violations = load_verified_published_release(session, pkg)
     assert violations == ()
     assert proven is not None
     assert proven.package.version == proven.release.release_version
@@ -124,7 +125,9 @@ def test_honest_fresh_publication_and_honest_reuse_share_these_semantics(  # typ
         embedding_function=fake_embedding,
     )
     assert first.published and not first.reused
-    assert load_published_release(session, full_candidate.package_uuid)[1] == ()
+    assert (
+        load_verified_published_release(session, full_candidate.package_uuid)[1] == ()
+    )
     assert downstream(session, first) == ()
 
     second = _finalize_core(
@@ -136,7 +139,9 @@ def test_honest_fresh_publication_and_honest_reuse_share_these_semantics(  # typ
         embedding_function=fake_embedding,
     )
     assert second.published and second.reused
-    assert load_published_release(session, full_candidate.package_uuid)[1] == ()
+    assert (
+        load_verified_published_release(session, full_candidate.package_uuid)[1] == ()
+    )
 
 
 def test_an_honest_fresh_publication_leaves_rows_that_satisfy_the_seam(  # type: ignore[no-untyped-def]
@@ -145,7 +150,10 @@ def test_an_honest_fresh_publication_leaves_rows_that_satisfy_the_seam(  # type:
     """The committed rows prove themselves, with no later repair."""
     first, *_ = published
     assert (
-        load_published_release(session, first.artifacts.release.package_uuid)[1] == ()
+        load_verified_published_release(session, first.artifacts.release.package_uuid)[
+            1
+        ]
+        == ()
     )
 
 
@@ -239,7 +247,114 @@ def _stale_report_reference(session: Session, pkg: str) -> None:
     release.corpus_report_reference = stale
 
 
+def _coherently_rewritten(**overrides: object) -> Tamper:
+    """Rewrite a report summary and make every *recorded* value agree with it.
+
+    The finding this closes. Each of these leaves the release perfectly closed
+    in its own terms: the payload is edited, ``evidence_report_hash`` is
+    recomputed over the edit, ``corpus_report_reference`` follows it, the report
+    still parses, its verdict is still internally successful, and every proof
+    identity still equals its column. Nothing that compares recorded values with
+    other recorded values can tell the difference — only recomputing the claim
+    from the ledger and reconciliation can.
+    """
+
+    def tamper(session: Session, pkg: str) -> None:
+        release = release_row(session, pkg)
+        payload = dict(release.report_payload or {})
+        payload.update(overrides)
+        release.report_payload = payload
+        release.evidence_report_hash = hash_obj(payload)
+        release.corpus_report_reference = release.evidence_report_hash
+
+    return tamper
+
+
+#: One rewrite per SQL-reconstructable report claim. Values are chosen to be
+#: internally consistent successes — an accounting that balances, totals that
+#: are plausible — so the only thing wrong with them is that they are not what
+#: the persisted corpus says.
+COHERENT_REWRITES: list[tuple[str, Tamper]] = [
+    ("declared-projection-count", _coherently_rewritten(declared_projection_count=99)),
+    (
+        "source-ledger-totals",
+        _coherently_rewritten(source_ledger_leaf_totals={"paragraph": 1}),
+    ),
+    ("represented-totals", _coherently_rewritten(represented_totals={"paragraph": 1})),
+    (
+        "excluded-totals-by-reason",
+        _coherently_rewritten(excluded_totals_by_reason={"running_header_footer": 7}),
+    ),
+    (
+        "unresolved-count-and-accounting",
+        # Both moved together so the report stays internally consistent: a
+        # rewrite that only moved one would be caught by the verdict rules.
+        _coherently_rewritten(
+            unresolved_leaves=0,
+            accounting={
+                "inventoried_leaves": 3,
+                "represented_leaves": 2,
+                "excluded_leaves": 1,
+                "unresolved_leaves": 0,
+            },
+        ),
+    ),
+    (
+        "accounting",
+        _coherently_rewritten(
+            accounting={
+                "inventoried_leaves": 4,
+                "represented_leaves": 3,
+                "excluded_leaves": 1,
+                "unresolved_leaves": 0,
+            }
+        ),
+    ),
+    (
+        "reconciliation-policy-reference",
+        _coherently_rewritten(
+            reconciliation_policy_reference={
+                "policy_version": "forged",
+                "policy_hash": "1" * 64,
+                "applied_policy_hash": "1" * 64,
+            }
+        ),
+    ),
+    (
+        "transform-identity",
+        _coherently_rewritten(
+            transform_identity={
+                "extractor": {"tool": "forged"},
+                "tool": "forged",
+                "tool_version": "9",
+                "source_manifest": [{"path": "x.py", "sha256": "2" * 64}],
+                "transform_source_hash": "3" * 64,
+                "component_b_invocation": {
+                    "entrypoint": "forged",
+                    "steps": ["a"],
+                    "deterministic": True,
+                },
+                "intermediate_representation_committed": False,
+            }
+        ),
+    ),
+    (
+        "vector-identity",
+        _coherently_rewritten(
+            rules_corpus_vector_identity={
+                "embedding_model_id": "forged-model",
+                "metadata_schema_version": 9,
+                "metadata_fields": ["a"],
+                "chunk_id_scheme": "forged",
+                "collection_name_scheme": "forged",
+            }
+        ),
+    ),
+]
+
+
 TAMPERS: list[tuple[str, Tamper]] = [
+    *COHERENT_REWRITES,
     (
         "package-published_at-cleared",
         lambda s, p: setattr(package_row(s, p), "published_at", None),
@@ -335,7 +450,7 @@ def test_a_refused_release_is_refused_by_downstream_consumption_and_by_reuse(
     tamper(session, pkg)
     session.commit()
 
-    assert load_published_release(session, pkg)[0] is None
+    assert load_verified_published_release(session, pkg)[0] is None
     assert downstream(session, first) != ()
 
     second = _finalize_core(
@@ -365,7 +480,7 @@ def test_the_seam_returns_the_pair_it_proved(session, published) -> None:  # typ
     """Callers get the proven rows, so nothing re-reads them unproven."""
     first, *_ = published
     pkg = first.artifacts.release.package_uuid
-    proven, _ = load_published_release(session, pkg)
+    proven, _ = load_verified_published_release(session, pkg)
     assert proven is not None
     assert proven.release.package_uuid == pkg
     assert proven.package.rules_package_id == pkg
@@ -377,10 +492,11 @@ def test_a_proven_pair_that_no_longer_reconstructs_is_still_refused_downstream( 
 ) -> None:
     """The seam and reconstruction own different halves, and both must hold.
 
-    Deleting the frozen policy row leaves the pair perfectly self-consistent —
-    every column, hash, and recorded identity still agrees — so the seam passes
-    it. What fails is the half the seam deliberately does not restate:
-    reconstruction from the persisted rows.
+    Deleting the frozen policy row leaves the *recorded rows* perfectly
+    self-consistent — every column, hash, and recorded identity still agrees —
+    so ``load_recorded_release_pair`` accepts it. That is exactly why row
+    closure was renamed and demoted to a prerequisite: what fails is
+    reconstruction, which only the full seam performs.
     """
     first, *_ = published
     pkg = first.artifacts.release.package_uuid
@@ -391,7 +507,8 @@ def test_a_proven_pair_that_no_longer_reconstructs_is_still_refused_downstream( 
     )
     session.flush()
 
-    assert load_published_release(session, pkg)[1] == ()
+    assert load_recorded_release_pair(session, pkg)[1] == ()
+    assert load_verified_published_release(session, pkg)[0] is None
     violations = downstream(session, first)
     assert any("does not reconstruct from persisted rows" in v for v in violations)
 
@@ -400,7 +517,7 @@ def test_an_absent_release_is_refused_without_deriving_further_findings(
     session,  # type: ignore[no-untyped-def]
 ) -> None:
     """A missing pair yields the real finding, not a cascade derived from it."""
-    proven, violations = load_published_release(session, "no-such-package")
+    proven, violations = load_verified_published_release(session, "no-such-package")
     assert proven is None
     assert len(violations) == 2
     assert any("rp_corpus_releases" in v for v in violations)

--- a/tests/ingestion/corpus/test_recorded_evidence.py
+++ b/tests/ingestion/corpus/test_recorded_evidence.py
@@ -1,34 +1,63 @@
-"""A recorded evidence report as a *successful* verdict — Issue 5c, PR #141 R3.
+"""The canonical evidence report as a structurally immutable value — Issue 5c.
 
-Identity is not sufficiency. A report edited to ``"fail"`` and rehashed keeps
-its five proof identities intact and still hashes to its recorded hash, so a
-downstream consumer that checks only identity accepts a release whose own
-evidence records that publication did not succeed.
+Two properties, proven separately.
 
-``recorded_success_violations`` is the one definition of what success looks like
-in the report's own numbers. ``build_report`` derives
+**It cannot be changed after it is parsed.** Two earlier representations were
+*conventionally* frozen and both were defeated by writing underneath the guard:
+a frozen Pydantic ``BaseModel`` through ``vars(report)[...] = {}``, and a frozen
+**slotted** dataclass through ``object.__setattr__(report, ...)``. The controls
+here run both attacks — plus every container mutation the earlier rounds
+surfaced — at the root and at every nested canonical value, and assert the
+payload, the verdict, and the hash are unchanged afterwards. They fail because
+the storage cannot be written, not because something later revalidates.
+
+**It is not a document until one parser says so.** Identity is not sufficiency:
+a report edited to ``"fail"`` and rehashed keeps its five proof identities and
+still hashes to its recorded hash. ``success_violations`` is the one definition
+of success in the report's own numbers; ``build_report`` derives
 ``prepublication_validation_status`` from the same predicate, so a contradictory
-report cannot be *written* here either — these controls therefore describe an
-edited or foreign payload, which is exactly the provenance a recorded report
-has when it is read back.
+report cannot be *written* — these controls describe an edited or foreign
+payload, which is exactly the provenance a recorded report has when read back.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
+from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
+from afterworlds.ingestion.corpus.hashing import canonical_bytes, hash_obj, sha256_hex
+from afterworlds.ingestion.corpus.models import LeafType
+from afterworlds.ingestion.corpus.pdf_source import extraction_config
 from afterworlds.ingestion.corpus.report import (
-    EVIDENCE_REPORT_SCHEMA_VERSION,
-    REQUIRED_REPORT_KEYS,
+    EvidenceReport,
     recorded_success_violations,
-    verdict_violations,
+    report_hash,
 )
+from afterworlds.ingestion.corpus.report_schema import (
+    EVIDENCE_REPORT_SCHEMA_VERSION,
+    PYTHON_TARGET,
+    CorpusEvidenceReport,
+    Pairs,
+    canonical_report,
+    parse_recorded_report,
+)
+from afterworlds.ingestion.corpus.transform_identity import transform_identity
+from afterworlds.models.retrieval import rules_corpus_vector_identity
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 
 
 def payload(**overrides: Any) -> dict[str, Any]:
-    """An honest successful report payload, with *overrides* applied."""
+    """An honest successful report payload, with *overrides* applied.
+
+    Built from the production identity builders rather than hand-written stubs.
+    A fixture that cannot survive the checks it is used to test is not evidence
+    of anything — every hand-written stand-in this suite has carried turned out
+    to be exactly that.
+    """
     base: dict[str, Any] = {
         "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
         "authoritative_source_hash": "a" * 64,
@@ -36,10 +65,19 @@ def payload(**overrides: Any) -> dict[str, Any]:
         "bundle_root_hash": "c" * 64,
         "frozen_source_ledger_hash": "d" * 64,
         "persisted_corpus_digest": "e" * 64,
-        "transform_identity": {"extractor": {}},
-        "rules_corpus_vector_identity": {"embedding_model_id": "m"},
-        "reproduction_target": {"python_target": "3.12"},
-        "reconciliation_policy_reference": {"policy_version": "v"},
+        "transform_identity": {
+            "extractor": extraction_config(),
+            **transform_identity(),
+        },
+        "rules_corpus_vector_identity": rules_corpus_vector_identity(
+            RetrievalMemoryConfig().embedding_model_id
+        ),
+        "reproduction_target": {"python_target": PYTHON_TARGET},
+        "reconciliation_policy_reference": {
+            "policy_version": "v1",
+            "policy_hash": "f" * 64,
+            "applied_policy_hash": "f" * 64,
+        },
         "source_ledger_leaf_totals": {"paragraph": 10},
         "represented_totals": {"paragraph": 8},
         "excluded_totals_by_reason": {"running_header_footer": 2},
@@ -54,30 +92,283 @@ def payload(**overrides: Any) -> dict[str, Any]:
         "findings": {"gaps": 0, "overlaps": 0, "orphans": 0, "duplications": 0},
         "invalid_locators": 0,
         "concordance_failures": 0,
-        "version_canaries": {"wish": True, "true-polymorph": True},
+        "version_canaries": {c.name: True for c in VERSION_CANARIES},
         "prepublication_validation_status": "pass",
     }
     base.update(overrides)
     return base
 
 
-def test_the_fixture_matches_the_declared_report_shape() -> None:
-    """Guards this module from drifting away from what build_report produces."""
-    assert set(payload()) == REQUIRED_REPORT_KEYS
+def parsed(**overrides: Any) -> CorpusEvidenceReport:
+    return canonical_report(payload(**overrides))
+
+
+def test_the_fixture_is_the_declared_shape() -> None:
+    """Guards this module from drifting away from the canonical declaration."""
+    assert set(payload()) == set(CorpusEvidenceReport._fields)
 
 
 def test_an_honest_successful_report_is_accepted() -> None:
     assert recorded_success_violations(payload()) == ()
-    assert verdict_violations(payload()) == ()
+    assert parsed().verdict_violations() == ()
+    assert parsed().success_violations() == ()
+
+
+def test_a_stored_json_round_trip_parses_to_the_same_value() -> None:
+    """A report read back out of a JSON column is the document it went in as."""
+    assert canonical_report(json.loads(json.dumps(payload()))) == parsed()
 
 
 # ---------------------------------------------------------------------------
-# The verdict itself
+# Structural immutability
+# ---------------------------------------------------------------------------
+
+
+def nested_values(report: CorpusEvidenceReport) -> dict[str, Any]:
+    """Every canonical value in the tree, so no node is proven by proxy."""
+    identity = report.transform_identity
+    return {
+        "transform_identity": identity,
+        "transform_identity.extractor": identity.extractor,
+        "transform_identity.source_manifest[0]": identity.source_manifest[0],
+        "transform_identity.component_b_invocation": identity.component_b_invocation,
+        "rules_corpus_vector_identity": report.rules_corpus_vector_identity,
+        "reproduction_target": report.reproduction_target,
+        "reconciliation_policy_reference": report.reconciliation_policy_reference,
+        "accounting": report.accounting,
+        "findings": report.findings,
+        "report": report,
+    }
+
+
+@pytest.mark.parametrize("label", sorted(nested_values(parsed())))
+def test_no_canonical_value_has_writable_backing_storage(label: str) -> None:
+    """``vars()`` and the base setter both fail, at every node of the tree.
+
+    ``object.__setattr__`` is the control that defeated the previous
+    representation: a slotted dataclass has no ``__dict__``, but the inherited
+    base setter still writes its slot storage. A ``NamedTuple`` has neither.
+    """
+    value = nested_values(parsed())[label]
+    assert not hasattr(value, "__dict__")
+    with pytest.raises(TypeError):
+        vars(value)
+    field = type(value)._fields[0]
+    with pytest.raises(AttributeError):
+        object.__setattr__(value, field, "forged")
+    with pytest.raises(AttributeError):
+        object.__setattr__(value, "novel_attribute", "forged")
+    with pytest.raises(AttributeError):
+        setattr(value, field, "forged")
+
+
+def test_a_failed_mutation_leaves_the_payload_verdict_and_hash_unchanged() -> None:
+    """The attack the previous round's finding named, and its consequences.
+
+    ``object.__setattr__(report, "version_canaries", {})`` emptied the canary
+    population, left ``success_violations()`` empty, and changed both the dump
+    and the hash. It now raises — because there is no storage to write, not
+    because something downstream revalidates.
+    """
+    report = parsed()
+    before = report.dump()
+    before_hash = report_hash(EvidenceReport(payload=report, persisted=True))
+
+    with pytest.raises(TypeError):
+        vars(report)["version_canaries"] = {}
+    with pytest.raises(AttributeError):
+        object.__setattr__(report, "version_canaries", {})
+    with pytest.raises(AttributeError):
+        object.__setattr__(report, "accounting", None)
+    with pytest.raises(AttributeError):
+        object.__setattr__(report.findings, "gaps", 0)
+
+    assert report.dump() == before
+    assert report_hash(EvidenceReport(payload=report, persisted=True)) == before_hash
+    assert report.success_violations() == ()
+
+
+@pytest.mark.parametrize(
+    "pick",
+    [
+        pytest.param(lambda r: r.version_canaries, id="canary-map"),
+        pytest.param(lambda r: r.source_ledger_leaf_totals, id="totals-map"),
+        pytest.param(lambda r: r.excluded_totals_by_reason, id="reason-map"),
+        pytest.param(lambda r: r.transform_identity.source_manifest, id="manifest"),
+        pytest.param(
+            lambda r: r.transform_identity.component_b_invocation.steps, id="steps"
+        ),
+        pytest.param(
+            lambda r: r.rules_corpus_vector_identity.metadata_fields, id="fields"
+        ),
+    ],
+)
+def test_no_container_in_the_tree_can_be_written(pick: Any) -> None:
+    """Every map is a ``Pairs`` and every array a tuple — neither has a setter.
+
+    A ``MappingProxyType`` would satisfy the first assertion and not the
+    reachability question behind it: a proxy is a view onto a real dictionary
+    that stays reachable through ``gc.get_referents``. There is no dictionary
+    here to reach.
+    """
+    container = pick(parsed())
+    assert isinstance(container, tuple)
+    assert not isinstance(container, list | dict)
+    with pytest.raises(TypeError):
+        container[0] = "forged"
+    with pytest.raises(AttributeError):
+        container.append("forged")
+
+
+def test_mutating_a_dump_cannot_reach_the_report() -> None:
+    """``dump()`` renders a fresh document; it does not expose internal state."""
+    report = parsed()
+    dumped = report.dump()
+    dumped["version_canaries"][VERSION_CANARIES[0].name] = False
+    dumped["source_ledger_leaf_totals"]["paragraph"] = 99
+    assert report.dump() == parsed().dump()
+    assert report.success_violations() == ()
+
+
+# ---------------------------------------------------------------------------
+# One parser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "bad"),
+    [
+        ("not-an-object", ["a", "list"]),
+        ("a-string", "5c-evidence-3"),
+        ("none", None),
+        ("extra-key", payload(unexpected_field=1)),
+        ("missing-key", {k: v for k, v in payload().items() if k != "accounting"}),
+        ("wrong-scalar-type", payload(authoritative_source_hash=64)),
+        ("true-for-a-count", payload(unresolved_leaves=True)),
+        ("string-for-a-count", payload(unresolved_leaves="0")),
+        ("float-for-a-count", payload(unresolved_leaves=0.0)),
+        ("negative-count", payload(invalid_locators=-1)),
+        ("nested-object-as-array", payload(accounting=[10, 8, 2, 0])),
+        ("nested-extra-key", payload(findings={"gaps": 0, "zz": 1})),
+        ("nested-missing-key", payload(findings={"gaps": 0})),
+        ("map-as-array", payload(represented_totals=[["paragraph", 8]])),
+        ("map-value-wrongly-typed", payload(represented_totals={"paragraph": "8"})),
+        ("flag-map-value-wrongly-typed", payload(version_canaries={"wish": 1})),
+        ("identity-replaced-wholesale", payload(transform_identity={})),
+        ("vector-identity-replaced", payload(rules_corpus_vector_identity={})),
+        ("unsupported-schema-version", payload(report_version="5c-evidence-2")),
+        ("unknown-validation-status", payload(prepublication_validation_status="ok")),
+    ],
+)
+def test_the_parser_refuses_anything_that_is_not_this_document(
+    label: str, bad: Any
+) -> None:
+    report, violations = parse_recorded_report(bad)
+    assert report is None
+    assert violations
+    # The construction-side counterpart raises on the same input: a build that
+    # cannot describe itself is a defect now, not an auditable finding later.
+    with pytest.raises(ValidationError):
+        canonical_report(bad)
+
+
+def test_a_positional_array_is_not_this_document() -> None:
+    """Pydantic's native ``NamedTuple`` handling would otherwise accept one.
+
+    The representation is a tuple tree, so without an explicit object-only guard
+    at every node a stored report could arrive as a JSON *array* — positionally
+    correct, structurally meaningless — and parse.
+    """
+    assert parse_recorded_report(list(payload().values()))[0] is None
+    assert parse_recorded_report(payload(accounting=[10, 8, 2, 0]))[0] is None
+
+
+# ---------------------------------------------------------------------------
+# Closed populations and closed domains
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "canaries"),
+    [
+        ("empty", {}),
+        ("one-missing", {c.name: True for c in VERSION_CANARIES[1:]}),
+        ("one-extra", {**{c.name: True for c in VERSION_CANARIES}, "extra": True}),
+        ("renamed", {f"{c.name}-x": True for c in VERSION_CANARIES}),
+    ],
+)
+def test_the_canary_population_is_closed(label: str, canaries: dict[str, bool]) -> None:
+    """Derived from the committed definitions, so it moves with them."""
+    assert len(VERSION_CANARIES) > 1
+    report, violations = parse_recorded_report(payload(version_canaries=canaries))
+    assert report is None
+    assert any("canonical population" in v for v in violations)
+
+
+@pytest.mark.parametrize("field", ["source_ledger_leaf_totals", "represented_totals"])
+def test_leaf_totals_may_not_name_types_outside_the_taxonomy(field: str) -> None:
+    report, violations = parse_recorded_report(payload(**{field: {"not_a_leaf": 1}}))
+    assert report is None
+    assert any("outside the taxonomy" in v for v in violations)
+
+
+def test_leaf_totals_may_be_any_subset_of_the_taxonomy() -> None:
+    """A corpus with no tables legitimately reports no ``table_cell``."""
+    assert canonical_report(payload(source_ledger_leaf_totals={}))
+    every = {leaf.value: 1 for leaf in LeafType}
+    assert canonical_report(
+        payload(
+            source_ledger_leaf_totals=every,
+            represented_totals=every,
+            excluded_totals_by_reason={},
+            accounting={
+                "inventoried_leaves": len(every),
+                "represented_leaves": len(every),
+                "excluded_leaves": 0,
+                "unresolved_leaves": 0,
+            },
+        )
+    )
+
+
+def test_exclusion_reason_codes_stay_free_strings() -> None:
+    """Reason validity is contextual: the frozen policy is not available here.
+
+    Reaching for it at parse time would create a second policy definition.
+    """
+    assert canonical_report(payload(excluded_totals_by_reason={"anything": 1}))
+
+
+# ---------------------------------------------------------------------------
+# The reproduction target
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("target", ["99.0", "3.13", "", "3.12.1"])
+def test_the_reproduction_target_is_bound_not_merely_declared(target: str) -> None:
+    """An edited-and-rehashed report cannot record a false reproduction target.
+
+    Bound on the field itself rather than compared somewhere downstream, so
+    there is no path that reads the report without the binding having held.
+    """
+    report, violations = parse_recorded_report(
+        payload(reproduction_target={"python_target": target})
+    )
+    assert report is None
+    assert any("canonical reproduction target" in v for v in violations)
+
+
+def test_the_reproduction_target_is_host_independent() -> None:
+    assert parsed().reproduction_target.python_target == PYTHON_TARGET
+
+
+# ---------------------------------------------------------------------------
+# The verdict
 # ---------------------------------------------------------------------------
 
 
 def test_a_failed_verdict_is_rejected_however_well_formed() -> None:
-    """The control the finding names: status edited to 'fail', nothing else."""
+    """The original control: status edited to 'fail', nothing else touched."""
     violations = recorded_success_violations(
         payload(prepublication_validation_status="fail")
     )
@@ -85,126 +376,165 @@ def test_a_failed_verdict_is_rejected_however_well_formed() -> None:
 
 
 @pytest.mark.parametrize(
-    "override",
+    ("label", "override"),
     [
-        pytest.param({"unresolved_leaves": 3}, id="unresolved-leaves"),
-        pytest.param({"invalid_locators": 1}, id="invalid-locators"),
-        pytest.param({"concordance_failures": 2}, id="concordance-failures"),
-        pytest.param(
-            {"findings": {"gaps": 1, "overlaps": 0, "orphans": 0, "duplications": 0}},
-            id="findings-gap",
-        ),
-        pytest.param(
-            {"findings": {"gaps": 0, "overlaps": 2, "orphans": 0, "duplications": 0}},
-            id="findings-overlap",
-        ),
-        pytest.param(
-            {"findings": {"gaps": 0, "overlaps": 0, "orphans": 1, "duplications": 0}},
-            id="findings-orphan",
-        ),
-        pytest.param(
-            {"findings": {"gaps": 0, "overlaps": 0, "orphans": 0, "duplications": 4}},
-            id="findings-duplication",
-        ),
-        pytest.param(
-            {"version_canaries": {"wish": True, "true-polymorph": False}},
-            id="failed-canary",
-        ),
-        pytest.param(
+        ("unresolved-leaves", {"unresolved_leaves": 3}),
+        ("invalid-locators", {"invalid_locators": 1}),
+        ("concordance-failures", {"concordance_failures": 2}),
+        (
+            "a-finding",
             {
-                "accounting": {
-                    "inventoried_leaves": 10,
-                    "represented_leaves": 8,
-                    "excluded_leaves": 2,
-                    "unresolved_leaves": 5,
+                "findings": {
+                    "gaps": 1,
+                    "overlaps": 0,
+                    "orphans": 0,
+                    "duplications": 0,
                 }
             },
-            id="accounting-unresolved",
         ),
-        pytest.param(
+        (
+            "an-unbalanced-equation",
             {
                 "accounting": {
-                    "inventoried_leaves": 99,
+                    "inventoried_leaves": 11,
                     "represented_leaves": 8,
                     "excluded_leaves": 2,
                     "unresolved_leaves": 0,
                 }
             },
-            id="accounting-equation-unbalanced",
         ),
     ],
 )
-def test_a_pass_verdict_over_contradictory_summaries_is_rejected(
-    override: dict[str, Any],
+def test_a_report_claiming_success_over_contradictory_summaries_is_rejected(
+    label: str, override: dict[str, Any]
 ) -> None:
-    """ "pass" is not a licence to ignore the numbers underneath it.
+    """Status "pass", numbers that say otherwise — the point of the check."""
+    assert recorded_success_violations(payload(**override))
 
-    Each payload keeps the status at ``"pass"`` and makes exactly one
-    success-bearing summary say otherwise. A verdict that survives its own
-    contradicting evidence is not a verdict.
+
+def test_a_failed_canary_is_not_a_successful_publication() -> None:
+    canaries = {c.name: True for c in VERSION_CANARIES}
+    canaries[VERSION_CANARIES[0].name] = False
+    violations = recorded_success_violations(payload(version_canaries=canaries))
+    assert any("did not pass" in v for v in violations)
+
+
+def test_unresolved_leaves_inside_the_accounting_is_also_a_failure() -> None:
+    """Both places the count appears are checked, not just the top-level one.
+
+    Distinct from the disagreement control below: here the two agree, and the
+    value they agree on is not zero.
     """
-    assert recorded_success_violations(payload(**override)) != ()
-
-
-def test_a_disagreeing_accounting_total_is_rejected() -> None:
-    """The duplicated unresolved count must agree with the top-level one."""
-    contradictory = payload(
-        unresolved_leaves=0,
-        accounting={
-            "inventoried_leaves": 10,
-            "represented_leaves": 7,
-            "excluded_leaves": 2,
-            "unresolved_leaves": 1,
-        },
+    violations = recorded_success_violations(
+        payload(
+            unresolved_leaves=2,
+            accounting={
+                "inventoried_leaves": 10,
+                "represented_leaves": 6,
+                "excluded_leaves": 2,
+                "unresolved_leaves": 2,
+            },
+        )
     )
-    violations = recorded_success_violations(contradictory)
+    assert any("accounting.unresolved_leaves is 2, not 0" in v for v in violations)
+
+
+def test_accounting_must_agree_with_the_top_level_unresolved_count() -> None:
+    violations = recorded_success_violations(
+        payload(
+            unresolved_leaves=1,
+            accounting={
+                "inventoried_leaves": 11,
+                "represented_leaves": 8,
+                "excluded_leaves": 2,
+                "unresolved_leaves": 0,
+            },
+        )
+    )
     assert any("disagrees with the top-level" in v for v in violations)
 
 
-# ---------------------------------------------------------------------------
-# Shape and type closure
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
-    "override",
-    [
-        pytest.param({"unresolved_leaves": "0"}, id="counter-as-string"),
-        pytest.param({"unresolved_leaves": True}, id="counter-as-boolean"),
-        pytest.param({"invalid_locators": None}, id="counter-as-null"),
-        pytest.param({"findings": "none"}, id="findings-as-string"),
-        pytest.param({"findings": {"gaps": "0"}}, id="finding-as-string"),
-        pytest.param({"version_canaries": []}, id="canaries-as-array"),
-        pytest.param({"version_canaries": {"wish": "yes"}}, id="canary-as-string"),
-        pytest.param({"accounting": None}, id="accounting-as-null"),
-        pytest.param(
-            {"accounting": {"inventoried_leaves": 10}}, id="accounting-incomplete"
-        ),
-    ],
+    "bad", [None, [], "text", {}, payload(accounting=None)], ids=str
 )
-def test_a_wrongly_typed_verdict_field_is_rejected(override: dict[str, Any]) -> None:
-    """A verdict cannot rest on a field whose type was never checked.
+def test_a_malformed_persisted_report_is_a_finding_not_an_exception(bad: Any) -> None:
+    """Unknown provenance: a bad stored report is auditable, never a crash."""
+    assert recorded_success_violations(bad)
 
-    ``True`` is called out separately: it is an ``int`` subclass, so a boolean
-    would otherwise read as the count ``1`` and could satisfy an equation.
+
+# ---------------------------------------------------------------------------
+# One serializer
+# ---------------------------------------------------------------------------
+
+
+def test_the_dump_round_trips_and_is_the_hashed_document() -> None:
+    report = parsed()
+    assert canonical_report(report.dump()) == report
+    assert report_hash(EvidenceReport(payload=report, persisted=True)) == sha256_hex(
+        canonical_bytes(report.dump())
+    )
+
+
+def test_serializing_the_value_directly_is_not_the_canonical_document() -> None:
+    """The hazard this representation introduces, held down by a control.
+
+    ``json.dumps`` raised ``TypeError`` on the previous dataclass. A
+    ``NamedTuple`` serializes *successfully*, as a positional array — so an
+    accidental ``canonical_bytes(report)`` would mint a wrong-but-plausible hash
+    instead of failing. Every hash, column, and comparison goes through
+    ``dump()``; this asserts the two cannot be confused.
     """
-    assert recorded_success_violations(payload(**override)) != ()
+    report = parsed()
+    assert canonical_bytes(report) != canonical_bytes(report.dump())
+    assert json.loads(canonical_bytes(report)) == json.loads(
+        json.dumps(list(report), default=list)
+    )
+    assert hash_obj(report) != report_hash(
+        EvidenceReport(payload=report, persisted=True)
+    )
 
 
-def test_a_missing_verdict_field_is_rejected() -> None:
-    incomplete = payload()
-    del incomplete["findings"]
-    violations = recorded_success_violations(incomplete)
-    assert any("missing" in v for v in violations)
+def test_maps_serialize_as_objects_even_when_empty() -> None:
+    """``Pairs`` is a type, not a heuristic over the pairs it happens to hold."""
+    dumped = canonical_report(payload(excluded_totals_by_reason={})).dump()
+    assert dumped["excluded_totals_by_reason"] == {}
+    assert isinstance(dumped["excluded_totals_by_reason"], dict)
 
 
-@pytest.mark.parametrize(
-    "value", [None, "report", 7, [], pytest.param({}, id="empty-object")]
-)
-def test_a_payload_that_is_not_this_report_is_rejected(value: object) -> None:
-    assert recorded_success_violations(value) != ()
+def test_arrays_serialize_as_arrays() -> None:
+    dumped = parsed().dump()
+    assert isinstance(dumped["transform_identity"]["source_manifest"], list)
+    assert isinstance(
+        dumped["transform_identity"]["component_b_invocation"]["steps"], list
+    )
 
 
-def test_an_obsolete_schema_version_is_rejected() -> None:
-    violations = recorded_success_violations(payload(report_version="5c-evidence-2"))
-    assert any("not the supported" in v for v in violations)
+def test_the_namedtuple_constructors_produce_new_values_never_edits() -> None:
+    """``_replace`` and ``_make`` build separate objects; they change nothing.
+
+    Worth stating because they are the two constructors a tuple tree adds. They
+    are not the escape the mutation controls above are about — neither writes to
+    an existing value — but a report they produce has bypassed the one parser
+    and is therefore not a canonical document, which is why ``build_report``
+    goes through ``canonical_report`` rather than constructing directly.
+    """
+    report = parsed()
+    before, before_hash = report.dump(), hash_obj(report.dump())
+
+    forged = report._replace(version_canaries=Pairs(()))
+    remade = CorpusEvidenceReport._make(report)
+
+    assert forged is not report
+    assert remade == report
+    assert report.dump() == before
+    assert hash_obj(report.dump()) == before_hash
+    assert report.success_violations() == ()
+    # And such a value is not something the parser would have produced.
+    assert parse_recorded_report(forged.dump())[0] is None
+
+
+def test_a_parsed_map_is_pairs_and_a_parsed_array_is_a_plain_tuple() -> None:
+    report = parsed()
+    assert isinstance(report.version_canaries, Pairs)
+    assert isinstance(report.transform_identity.source_manifest, tuple)
+    assert not isinstance(report.transform_identity.source_manifest, Pairs)

--- a/tests/ingestion/corpus/test_recorded_evidence.py
+++ b/tests/ingestion/corpus/test_recorded_evidence.py
@@ -22,20 +22,29 @@ payload, which is exactly the provenance a recorded report has when read back.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
+from afterworlds.ingestion.corpus import report as report_module
 from afterworlds.ingestion.corpus.concordance import VERSION_CANARIES
 from afterworlds.ingestion.corpus.hashing import canonical_bytes, hash_obj, sha256_hex
-from afterworlds.ingestion.corpus.models import LeafType
+from afterworlds.ingestion.corpus.models import (
+    LeafType,
+    ReconciliationFindings,
+    ReconciliationMember,
+    SourceLedger,
+)
 from afterworlds.ingestion.corpus.pdf_source import extraction_config
+from afterworlds.ingestion.corpus.policy import FROZEN_POLICY
 from afterworlds.ingestion.corpus.report import (
-    EvidenceReport,
+    REPORT_PROOF_COLUMNS,
     recorded_success_violations,
     report_hash,
+    state_derived_fields,
 )
 from afterworlds.ingestion.corpus.report_schema import (
     EVIDENCE_REPORT_SCHEMA_VERSION,
@@ -172,7 +181,7 @@ def test_a_failed_mutation_leaves_the_payload_verdict_and_hash_unchanged() -> No
     """
     report = parsed()
     before = report.dump()
-    before_hash = report_hash(EvidenceReport(payload=report, persisted=True))
+    before_hash = report_hash(report)
 
     with pytest.raises(TypeError):
         vars(report)["version_canaries"] = {}
@@ -184,7 +193,7 @@ def test_a_failed_mutation_leaves_the_payload_verdict_and_hash_unchanged() -> No
         object.__setattr__(report.findings, "gaps", 0)
 
     assert report.dump() == before
-    assert report_hash(EvidenceReport(payload=report, persisted=True)) == before_hash
+    assert report_hash(report) == before_hash
     assert report.success_violations() == ()
 
 
@@ -470,9 +479,7 @@ def test_a_malformed_persisted_report_is_a_finding_not_an_exception(bad: Any) ->
 def test_the_dump_round_trips_and_is_the_hashed_document() -> None:
     report = parsed()
     assert canonical_report(report.dump()) == report
-    assert report_hash(EvidenceReport(payload=report, persisted=True)) == sha256_hex(
-        canonical_bytes(report.dump())
-    )
+    assert report_hash(report) == sha256_hex(canonical_bytes(report.dump()))
 
 
 def test_serializing_the_value_directly_is_not_the_canonical_document() -> None:
@@ -489,9 +496,7 @@ def test_serializing_the_value_directly_is_not_the_canonical_document() -> None:
     assert json.loads(canonical_bytes(report)) == json.loads(
         json.dumps(list(report), default=list)
     )
-    assert hash_obj(report) != report_hash(
-        EvidenceReport(payload=report, persisted=True)
-    )
+    assert hash_obj(report) != report_hash(report)
 
 
 def test_maps_serialize_as_objects_even_when_empty() -> None:
@@ -507,6 +512,137 @@ def test_arrays_serialize_as_arrays() -> None:
     assert isinstance(
         dumped["transform_identity"]["component_b_invocation"]["steps"], list
     )
+
+
+def test_every_report_field_has_an_owner_and_no_field_is_uncompared() -> None:
+    """The completeness claim behind "one report-context verifier", as a test.
+
+    ``report_state_violations`` is only the single definition of report-versus-
+    state agreement if every field is actually routed somewhere. Nothing else
+    fails if a field is added to the document and not to
+    :func:`state_derived_fields` — it silently stops being compared, which is
+    precisely how coherently rewritten summaries survived before.
+
+    So the declaration is partitioned exactly three ways, with no remainder:
+    recomputed from reconstructed state, compared against a release column, or
+    on the explicit list of claims that are neither.
+    """
+    derived = set(
+        state_derived_fields(
+            ledger=SourceLedger(
+                source_document="d",
+                source_version="1",
+                source_sha256="0" * 64,
+                extraction_config={},
+                containers=(),
+                leaves=(),
+            ),
+            recon=ReconciliationMember(
+                policy_version="v",
+                policy_hash="0" * 64,
+                dispositions=(),
+                projections=(),
+                findings=ReconciliationFindings((), (), (), (), ()),
+                inventoried_leaves=0,
+                represented_leaves=0,
+                excluded_leaves=0,
+                unresolved_leaves=0,
+            ),
+            policy=FROZEN_POLICY,
+            transform_config={},
+        )
+    )
+    identities = {key for key, _ in REPORT_PROOF_COLUMNS}
+    #: Neither reconstructable from SQL nor a release column.
+    #:
+    #: - ``report_version``, ``reproduction_target`` and
+    #:   ``prepublication_validation_status`` are intrinsic: the parser refuses
+    #:   any other value, so there is nothing contextual left to compare.
+    #: - ``invalid_locators``, ``concordance_failures`` and ``version_canaries``
+    #:   are measured against the authoritative PDF, which SQL cannot reproduce.
+    #:   They keep their recorded-successful-form treatment under the
+    #:   2026-08-01 Owner Decision, and the paths holding pages re-run them.
+    neither = {
+        "report_version",
+        "reproduction_target",
+        "prepublication_validation_status",
+        "invalid_locators",
+        "concordance_failures",
+        "version_canaries",
+    }
+    fields = set(CorpusEvidenceReport._fields)
+    assert derived & identities == set()
+    assert derived & neither == set()
+    assert identities & neither == set()
+    assert derived | identities | neither == fields
+
+
+def test_the_evidence_report_name_is_the_canonical_class_not_a_wrapper() -> None:
+    """``EvidenceReport`` survives as a name only — the same class object.
+
+    A frozen ``EvidenceReport`` dataclass used to hold the canonical payload and
+    *be* the hash-bearing authority, so ``object.__setattr__(report, "payload",
+    forged)`` replaced the whole document after construction while the tuple
+    tree inside stayed perfectly immutable. It protected the wrong thing.
+
+    The name is retained because ``pipeline.py`` imports it and that module's
+    source bytes are bound into the transform identity: retyping an annotation
+    there would remint the package UUID and release version over a
+    post-persistence plumbing edit. So this asserts the name resolves to the
+    canonical class *itself* — not a subclass, not an adapter, nothing with a
+    ``payload`` to substitute.
+    """
+    assert report_module.EvidenceReport is CorpusEvidenceReport
+    assert not dataclasses.is_dataclass(report_module.EvidenceReport)
+    assert not hasattr(report_module.EvidenceReport, "payload")
+    assert not hasattr(report_module.EvidenceReport, "persisted")
+    assert "payload" not in CorpusEvidenceReport._fields
+    assert "persisted" not in CorpusEvidenceReport._fields
+    # ``report_hash`` takes the canonical value; ``test_ledger_pipeline`` proves
+    # ``build_report`` returns one, over a real release.
+    assert report_hash(parsed()) == hash_obj(parsed().dump())
+
+
+def test_the_original_wrapper_attack_has_no_field_to_target() -> None:
+    """The exact escape from the previous round, run against the new design.
+
+    ``object.__setattr__(completed_report, "payload", forged_payload)`` used to
+    succeed and replace the document consumed by ``dump()``, ``report_hash()``,
+    persistence, and the gate. It fails now for the strongest available reason:
+    there is no ``payload`` field, on a type with no writable storage at all.
+    """
+    report = parsed()
+    forged = parsed(declared_projection_count=99)
+    before, before_hash = report.dump(), report_hash(report)
+
+    with pytest.raises(AttributeError):
+        object.__setattr__(report, "payload", forged)
+    with pytest.raises(AttributeError):
+        object.__setattr__(report, "persisted", False)
+
+    assert report.dump() == before
+    assert report_hash(report) == before_hash
+
+
+def test_nothing_can_substitute_a_payload_between_construction_and_hashing() -> None:
+    """The report handed to the hash is the one that was built.
+
+    With a wrapper, "the report" and "the payload it carries" were two objects
+    and only the inner one was safe. They are the same object now, so the only
+    way to change what gets hashed is to change the canonical value — which
+    every control above shows is impossible.
+    """
+    report = parsed()
+    before = report_hash(report)
+    forged = parsed(declared_projection_count=99)
+    assert report_hash(forged) != before
+
+    with pytest.raises(AttributeError):
+        object.__setattr__(report, "declared_projection_count", 99)
+    for field in CorpusEvidenceReport._fields:
+        with pytest.raises(AttributeError):
+            object.__setattr__(report, field, getattr(forged, field))
+    assert report_hash(report) == before
 
 
 def test_the_namedtuple_constructors_produce_new_values_never_edits() -> None:

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -65,15 +65,11 @@ from afterworlds.ingestion.corpus.policy import (
     FROZEN_POLICY,
     policy_hash,
 )
-from afterworlds.ingestion.corpus.report import (
-    EvidenceReport as CorpusEvidenceReport,
-)
-from afterworlds.ingestion.corpus.report import (
-    build_report,
-)
+from afterworlds.ingestion.corpus.report import build_report
 from afterworlds.ingestion.corpus.report import (
     report_hash as corpus_report_hash,
 )
+from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
 from afterworlds.ingestion.mechanical.accounting import batch_diff_hash, derive_span_id
 from afterworlds.ingestion.mechanical.bound_corpus import (
     BoundCorpusSnapshot,
@@ -317,7 +313,6 @@ def _build_bound_report(
             content_failures=(),
         ),
         canaries=BOUND_CANARIES,
-        persisted=True,
     )
 
 

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -27,8 +27,17 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from afterworlds.ingestion.corpus.bundle import build_bundle, reconciliation_hash
-from afterworlds.ingestion.corpus.concordance import ConcordanceResult
+from afterworlds.ingestion.corpus.bundle import (
+    build_bundle,
+    reconciliation_hash,
+    transform_config_payload,
+)
+from afterworlds.ingestion.corpus.concordance import (
+    VERSION_CANARIES,
+    CanaryResult,
+    ConcordanceResult,
+)
+from afterworlds.ingestion.corpus.hashing import hash_obj
 from afterworlds.ingestion.corpus.ledger import ledger_hash
 from afterworlds.ingestion.corpus.models import (
     CorpusBundleMembers,
@@ -42,6 +51,7 @@ from afterworlds.ingestion.corpus.models import (
     ReconciliationMember,
     SourceLedger,
 )
+from afterworlds.ingestion.corpus.pdf_source import extraction_config
 from afterworlds.ingestion.corpus.persistence import (
     _load_ledger,
     _load_members,
@@ -54,10 +64,6 @@ from afterworlds.ingestion.corpus.persistence import (
 from afterworlds.ingestion.corpus.policy import (
     FROZEN_POLICY,
     policy_hash,
-    policy_payload,
-)
-from afterworlds.ingestion.corpus.report import (
-    EVIDENCE_REPORT_SCHEMA_VERSION as CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
 )
 from afterworlds.ingestion.corpus.report import (
     EvidenceReport as CorpusEvidenceReport,
@@ -115,10 +121,12 @@ from afterworlds.ingestion.mechanical.representation import (
     reference_target_key,
     relationship_target_key,
 )
+from afterworlds.models.retrieval import rules_corpus_vector_identity
 from afterworlds.persistence.database import create_engine, create_session_factory
 from afterworlds.persistence.orm.base import Base
 from afterworlds.persistence.orm.corpus import CorpusReleaseORM
 from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.pipeline.retrieval.config import RetrievalMemoryConfig
 
 NOW = "2026-07-31T00:00:00Z"
 DATA_DIR = Path(__file__).resolve().parent / "data"
@@ -177,7 +185,6 @@ DEFAULT_COVERAGE = (
 
 SOURCE_DOCUMENT = "D&D SRD 5.2.1"
 AUTHORITATIVE_SOURCE_HASH = "a" * 64
-TRANSFORM_CONFIG_HASH = "b" * 64
 #: Opaque here on purpose: the persisted-corpus digest binds the actual
 #: read-back vector state as well as SQL, so it is an exact recorded value the
 #: 5d gate checks rather than one it can recompute from a session.
@@ -255,10 +262,34 @@ BOUND_RECONCILIATION = ReconciliationMember(
 
 BOUND_BUNDLE = build_bundle(BOUND_LEDGER, BOUND_MEMBERS, BOUND_RECONCILIATION)
 
-BOUND_TRANSFORM_CONFIG: dict[str, object] = {
-    "reconciliation_policy": policy_payload(FROZEN_POLICY),
-    "evidence_report_schema_version": CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
-}
+#: Built by 5c's own :func:`transform_config_payload`, not hand-written. The
+#: recorded configuration is now proven to hash to the recorded
+#: ``transform_config_hash``, so a thin stand-in would be exactly the forgery the
+#: negative controls exist to catch.
+BOUND_TRANSFORM_CONFIG: dict[str, object] = transform_config_payload(
+    extraction_config(),
+    FROZEN_POLICY,
+    rules_corpus_vector_identity(RetrievalMemoryConfig().embedding_model_id),
+)
+#: **Derived**, never declared. Its predecessor was the constant ``"b" * 64``,
+#: chosen when nothing recomputed it; under the published-release closure that
+#: constant is a release whose configuration does not hash to its own recorded
+#: hash — a forgery, correctly refused.
+TRANSFORM_CONFIG_HASH = hash_obj(BOUND_TRANSFORM_CONFIG)
+
+#: The full canonical canary population, derived from the committed definitions
+#: rather than listed here, all passing. The bounded release is a *successful*
+#: publication; an empty canary run is not one.
+BOUND_CANARIES = tuple(
+    CanaryResult(
+        name=canary.name,
+        printed_page=canary.printed_page,
+        passed=True,
+        missing=(),
+        unexpected=(),
+    )
+    for canary in VERSION_CANARIES
+)
 
 
 def _build_bound_report(
@@ -285,7 +316,7 @@ def _build_bound_report(
             locator_failures=(),
             content_failures=(),
         ),
-        canaries=(),
+        canaries=BOUND_CANARIES,
         persisted=True,
     )
 
@@ -706,7 +737,7 @@ def rerecord_release_proof(session: Session) -> None:
         recon=recon,
         bundle_root_hash=bundle.bundle_root_hash,
     )
-    release.report_payload = report.payload
+    release.report_payload = report.dump()
     release.evidence_report_hash = corpus_report_hash(report)
     release.corpus_report_reference = release.evidence_report_hash
     session.flush()
@@ -739,7 +770,7 @@ def _seed_bound_release(session: Session) -> None:
         reconciliation_hash=reconciliation_hash(BOUND_RECONCILIATION),
         corpus_report_reference=BOUND_EVIDENCE_REPORT_HASH,
         transform_config=BOUND_TRANSFORM_CONFIG,
-        report_payload=BOUND_REPORT.payload,
+        report_payload=BOUND_REPORT.dump(),
         now=NOW,
     )
     _persist_bundle_rows(

--- a/tests/ingestion/mechanical/data/bounded_oracle.json
+++ b/tests/ingestion/mechanical/data/bounded_oracle.json
@@ -3,7 +3,7 @@
     "package_uuid": "pkg-5c",
     "release_version": "rel-5c",
     "authoritative_source_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "transform_config_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "transform_config_hash": "77720c2f3b8c9b88363d48050466fb8e3a26f8476b63145d1b5928ff2581ef3e",
     "bundle_root_hash": "5f4471769d7ebf6650c3d07ba0093803b3032e71c4ebd5a4039da0aac372bbfd",
     "persisted_corpus_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
   },

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -762,6 +762,47 @@ def test_a_fabricated_binding_both_sides_agree_on_still_fails(
             lambda s: _coordinated_transform_edit(s, "evidence_report_schema_version"),
             id="transform-config-and-report-edited-together",
         ),
+        # --- the report describes a corpus other than the persisted one ------
+        # Each rewrite is internally successful and fully rehashed, so every
+        # comparison among *recorded* values still agrees. Only recomputing the
+        # claim from the reconstructed ledger and reconciliation catches it.
+        pytest.param(
+            lambda s: _rewrite_release_report(s, declared_projection_count=99),
+            id="report-declares-a-projection-count-the-corpus-does-not-have",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(
+                s, source_ledger_leaf_totals={"paragraph": 1}
+            ),
+            id="report-states-leaf-totals-the-ledger-does-not-have",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(s, represented_totals={"paragraph": 1}),
+            id="report-states-represented-totals-reconciliation-does-not-have",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(
+                s,
+                accounting={
+                    "inventoried_leaves": 4,
+                    "represented_leaves": 3,
+                    "excluded_leaves": 1,
+                    "unresolved_leaves": 0,
+                },
+            ),
+            id="report-states-accounting-the-corpus-does-not-support",
+        ),
+        pytest.param(
+            lambda s: _rewrite_release_report(
+                s,
+                reconciliation_policy_reference={
+                    "policy_version": "forged",
+                    "policy_hash": "1" * 64,
+                    "applied_policy_hash": "1" * 64,
+                },
+            ),
+            id="report-names-a-policy-the-reconstruction-did-not-apply",
+        ),
     ],
 )
 def test_an_unpublishable_5c_release_fails_even_when_everything_agrees(

--- a/tests/ingestion/mechanical/test_publication.py
+++ b/tests/ingestion/mechanical/test_publication.py
@@ -19,16 +19,9 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from afterworlds.ingestion.corpus.report import (
-    REQUIRED_REPORT_KEYS,
-    recorded_success_violations,
-)
-from afterworlds.ingestion.corpus.report import (
-    EvidenceReport as CorpusEvidenceReport,
-)
-from afterworlds.ingestion.corpus.report import (
-    report_hash as corpus_report_hash,
-)
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.corpus.report import recorded_success_violations
+from afterworlds.ingestion.corpus.report_schema import CorpusEvidenceReport
 from afterworlds.ingestion.mechanical import publication
 from afterworlds.ingestion.mechanical.gate import (
     GateFailureCategory,
@@ -628,21 +621,49 @@ def _rewrite_release_report(session: Session, **overrides: object) -> None:
     payload = dict(release.report_payload or {})
     payload.update(overrides)
     release.report_payload = payload
-    release.evidence_report_hash = corpus_report_hash(
-        CorpusEvidenceReport(payload=payload, persisted=True)
-    )
+    # Hashed as raw stored bytes, not through the canonical serializer: the
+    # point of these controls is a database row someone edited and rehashed, and
+    # some of them are deliberately no longer this schema at all.
+    release.evidence_report_hash = hash_obj(payload)
     release.corpus_report_reference = release.evidence_report_hash
+
+
+def _stale_report_reference(session: Session) -> None:
+    """Point the reference at a real report — the *previous* one.
+
+    Harder than a null or a random hash: the reference still names a report
+    that genuinely existed, so only comparing it with the release's own
+    ``evidence_report_hash`` catches it.
+    """
+    release = release_row(session)
+    stale = release.evidence_report_hash
+    _rewrite_release_report(session, declared_projection_count=99)
+    release.corpus_report_reference = stale
+
+
+def _coordinated_transform_edit(session: Session, key: str) -> None:
+    """Edit the stored transform configuration *and* agree the report with it.
+
+    The report is rehashed and its reference updated, so the two documents agree
+    with each other perfectly. Only recomputing the configuration's own hash
+    against the recorded ``transform_config_hash`` catches it — which is the
+    invariant this control exists for.
+    """
+    release = release_row(session)
+    config = dict(release.transform_config)
+    config[key] = "forged"
+    release.transform_config = config
 
 
 def test_the_bounded_release_report_is_a_successful_5c_verdict() -> None:
     """The fixture's report is a real ``build_report`` output, and it passes.
 
-    Also a drift guard: if ``build_report`` gains or renames a key without
-    ``REQUIRED_REPORT_KEYS`` following, this fails rather than quietly letting
-    the recorded-verdict check stop covering the new field.
+    Also a drift guard, now against the schema rather than a parallel key list:
+    the emitted document's keys are exactly the canonical declaration's fields,
+    so a field added to one and not the other fails here.
     """
-    assert set(BOUND_REPORT.payload) == REQUIRED_REPORT_KEYS
-    assert recorded_success_violations(BOUND_REPORT.payload) == ()
+    assert set(BOUND_REPORT.dump()) == set(CorpusEvidenceReport._fields)
+    assert recorded_success_violations(BOUND_REPORT.dump()) == ()
 
 
 def test_a_fabricated_binding_both_sides_agree_on_still_fails(
@@ -715,6 +736,31 @@ def test_a_fabricated_binding_both_sides_agree_on_still_fails(
         pytest.param(
             lambda s: _rewrite_release_report(s, concordance_failures=1),
             id="release-evidence-claims-pass-over-concordance-failures",
+        ),
+        # --- the package/release *pair*, not either row alone ----------------
+        pytest.param(
+            lambda s: setattr(package_row(s), "published_at", None),
+            id="package-records-no-published_at",
+        ),
+        pytest.param(
+            lambda s: setattr(package_row(s), "version", "rel-forged"),
+            id="package-version-edited-away-from-the-release",
+        ),
+        pytest.param(
+            lambda s: setattr(release_row(s), "corpus_report_reference", None),
+            id="report-reference-cleared",
+        ),
+        pytest.param(
+            lambda s: setattr(release_row(s), "corpus_report_reference", "9" * 64),
+            id="report-reference-names-an-unrelated-report",
+        ),
+        pytest.param(
+            _stale_report_reference,
+            id="report-reference-names-the-previous-report",
+        ),
+        pytest.param(
+            lambda s: _coordinated_transform_edit(s, "evidence_report_schema_version"),
+            id="transform-config-and-report-edited-together",
         ),
     ],
 )


### PR DESCRIPTION
Replaces #142, which was frozen after its hard stop fired and closed as superseded. Based directly on `feature/issue-5d-publication-gate` at `b35386c`; **no implementation commit from #142 is cherry-picked.** That branch is used only as a defect catalogue, a source of adversarial controls, and the record of two rejected representations.

## Why a replacement rather than a fifth round

Four rounds on #142 replaced the representation and then the closure, and the same defect family escaped each replacement:

| Round | What was replaced | Escape |
| --- | --- | --- |
| 1–2 | Hand-maintained key inventories beside a dict-literal builder | Two definitions of one document |
| 3 | Frozen Pydantic `BaseModel` | `vars(report)[...] = {}` reached past the freeze |
| 4 | Frozen **slotted** Pydantic dataclass | `object.__setattr__(report, ...)` overwrites slot storage |
| 4 | Recorded-release closure at one seam | Reuse never called it; the field audit's unit was the row, not the pair |

Both representations were *conventionally* frozen — immutability enforced by a setter that a lower-level setter bypasses. Both closures were a function one caller happened to call. The two corrections below are structural in the first case and shared in the second.

## Boundary A — canonical report authority

`CorpusEvidenceReport` and every nested type is a `NamedTuple`; arrays are tuples; maps are `Pairs`, a `tuple` subclass of sorted key/value pairs. A `NamedTuple` keeps its values in the tuple itself: no instance dictionary, no slot descriptor, nothing for any setter to reach. Immutability is a property of the storage rather than of a guard.

`Pairs` is chosen over `MappingProxyType` for the same reason a proxy is not enough: a proxy is a *view* onto a real dictionary that stays reachable through `gc.get_referents`. A pair tuple has no backing dictionary at all.

Spike results, run before implementation:

| Candidate | `object.__setattr__` | `vars()` | `__dict__` |
| --- | --- | --- | --- |
| Frozen `BaseModel` | writes | writes | present |
| Frozen + slotted dataclass (#142 head) | **writes** | raises | absent |
| `NamedTuple` | raises | raises | absent |
| `tuple` subclass | raises | raises | absent |

**One parser.** A single `TypeAdapter`. Pydantic validates ingress and never holds the value: strict per-scalar aliases (`true` is not an integer, `"0"` is not an integer), `BeforeValidator` requiring a JSON *object* at every node, `AfterValidator` for the closed canary population, the leaf-type domain, the canonical `report_version`, and the canonical `python_target`.

**One construction path.** `build_report` assembles a plain dict and hands it to `canonical_report(...)`. This matters more than it did before: a `NamedTuple` constructor runs no validators, so direct construction is deliberately never a production path.

**No completed-report wrapper.** `build_report` returns `CorpusEvidenceReport`; `report_hash` takes one; `ReleaseArtifacts.report` carries one. An earlier design wrapped the payload in a frozen dataclass alongside a caller-supplied `persisted` flag, and that wrapper — not the payload — was the hash-bearing authority, so `object.__setattr__(report, "payload", forged)` replaced the whole document. Both the flag and `build_report`'s `persisted` parameter are deleted; that the report postdates persistence is structural, since gate condition 17 recomputes `persisted_corpus_digest` over reconstructed state and `ReleaseArtifacts` has exactly two construction sites, both post-reconstruction.

**`EvidenceReport` is retained as a runtime alias** of the canonical class — `EvidenceReport is CorpusEvidenceReport`, no `payload`, no `persisted`, no alternate serializer. `pipeline.py` imports that name and its source bytes are bound into the transform identity, so retyping the annotation would remint the package UUID and release version over post-persistence plumbing. The alias keeps that audited module byte-identical while leaving one report representation in the system.

**One serializer.** `dump()` walks the tree and reads field names off the declaration, so it cannot drift from it. Every hash, the SQL column, stored-hash verification, contextual comparison, and reuse reconstruction read it.

**A hazard this representation introduces, and its control.** `json.dumps` raised `TypeError` on the previous dataclass. A `NamedTuple` serializes *successfully*, as a positional array — so an accidental `canonical_bytes(report)` would mint a wrong-but-plausible hash rather than failing. A control asserts the raw object's canonical bytes differ from the payload's and that the two hashes are distinguishable. Pydantic's own `dump_python` is unusable here for the same reason, which is why the serializer is a small explicit walk.

## Boundary B — published-release authority

Two named concepts, because one name was overclaiming. **`load_recorded_release_pair`** proves the recorded rows are internally closed — existence, statuses, enablement, `published_at`, `package.version == release.release_version`, the four post-persistence columns as a set, `hash_obj(transform_config) == transform_config_hash`, the report parsing and hashing to `evidence_report_hash`, `corpus_report_reference == evidence_report_hash`, proof-column equality, schema version, self-contained verdict. Its unit is the **pair**, not either row. It is necessary and explicitly not sufficient: everything it proves is a relationship among *recorded values*, so a report whose totals, accounting, and projection count were rewritten to different but internally successful values, rehashed, and re-referenced satisfies all of it.

**`load_verified_published_release`** is the seam a lifecycle may act on: recorded closure, then policy/ledger/reconciliation/member/source reconstruction, reconstruction identity checks, report-versus-reconstructed-state verification, and membership verification. It returns the reconstruction it proved — including the membership violations it measured — so no caller loads a second independently-trusted copy or defaults its publication evidence.

**One report-context verifier.** `report_state_violations` takes one `report.dump()`, serializes no nested fragment independently, and recomputes the SQL-reconstructable claims through `state_derived_fields` — the same function `build_report` emits them from. A drift guard partitions the 21 declared fields exactly into 10 recomputed from state, 5 compared against release columns, and 6 that are neither, with no remainder, so a new field cannot silently stop being compared.

**Every caller:**

| Caller | Why |
| --- | --- |
| `verify_published_release` — downstream 5d entry, reached from `mechanical/gate.py` step 0 | Proves published authority before comparing 5d's six declared values against it |
| `_finalize_core` verified reuse | A release refused downstream cannot be returned as `published=True, reused=True`; proves *before* reconstructing, so artifacts are never assembled around unaccepted rows |
| `_finalize_core` fresh publication, after the status writes and before `commit()` | The same proof gates a fresh success; failing rolls back rather than committing a release the seam would later refuse |

`run_gate` calls `report_state_violations` too, because a fresh publication has no proven release to load yet. Reuse therefore runs it twice — accepted redundancy, deliberately preferred over giving one caller its own copy of the comparison.

Reuse now proves the pair **before** reconstructing rather than after, so artifacts are never assembled around rows nothing has accepted. `_reconstruct_artifacts` refuses missing post-persistence columns with a typed error instead of a bare `assert` (an `assert` disappears under `-O`).

Two `PersistedReportError` raises inside `_reconstruct_artifacts` became unreachable as a result and are marked `# pragma: no cover`; they stay as backstops because assembling artifacts around a half-written release would produce something that looks whole. The `PolicyReconstructionError` half of the surrounding `except` remains live — the seam does not call `_load_policy`, so a deleted policy row still lands there.

`policy_hash` is deliberately not re-verified in the seam: `_load_policy` already validates a closed cross-reference chain across the policy, reconciliation, and release rows and fails closed. A second statement of it would be the two-definitions defect again.

## Acceptance coverage

**Representation** — a build that cannot describe itself fails at *build* time, not only when someone reads it back: `build_report` routes through the one parser, which is what makes construction validated at all when a `NamedTuple` constructor runs none. Then: `vars()` and `object.__setattr__` (existing field, novel field, plain `setattr`) all fail at the root and at all nine nested values; every map, array, manifest, and identity container refuses item assignment and `append`; a failed mutation leaves payload, verdict, and hash unchanged; a mutated `dump()` cannot reach the report; 20 parser-refusal cases; a positional array is refused; one serializer proven by construction and by the direct-serialization control.

**Lifecycle closure** — 16 tamper controls, each asserted against **both** paths in one parametrisation, so an invariant cannot be added to one caller alone: package `published_at` cleared, package unpublished, package disabled, `rp_packages.version` edited away from the release, release unpublished, coordinated transform-config edit, each post-persistence column cleared, report reference cleared / unrelated / naming the *previous* report, report not hashing to its recorded hash, report identity disagreeing with its column, failed verdict, and pass-over-unresolved-leaves. Honest fresh publication and honest verified reuse pass the same seam on the complete corpus. Six new `BOUND_RELEASE` controls propagate through mechanical publication as `STALE`.

**Fresh publication** — driven by fault injection rather than a positive assertion, because the other two callers can be exercised by editing rows *after* publication while this one has to be made to write a bad pair while it runs. A monkeypatched `_persist_package_and_source` writes a package version the release does not carry; the control asserts the refusal **and** that no published package or release row survives, which is the rollback rather than merely the verdict.

**Ported from #142** — canary population, verdict semantics, identity-map shape, variable-map shape and count domains, reproduction target, serialization and hashing, contextual comparisons, malformed persisted reports. Controls that only asserted an intermediate implementation detail were left behind; `test_report_schema_ok_fails_closed_on_bad_schema` was rewritten because its raw-dictionary cases now belong to the parse boundary, which is stated in its docstring.

## Test evidence

Parity against clean base `b35386c` — the untyped dict-based report — on identical deterministic inputs: `diff` produced **no output** across the complete payload, `report_hash`, `package_uuid`, `release_version`, `transform_config_hash`, and `bundle_root_hash`. All **eleven** `TRANSFORM_SOURCE_MODULES` entries hash identically, `pipeline.py` is byte-identical (`git diff --exit-code` clean, SHA-256 `f0af4fdb…` matching the base manifest entry), and `transform_source_hash` is unchanged. `5c-evidence-3` stands.

An intermediate local implementation retyped `ReleaseArtifacts.report` in `pipeline.py` and thereby reminted the release — a whole-file-hash side effect of an audited module, not a transform change, since the canonical payload was byte-identical throughout. **It was not pushed.** The runtime alias removes the remint.

Black, Ruff, `mypy --strict` (211 source files) clean. Ingestion 875 passed (75 typed-schema, 24 published-release seam). Full default suite at head `2ef72ae`: **3191 passed, 10 skipped, 93.55%**. Coverage on the changed modules: `report_schema.py` 100%, `report.py` 100%, `persistence.py` 99% — its three remaining lines are pre-existing, `delete_release` among them.

The bounded mechanical fixture declared `transform_config_hash = "b" * 64`, which is not the hash of its own configuration — a synthetic constant chosen when nothing recomputed it, and a forgery under the recorded-transform-hash invariant. It is derived now and `bounded_oracle.json` regenerated.

**No CI runs on this stacked PR** — `ci.yml` triggers only on `pull_request` targeting `main`. Unchanged deliberately; CI covers the merged result when #141 runs against `main`.

## Architecture Notes

No drift from design principles. Invariant 11 (operational state reconstructable from explicit records) is the one being closed rather than deviated from: a published release is now provable from its persisted rows through a single seam that every lifecycle path calls, and the evidence report is a structurally immutable value with one parser and one serializer.

No Owner Decision, ADR amendment, Issue amendment, or schema-version decision applies. Every invariant in the seam is one `run_gate` already defines; the implementation is being brought into agreement with existing 5c publication semantics. The 2026-08-01 Owner Decision on the persisted-corpus digest is unchanged and Chroma is not reopened — the digest is verified as an exact recorded value, its cross-store half still provable only by `finalize_release`.

Construction plan, spike evidence, all three callers, and the package/release field disposition table: [`.claude/review-notes/pr-143-issue-5c-release-proof-plan.md`](.claude/review-notes/pr-143-issue-5c-release-proof-plan.md).

CRD Issue 5c / #137. Draft and unmerged, targeting `feature/issue-5d-publication-gate`; #141 remains paused and unmerged.
