### PR TITLE
fix(corpus): align 5c code with operational reliability

### DIFF
--- a/alembic/versions/0022_corpus_operational_contract.py
+++ b/alembic/versions/0022_corpus_operational_contract.py
@@ -1,0 +1,35 @@
+"""Add the versioned operational corpus trust seam — CRD Issue 5c (#145).
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-08-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0022"
+down_revision: str | None = "0021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("rp_corpus_releases") as batch:
+        batch.add_column(
+            sa.Column("corpus_contract_version", sa.String(64), nullable=True)
+        )
+        batch.add_column(
+            sa.Column("operational_corpus_digest", sa.String(64), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("rp_corpus_releases") as batch:
+        batch.drop_column("operational_corpus_digest")
+        batch.drop_column("corpus_contract_version")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,9 @@ dependencies = [
     "openai>=1.0",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    # SRD corpus transform (CRD Issue 5c). Pinned exactly: the corpus release is
-    # byte-for-byte reproducible only against a fixed extractor version. The
-    # transform records these identities (Component B); bumping either version is
-    # a transform-config change that yields a new draft release (Component A).
+    # SRD corpus transform (CRD Issue 5c). Pinning the extractor protects
+    # operationally meaningful extraction behavior. Deliberate compatibility
+    # changes bump the semantic transform version and yield a new draft release.
     "pdfplumber==0.11.10",
     "pdfminer.six==20260107",
 ]

--- a/src/afterworlds/ingestion/corpus/bundle.py
+++ b/src/afterworlds/ingestion/corpus/bundle.py
@@ -1,7 +1,7 @@
 """Canonical bundle, persisted-corpus digest, transform identity — Issue 5c.
 
-Components K (bundle root), A (five top-level identities and the persisted-corpus
-digest), and B (transform source/configuration hash covering the frozen policy).
+The module retains the historical v1 bundle and identity shape while applying
+the operational-reliability amendment's semantic compatibility boundary.
 
 The bundle-root hash covers the frozen ledger, the canonical corpus members, the
 reconciliation member, and the ordered bundle-member manifest — and excludes
@@ -23,11 +23,14 @@ from afterworlds.ingestion.corpus.models import (
     SourceLedger,
 )
 from afterworlds.ingestion.corpus.policy import policy_hash, policy_payload
-from afterworlds.ingestion.corpus.report import EVIDENCE_REPORT_SCHEMA_VERSION
 from afterworlds.ingestion.corpus.table_inventory import committed_inventory_hash
 from afterworlds.ingestion.corpus.transform_identity import transform_identity
 
 RELEASE_VERSION_PREFIX = "5.2.1-corpus"
+# Historical v1 key/value retained so the approved logical corpus keeps its
+# existing package identity.  It is no longer coupled to the current diagnostic
+# evidence-report schema; report evolution is not a corpus compatibility change.
+_V1_REPORT_IDENTITY_COMPATIBILITY = "5c-evidence-3"
 
 
 # ---------------------------------------------------------------------------
@@ -42,11 +45,10 @@ def transform_config_payload(
 ) -> dict[str, object]:
     """The committed transform inputs (Component B).
 
-    The extractor config and frozen policy alone do not capture a change to the
-    first-party transform *code* (segmentation, chunk generation, canonical
-    identity derivation). ``transform_identity`` binds a source manifest over the
-    audited first-party modules, so any covered code change moves this payload's
-    hash — hence the package UUID and release version (PR #134 P1).
+    ``transform_identity`` records the explicit semantic transform version.
+    Incidental source edits do not move this payload; a reviewed change to
+    extraction, segmentation, canonical corpus content, provenance, or consumer
+    compatibility must deliberately bump that version.
 
     ``vector_identity`` binds the identity-bearing rules-corpus vector
     configuration (embedding model + logical schema/ID/metadata contract, see
@@ -61,14 +63,9 @@ def transform_config_payload(
     (regenerating the inventory after a reviewed table-reconstruction change)
     mints a new immutable release (PR #134 R15 F4).
 
-    ``evidence_report_schema_version`` binds the canonical evidence-report schema
-    version (Component H). The evidence-report hash is a post-persistence proof
-    identity, so a *schema* change (e.g. the R16 ``reproduction_environment`` →
-    ``reproduction_target`` shape change) must mint a new immutable release rather
-    than being validated-and-reused under a predecessor's identity — otherwise
-    reuse loads the obsolete-shape stored report and accepts it (PR #134 R17). An
-    explicit version (not a byte-level hash of ``report.py``) is bound so only an
-    intentional schema change remints, never a comment/logging edit.
+    ``evidence_report_schema_version`` is retained at its v1 value for identity
+    compatibility with the already approved logical corpus.  The key is legacy
+    identity metadata, not the version of the current diagnostic report.
     """
     return {
         "extraction_config": extraction_config,
@@ -76,7 +73,7 @@ def transform_config_payload(
         "transform_identity": transform_identity(),
         "rules_corpus_vector_identity": vector_identity,
         "expected_table_inventory_hash": committed_inventory_hash(),
-        "evidence_report_schema_version": EVIDENCE_REPORT_SCHEMA_VERSION,
+        "evidence_report_schema_version": _V1_REPORT_IDENTITY_COMPATIBILITY,
     }
 
 

--- a/src/afterworlds/ingestion/corpus/gate.py
+++ b/src/afterworlds/ingestion/corpus/gate.py
@@ -58,6 +58,7 @@ class PublicationEvidence:
     chunk_membership_violations: int
     source_membership_violations: int
     vector_verification_failures: tuple[str, ...]
+    operational_integrity_failures: tuple[str, ...] = ()
 
 
 def run_gate(
@@ -291,6 +292,12 @@ def run_gate(
     #     structural count.
     if evidence.source_membership_violations != 0:
         f.append("persisted source-membership invariant violation present")
+
+    # 24. The direct, versioned SQLite corpus surface consumed by downstream 5d
+    #     is closed and internally reachable.  This is operational integrity,
+    #     not a replay of the historical publication proof.
+    for violation in evidence.operational_integrity_failures:
+        f.append(f"operational corpus: {violation}")
 
     return GateResult(passed=not f, failures=tuple(f))
 

--- a/src/afterworlds/ingestion/corpus/hashing.py
+++ b/src/afterworlds/ingestion/corpus/hashing.py
@@ -1,7 +1,6 @@
 """Deterministic hashing and content-derived identity — CRD Issue 5c.
 
-Completion Contract A requires byte-for-byte reproducibility (Component K) and
-proof identities that are stable across clean checkouts (Component A). Every
+Issue 5c requires substantive reproducibility and stable release identities. Every
 identifier and every hash in the corpus pipeline is derived from content, never
 from wall-clock time or ``uuid4()``. This module is the single source of truth
 for how bytes become hashes and how content becomes UUIDs.

--- a/src/afterworlds/ingestion/corpus/operational.py
+++ b/src/afterworlds/ingestion/corpus/operational.py
@@ -1,0 +1,431 @@
+"""Narrow operational corpus contract consumed by CRD Issue 5d.
+
+This module is the downstream trust seam established by CRD Issue 5c's
+2026-08-03 operational-reliability amendment.  It verifies the exact SQLite
+state that 5d consumes without replaying 5c's publication history and without
+opening ChromaDB.
+
+The operational digest covers represented source leaves, authoritative chunks,
+their source membership, and the projection edges connecting them.  Ledgers,
+reconciliation policy, bundle genealogy, and the diagnostic evidence report
+remain 5c-internal publication machinery and are deliberately outside this
+downstream contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.persistence.orm.corpus import (
+    CorpusProjectionORM,
+    CorpusReleaseORM,
+    LedgerLeafORM,
+    SourceLedgerORM,
+)
+from afterworlds.persistence.orm.rules_package import (
+    RuleChunkORM,
+    RuleSourceORM,
+    RulesPackageORM,
+)
+
+CORPUS_CONTRACT_VERSION = "5c-operational-1"
+
+
+class OperationalCorpusVerificationError(RuntimeError):
+    """Raised when a release cannot be trusted through the operational seam."""
+
+    def __init__(self, violations: tuple[str, ...]) -> None:
+        super().__init__("; ".join(violations))
+        self.violations = violations
+
+
+@dataclass(frozen=True)
+class OperationalSource:
+    source_id: str
+    rules_package_id: str
+    name: str
+    category: str
+    precedence_rank: int
+    is_enabled: bool
+
+
+@dataclass(frozen=True)
+class OperationalLeaf:
+    leaf_id: str
+    printed_page: int
+    page_index: int
+    leaf_type: str
+    content: str
+    char_start: int
+    char_end: int
+    occurrence_index: int
+    container_path: tuple[str, ...]
+    table_id: str | None
+    table_row: int | None
+    table_col: int | None
+    table_segment: int | None
+
+
+@dataclass(frozen=True)
+class OperationalChunk:
+    chunk_id: str
+    source_id: str
+    subsystem: str
+    content: str
+    source_document: str
+    source_locator_type: str
+    source_locator_value: str
+    source_section_label: str | None
+    is_enabled: bool
+
+
+@dataclass(frozen=True)
+class OperationalProjection:
+    projection_id: str
+    leaf_id: str
+    chunk_id: str
+    role: str
+    cover_start: int
+    cover_end: int
+
+
+@dataclass(frozen=True)
+class OperationalCorpusSnapshot:
+    """The complete versioned SQLite corpus surface approved for 5d."""
+
+    package_uuid: str
+    release_version: str
+    authoritative_source_hash: str
+    corpus_contract_version: str
+    persisted_corpus_digest: str
+    source_document: str
+    source_version: str
+    sources: tuple[OperationalSource, ...]
+    leaves: tuple[OperationalLeaf, ...]
+    chunks: tuple[OperationalChunk, ...]
+    projections: tuple[OperationalProjection, ...]
+
+
+def operational_corpus_payload(
+    snapshot: OperationalCorpusSnapshot,
+) -> dict[str, object]:
+    """Canonical payload of only the authoritative state 5d consumes."""
+    return {
+        "package_uuid": snapshot.package_uuid,
+        "release_version": snapshot.release_version,
+        "authoritative_source_hash": snapshot.authoritative_source_hash,
+        "corpus_contract_version": snapshot.corpus_contract_version,
+        "persisted_corpus_digest": snapshot.persisted_corpus_digest,
+        "source_document": snapshot.source_document,
+        "source_version": snapshot.source_version,
+        "sources": [
+            {
+                "source_id": source.source_id,
+                "rules_package_id": source.rules_package_id,
+                "name": source.name,
+                "category": source.category,
+                "precedence_rank": source.precedence_rank,
+                "is_enabled": source.is_enabled,
+            }
+            for source in snapshot.sources
+        ],
+        "represented_leaves": [
+            {
+                "leaf_id": leaf.leaf_id,
+                "printed_page": leaf.printed_page,
+                "page_index": leaf.page_index,
+                "leaf_type": leaf.leaf_type,
+                "content": leaf.content,
+                "char_start": leaf.char_start,
+                "char_end": leaf.char_end,
+                "occurrence_index": leaf.occurrence_index,
+                "container_path": list(leaf.container_path),
+                "table_id": leaf.table_id,
+                "table_row": leaf.table_row,
+                "table_col": leaf.table_col,
+                "table_segment": leaf.table_segment,
+            }
+            for leaf in snapshot.leaves
+        ],
+        "chunks": [
+            {
+                "chunk_id": chunk.chunk_id,
+                "source_id": chunk.source_id,
+                "subsystem": chunk.subsystem,
+                "content": chunk.content,
+                "source_document": chunk.source_document,
+                "source_locator_type": chunk.source_locator_type,
+                "source_locator_value": chunk.source_locator_value,
+                "source_section_label": chunk.source_section_label,
+                "is_enabled": chunk.is_enabled,
+            }
+            for chunk in snapshot.chunks
+        ],
+        "projections": [
+            {
+                "projection_id": edge.projection_id,
+                "leaf_id": edge.leaf_id,
+                "chunk_id": edge.chunk_id,
+                "role": edge.role,
+                "cover_start": edge.cover_start,
+                "cover_end": edge.cover_end,
+            }
+            for edge in snapshot.projections
+        ],
+    }
+
+
+def operational_corpus_digest(snapshot: OperationalCorpusSnapshot) -> str:
+    return hash_obj(operational_corpus_payload(snapshot))
+
+
+def build_operational_corpus_snapshot(
+    session: Session,
+    package_uuid: str,
+    *,
+    corpus_contract_version: str,
+    persisted_corpus_digest: str,
+) -> OperationalCorpusSnapshot:
+    """Read the downstream corpus surface directly from SQLite."""
+    release = session.get(CorpusReleaseORM, package_uuid)
+    ledger = session.get(SourceLedgerORM, package_uuid)
+    if release is None or ledger is None:
+        missing = "release" if release is None else "source ledger"
+        raise OperationalCorpusVerificationError(
+            (f"package {package_uuid} has no {missing} row",)
+        )
+
+    sources = tuple(
+        OperationalSource(
+            source_id=row.source_id,
+            rules_package_id=row.rules_package_id,
+            name=row.name,
+            category=row.category,
+            precedence_rank=row.precedence_rank,
+            is_enabled=row.is_enabled,
+        )
+        for row in session.execute(
+            select(RuleSourceORM)
+            .where(RuleSourceORM.rules_package_id == package_uuid)
+            .order_by(RuleSourceORM.precedence_rank, RuleSourceORM.source_id)
+        ).scalars()
+    )
+    leaves = tuple(
+        OperationalLeaf(
+            leaf_id=row.leaf_id,
+            printed_page=row.printed_page,
+            page_index=row.page_index,
+            leaf_type=row.leaf_type,
+            content=row.content,
+            char_start=row.char_start,
+            char_end=row.char_end,
+            occurrence_index=row.occurrence_index,
+            container_path=tuple(row.container_path),
+            table_id=row.table_id,
+            table_row=row.table_row,
+            table_col=row.table_col,
+            table_segment=row.table_segment,
+        )
+        for row in session.execute(
+            select(LedgerLeafORM)
+            .where(
+                LedgerLeafORM.package_uuid == package_uuid,
+                LedgerLeafORM.disposition == "represented",
+            )
+            .order_by(LedgerLeafORM.leaf_id)
+        ).scalars()
+    )
+    chunks = tuple(
+        OperationalChunk(
+            chunk_id=row.chunk_id,
+            source_id=row.source_id,
+            subsystem=row.subsystem,
+            content=row.content,
+            source_document=row.source_document,
+            source_locator_type=row.source_locator_type,
+            source_locator_value=row.source_locator_value,
+            source_section_label=row.source_section_label,
+            is_enabled=row.is_enabled,
+        )
+        for row in session.execute(
+            select(RuleChunkORM)
+            .where(RuleChunkORM.rules_package_id == package_uuid)
+            .order_by(RuleChunkORM.chunk_id)
+        ).scalars()
+    )
+    projections = tuple(
+        OperationalProjection(
+            projection_id=row.projection_id,
+            leaf_id=row.leaf_id,
+            chunk_id=row.chunk_id,
+            role=row.role,
+            cover_start=row.cover_start,
+            cover_end=row.cover_end,
+        )
+        for row in session.execute(
+            select(CorpusProjectionORM)
+            .where(CorpusProjectionORM.package_uuid == package_uuid)
+            .order_by(
+                CorpusProjectionORM.chunk_id,
+                CorpusProjectionORM.leaf_id,
+                CorpusProjectionORM.cover_start,
+                CorpusProjectionORM.cover_end,
+                CorpusProjectionORM.projection_id,
+            )
+        ).scalars()
+    )
+    return OperationalCorpusSnapshot(
+        package_uuid=package_uuid,
+        release_version=release.release_version,
+        authoritative_source_hash=release.authoritative_source_hash,
+        corpus_contract_version=corpus_contract_version,
+        persisted_corpus_digest=persisted_corpus_digest,
+        source_document=ledger.source_document,
+        source_version=ledger.source_version,
+        sources=sources,
+        leaves=leaves,
+        chunks=chunks,
+        projections=projections,
+    )
+
+
+def operational_structure_violations(
+    snapshot: OperationalCorpusSnapshot,
+) -> tuple[str, ...]:
+    """Validate reachability and closure of the narrow downstream surface."""
+    violations: list[str] = []
+    pkg = snapshot.package_uuid
+    sources = {source.source_id: source for source in snapshot.sources}
+    if set(sources) != {pkg}:
+        violations.append(
+            f"expected exactly one authoritative source {pkg}, found {sorted(sources)}"
+        )
+    authoritative = sources.get(pkg)
+    if authoritative is not None:
+        if authoritative.rules_package_id != pkg:
+            violations.append("authoritative source belongs to another package")
+        if not authoritative.is_enabled:
+            violations.append("authoritative source is disabled")
+
+    leaf_by_id = {leaf.leaf_id: leaf for leaf in snapshot.leaves}
+    chunk_by_id = {chunk.chunk_id: chunk for chunk in snapshot.chunks}
+    projected_leaves: set[str] = set()
+    projected_chunks: set[str] = set()
+    projection_ids: set[str] = set()
+    for edge in snapshot.projections:
+        if edge.projection_id in projection_ids:
+            violations.append(f"duplicate projection id {edge.projection_id}")
+        projection_ids.add(edge.projection_id)
+        leaf = leaf_by_id.get(edge.leaf_id)
+        chunk = chunk_by_id.get(edge.chunk_id)
+        if leaf is None:
+            violations.append(
+                f"projection {edge.projection_id} references absent represented leaf "
+                f"{edge.leaf_id}"
+            )
+        else:
+            projected_leaves.add(edge.leaf_id)
+            if not (0 <= edge.cover_start < edge.cover_end <= len(leaf.content)):
+                violations.append(
+                    f"projection {edge.projection_id} has invalid leaf coverage"
+                )
+        if chunk is None:
+            violations.append(
+                "projection "
+                f"{edge.projection_id} references absent chunk {edge.chunk_id}"
+            )
+        else:
+            projected_chunks.add(edge.chunk_id)
+
+    for leaf_id in sorted(set(leaf_by_id) - projected_leaves):
+        violations.append(f"represented leaf {leaf_id} has no authoritative projection")
+    for chunk_id in sorted(set(chunk_by_id) - projected_chunks):
+        violations.append(f"chunk {chunk_id} has no authoritative projection")
+    for chunk in snapshot.chunks:
+        if chunk.source_id != pkg:
+            violations.append(
+                f"chunk {chunk.chunk_id} belongs to source {chunk.source_id}, not {pkg}"
+            )
+        if not chunk.is_enabled:
+            violations.append(f"authoritative chunk {chunk.chunk_id} is disabled")
+    if not snapshot.leaves:
+        violations.append("operational corpus contains no represented leaves")
+    if not snapshot.chunks:
+        violations.append("operational corpus contains no authoritative chunks")
+    return tuple(violations)
+
+
+def load_verified_operational_corpus(
+    session: Session,
+    package_uuid: str,
+    *,
+    release_version: str,
+    authoritative_source_hash: str,
+    transform_config_hash: str,
+    bundle_root_hash: str,
+    persisted_corpus_digest: str,
+    supported_contract_versions: frozenset[str],
+) -> OperationalCorpusSnapshot:
+    """Verify and return one approved release without historical re-proof."""
+    violations: list[str] = []
+    release = session.get(CorpusReleaseORM, package_uuid)
+    package = session.get(RulesPackageORM, package_uuid)
+    ledger = session.get(SourceLedgerORM, package_uuid)
+    if release is None:
+        raise OperationalCorpusVerificationError(
+            (f"no published corpus release for package {package_uuid}",)
+        )
+    if package is None:
+        violations.append(f"no Rules Package row for {package_uuid}")
+    else:
+        if package.version != release.release_version:
+            violations.append("package version and corpus release version disagree")
+        if package.publication_status != "published" or not package.is_enabled:
+            violations.append("Rules Package is not published and enabled")
+    if release.publication_status != "published":
+        violations.append("corpus release is not published")
+
+    for name, expected in (
+        ("release_version", release_version),
+        ("authoritative_source_hash", authoritative_source_hash),
+        ("transform_config_hash", transform_config_hash),
+        ("bundle_root_hash", bundle_root_hash),
+        ("persisted_corpus_digest", persisted_corpus_digest),
+    ):
+        if getattr(release, name) != expected:
+            violations.append(f"declared {name} does not match the published release")
+
+    if ledger is None:
+        violations.append("published release has no authoritative source ledger")
+    elif ledger.source_sha256 != release.authoritative_source_hash:
+        violations.append("source ledger hash disagrees with the published source")
+
+    contract_version = release.corpus_contract_version
+    recorded_digest = release.operational_corpus_digest
+    if contract_version not in supported_contract_versions:
+        violations.append(f"unsupported corpus contract version {contract_version!r}")
+    if not recorded_digest:
+        violations.append("published release has no operational corpus digest")
+    if violations:
+        raise OperationalCorpusVerificationError(tuple(violations))
+
+    assert contract_version is not None
+    assert release.persisted_corpus_digest is not None
+    snapshot = build_operational_corpus_snapshot(
+        session,
+        package_uuid,
+        corpus_contract_version=contract_version,
+        persisted_corpus_digest=release.persisted_corpus_digest,
+    )
+    violations.extend(operational_structure_violations(snapshot))
+    if operational_corpus_digest(snapshot) != recorded_digest:
+        violations.append(
+            "authoritative SQLite corpus does not match its operational digest"
+        )
+    if violations:
+        raise OperationalCorpusVerificationError(tuple(violations))
+    return snapshot

--- a/src/afterworlds/ingestion/corpus/persistence.py
+++ b/src/afterworlds/ingestion/corpus/persistence.py
@@ -62,6 +62,12 @@ from afterworlds.ingestion.corpus.models import (
     ReleaseRecord,
     SourceLedger,
 )
+from afterworlds.ingestion.corpus.operational import (
+    CORPUS_CONTRACT_VERSION,
+    build_operational_corpus_snapshot,
+    operational_corpus_digest,
+    operational_structure_violations,
+)
 from afterworlds.ingestion.corpus.pdf_source import ExtractedPage
 from afterworlds.ingestion.corpus.pipeline import CandidateRelease, ReleaseArtifacts
 from afterworlds.ingestion.corpus.policy import (
@@ -71,7 +77,6 @@ from afterworlds.ingestion.corpus.policy import (
     policy_payload,
 )
 from afterworlds.ingestion.corpus.report import (
-    EVIDENCE_REPORT_SCHEMA_VERSION,
     EvidenceReport,
     build_report,
     report_hash,
@@ -157,6 +162,8 @@ def _persist_release_record(
     bundle_root_hash: str,
     evidence_report_hash: str | None,
     persisted_corpus_digest: str | None,
+    corpus_contract_version: str | None,
+    operational_corpus_digest_value: str | None,
     ledger_hash: str,
     policy_hash: str,
     reconciliation_hash: str,
@@ -182,6 +189,8 @@ def _persist_release_record(
             bundle_root_hash=bundle_root_hash,
             evidence_report_hash=evidence_report_hash,
             persisted_corpus_digest=persisted_corpus_digest,
+            corpus_contract_version=corpus_contract_version,
+            operational_corpus_digest=operational_corpus_digest_value,
             ledger_hash=ledger_hash,
             policy_hash=policy_hash,
             reconciliation_hash=reconciliation_hash,
@@ -340,6 +349,8 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
         bundle_root_hash=ident.bundle_root_hash,
         evidence_report_hash=ident.evidence_report_hash,
         persisted_corpus_digest=ident.persisted_corpus_digest,
+        corpus_contract_version=CORPUS_CONTRACT_VERSION,
+        operational_corpus_digest_value=None,
         ledger_hash=rel.ledger_hash,
         policy_hash=rel.policy_hash,
         reconciliation_hash=rel.reconciliation_hash,
@@ -358,6 +369,16 @@ def persist_release(session: Session, artifacts: ReleaseArtifacts, *, now: str) 
         members=artifacts.members,
         now=now,
     )
+    snapshot = build_operational_corpus_snapshot(
+        session,
+        pkg,
+        corpus_contract_version=CORPUS_CONTRACT_VERSION,
+        persisted_corpus_digest=ident.persisted_corpus_digest,
+    )
+    release_row = session.get(CorpusReleaseORM, pkg)
+    assert release_row is not None
+    release_row.operational_corpus_digest = operational_corpus_digest(snapshot)
+    session.flush()
 
 
 # ---------------------------------------------------------------------------
@@ -664,30 +685,6 @@ def verify_persisted_page_coverage(session: Session, pkg: str) -> tuple[str, ...
             + (" …" if len(missing) > 8 else ""),
         )
     return ()
-
-
-def _report_schema_ok(report_payload: object, transform_config: object) -> bool:
-    """Reuse-compatibility check for the evidence-report schema (R17).
-
-    Reuse validates the *stored* report against its *stored* hash, so an
-    obsolete-schema report (e.g. the pre-R16 host-dependent ``reproduction_environment``
-    shape) would pass that check and be silently reused. Binding the schema version
-    into the transform identity already gives a differently-schema'd release a
-    different ``package_uuid`` (so it is not matched on the fresh path); this is the
-    fail-closed backstop on the reuse path.
-
-    True iff the persisted report's recorded ``report_version`` equals the currently
-    supported :data:`EVIDENCE_REPORT_SCHEMA_VERSION` **and** the persisted transform
-    config records the same version. Missing / obsolete / contradictory / malformed
-    → False.
-    """
-    if not isinstance(report_payload, dict) or not isinstance(transform_config, dict):
-        return False
-    return (
-        report_payload.get("report_version") == EVIDENCE_REPORT_SCHEMA_VERSION
-        and transform_config.get("evidence_report_schema_version")
-        == EVIDENCE_REPORT_SCHEMA_VERSION
-    )
 
 
 def verify_single_source(session: Session, pkg: str) -> tuple[str, ...]:
@@ -1164,12 +1161,52 @@ def _finalize_core(
             and len(artifacts.members.chunks) == len(candidate.members.chunks)
             and not membership_violations
         )
+        operational_failures: list[str] = []
+        backfill_operational_contract = (
+            existing.corpus_contract_version is None
+            and existing.operational_corpus_digest is None
+        )
+        if (existing.corpus_contract_version is None) != (
+            existing.operational_corpus_digest is None
+        ):
+            operational_failures.append(
+                "operational corpus contract metadata is partially populated"
+            )
+        if existing.corpus_contract_version not in (
+            None,
+            CORPUS_CONTRACT_VERSION,
+        ):
+            operational_failures.append(
+                "unsupported operational corpus contract version "
+                f"{existing.corpus_contract_version!r}"
+            )
+        assert existing.persisted_corpus_digest is not None
+        operational_snapshot = build_operational_corpus_snapshot(
+            session,
+            pkg,
+            corpus_contract_version=(
+                existing.corpus_contract_version or CORPUS_CONTRACT_VERSION
+            ),
+            persisted_corpus_digest=existing.persisted_corpus_digest,
+        )
+        operational_failures.extend(
+            operational_structure_violations(operational_snapshot)
+        )
+        current_operational_digest = operational_corpus_digest(operational_snapshot)
+        if (
+            existing.operational_corpus_digest is not None
+            and existing.operational_corpus_digest != current_operational_digest
+        ):
+            operational_failures.append(
+                "authoritative SQLite corpus does not match its operational digest"
+            )
         evidence = PublicationEvidence(
             sql_persist_ok=sql_persist_ok,
             vector_write_ok=vector_result.ok,
             chunk_membership_violations=len(membership_violations),
             source_membership_violations=len(source_violations),
             vector_verification_failures=vector_result.failures,
+            operational_integrity_failures=tuple(operational_failures),
         )
         # Re-run the *full* gate against the reconstructed existing release —
         # not just the digest — so a reuse can't be accepted on a release whose
@@ -1186,15 +1223,7 @@ def _finalize_core(
             and package_row.publication_status == "published"
         )
         page_coverage_violations = verify_persisted_page_coverage(session, pkg)
-        schema_ok = _report_schema_ok(
-            artifacts.report.payload, artifacts.release.transform_config
-        )
-        if (
-            not gate.passed
-            or not package_state_ok
-            or page_coverage_violations
-            or not schema_ok
-        ):
+        if not gate.passed or not package_state_ok or page_coverage_violations:
             failures = list(gate.failures)
             if not package_state_ok:
                 failures.append(
@@ -1203,19 +1232,20 @@ def _finalize_core(
                     "rp_corpus_releases row"
                 )
             failures.extend(page_coverage_violations)
-            if not schema_ok:
-                failures.append(
-                    "persisted evidence-report schema version "
-                    f"(report={artifacts.report.payload.get('report_version')!r}) is "
-                    "missing/obsolete/contradictory vs the supported "
-                    f"{EVIDENCE_REPORT_SCHEMA_VERSION!r} — refusing to reuse"
-                )
             return FinalizeResult(
                 published=False,
                 reused=False,
                 artifacts=None,
                 gate=GateResult(passed=False, failures=tuple(failures)),
             )
+        if backfill_operational_contract:
+            # Migration 0022 introduces only verification metadata.  Backfill a
+            # pre-amendment published row solely after the full 5c reuse gate and
+            # live Chroma verification pass; corpus content and release identity
+            # remain untouched.
+            existing.corpus_contract_version = CORPUS_CONTRACT_VERSION
+            existing.operational_corpus_digest = current_operational_digest
+            session.commit()
         return FinalizeResult(
             published=True, reused=True, artifacts=artifacts, gate=gate
         )
@@ -1245,6 +1275,8 @@ def _finalize_core(
             bundle_root_hash=candidate.bundle.bundle_root_hash,
             evidence_report_hash=None,
             persisted_corpus_digest=None,
+            corpus_contract_version=CORPUS_CONTRACT_VERSION,
+            operational_corpus_digest_value=None,
             ledger_hash=candidate.ledger_hash,
             policy_hash=candidate.policy_hash,
             reconciliation_hash=candidate.reconciliation_hash,
@@ -1297,6 +1329,26 @@ def _finalize_core(
             sources,
             vector_state,
         )
+
+        # Direct SQLite contract consumed by downstream 5d.  It is derived from
+        # the exact rows 5d receives and deliberately excludes Chroma and 5c's
+        # diagnostic proof genealogy.
+        release_row = session.execute(
+            select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
+        ).scalar_one()
+        release_row.persisted_corpus_digest = digest
+        release_row.corpus_contract_version = CORPUS_CONTRACT_VERSION
+        session.flush()
+        operational_snapshot = build_operational_corpus_snapshot(
+            session,
+            pkg,
+            corpus_contract_version=CORPUS_CONTRACT_VERSION,
+            persisted_corpus_digest=digest,
+        )
+        fresh_operational_failures = operational_structure_violations(
+            operational_snapshot
+        )
+        operational_digest = operational_corpus_digest(operational_snapshot)
 
         # --- e: post-persistence evidence report; f: hash it ------------------
         concordance = check_concordance(members.chunks, candidate.pages)
@@ -1363,14 +1415,14 @@ def _finalize_core(
             chunk_membership_violations=len(membership_violations),
             source_membership_violations=len(source_violations),
             vector_verification_failures=vector_result.failures,
+            operational_integrity_failures=fresh_operational_failures,
         )
 
         # --- g: fill in the post-persistence identity, then run the final gate -
-        release_row = session.execute(
-            select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == pkg)
-        ).scalar_one()
         release_row.evidence_report_hash = report_h
         release_row.persisted_corpus_digest = digest
+        release_row.corpus_contract_version = CORPUS_CONTRACT_VERSION
+        release_row.operational_corpus_digest = operational_digest
         release_row.corpus_report_reference = report_h
         release_row.report_payload = report.payload
         session.flush()

--- a/src/afterworlds/ingestion/corpus/pipeline.py
+++ b/src/afterworlds/ingestion/corpus/pipeline.py
@@ -28,7 +28,7 @@ memory. :func:`afterworlds.ingestion.corpus.persistence.finalize_release`
 performs steps c–g against a live session and returns the completed
 :class:`ReleaseArtifacts`.
 
-A clean checkout regenerates a0–g byte-for-byte from committed inputs.
+A clean checkout regenerates the same substantive corpus from committed inputs.
 """
 
 from __future__ import annotations

--- a/src/afterworlds/ingestion/corpus/report.py
+++ b/src/afterworlds/ingestion/corpus/report.py
@@ -45,7 +45,9 @@ PYTHON_TARGET = "3.12"
 # change mints a NEW immutable release instead of being reused under a
 # predecessor's identity (R17 mechanism). It is deliberately an *explicit* schema
 # identity rather than a byte-level hash of report.py: only an intentional
-# canonical-shape change should remint, never a comment/docstring/logging edit.
+# canonical-shape change should be explicit.  Since the 2026-08-03 operational-
+# reliability amendment, this diagnostic version no longer participates in the
+# package UUID or release version.
 EVIDENCE_REPORT_SCHEMA_VERSION = "5c-evidence-3"
 
 
@@ -97,8 +99,8 @@ def build_report(
     )
 
     payload: dict[str, object] = {
-        # Canonical schema version, also bound into the transform identity so a
-        # schema change remints the release rather than being reused (R17).
+        # Diagnostic schema version. Report evolution is deliberately independent
+        # of the published corpus identity.
         "report_version": EVIDENCE_REPORT_SCHEMA_VERSION,
         # Proof hashes (NOT this report's own hash).
         "authoritative_source_hash": authoritative_source_hash,
@@ -129,8 +131,8 @@ def build_report(
         # ``transform_identity`` above. This is host-independent by construction —
         # no runtime host name, OS, architecture, absolute path, timestamp, or PID
         # enters this identity-bearing payload, so the same committed inputs yield a
-        # byte-identical evidence report (hence release identity) on every supported
-        # host (PR #134 R16). Actual host diagnostics are logged, never hashed.
+        # stable diagnostic report on every supported host (PR #134 R16).
+        # Actual host diagnostics are logged, never hashed.
         "reproduction_target": {"python_target": PYTHON_TARGET},
         "reconciliation_policy_reference": {
             "policy_version": policy.policy_version,

--- a/src/afterworlds/ingestion/corpus/transform_identity.py
+++ b/src/afterworlds/ingestion/corpus/transform_identity.py
@@ -1,57 +1,30 @@
-"""First-party transform identity + source manifest — CRD Issue 5c, Component B.
+"""Declared semantic transform identity — CRD Issue 5c (#145).
 
-The transform source/configuration hash (Component B) must change whenever *any*
-first-party code that can affect the candidate corpus or its canonical
-identities (Component K steps a0–a3, and the canonical-payload/identity code in
-step b) changes — not only when the extractor version or the frozen policy
-changes. Otherwise a segmentation fix in ``ledger`` or a chunk-generation change
-in ``transform`` keeps the same ``transform_config_hash`` → same ``package_uuid``
-/ ``release_version`` → ``finalize_release`` reuses the *old* persisted corpus as
-a no-op instead of minting the new immutable draft the changed code requires
-(PR #134 P1, ``bundle.py:40``).
+Release identity follows the authoritative source and the approved logical
+corpus, not every byte of every implementation file.  The original Issue 5c
+implementation hashed eleven Python modules; comments, annotations, logging,
+and other incidental edits therefore reminted an unchanged corpus.
 
-This module derives that identity **automatically** from the actual committed
-source bytes of a fixed, audited set of first-party modules. There is no
-manually bumped version whose omission could silently bypass detection: the
-aggregate ``transform_source_hash`` is a pure function of those files' bytes, so
-editing any of them moves the hash with no human action. ``TRANSFORM_TOOL_VERSION``
-is a descriptive label only and gates nothing.
-
-Manifest audit (bounded transitive walk of Component K steps a0–b; each first-
-party corpus module inspected and dispositioned — see the review-note remediation
-log for the full table). A module is *included* iff its source bytes can change
-the candidate corpus or a canonical identity; *already-covered* iff its effect is
-bound some other way; *verification-only* iff it cannot change the candidate bytes:
-
-    included         pdf_source, ledger, tables, transform, reconcile, policy,
-                     bundle, hashing, models, pipeline, transform_identity
-    already-covered  models.retrieval.rules_corpus_vector_identity (its *output*,
-                     the vector identity, is bound into transform_config directly)
-    verification-only  concordance, report, gate, persistence, vector_publication,
-                     source_completeness  (verification / post-persistence /
-                     runtime only)
-
-``tables`` reached the manifest via ``ledger`` (a1→a2 segmentation): it owns table
-segmentation, cell contents/ids, and row/column metadata, so a change there must
-mint a new release (PR #134 R15 F1). The Finding-4 expected-table inventory is a
-candidate-affecting *data* input; its hash is bound into the transform config
-payload alongside this source hash (see ``bundle.transform_config_payload``).
+``TRANSFORM_TOOL_VERSION`` is now the explicit semantic compatibility version.
+It must be bumped when extraction, segmentation, canonical corpus content,
+provenance, or compatibility changes meaningfully.  The frozen v1 manifest is
+retained in the payload solely to preserve the honest identity of the already
+approved v1 logical corpus.  It is historical identity metadata, not a claim
+that current source bytes still equal those pre-amendment hashes.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from afterworlds.ingestion.corpus.hashing import hash_obj, sha256_hex
+from afterworlds.ingestion.corpus.hashing import hash_obj
 
-# Descriptive label for the transform toolchain. Change detection does NOT rely
-# on this string — it relies on TRANSFORM_SOURCE_MODULES' actual bytes below.
 TRANSFORM_TOOL_NAME = "afterworlds-srd-corpus-transform"
+# Bump deliberately for a meaningful logical-corpus or compatibility change.
 TRANSFORM_TOOL_VERSION = "1"
 
-# The audited first-party modules whose source bytes are bound into the transform
-# identity. Ordering here is irrelevant to the aggregate hash (entries are sorted
-# by canonical path before hashing) but is kept alphabetical for readability.
+# Historical v1 source set retained for API compatibility and for the exact
+# pre-amendment transform payload.  It no longer drives automatic byte checks.
 TRANSFORM_SOURCE_MODULES: tuple[str, ...] = (
     "bundle.py",
     "hashing.py",
@@ -66,77 +39,65 @@ TRANSFORM_SOURCE_MODULES: tuple[str, ...] = (
     "transform_identity.py",
 )
 
-# Canonical repository-relative directory these modules live in. Recorded in the
-# manifest so the paths are stable across checkouts and machines.
+_V1_SOURCE_MANIFEST: tuple[tuple[str, str], ...] = (
+    ("bundle.py", "9b3578de32454b3e87b7f7760c76128b6452a5cbc152e9ec4ae7e315d162db33"),
+    ("hashing.py", "dfbb8e9eaaded95c7aa2a72351e9301953ee5f15fa332dbc706a9307828b2915"),
+    ("ledger.py", "6717e8e4ab908aa02d8df0e87a453d1e1032f911cb26075168f2ac0e2b8610b3"),
+    ("models.py", "d6de262fd9235253de7dc1c7c2163726fd0ce0b26b7dba8ee7ecf06902abb190"),
+    (
+        "pdf_source.py",
+        "a205eafd02e9f754bfaca7e629b7de646a074b476f16066c6af2bb4caddf7453",
+    ),
+    ("pipeline.py", "f0af4fdb86fe76b957ab82f74dd26968d70ac3593634136d093c8584482773bc"),
+    ("policy.py", "a58a3e03b28289d5a4c6869d7e3171676924e5090f305afe8b4e79eb1a37198f"),
+    (
+        "reconcile.py",
+        "e24184fdc5ef556c9f9b401b74c19d94cf0c98400f3f8a6e0ca43fb02fe2f277",
+    ),
+    ("tables.py", "db88f21111892c9cb607e756a94df2ef315426bf84ec6733938e79fe2073cfa0"),
+    (
+        "transform.py",
+        "a74bf829bdbdf94fec30cb0124e8d42f42a4837588d039afdf9f8325142610a7",
+    ),
+    (
+        "transform_identity.py",
+        "77b50cb8c835f7ea12a5e786172d9dd03035fafb3cf5a7593dd1ee15fd6b2a18",
+    ),
+)
+_V1_TRANSFORM_SOURCE_HASH = (
+    "6332f201eba9cba19d699a06c6c12580de5ef1c7f349fadacd2045c0e5312cc0"
+)
 _CORPUS_PKG_REL = "src/afterworlds/ingestion/corpus"
-_CORPUS_DIR = Path(__file__).resolve().parent
 
 
 class TransformSourceMissingError(RuntimeError):
-    """Raised when an audited transform-source module is absent — fail closed."""
-
-
-def _source_sha256(data: bytes) -> str:
-    """SHA-256 of source *data* with newlines normalized to ``\\n``.
-
-    Normalization (matching the pipeline's canonical ``\\n`` discipline) makes
-    the identity insensitive to a CRLF checkout while still moving on any real
-    content change — the same reasoning as geometry rounding for extraction.
-    ``.gitattributes`` already pins ``*.py`` to ``eol=lf``; this is belt-and-
-    suspenders.
-    """
-    normalized = data.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
-    return sha256_hex(normalized)
+    """Legacy public exception retained for import compatibility."""
 
 
 def aggregate_source_hash(entries: list[tuple[str, str]]) -> str:
-    """Pure aggregate over ``(repo_relative_path, source_sha256)`` pairs.
-
-    Deterministic and independent of input ordering (entries are sorted by path).
-    Any change to any covered file's ``source_sha256`` — hence any change to its
-    bytes — changes the aggregate.
-    """
+    """Canonical aggregate helper retained for diagnostic tooling."""
     ordered = sorted(entries)
-    return hash_obj([{"path": p, "sha256": h} for p, h in ordered])
+    return hash_obj([{"path": path, "sha256": digest} for path, digest in ordered])
 
 
 def transform_source_manifest(root: Path | None = None) -> dict[str, object]:
-    """Read the audited modules from *root* and return their manifest + aggregate.
+    """Return the frozen v1 manifest used by the approved logical corpus.
 
-    *root* defaults to the real corpus package directory; a caller may pass a
-    copy of the tree to prove byte-sensitivity in a test. Repo-relative paths are
-    always canonical regardless of *root*, so the identity is location-stable.
-    Fails closed if any audited module is missing.
+    ``root`` remains accepted so older callers do not break, but source-tree
+    inspection is intentionally no longer part of release identity.
     """
-    # ponytail: `root` param exists only so tests can point at a mutated copy of
-    # the source tree; production always uses the real package dir.
-    base = root if root is not None else _CORPUS_DIR
-    modules: list[dict[str, str]] = []
-    entries: list[tuple[str, str]] = []
-    for name in sorted(TRANSFORM_SOURCE_MODULES):
-        path = base / name
-        if not path.is_file():
-            raise TransformSourceMissingError(
-                f"audited transform-source module missing: {path}"
-            )
-        rel = f"{_CORPUS_PKG_REL}/{name}"
-        digest = _source_sha256(path.read_bytes())
-        modules.append({"path": rel, "sha256": digest})
-        entries.append((rel, digest))
+    del root
     return {
-        "modules": modules,
-        "transform_source_hash": aggregate_source_hash(entries),
+        "modules": [
+            {"path": f"{_CORPUS_PKG_REL}/{name}", "sha256": digest}
+            for name, digest in _V1_SOURCE_MANIFEST
+        ],
+        "transform_source_hash": _V1_TRANSFORM_SOURCE_HASH,
     }
 
 
 def transform_identity(root: Path | None = None) -> dict[str, object]:
-    """The complete first-party transform identity (Component B).
-
-    Tool label + auto-derived source manifest/hash + the deterministic Component
-    B invocation + whether an intermediate representation is committed. This is
-    embedded in the transform source/configuration payload and drives the
-    transform hash, package UUID, and release version.
-    """
+    """Return the explicit semantic identity of the corpus transformation."""
     manifest = transform_source_manifest(root)
     return {
         "tool": TRANSFORM_TOOL_NAME,
@@ -154,7 +115,5 @@ def transform_identity(root: Path | None = None) -> dict[str, object]:
             ),
             "deterministic": True,
         },
-        # No intermediate representation is committed to the repository; the
-        # corpus is regenerated deterministically from the PDF + these sources.
         "intermediate_representation_committed": False,
     }

--- a/src/afterworlds/persistence/orm/corpus.py
+++ b/src/afterworlds/persistence/orm/corpus.py
@@ -55,6 +55,15 @@ class CorpusReleaseORM(Base):
     persisted_corpus_digest: Mapped[str | None] = mapped_column(
         sa.String(64), nullable=True
     )
+    # Versioned, direct SQLite trust seam consumed by CRD Issue 5d.  These are
+    # post-persistence values and remain nullable only so migration 0022 can
+    # represent pre-amendment releases until 5c verified reuse backfills them.
+    corpus_contract_version: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
+    operational_corpus_digest: Mapped[str | None] = mapped_column(
+        sa.String(64), nullable=True
+    )
     ledger_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     policy_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     reconciliation_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)

--- a/tests/ingestion/corpus/test_operational_contract.py
+++ b/tests/ingestion/corpus/test_operational_contract.py
@@ -1,0 +1,129 @@
+"""Versioned downstream corpus trust seam — CRD Issue 5c (#145)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete, select
+
+from afterworlds.ingestion.corpus.operational import (
+    CORPUS_CONTRACT_VERSION,
+    OperationalCorpusVerificationError,
+    load_verified_operational_corpus,
+)
+from afterworlds.ingestion.corpus.persistence import persist_release
+from afterworlds.persistence.orm.corpus import (
+    CorpusProjectionORM,
+    CorpusReleaseORM,
+    LedgerLeafORM,
+)
+from afterworlds.persistence.orm.rules_package import RuleChunkORM, RulesPackageORM
+
+_NOW = "2026-08-03T00:00:00Z"
+
+
+def _published(session, release):  # type: ignore[no-untyped-def]
+    persist_release(session, release, now=_NOW)
+    package_uuid = release.release.package_uuid
+    package = session.get(RulesPackageORM, package_uuid)
+    corpus = session.get(CorpusReleaseORM, package_uuid)
+    assert package is not None and corpus is not None
+    package.publication_status = "published"
+    corpus.publication_status = "published"
+    session.commit()
+    return package_uuid
+
+
+def _load(session, release):  # type: ignore[no-untyped-def]
+    identity = release.release.identity
+    return load_verified_operational_corpus(
+        session,
+        release.release.package_uuid,
+        release_version=release.release.release_version,
+        authoritative_source_hash=identity.authoritative_source_hash,
+        transform_config_hash=identity.transform_config_hash,
+        bundle_root_hash=identity.bundle_root_hash,
+        persisted_corpus_digest=identity.persisted_corpus_digest,
+        supported_contract_versions=frozenset({CORPUS_CONTRACT_VERSION}),
+    )
+
+
+def test_honest_release_returns_the_exact_downstream_snapshot(session, compact_release):
+    _published(session, compact_release)
+    snapshot = _load(session, compact_release)
+    assert snapshot.corpus_contract_version == CORPUS_CONTRACT_VERSION
+    assert len(snapshot.leaves) == compact_release.reconciliation.represented_leaves
+    assert {chunk.chunk_id for chunk in snapshot.chunks} == {
+        chunk.chunk_id for chunk in compact_release.members.chunks
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["leaf_content", "chunk_content", "projection_coverage", "missing_chunk"],
+)
+def test_sqlite_corpus_mutation_fails_direct_integrity(
+    session, compact_release, mutation
+):
+    package_uuid = _published(session, compact_release)
+    if mutation == "leaf_content":
+        row = session.execute(
+            select(LedgerLeafORM)
+            .where(
+                LedgerLeafORM.package_uuid == package_uuid,
+                LedgerLeafORM.disposition == "represented",
+            )
+            .limit(1)
+        ).scalar_one()
+        row.content += " tampered"
+    elif mutation == "chunk_content":
+        row = session.execute(
+            select(RuleChunkORM)
+            .where(RuleChunkORM.rules_package_id == package_uuid)
+            .limit(1)
+        ).scalar_one()
+        row.content += " tampered"
+    elif mutation == "projection_coverage":
+        row = session.execute(
+            select(CorpusProjectionORM)
+            .where(CorpusProjectionORM.package_uuid == package_uuid)
+            .limit(1)
+        ).scalar_one()
+        row.cover_end += 1
+    else:
+        chunk_id = session.execute(
+            select(RuleChunkORM.chunk_id)
+            .where(RuleChunkORM.rules_package_id == package_uuid)
+            .limit(1)
+        ).scalar_one()
+        session.execute(delete(RuleChunkORM).where(RuleChunkORM.chunk_id == chunk_id))
+    session.commit()
+
+    with pytest.raises(OperationalCorpusVerificationError):
+        _load(session, compact_release)
+
+
+def test_unpublished_or_unsupported_release_fails_closed(session, compact_release):
+    package_uuid = _published(session, compact_release)
+    row = session.get(CorpusReleaseORM, package_uuid)
+    assert row is not None
+    row.corpus_contract_version = "future-contract"
+    session.commit()
+    with pytest.raises(OperationalCorpusVerificationError, match="unsupported"):
+        _load(session, compact_release)
+
+    row.corpus_contract_version = CORPUS_CONTRACT_VERSION
+    row.publication_status = "draft"
+    session.commit()
+    with pytest.raises(OperationalCorpusVerificationError, match="not published"):
+        _load(session, compact_release)
+
+
+def test_diagnostic_report_is_not_downstream_authority(session, compact_release):
+    package_uuid = _published(session, compact_release)
+    row = session.get(CorpusReleaseORM, package_uuid)
+    assert row is not None
+    row.report_payload = {"diagnostic": "new shape"}
+    row.evidence_report_hash = "not consulted by the operational seam"
+    row.corpus_report_reference = "also diagnostic"
+    session.commit()
+    assert _load(session, compact_release).package_uuid == package_uuid

--- a/tests/ingestion/corpus/test_persistence_quarantine.py
+++ b/tests/ingestion/corpus/test_persistence_quarantine.py
@@ -888,41 +888,11 @@ def test_completeness_rejects_page_corruption_and_leaves_no_state(
 #  see test_migration_0018_deletes_incomplete_package_and_dependent_rows.)
 
 
-def test_report_schema_ok_fails_closed_on_bad_schema():
-    """R17 unit: ``_report_schema_ok`` is the reuse-path backstop for the evidence-
-    report schema. Current + matching (report AND transform config) → True;
-    obsolete, contradictory, missing, or malformed → False (fail closed)."""
-    from afterworlds.ingestion.corpus.persistence import _report_schema_ok
-    from afterworlds.ingestion.corpus.report import EVIDENCE_REPORT_SCHEMA_VERSION as V
-
-    assert _report_schema_ok(
-        {"report_version": V}, {"evidence_report_schema_version": V}
-    )
-    # obsolete pre-R16 report version
-    assert not _report_schema_ok(
-        {"report_version": "5c-evidence-1"}, {"evidence_report_schema_version": V}
-    )
-    # contradictory: report current, transform config stale or absent
-    assert not _report_schema_ok({"report_version": V}, {})
-    assert not _report_schema_ok(
-        {"report_version": V}, {"evidence_report_schema_version": "5c-evidence-1"}
-    )
-    # missing report version
-    assert not _report_schema_ok({}, {"evidence_report_schema_version": V})
-    # malformed payloads
-    assert not _report_schema_ok(None, {"evidence_report_schema_version": V})
-    assert not _report_schema_ok({"report_version": V}, None)
-
-
-def test_reuse_rejects_obsolete_evidence_report_schema(
-    session, candidate, chroma_client, retrieval_config, fake_embedding
+def test_reuse_accepts_older_diagnostic_report_schema_when_integrity_holds(
+    session, full_candidate, chroma_client, retrieval_config, fake_embedding
 ):
-    """R17: reuse fails closed when the persisted evidence report is a valid but
-    *obsolete* (pre-R16) schema whose stored hash still matches — the case the
-    report-hash check cannot catch. Simulate a pre-R16 ``report_version`` on the
-    published release (recomputing the stored hash so the gate's hash check passes,
-    isolating the schema backstop) and assert the reuse attempt surfaces the schema
-    failure and does not reuse."""
+    """Diagnostic report shape is not release compatibility or source authority."""
+    candidate = full_candidate
     from afterworlds.ingestion.corpus.report import EvidenceReport, report_hash
 
     first = _finalize(
@@ -942,14 +912,14 @@ def test_reuse_rejects_obsolete_evidence_report_schema(
     row.evidence_report_hash = report_hash(
         EvidenceReport(payload=payload, persisted=True)
     )
+    row.corpus_report_reference = row.evidence_report_hash
     session.commit()
 
     result = _finalize(
         session, candidate, chroma_client, retrieval_config, fake_embedding
     )
-    assert not result.published and not result.reused
-    assert result.gate is not None
-    assert any("schema version" in f for f in result.gate.failures)
+    assert result.published and result.reused
+    assert result.gate is not None and result.gate.passed
 
 
 def test_repeated_finalize_is_idempotent_and_does_not_mutate(
@@ -973,6 +943,29 @@ def test_repeated_finalize_is_idempotent_and_does_not_mutate(
     )
     assert second.published and second.reused and second.artifacts is not None
     assert second.artifacts.release.identity == first.artifacts.release.identity
+
+
+def test_verified_reuse_backfills_the_operational_contract(
+    session, full_candidate, chroma_client, retrieval_config, fake_embedding
+):
+    """Migration-era releases acquire the new seam only after full verified reuse."""
+    first = _finalize(
+        session, full_candidate, chroma_client, retrieval_config, fake_embedding
+    )
+    assert first.published and not first.reused
+
+    row = session.get(CorpusReleaseORM, full_candidate.package_uuid)
+    assert row is not None
+    row.corpus_contract_version = None
+    row.operational_corpus_digest = None
+    session.commit()
+
+    second = _finalize(
+        session, full_candidate, chroma_client, retrieval_config, fake_embedding
+    )
+    assert second.published and second.reused
+    assert row.corpus_contract_version == "5c-operational-1"
+    assert row.operational_corpus_digest
 
     rows = (
         session.execute(

--- a/tests/ingestion/corpus/test_transform_identity.py
+++ b/tests/ingestion/corpus/test_transform_identity.py
@@ -1,20 +1,8 @@
-"""First-party transform-identity tests — Issue 5c, PR #134 P1.
-
-The transform source/configuration hash must move whenever any audited
-first-party transform-source module changes, so a transform-code change mints a
-new immutable release identity instead of reusing the predecessor. These tests
-prove byte-sensitivity, the audited coverage set (the no-silent-bypass guard),
-and the binding into package UUID / release version — without a full-corpus
-rebuild.
-"""
+"""Semantic transform-identity tests — CRD Issue 5c operational correction."""
 
 from __future__ import annotations
 
-import shutil
-from pathlib import Path
-
-import pytest
-
+from afterworlds.ingestion.corpus import report
 from afterworlds.ingestion.corpus.bundle import (
     derive_package_uuid,
     derive_release_version,
@@ -26,154 +14,71 @@ from afterworlds.ingestion.corpus.pdf_source import PDF_SHA256, extraction_confi
 from afterworlds.ingestion.corpus.policy import FROZEN_POLICY
 from afterworlds.ingestion.corpus.transform_identity import (
     TRANSFORM_SOURCE_MODULES,
-    TransformSourceMissingError,
+    TRANSFORM_TOOL_VERSION,
     aggregate_source_hash,
     transform_identity,
     transform_source_manifest,
 )
 
-_CORPUS_DIR = Path(__file__).resolve().parents[3] / ("src/afterworlds/ingestion/corpus")
-
-
-# --- aggregate purity --------------------------------------------------------
-
 
 def test_aggregate_source_hash_is_order_independent():
-    a = [("z.py", "1" * 64), ("a.py", "2" * 64)]
-    assert aggregate_source_hash(a) == aggregate_source_hash(list(reversed(a)))
+    entries = [("z.py", "1" * 64), ("a.py", "2" * 64)]
+    assert aggregate_source_hash(entries) == aggregate_source_hash(
+        list(reversed(entries))
+    )
 
 
-def test_aggregate_source_hash_changes_on_any_byte():
-    base = [("a.py", "1" * 64), ("b.py", "2" * 64)]
-    flipped = [("a.py", "1" * 64), ("b.py", "3" * 64)]
-    assert aggregate_source_hash(base) != aggregate_source_hash(flipped)
-
-
-# --- coverage set (no silent bypass) -----------------------------------------
-
-
-def test_manifest_covers_exactly_the_audited_modules():
-    """Locks the audit disposition: if a covered module silently drops out of
-    coverage, this fails — the change-detection guarantee can't be bypassed by
-    quietly removing a file from the manifest."""
+def test_v1_manifest_is_frozen_identity_metadata():
     manifest = transform_source_manifest()
-    got = {m["path"].rsplit("/", 1)[1] for m in manifest["modules"]}  # type: ignore[index]
-    assert got == set(TRANSFORM_SOURCE_MODULES)
+    assert manifest["transform_source_hash"] == (
+        "6332f201eba9cba19d699a06c6c12580de5ef1c7f349fadacd2045c0e5312cc0"
+    )
+    assert {entry["path"].rsplit("/", 1)[1] for entry in manifest["modules"]} == set(
+        TRANSFORM_SOURCE_MODULES
+    )
 
 
-def test_manifest_reflects_real_source_bytes_not_a_constant():
-    """Each recorded sha256 must be the real (newline-normalized) file digest, so
-    the identity is derived from actual bytes rather than a hardcoded value."""
-    import hashlib
-
-    manifest = transform_source_manifest()
-    for entry in manifest["modules"]:  # type: ignore[union-attr]
-        name = entry["path"].rsplit("/", 1)[1]  # type: ignore[index]
-        raw = (_CORPUS_DIR / name).read_bytes()
-        norm = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
-        assert entry["sha256"] == hashlib.sha256(norm).hexdigest()  # type: ignore[index]
+def test_incidental_source_tree_location_or_bytes_do_not_move_identity(tmp_path):
+    # The compatibility argument remains accepted for callers, but release
+    # identity no longer reads arbitrary implementation bytes from it.
+    (tmp_path / "transform.py").write_text("# comment-only change\n")
+    assert transform_identity(tmp_path) == transform_identity()
 
 
-# --- byte-sensitivity via a mutated copy of the tree -------------------------
-
-
-@pytest.mark.parametrize("target", TRANSFORM_SOURCE_MODULES)
-def test_changing_any_covered_source_byte_moves_transform_source_hash(tmp_path, target):
-    """Copy the corpus tree, flip one byte in each covered module in turn, and
-    assert the aggregate transform-source hash moves — automatically, with no
-    version bump."""
-    real = transform_source_manifest()["transform_source_hash"]
-    copy_dir = tmp_path / "corpus"
-    copy_dir.mkdir()
-    for name in TRANSFORM_SOURCE_MODULES:
-        shutil.copy(_CORPUS_DIR / name, copy_dir / name)
-    p = copy_dir / target
-    p.write_bytes(p.read_bytes() + b"\n# tamper\n")
-    changed = transform_source_manifest(copy_dir)["transform_source_hash"]
-    assert changed != real
-
-
-@pytest.mark.parametrize("mutated_module", ["ledger.py", "tables.py"])
-def test_transform_code_change_moves_config_hash_uuid_and_version(
-    tmp_path, mutated_module
-):
-    """A transform-source change (PDF + extractor config + policy fixed) moves the
-    transform_config_hash and therefore both the package UUID and release
-    version — so finalize_release cannot reuse the predecessor's identity.
-    ``tables.py`` (table segmentation/ids/row-col metadata) is covered explicitly
-    (PR #134 R15 F1)."""
+def test_deliberate_semantic_version_change_moves_uuid_and_release_version():
     ex = extraction_config()
-    vid = {"embedding_model_id": "m", "metadata_fields": ["subsystem"]}
-    # Build the COMPLETE production transform payload (all identity fields —
-    # extractor config, policy, transform identity, vector identity, expected-table
-    # inventory hash, evidence-report schema version). Mutating only the transform
-    # identity keeps every other field equal, so the inequality below is a genuine
-    # difference in the transform-source hash, not an artifact of an omitted field
-    # (R17: don't let a partial payload make the assertion vacuous).
-    real_payload = transform_config_payload(ex, FROZEN_POLICY, vid)
-    real_hash = transform_config_hash(ex, FROZEN_POLICY, vid)
-    assert hash_obj(real_payload) == real_hash  # helper builds the production shape
-
-    # Simulate a code-only change by recomputing the identity against a mutated
-    # copy of the source tree (same PDF, extractor config, policy, and vector id).
-    copy_dir = tmp_path / "corpus"
-    copy_dir.mkdir()
-    for name in TRANSFORM_SOURCE_MODULES:
-        shutil.copy(_CORPUS_DIR / name, copy_dir / name)
-    p = copy_dir / mutated_module
-    p.write_bytes(p.read_bytes() + b"\n# segmentation tweak\n")
-    mutated_identity = transform_identity(copy_dir)
-    mutated_payload = {**real_payload, "transform_identity": mutated_identity}
-    mutated_hash = hash_obj(mutated_payload)
-
-    assert mutated_hash != real_hash
-    assert derive_package_uuid(PDF_SHA256, mutated_hash) != derive_package_uuid(
-        PDF_SHA256, real_hash
+    vector_identity = {"embedding_model_id": "m", "metadata_fields": ["subsystem"]}
+    base = transform_config_payload(ex, FROZEN_POLICY, vector_identity)
+    changed_identity = {
+        **base["transform_identity"],
+        "tool_version": f"{TRANSFORM_TOOL_VERSION}-meaningful-change",
+    }
+    changed = {**base, "transform_identity": changed_identity}
+    base_hash = hash_obj(base)
+    changed_hash = hash_obj(changed)
+    assert changed_hash != base_hash
+    assert derive_package_uuid(PDF_SHA256, changed_hash) != derive_package_uuid(
+        PDF_SHA256, base_hash
     )
-    assert derive_release_version(PDF_SHA256, mutated_hash) != derive_release_version(
-        PDF_SHA256, real_hash
+    assert derive_release_version(PDF_SHA256, changed_hash) != derive_release_version(
+        PDF_SHA256, base_hash
     )
 
 
-def test_report_schema_version_is_bound_into_identity():
-    """R17: the canonical evidence-report schema version is part of the transform
-    payload, so changing it moves the transform hash, package UUID, and release
-    version — a report-schema change mints a new immutable release instead of
-    being reused under a predecessor's identity."""
+def test_diagnostic_report_schema_does_not_move_corpus_identity(monkeypatch):
     ex = extraction_config()
-    vid = {"embedding_model_id": "m", "metadata_fields": ["subsystem"]}
-    base = transform_config_payload(ex, FROZEN_POLICY, vid)
-    # Present in the production shape (and the inventory hash too — completeness).
-    assert base["evidence_report_schema_version"]
-    assert base["expected_table_inventory_hash"]
-    variant = {**base, "evidence_report_schema_version": "5c-evidence-OTHER"}
-    bh, vh = hash_obj(base), hash_obj(variant)
-    assert bh != vh
-    assert derive_package_uuid(PDF_SHA256, bh) != derive_package_uuid(PDF_SHA256, vh)
-    assert derive_release_version(PDF_SHA256, bh) != derive_release_version(
-        PDF_SHA256, vh
-    )
+    vector_identity = {"embedding_model_id": "m", "metadata_fields": ["subsystem"]}
+    before = transform_config_hash(ex, FROZEN_POLICY, vector_identity)
+    monkeypatch.setattr(report, "EVIDENCE_REPORT_SCHEMA_VERSION", "diagnostic-vNEXT")
+    after = transform_config_hash(ex, FROZEN_POLICY, vector_identity)
+    assert after == before
 
 
-def test_identical_sources_are_deterministic():
-    assert (
-        transform_source_manifest()["transform_source_hash"]
-        == transform_source_manifest()["transform_source_hash"]
-    )
-
-
-# --- fail closed + Component B record -----------------------------------------
-
-
-def test_missing_covered_module_fails_closed(tmp_path):
-    with pytest.raises(TransformSourceMissingError):
-        transform_source_manifest(tmp_path)  # empty dir → module missing
-
-
-def test_transform_identity_records_component_b_invocation_and_ir_flag():
-    ti = transform_identity()
-    assert ti["transform_source_hash"]
-    assert ti["intermediate_representation_committed"] is False
-    inv = ti["component_b_invocation"]
-    assert inv["deterministic"] is True  # type: ignore[index]
-    assert "build_candidate" in inv["entrypoint"]  # type: ignore[index]
+def test_transform_identity_records_declared_invocation():
+    identity = transform_identity()
+    assert identity["tool_version"] == TRANSFORM_TOOL_VERSION
+    assert identity["transform_source_hash"]
+    assert identity["intermediate_representation_committed"] is False
+    invocation = identity["component_b_invocation"]
+    assert invocation["deterministic"] is True  # type: ignore[index]
+    assert "build_candidate" in invocation["entrypoint"]  # type: ignore[index]


### PR DESCRIPTION
Closes #145.

## Contract-to-code audit result

No further Owner Decision was required. The bounded audit retained the safeguards that prevent concrete operational failures (incomplete/wrong source, stale reuse, corruption, partial publication, lost provenance, and incompatible downstream use) and corrected three mechanism-level mismatches with the 2026-08-03 Operational Reliability Amendment:

- release identity no longer changes for incidental Python or diagnostic-report edits;
- Issue 5c now exposes a narrow, versioned, direct SQLite trust seam for Issue 5d;
- the diagnostic evidence report is no longer downstream compatibility authority.

## Implementation

- Adds `5c-operational-1`, an operational corpus snapshot/digest over the represented source leaves, authoritative chunks/source membership, and projection edges that 5d consumes.
- Adds fail-closed verification of publication state, the existing release binding, supported corpus contract version, direct SQLite structure, and the recorded operational digest.
- Excludes Chroma and the historical 5c proof graph from downstream verification.
- Preserves fresh-publication and verified-reuse Chroma checks.
- Preserves the current honest package UUID/release version while replacing automatic source-byte identity churn with an explicit semantic transform version.
- Decouples diagnostic report schema evolution from package identity and reuse.
- Adds migration 0022. Existing published releases receive the new contract metadata only after full verified reuse succeeds; corpus content and release identity are not rewritten.

## Verification

- changed-file Black: pass
- changed-file Ruff: pass
- mypy (207 source files): pass
- operational seam and transform identity tests: 13 pass
- corpus persistence/quarantine suite: 67 pass after updating the superseded report-schema expectation
- migration upgrade/downgrade and application bootstrap: 3 pass
- legacy operational-contract backfill: pass
- `git diff --check`: pass

Repository-wide Black/Ruff remain red on pre-existing migration formatting/lint debt outside this PR; no unrelated files were changed.

## Stack disposition

PR #143 is superseded by the amended contract and this direct operational seam. Once this correction is accepted, PR #141 should be restacked onto it and its 5c consumer replaced with `load_verified_operational_corpus`. This PR does not merge #144, #141, or itself.