### PR TITLE
fix(frontend): remediate new npm audit advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2507,9 +2507,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3006,9 +3006,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,10 +22,9 @@
     "react-dom": "^18.3.1"
   },
   "overrides": {
-    "@redocly/openapi-core@1.34.17": {
-      "js-yaml": "4.3.0"
-    },
     "brace-expansion": "5.0.9",
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.17",
     "eslint": {
       "minimatch": "^10"
     },


### PR DESCRIPTION
Remediates the two high-severity transitive dependency advisories disclosed after #147. This security-maintenance PR remains separate from CRD Issue 5d.

## Changes

- replace the Redocly-scoped `js-yaml` override with a graph-wide pin to patched `js-yaml` 4.3.1, covering both Redocly and ESLint;
- pin transitive `nanoid` to patched 3.3.17 for the Vite/PostCSS path;
- regenerate only the affected lockfile entries.

## Architecture Notes

No drift from design principles.

This is dependency-security maintenance only. It changes no application code, API contract, product behavior, CRD scope, or ownership boundary.

## Advisory coverage

- `js-yaml` GHSA-5p4m-2wfm-xmqj: vulnerable 4.3.0 → patched 4.3.1;
- `nanoid` GHSA-2v37-7h3g-55p8: vulnerable 3.3.16 → patched 3.3.17.

The installed graph resolves both ESLint and Redocly to `js-yaml` 4.3.1, and Vite/PostCSS to `nanoid` 3.3.17.

## Local verification

- clean `npm ci`: passed;
- `npm audit --audit-level=high`: 0 vulnerabilities;
- TypeScript typecheck: passed;
- ESLint: passed;
- Prettier check: passed;
- Vitest: 45 passed;
- OpenAPI TypeScript drift check: passed;
- production build: passed;
- `git diff --check`: passed.

Local checks ran under the available Node 24 runtime. The repository pins Node 22; default CI is the authoritative clean-runner verification. Local E2E could not launch because this workspace lacked Chromium, and the attempted Playwright browser download failed at the environment proxy's TLS-validation boundary. Default CI installs Chromium independently and must pass before merge.

Do not merge pending full default CI and Codex review.