### PR TITLE
fix(frontend): remediate npm audit advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2983,13 +2983,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3270,9 +3270,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@redocly/openapi-core@1.34.17": {
       "js-yaml": "4.3.0"
     },
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "eslint": {
       "minimatch": "^10"
     },


### PR DESCRIPTION
Remediates the baseline npm advisories exposed by default CI while verifying #141. This is intentionally separate from CRD Issue 5d.

## Changes

- update the explicit `brace-expansion` override from 5.0.8 to patched 5.0.9;
- refresh the lockfile to `minimatch` 10.2.6 and `postcss` 8.5.25;
- retain all existing dependency ranges and application code.

## Architecture Notes

No drift from design principles.

This is a dependency-security maintenance change only. It does not alter frontend behavior, API contracts, CRD scope, or ownership boundaries.

## Verification

Using the repository's pinned Node 22 line:

- `npm audit --audit-level=high`: 0 vulnerabilities;
- TypeScript typecheck: passed;
- ESLint: passed;
- Prettier check: passed;
- Vitest: 45 passed;
- production build: passed;
- `git diff --check`: passed.

#141's terminal CI independently passed Python tests, Black, Ruff, strict mypy, pip-audit, and E2E; its sole failure was this pre-existing npm advisory.