### PR TITLE
CRD Issue 5d PR 3 — runtime authority binding, selectors, views, and typed overrides

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -18,6 +18,7 @@ import afterworlds.persistence.orm.story_bible  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.corpus  # noqa: F401
 import afterworlds.persistence.orm.mechanical  # noqa: F401
+import afterworlds.persistence.orm.rules_authority  # noqa: F401
 import afterworlds.persistence.orm.rolling_summary  # noqa: F401
 import afterworlds.persistence.orm.rpg  # noqa: F401
 import afterworlds.persistence.orm.retrieval  # noqa: F401

--- a/alembic/versions/0024_rules_authority_runtime.py
+++ b/alembic/versions/0024_rules_authority_runtime.py
@@ -135,37 +135,74 @@ def upgrade() -> None:
     # cannot reconstruct the authority that was originally applied. These
     # retained rows are the evidence a recorded binding depends on, so the
     # database refuses the rewrite rather than leaving it to be noticed later.
-    #
-    # DELETE is guarded on the two content tables but deliberately not on
-    # rp_override_set_scopes: the scope association's lifecycle is its package's,
-    # and blocking DELETE there would make deleting a package impossible. A
-    # removed association fails replay closed, never with false provenance.
-    for table, verbs in (
-        ("rp_override_set_versions", ("UPDATE", "DELETE")),
-        ("rp_override_set_entries", ("UPDATE", "DELETE")),
-        ("rp_override_set_scopes", ("UPDATE",)),
+    for table in (
+        "rp_override_set_versions",
+        "rp_override_set_entries",
+        "rp_override_set_scopes",
     ):
-        for verb in verbs:
-            op.execute(
-                f"""
-                CREATE TRIGGER prevent_{table}_{verb.lower()}
-                BEFORE {verb} ON {table}
-                BEGIN
-                    SELECT RAISE(
-                        ABORT,
-                        '{table} is append-only: {verb} is forbidden'
-                    );
-                END
-                """
-            )
+        op.execute(
+            f"""
+            CREATE TRIGGER prevent_{table}_update
+            BEFORE UPDATE ON {table}
+            BEGIN
+                SELECT RAISE(ABORT, '{table} is append-only: UPDATE is forbidden');
+            END
+            """
+        )
+
+    for table in ("rp_override_set_versions", "rp_override_set_entries"):
+        op.execute(
+            f"""
+            CREATE TRIGGER prevent_{table}_delete
+            BEFORE DELETE ON {table}
+            BEGIN
+                SELECT RAISE(ABORT, '{table} is append-only: DELETE is forbidden');
+            END
+            """
+        )
+
+    # The scope association proves a retained version belongs to the package and
+    # release a binding names, so a directly deleted association destroys replay
+    # evidence while the package is still live — replay then fails closed, but
+    # the evidence is gone and cannot be reconstructed.
+    #
+    # It cannot take the blanket DELETE guard above, because deleting a package
+    # is the one contractual way an association goes away. The guard is therefore
+    # conditional on the owning package still existing. SQLite removes the parent
+    # row before cascading to children, so during a package deletion this WHEN
+    # clause is already false and the cascade proceeds; a direct DELETE against a
+    # live package is refused. Verified against the engine rather than assumed.
+    op.execute(
+        """
+        CREATE TRIGGER prevent_rp_override_set_scopes_delete
+        BEFORE DELETE ON rp_override_set_scopes
+        WHEN EXISTS (
+            SELECT 1 FROM rp_packages
+            WHERE rules_package_id = OLD.package_uuid
+        )
+        BEGIN
+            SELECT RAISE(
+                ABORT,
+                'rp_override_set_scopes is append-only while its package is live'
+            );
+        END
+        """
+    )
 
     # Guarding UPDATE and DELETE is not enough on SQLite. `INSERT OR REPLACE`
     # resolves a conflict by deleting the existing row and inserting the new one,
     # and with `recursive_triggers` off — the default — that implicit delete does
     # not fire the BEFORE DELETE trigger above. A retained row could therefore be
-    # rewritten wholesale without any guard firing. These BEFORE INSERT triggers
-    # refuse the re-insert directly, which is the only point REPLACE cannot slip
-    # past.
+    # rewritten wholesale without any guard firing.
+    #
+    # These BEFORE INSERT guards are **content-aware**, and that is what lets the
+    # service retain idempotently under concurrency. A guard that aborted on mere
+    # existence would also abort the loser of a benign race, so
+    # `INSERT ... ON CONFLICT DO NOTHING` could not be used and the expected race
+    # would surface as an application failure. Rejecting only an insert that would
+    # *change* retained content keeps immutability exact while leaving a
+    # byte-identical re-insert a no-op. The two mechanisms are designed together;
+    # neither works without the other.
     op.execute(
         """
         CREATE TRIGGER prevent_rp_override_set_versions_reinsert
@@ -173,15 +210,20 @@ def upgrade() -> None:
         WHEN EXISTS (
             SELECT 1 FROM rp_override_set_versions
             WHERE override_set_uuid = NEW.override_set_uuid
+              AND entry_count IS NOT NEW.entry_count
         )
         BEGIN
             SELECT RAISE(
                 ABORT,
-                'rp_override_set_versions is append-only: replacing a retained version is forbidden'
+                'rp_override_set_versions is append-only: rewrite refused'
             );
         END
         """
     )
+
+    # ``IS NOT`` rather than ``<>`` throughout: the target component and fact keys
+    # are nullable, and ``<>`` against NULL yields NULL, so a NULL-to-value change
+    # would slip past an inequality comparison.
     op.execute(
         """
         CREATE TRIGGER prevent_rp_override_set_entries_reinsert
@@ -190,29 +232,23 @@ def upgrade() -> None:
             SELECT 1 FROM rp_override_set_entries
             WHERE override_set_uuid = NEW.override_set_uuid
               AND apply_order = NEW.apply_order
+              AND (
+                   override_id IS NOT NEW.override_id
+                OR override_origin IS NOT NEW.override_origin
+                OR target_kind IS NOT NEW.target_kind
+                OR target_record_key IS NOT NEW.target_record_key
+                OR target_component_key IS NOT NEW.target_component_key
+                OR target_fact_key IS NOT NEW.target_fact_key
+                OR override_operation IS NOT NEW.override_operation
+                OR precedence IS NOT NEW.precedence
+                OR is_enabled IS NOT NEW.is_enabled
+                OR payload IS NOT NEW.payload
+              )
         )
         BEGIN
             SELECT RAISE(
                 ABORT,
-                'rp_override_set_entries is append-only: replacing a retained entry is forbidden'
-            );
-        END
-        """
-    )
-    op.execute(
-        """
-        CREATE TRIGGER prevent_rp_override_set_scopes_reinsert
-        BEFORE INSERT ON rp_override_set_scopes
-        WHEN EXISTS (
-            SELECT 1 FROM rp_override_set_scopes
-            WHERE override_set_uuid = NEW.override_set_uuid
-              AND package_uuid = NEW.package_uuid
-              AND release_version = NEW.release_version
-        )
-        BEGIN
-            SELECT RAISE(
-                ABORT,
-                'rp_override_set_scopes is append-only: replacing a retained association is forbidden'
+                'rp_override_set_entries is append-only: rewrite refused'
             );
         END
         """
@@ -221,6 +257,9 @@ def upgrade() -> None:
     # A version is sealed once it holds the entry count it declared. Without
     # this, a plain INSERT with the next apply_order silently extends a retained
     # version — the unique constraint only stops reusing an existing position.
+    # The ``NOT EXISTS`` clause exempts a re-insert at a position the version
+    # already holds, which is the idempotent-retention path; only a genuinely new
+    # position is sealed out.
     op.execute(
         """
         CREATE TRIGGER seal_rp_override_set_entries
@@ -232,10 +271,15 @@ def upgrade() -> None:
             SELECT entry_count FROM rp_override_set_versions
             WHERE override_set_uuid = NEW.override_set_uuid
         )
+        AND NOT EXISTS (
+            SELECT 1 FROM rp_override_set_entries
+            WHERE override_set_uuid = NEW.override_set_uuid
+              AND apply_order = NEW.apply_order
+        )
         BEGIN
             SELECT RAISE(
                 ABORT,
-                'rp_override_set_entries is sealed: the retained version already holds every entry it declared'
+                'rp_override_set_entries is sealed: version already complete'
             );
         END
         """
@@ -245,9 +289,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     for trigger in (
         "seal_rp_override_set_entries",
-        "prevent_rp_override_set_scopes_reinsert",
         "prevent_rp_override_set_entries_reinsert",
         "prevent_rp_override_set_versions_reinsert",
+        "prevent_rp_override_set_scopes_delete",
         "prevent_rp_override_set_scopes_update",
         "prevent_rp_override_set_entries_update",
         "prevent_rp_override_set_entries_delete",

--- a/alembic/versions/0024_rules_authority_runtime.py
+++ b/alembic/versions/0024_rules_authority_runtime.py
@@ -62,17 +62,15 @@ def upgrade() -> None:
         sa.Column("note", sa.Text, nullable=True),
     )
 
+    # Content-addressed and package-independent. The identity is derived from
+    # the ordered entries alone, so identical states across packages — including
+    # every package's empty override set — resolve to one row. An owning
+    # package_uuid with ON DELETE CASCADE would name whichever package retained
+    # it first and would delete shared replay evidence when *that* package is
+    # deleted, breaking recorded bindings of unrelated packages.
     op.create_table(
         "rp_override_set_versions",
         sa.Column("override_set_uuid", sa.String(36), primary_key=True),
-        sa.Column(
-            "package_uuid",
-            sa.String(36),
-            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        ),
-        sa.Column("release_version", sa.String(64), nullable=False),
         sa.Column("entry_count", sa.Integer, nullable=False),
         sa.Column("recorded_at", sa.String(64), nullable=False),
     )
@@ -105,8 +103,33 @@ def upgrade() -> None:
         ),
     )
 
+    # Append-only triggers on both retained tables, matching the convention this
+    # repository already applies to entitlement_event, provider_refusal_log, and
+    # rpg_roll_audit. Reconstruction re-derives the identity on read and so can
+    # *detect* a rewritten version, but detection only reports that replay is
+    # broken — it cannot reconstruct the authority that was originally applied.
+    # These retained rows are the evidence a recorded binding depends on, so the
+    # database refuses the rewrite rather than leaving it to be noticed later.
+    for table in ("rp_override_set_versions", "rp_override_set_entries"):
+        for verb in ("UPDATE", "DELETE"):
+            op.execute(
+                f"""
+                CREATE TRIGGER prevent_{table}_{verb.lower()}
+                BEFORE {verb} ON {table}
+                BEGIN
+                    SELECT RAISE(
+                        ABORT,
+                        '{table} is append-only: {verb} is forbidden'
+                    );
+                END
+                """
+            )
+
 
 def downgrade() -> None:
+    for table in ("rp_override_set_versions", "rp_override_set_entries"):
+        for verb in ("update", "delete"):
+            op.execute(f"DROP TRIGGER IF EXISTS prevent_{table}_{verb}")
     op.drop_table("rp_override_set_entries")
     op.drop_table("rp_override_set_versions")
     op.drop_table("rp_mech_overrides")

--- a/alembic/versions/0024_rules_authority_runtime.py
+++ b/alembic/versions/0024_rules_authority_runtime.py
@@ -203,6 +203,20 @@ def upgrade() -> None:
     # *change* retained content keeps immutability exact while leaving a
     # byte-identical re-insert a no-op. The two mechanisms are designed together;
     # neither works without the other.
+    #
+    # A header carrying the *same* entry_count is therefore let past this guard,
+    # and an `INSERT OR REPLACE` at that shape still cannot destroy anything: a
+    # foreign-key CASCADE is not the same thing as REPLACE's own conflict
+    # resolution. The latter skips BEFORE DELETE triggers while
+    # `recursive_triggers` is off; the former fires them. So the implicit delete
+    # of the header cascades into the entries and the scope association, each of
+    # which raises from its own DELETE guard and aborts the whole statement.
+    # What is left is a header with no entries and no association — a shape
+    # retention cannot produce, since the scope is written in the same unit, and
+    # one that already fails replay closed for want of a scope. Its only writable
+    # column is the `recorded_at` audit stamp, which ADR-005d Decision 9 keeps
+    # outside identity. Asserted state by state in
+    # tests/persistence/test_rules_authority_migration.py rather than argued.
     op.execute(
         """
         CREATE TRIGGER prevent_rp_override_set_versions_reinsert

--- a/alembic/versions/0024_rules_authority_runtime.py
+++ b/alembic/versions/0024_rules_authority_runtime.py
@@ -1,0 +1,112 @@
+"""Runtime mechanical authority: typed overrides and retained override sets.
+
+CRD Issue 5d (#137), PR 3. Adds the runtime half of ADR-005d Decisions 9 and 10:
+
+* ``rp_mech_overrides`` — the mutable authoring surface for typed
+  record/component/fact overrides. Separate from ``rp_overrides``, which holds
+  the distinct chunk-targeting prose override family and still carries the
+  obsolete ``target_entity_id`` column the final legacy-retirement PR removes.
+* ``rp_override_set_versions`` / ``rp_override_set_entries`` — the immutable,
+  append-only replay evidence an ``override_set_uuid`` names. The version's
+  primary key *is* the content-derived identity of the canonical ordered
+  override state, so recording an identical state twice is a no-op and two
+  different states can never share a version.
+
+Additive only. Nothing existing is altered or dropped, no projection becomes
+active by migrating, and the legacy ``MechanicalEntity`` path is untouched.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-08-08
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0024"
+down_revision: str | None = "0023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "rp_mech_overrides",
+        sa.Column("override_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "package_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("release_version", sa.String(64), nullable=False),
+        sa.Column("target_kind", sa.String(16), nullable=False),
+        sa.Column("target_record_key", sa.String(255), nullable=False),
+        sa.Column("target_component_key", sa.String(255), nullable=True),
+        sa.Column("target_fact_key", sa.String(32), nullable=True),
+        sa.Column("override_origin", sa.String(32), nullable=False),
+        sa.Column("override_operation", sa.String(16), nullable=False),
+        sa.Column("payload", sa.JSON, nullable=False),
+        sa.Column("precedence", sa.Integer, nullable=False),
+        sa.Column(
+            "is_enabled", sa.Boolean, nullable=False, server_default=sa.true()
+        ),
+        sa.Column("created_at", sa.String(64), nullable=False),
+        sa.Column("created_by", sa.String(255), nullable=True),
+        sa.Column("note", sa.Text, nullable=True),
+    )
+
+    op.create_table(
+        "rp_override_set_versions",
+        sa.Column("override_set_uuid", sa.String(36), primary_key=True),
+        sa.Column(
+            "package_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("release_version", sa.String(64), nullable=False),
+        sa.Column("entry_count", sa.Integer, nullable=False),
+        sa.Column("recorded_at", sa.String(64), nullable=False),
+    )
+
+    op.create_table(
+        "rp_override_set_entries",
+        sa.Column("row_id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "override_set_uuid",
+            sa.String(36),
+            sa.ForeignKey(
+                "rp_override_set_versions.override_set_uuid", ondelete="CASCADE"
+            ),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("apply_order", sa.Integer, nullable=False),
+        sa.Column("override_id", sa.String(36), nullable=False),
+        sa.Column("override_origin", sa.String(32), nullable=False),
+        sa.Column("target_kind", sa.String(16), nullable=False),
+        sa.Column("target_record_key", sa.String(255), nullable=False),
+        sa.Column("target_component_key", sa.String(255), nullable=True),
+        sa.Column("target_fact_key", sa.String(32), nullable=True),
+        sa.Column("override_operation", sa.String(16), nullable=False),
+        sa.Column("precedence", sa.Integer, nullable=False),
+        sa.Column("is_enabled", sa.Boolean, nullable=False),
+        sa.Column("payload", sa.JSON, nullable=False),
+        sa.UniqueConstraint(
+            "override_set_uuid", "apply_order", name="uq_rp_override_set_entry_order"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("rp_override_set_entries")
+    op.drop_table("rp_override_set_versions")
+    op.drop_table("rp_mech_overrides")

--- a/alembic/versions/0024_rules_authority_runtime.py
+++ b/alembic/versions/0024_rules_authority_runtime.py
@@ -103,15 +103,49 @@ def upgrade() -> None:
         ),
     )
 
-    # Append-only triggers on both retained tables, matching the convention this
-    # repository already applies to entitlement_event, provider_refusal_log, and
-    # rpg_roll_audit. Reconstruction re-derives the identity on read and so can
-    # *detect* a rewritten version, but detection only reports that replay is
-    # broken — it cannot reconstruct the authority that was originally applied.
-    # These retained rows are the evidence a recorded binding depends on, so the
+    # Which package/release retained which shared content. An association rather
+    # than a column on the version, because the version is shared by every scope
+    # holding identical override state — including every package's empty set.
+    # Deleting a package drops its own association here and leaves the shared
+    # content, and every other package's association, untouched.
+    op.create_table(
+        "rp_override_set_scopes",
+        sa.Column(
+            "override_set_uuid",
+            sa.String(36),
+            sa.ForeignKey(
+                "rp_override_set_versions.override_set_uuid", ondelete="CASCADE"
+            ),
+            primary_key=True,
+        ),
+        sa.Column(
+            "package_uuid",
+            sa.String(36),
+            sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("release_version", sa.String(64), primary_key=True),
+        sa.Column("first_recorded_at", sa.String(64), nullable=False),
+    )
+
+    # Append-only triggers, matching the convention this repository already
+    # applies to entitlement_event, provider_refusal_log, and rpg_roll_audit.
+    # Reconstruction re-derives the identity on read and so can *detect* a
+    # rewritten version, but detection only reports that replay is broken — it
+    # cannot reconstruct the authority that was originally applied. These
+    # retained rows are the evidence a recorded binding depends on, so the
     # database refuses the rewrite rather than leaving it to be noticed later.
-    for table in ("rp_override_set_versions", "rp_override_set_entries"):
-        for verb in ("UPDATE", "DELETE"):
+    #
+    # DELETE is guarded on the two content tables but deliberately not on
+    # rp_override_set_scopes: the scope association's lifecycle is its package's,
+    # and blocking DELETE there would make deleting a package impossible. A
+    # removed association fails replay closed, never with false provenance.
+    for table, verbs in (
+        ("rp_override_set_versions", ("UPDATE", "DELETE")),
+        ("rp_override_set_entries", ("UPDATE", "DELETE")),
+        ("rp_override_set_scopes", ("UPDATE",)),
+    ):
+        for verb in verbs:
             op.execute(
                 f"""
                 CREATE TRIGGER prevent_{table}_{verb.lower()}
@@ -125,11 +159,103 @@ def upgrade() -> None:
                 """
             )
 
+    # Guarding UPDATE and DELETE is not enough on SQLite. `INSERT OR REPLACE`
+    # resolves a conflict by deleting the existing row and inserting the new one,
+    # and with `recursive_triggers` off — the default — that implicit delete does
+    # not fire the BEFORE DELETE trigger above. A retained row could therefore be
+    # rewritten wholesale without any guard firing. These BEFORE INSERT triggers
+    # refuse the re-insert directly, which is the only point REPLACE cannot slip
+    # past.
+    op.execute(
+        """
+        CREATE TRIGGER prevent_rp_override_set_versions_reinsert
+        BEFORE INSERT ON rp_override_set_versions
+        WHEN EXISTS (
+            SELECT 1 FROM rp_override_set_versions
+            WHERE override_set_uuid = NEW.override_set_uuid
+        )
+        BEGIN
+            SELECT RAISE(
+                ABORT,
+                'rp_override_set_versions is append-only: replacing a retained version is forbidden'
+            );
+        END
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER prevent_rp_override_set_entries_reinsert
+        BEFORE INSERT ON rp_override_set_entries
+        WHEN EXISTS (
+            SELECT 1 FROM rp_override_set_entries
+            WHERE override_set_uuid = NEW.override_set_uuid
+              AND apply_order = NEW.apply_order
+        )
+        BEGIN
+            SELECT RAISE(
+                ABORT,
+                'rp_override_set_entries is append-only: replacing a retained entry is forbidden'
+            );
+        END
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER prevent_rp_override_set_scopes_reinsert
+        BEFORE INSERT ON rp_override_set_scopes
+        WHEN EXISTS (
+            SELECT 1 FROM rp_override_set_scopes
+            WHERE override_set_uuid = NEW.override_set_uuid
+              AND package_uuid = NEW.package_uuid
+              AND release_version = NEW.release_version
+        )
+        BEGIN
+            SELECT RAISE(
+                ABORT,
+                'rp_override_set_scopes is append-only: replacing a retained association is forbidden'
+            );
+        END
+        """
+    )
+
+    # A version is sealed once it holds the entry count it declared. Without
+    # this, a plain INSERT with the next apply_order silently extends a retained
+    # version — the unique constraint only stops reusing an existing position.
+    op.execute(
+        """
+        CREATE TRIGGER seal_rp_override_set_entries
+        BEFORE INSERT ON rp_override_set_entries
+        WHEN (
+            SELECT COUNT(*) FROM rp_override_set_entries
+            WHERE override_set_uuid = NEW.override_set_uuid
+        ) >= (
+            SELECT entry_count FROM rp_override_set_versions
+            WHERE override_set_uuid = NEW.override_set_uuid
+        )
+        BEGIN
+            SELECT RAISE(
+                ABORT,
+                'rp_override_set_entries is sealed: the retained version already holds every entry it declared'
+            );
+        END
+        """
+    )
+
 
 def downgrade() -> None:
-    for table in ("rp_override_set_versions", "rp_override_set_entries"):
-        for verb in ("update", "delete"):
-            op.execute(f"DROP TRIGGER IF EXISTS prevent_{table}_{verb}")
+    for trigger in (
+        "seal_rp_override_set_entries",
+        "prevent_rp_override_set_scopes_reinsert",
+        "prevent_rp_override_set_entries_reinsert",
+        "prevent_rp_override_set_versions_reinsert",
+        "prevent_rp_override_set_scopes_update",
+        "prevent_rp_override_set_entries_update",
+        "prevent_rp_override_set_entries_delete",
+        "prevent_rp_override_set_versions_update",
+        "prevent_rp_override_set_versions_delete",
+    ):
+        op.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+    op.drop_table("rp_override_set_scopes")
     op.drop_table("rp_override_set_entries")
     op.drop_table("rp_override_set_versions")
     op.drop_table("rp_mech_overrides")

--- a/src/afterworlds/models/__init__.py
+++ b/src/afterworlds/models/__init__.py
@@ -59,7 +59,7 @@ from afterworlds.models.rpg import (
     VisibleRelationship,
     WriterAdjudicationView,
 )
-from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.models.rules_package import RuleSliceRequest, RulesPackageBinding
 from afterworlds.models.session import (
     BranchingSessionState,
     BranchNode,
@@ -136,6 +136,7 @@ __all__ = [
     "AssembledContext",
     # rules package
     "RuleSliceRequest",
+    "RulesPackageBinding",
     # character sheet
     "Dnd5eAbilityScores",
     "Dnd5eActiveCondition",

--- a/src/afterworlds/models/rules_package.py
+++ b/src/afterworlds/models/rules_package.py
@@ -404,21 +404,100 @@ class IngestionConfig:
     extra_tags: list[str] = field(default_factory=list)
 
 
+class RulesPackageBinding(BaseModel):
+    """The exact four-component effective binding (ADR-005d Decision 9).
+
+    ``mechanical_projection_uuid`` identifies the immutable base projection;
+    ``override_set_uuid`` identifies the exact applied effective override set.
+    The two are never collapsed into one value: an override change mints a new
+    override-set identity and leaves the base projection identity untouched, and
+    a binding that carried only one of them could resolve to different DCs,
+    effects, or disabled mechanics over time.
+
+    Every field is a ``UUID`` or an exact release string — never a slug, display
+    name, or filename. A human-facing slug may resolve *to* a binding through
+    one code-owned service, but it is never the binding itself.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    package_uuid: UUID
+    release_version: str
+    mechanical_projection_uuid: UUID
+    override_set_uuid: UUID
+
+
 class RuleSliceRequest(BaseModel):
-    """Typed parameter bundle for RulesPackageService.get_active_rule_slice.
+    """Typed parameter bundle for RulesPackageService rule-slice reads.
 
     Introduced in Issue 8 (Context Builder) per the instruction to reuse this
     model from Issue 5a's namespace rather than creating a parallel model in
     the Context Builder.  The model was not defined during Issue 5a — it is
     added here now.  See PR Architecture Notes for scope rationale.
+
+    CRD Issue 5d extends this same model rather than introducing a parallel
+    request type (#137 contract 6).  Three things changed:
+
+    * **The package reference may be a UUID or a human-facing slug, and exactly
+      one of them must be supplied.**  ``package_slug`` resolves through the one
+      code-owned service in
+      :mod:`afterworlds.services.rules_authority.binding`; it never becomes
+      authority itself.  A caller that previously swallowed a non-UUID reference
+      and silently omitted the request now states which form it holds.
+    * **Deterministic mechanical selectors**, ``record_selectors`` and
+      ``component_selectors``, name exact semantic keys in the bound projection.
+    * **``whole_package`` is explicit.**  A request that selects nothing and
+      does not set it is ``INVALID_SELECTOR`` — refused at construction, so the
+      accidentally-empty selector cannot reach a service and come back as an
+      empty result that reads like "no rules apply".
     """
 
-    package_id: UUID
+    model_config = ConfigDict(frozen=True)
+
+    package_id: UUID | None = None
+    package_slug: str | None = None
     subsystem_tags: list[RuleSubsystemEnum] = Field(default_factory=list)
     entity_refs: list[tuple[MechanicalEntityTypeEnum, str]] = Field(
         default_factory=list
     )
     include_non_published: bool = False
+
+    #: A previously recorded binding to revalidate.  Supplied by a consumer that
+    #: stored one; runtime resolution reports ``STALE`` when it no longer
+    #: matches, rather than silently re-resolving against current overrides.
+    recorded_binding: RulesPackageBinding | None = None
+    record_selectors: tuple[str, ...] = ()
+    component_selectors: tuple[tuple[str, str], ...] = ()
+    whole_package: bool = False
+
+    @model_validator(mode="after")
+    def exactly_one_package_reference(self) -> Self:
+        """Exactly one of package_id or package_slug identifies the package."""
+        by_id = self.package_id is not None
+        by_slug = self.package_slug is not None and bool(self.package_slug.strip())
+        if by_id == by_slug:
+            raise ValueError(
+                "exactly one of package_id or package_slug must be supplied; got "
+                f"package_id={self.package_id!r}, package_slug={self.package_slug!r}"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def selects_something_explicitly(self) -> Self:
+        """Refuse the accidentally empty selector set (#137 contract 6)."""
+        if self.whole_package:
+            return self
+        if (
+            self.subsystem_tags
+            or self.entity_refs
+            or self.record_selectors
+            or self.component_selectors
+        ):
+            return self
+        raise ValueError(
+            "rule slice request selects nothing: supply subsystem tags, entity "
+            "refs, record/component selectors, or set whole_package=True"
+        )
 
 
 class ActiveRuleSlice(BaseModel):

--- a/src/afterworlds/persistence/database.py
+++ b/src/afterworlds/persistence/database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from typing import Any
 
 import sqlalchemy as sa
@@ -33,3 +34,40 @@ def create_engine(url: str, **kwargs: Any) -> sa.Engine:
 def create_session_factory(engine: sa.Engine) -> sessionmaker[Session]:
     """Return a configured :class:`sessionmaker` bound to *engine*."""
     return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def ensure_physical_transaction(session: Session) -> None:
+    """Guarantee that SQLite has actually issued ``BEGIN`` for *session*.
+
+    ``sqlite3`` is used here with its legacy transaction control, so the driver
+    opens a transaction implicitly only before ``INSERT``/``UPDATE``/``DELETE``/
+    ``REPLACE``. A session that has so far only read is logically inside a
+    SQLAlchemy transaction while the connection is still in **autocommit** at the
+    SQLite level, and the two disagreeing is not merely cosmetic:
+
+    * ``SAVEPOINT`` issued in autocommit *starts* a transaction, and releasing
+      that outermost savepoint therefore **commits** it. Work a caller believed
+      was pending in its own transaction is durable the moment the savepoint is
+      released, and a later ``rollback()`` — even one from an explicit
+      ``with session.begin():`` — cannot take it back.
+    * SQLAlchemy's logical transaction state does not tell you which case you are
+      in, so this checks the DBAPI connection itself rather than inferring it.
+
+    Emitting ``BEGIN`` first makes any subsequent savepoint genuinely nested:
+    release stops committing, and the enclosing transaction owns the commit
+    boundary as callers already assume. The statement goes through the same
+    connection SQLAlchemy is using, and ``sqlite3`` tracks the resulting
+    transaction through ``sqlite3_get_autocommit``, so ``commit()`` and
+    ``rollback()`` continue to behave normally.
+
+    A no-op on any other driver, and on a session that has already written:
+    those have a physical transaction open already. Deliberately scoped to the
+    call sites that need it rather than applied engine-wide — making every
+    SQLAlchemy transaction physical would change lock acquisition for every
+    service and migration in the repository, which is a far wider change than
+    the guarantee it buys here.
+    """
+    connection = session.connection()
+    raw = connection.connection.dbapi_connection
+    if isinstance(raw, sqlite3.Connection) and not raw.in_transaction:
+        connection.exec_driver_sql("BEGIN")

--- a/src/afterworlds/persistence/orm/rules_authority.py
+++ b/src/afterworlds/persistence/orm/rules_authority.py
@@ -102,25 +102,28 @@ class OverrideSetVersionORM(Base):
     rather than a second row, and two different states can never share a
     version.
 
-    ``package_uuid`` and ``release_version`` record the scope this version was
-    resolved for. They are retained for retrieval and diagnosis and are
-    deliberately **not** part of the identity payload: the identity is derived
-    from the ordered entries alone, which is what gives the empty override set
-    one deterministic identity rather than one per package.
+    **A version is content, not a possession of one package.** Because the
+    identity is derived from the ordered entries alone — which is what gives the
+    empty override set one deterministic identity rather than one per package —
+    identical states across packages resolve to the same row, and every package
+    with no overrides shares it. It therefore carries no ``package_uuid`` and no
+    foreign key: an owning column would name whichever package happened to
+    retain it first, and cascading that package's deletion would delete replay
+    evidence that recorded bindings of unrelated packages still depend on.
+    Package scope belongs to the enclosing binding, which supplies it already.
 
-    ``recorded_at`` is audit metadata and never participates in identity.
+    ``recorded_at`` is audit metadata — when this content was *first* observed —
+    and never participates in identity.
+
+    Append-only, enforced by database triggers (migration ``0024``) as the
+    repository does for its other append-only evidence tables. Verification on
+    read can only report that replay is broken; the triggers are what stop it
+    from being broken by an ordinary ORM mistake.
     """
 
     __tablename__ = "rp_override_set_versions"
 
     override_set_uuid: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
-    package_uuid: Mapped[str] = mapped_column(
-        sa.String(36),
-        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    release_version: Mapped[str] = mapped_column(sa.String(64), nullable=False)
     entry_count: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     recorded_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
 
@@ -136,6 +139,9 @@ class OverrideSetEntryORM(Base):
 
     ``(override_set_uuid, apply_order)`` is unique: the retained order is the
     order that was applied, and two entries cannot claim the same position.
+
+    Append-only, enforced by database triggers (migration ``0024``) for the same
+    reason as its version header.
     """
 
     __tablename__ = "rp_override_set_entries"

--- a/src/afterworlds/persistence/orm/rules_authority.py
+++ b/src/afterworlds/persistence/orm/rules_authority.py
@@ -1,6 +1,6 @@
 """Runtime mechanical-authority tables — CRD Issue 5d, Decisions 9 and 10.
 
-Three tables, and the split between them is the whole point of ADR-005d
+Four tables, and the split between them is the whole point of ADR-005d
 Decision 9:
 
 * ``rp_mech_overrides`` is the **authoring surface**. Rows here are mutable:
@@ -9,6 +9,10 @@ Decision 9:
   **retained replay evidence**. Rows here are append-only and immutable, keyed
   by the content-derived ``override_set_uuid`` of the exact canonical ordered
   override state that produced them.
+* ``rp_override_set_scopes`` records **which package and release retained which
+  content**. It exists at a third grain because a version is content: identical
+  override state across packages is one row, so the version itself cannot say
+  whose it is, and replay would otherwise have to take a binding at its word.
 
 Recording only the identifier and re-deriving from current rows was rejected in
 the PR #138 review: the identifier would name state that no longer exists the
@@ -148,11 +152,23 @@ class OverrideSetScopeORM(Base):
     association — its own recorded bindings die with it — while the shared
     version and every other package's association survive untouched.
 
-    Append-only against ``UPDATE`` and re-``INSERT``, but deliberately **not**
-    against ``DELETE``: the delete path is how the package cascade above works,
-    and blocking it would make deleting a package impossible. A deleted
-    association fails replay closed with a retention defect, never with false
-    provenance.
+    Append-only, and the ``DELETE`` guard is **conditional** rather than absent
+    (migration ``0024``). It refuses a delete only while the owning package is
+    still live, which is what makes the two requirements compatible: deleting a
+    package remains possible, because SQLite removes the parent row before
+    cascading and the guard's condition is already false by the time the child
+    trigger fires, while a direct delete against a live package's association is
+    rejected. An association that goes away by the contractual route fails replay
+    closed with a retention defect, never with false provenance.
+
+    Re-inserting an *identical* association is a no-op rather than an error:
+    :func:`~afterworlds.services.rules_authority.retention.retain_override_set`
+    writes through ``INSERT ... ON CONFLICT DO NOTHING``, so two sessions
+    retaining the same content under the same scope converge instead of racing.
+    The association *is* its primary key — version, package, and release
+    together — so the only column a repeat could disturb is the
+    ``first_recorded_at`` audit stamp, which the conflict clause leaves at the
+    first observation. ``UPDATE`` is refused outright.
     """
 
     __tablename__ = "rp_override_set_scopes"

--- a/src/afterworlds/persistence/orm/rules_authority.py
+++ b/src/afterworlds/persistence/orm/rules_authority.py
@@ -128,6 +128,50 @@ class OverrideSetVersionORM(Base):
     recorded_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
 
 
+class OverrideSetScopeORM(Base):
+    """One package/release a retained override-set version was recorded for.
+
+    The version row is content and is deliberately shared: identical override
+    state across packages is one row, and every package with no overrides shares
+    the empty set. That sharing is what makes this table necessary. Without it
+    the version carries no record of *which* scopes it was ever retained for, so
+    replay has to take the caller's binding at its word — and because semantic
+    keys are stable across SRD-derived releases by design, an override set
+    retained for one package finds live targets in another and replays with the
+    wrong provenance.
+
+    So scope is an *association*, not a column on the content: many packages may
+    legitimately share one version, and each records its own row here.
+
+    ``ON DELETE CASCADE`` on ``package_uuid`` is correct at this grain and was
+    the defect at the other one. Deleting a package removes that package's
+    association — its own recorded bindings die with it — while the shared
+    version and every other package's association survive untouched.
+
+    Append-only against ``UPDATE`` and re-``INSERT``, but deliberately **not**
+    against ``DELETE``: the delete path is how the package cascade above works,
+    and blocking it would make deleting a package impossible. A deleted
+    association fails replay closed with a retention defect, never with false
+    provenance.
+    """
+
+    __tablename__ = "rp_override_set_scopes"
+
+    override_set_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_override_set_versions.override_set_uuid", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    package_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    release_version: Mapped[str] = mapped_column(sa.String(64), primary_key=True)
+    #: When this scope first retained this content. Audit metadata only.
+    first_recorded_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
 class OverrideSetEntryORM(Base):
     """One retained entry of an immutable override-set version.
 

--- a/src/afterworlds/persistence/orm/rules_authority.py
+++ b/src/afterworlds/persistence/orm/rules_authority.py
@@ -1,0 +1,170 @@
+"""Runtime mechanical-authority tables — CRD Issue 5d, Decisions 9 and 10.
+
+Three tables, and the split between them is the whole point of ADR-005d
+Decision 9:
+
+* ``rp_mech_overrides`` is the **authoring surface**. Rows here are mutable:
+  an operator edits, disables, reprioritizes, retargets, or deletes them.
+* ``rp_override_set_versions`` and ``rp_override_set_entries`` are the
+  **retained replay evidence**. Rows here are append-only and immutable, keyed
+  by the content-derived ``override_set_uuid`` of the exact canonical ordered
+  override state that produced them.
+
+Recording only the identifier and re-deriving from current rows was rejected in
+the PR #138 review: the identifier would name state that no longer exists the
+moment an override is edited, so audit and replay could detect divergence but
+could not reconstruct the authority actually applied. The retained entries are
+what makes the binding *provenance-exact* — they carry the stable override
+identity and origin as well as the mechanical change, so an audit can name which
+authoritative record supplied each change.
+
+Typed mechanical overrides live in their own table rather than extending
+``rp_overrides``. The existing chunk-targeting prose override is a different
+family with a different payload contract (#137 contract 6 keeps them distinct),
+and ``rp_overrides`` still carries the ``target_entity_id`` column of the
+obsolete ``MechanicalEntity`` family, which the final activation/legacy PR
+removes. Sharing one table would couple this schema to that removal.
+
+``payload`` is the one JSON column, and it is not a generic escape hatch: it
+holds the validated field set of one closed typed patch family, rebuilt through
+explicit per-family builders that reject an unknown or malformed shape (see
+:mod:`afterworlds.services.rules_authority.patches`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from afterworlds.persistence.orm.base import Base
+
+
+class MechanicalOverrideORM(Base):
+    """One authored typed override against a package's mechanical authority.
+
+    Mutable by design — this is where an operator authors. Everything an audit
+    needs to reconstruct a past effective view is copied into the retained
+    override-set version at binding-resolution time, so editing or deleting a
+    row here never rewrites history.
+
+    ``release_version`` is the release the override was authored against. A row
+    authored against a different release than the one being resolved is a
+    cross-release patch and fails as ``INVALID_OVERRIDE``; it is not silently
+    applied and not silently skipped.
+
+    ``created_at``, ``created_by``, and ``note`` are audit metadata. None of
+    them participates in applicability, ordering, or resolution, so none of them
+    reaches the override-set identity (ADR-005d Decision 9).
+    """
+
+    __tablename__ = "rp_mech_overrides"
+
+    override_id: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    package_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    release_version: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+    # Exact typed target identity. Semantic keys, never derived projection IDs:
+    # a derived ID would bind every override to one projection UUID and expire
+    # the whole override set the next time the same release is reprojected.
+    target_kind: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    target_record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    target_component_key: Mapped[str | None] = mapped_column(
+        sa.String(255), nullable=True
+    )
+    target_fact_key: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+
+    override_origin: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    override_operation: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)
+    precedence: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    is_enabled: Mapped[bool] = mapped_column(
+        sa.Boolean, nullable=False, default=True, server_default=sa.true()
+    )
+
+    # Audit metadata — deliberately outside the override-set identity.
+    created_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    created_by: Mapped[str | None] = mapped_column(sa.String(255), nullable=True)
+    note: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+
+
+class OverrideSetVersionORM(Base):
+    """One immutable, replayable override-set version.
+
+    The primary key *is* the content-derived identity of the canonical ordered
+    override state, so re-recording an identical state is an idempotent no-op
+    rather than a second row, and two different states can never share a
+    version.
+
+    ``package_uuid`` and ``release_version`` record the scope this version was
+    resolved for. They are retained for retrieval and diagnosis and are
+    deliberately **not** part of the identity payload: the identity is derived
+    from the ordered entries alone, which is what gives the empty override set
+    one deterministic identity rather than one per package.
+
+    ``recorded_at`` is audit metadata and never participates in identity.
+    """
+
+    __tablename__ = "rp_override_set_versions"
+
+    override_set_uuid: Mapped[str] = mapped_column(sa.String(36), primary_key=True)
+    package_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_packages.rules_package_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    release_version: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    entry_count: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    recorded_at: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+
+
+class OverrideSetEntryORM(Base):
+    """One retained entry of an immutable override-set version.
+
+    A complete provenance-exact copy of the override as it applied: stable
+    identity, origin, exact typed target, operation, precedence, resolved apply
+    order, enablement state, and the complete validated payload. Nothing here
+    points back at ``rp_mech_overrides`` for its content, because the whole
+    purpose of this table is to outlive that row.
+
+    ``(override_set_uuid, apply_order)`` is unique: the retained order is the
+    order that was applied, and two entries cannot claim the same position.
+    """
+
+    __tablename__ = "rp_override_set_entries"
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "override_set_uuid", "apply_order", name="uq_rp_override_set_entry_order"
+        ),
+    )
+
+    row_id: Mapped[int] = mapped_column(
+        sa.Integer, primary_key=True, autoincrement=True
+    )
+    override_set_uuid: Mapped[str] = mapped_column(
+        sa.String(36),
+        sa.ForeignKey("rp_override_set_versions.override_set_uuid", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    apply_order: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+
+    override_id: Mapped[str] = mapped_column(sa.String(36), nullable=False)
+    override_origin: Mapped[str] = mapped_column(sa.String(32), nullable=False)
+    target_kind: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    target_record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
+    target_component_key: Mapped[str | None] = mapped_column(
+        sa.String(255), nullable=True
+    )
+    target_fact_key: Mapped[str | None] = mapped_column(sa.String(32), nullable=True)
+    override_operation: Mapped[str] = mapped_column(sa.String(16), nullable=False)
+    precedence: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    is_enabled: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(sa.JSON, nullable=False)

--- a/src/afterworlds/pipeline/orchestrator/service.py
+++ b/src/afterworlds/pipeline/orchestrator/service.py
@@ -88,6 +88,7 @@ from afterworlds.pipeline.branching.models import (
 from afterworlds.pipeline.rpg.models import AdjudicationPassError
 from afterworlds.pipeline.rpg.pending import PendingRollDuplicateError
 from afterworlds.pipeline.writing.models import WritingOocExtractionUsageError
+from afterworlds.services.rules_authority import AuthorityOutcome, PackageResolution
 
 if TYPE_CHECKING:
     from afterworlds.models.character_sheet import Dnd5eCharacterSheet
@@ -388,6 +389,11 @@ class OrchestratorService:
             Callable[[UUID], tuple[RpgSessionState, Dnd5eCharacterSheet]] | None
         ) = None,
         rpg_session_resolver: Callable[[UUID], RpgSessionState | None] | None = None,
+        #: Resolves an RPG sheet's rules-package reference — a UUID or a
+        #: human-facing slug — through CRD Issue 5d's one code-owned path.
+        rules_package_reference_resolver: (
+            Callable[[str], PackageResolution] | None
+        ) = None,
         rpg_dice_service: DiceService | None = None,
         rpg_pending_roll_service: PendingRollRequestService | None = None,
         rpg_visible_state_service: RpgVisibleStateService | None = None,
@@ -424,6 +430,7 @@ class OrchestratorService:
         self._rpg_adjudication_service = rpg_adjudication_service
         self._rpg_session_sheet_resolver = rpg_session_sheet_resolver
         self._rpg_session_resolver = rpg_session_resolver
+        self._rules_package_reference_resolver = rules_package_reference_resolver
         self._rpg_dice_service = rpg_dice_service
         self._rpg_pending_roll_service = rpg_pending_roll_service
         self._rpg_visible_state_service = rpg_visible_state_service
@@ -639,16 +646,30 @@ class OrchestratorService:
                     turn_start,
                     f"RPG session/sheet resolution failed: {exc}",
                 )
-            # Only build a rule slice for IN_PLAY sessions; setup turns do not
-            # run adjudication so the context builder does not need the slice.
+            # Only resolve rules-package authority for IN_PLAY sessions; setup
+            # turns do not run adjudication.
+            #
+            # CRD Issue 5d (#137 contract 6) removed two fail-open behaviours
+            # that used to live here. The sheet's ``rules_package_id`` may be a
+            # UUID or a human-facing slug, and a non-UUID reference was parsed
+            # with ``UUID(...)`` and, on ``ValueError``, silently dropped — a
+            # malformed reference and a package with no rules produced the same
+            # silence. It now resolves through the one code-owned path, and a
+            # reference that does not resolve fails the turn explicitly.
+            #
+            # The request this used to build carried no selectors at all, so the
+            # slice it produced was always empty (ADR-005d Decision 9's
+            # accidentally-empty selector, which ``RuleSliceRequest`` now refuses
+            # to construct). It is not replaced with a whole-package request:
+            # which mechanics an adjudicating turn needs is CRD Issue 15c's
+            # selection contract, and inventing one here would be this layer
+            # deciding product semantics it does not own.
             if pre_session_state.play_status is RpgPlayStatus.IN_PLAY:
-                try:
-                    _pkg_uuid = UUID(pre_sheet.rules_package_id)
-                    rule_slice_request = RuleSliceRequest(package_id=_pkg_uuid)
-                except ValueError:
-                    # Non-UUID binding (slug) — omit request; adjudication
-                    # proceeds without a rule slice and produces "undetermined".
-                    rule_slice_request = None
+                failure = self._resolve_rules_package_reference(
+                    pre_sheet.rules_package_id, intent_result, latency, turn_start
+                )
+                if failure is not None:
+                    return failure
 
         # 2a-retrieval. Build the retrieval query request before context
         # assembly (ADR-018 D8) — orchestrator-owned and deterministic,
@@ -3679,6 +3700,47 @@ class OrchestratorService:
             total_latency_ms=total_ms,
             pass_latency_breakdown=dict(latency),
             stable_prefix_cache_warmed=cache_warmed,
+        )
+
+    def _resolve_rules_package_reference(
+        self,
+        reference: str,
+        intent_result: IntentClassificationResult,
+        latency: dict[str, int],
+        turn_start: float,
+    ) -> OrchestrationResult | None:
+        """Resolve an RPG sheet's rules-package reference, or fail the turn.
+
+        Returns ``None`` when the reference is usable and a typed
+        ``PIPELINE_ERROR`` otherwise. CRD Issue 5d requires a slug to resolve
+        through one code-owned service and an unresolvable, ambiguous, or
+        malformed reference to fail explicitly (#137 contract 6); none of those
+        may be swallowed into a turn that proceeds as though the Sojourner's
+        sheet named nothing.
+
+        With no resolver wired there is nothing to resolve *against*, and the
+        turn proceeds without mechanical authority — ADR-015's ``undetermined``
+        behaviour, reached by an explicit branch rather than by catching a
+        ``ValueError`` from a speculative ``UUID(...)`` parse. That parse is
+        what made the removed path fail open: it could not tell a malformed
+        reference from a package that simply has no rules, and answered both
+        with silence. How a Character Sheet stores and revalidates its package
+        reference is CRD Issue 2b's, so this layer resolves what it is given and
+        decides nothing about the storage.
+        """
+        if self._rules_package_reference_resolver is None:
+            return None
+
+        resolution = self._rules_package_reference_resolver(reference)
+        if resolution.outcome is AuthorityOutcome.RESOLVED:
+            return None
+        return self._pipeline_error(
+            intent_result,
+            latency,
+            turn_start,
+            f"RPG rules package reference {reference!r} did not resolve: "
+            f"{resolution.outcome.value}"
+            + (f" ({resolution.detail})" if resolution.detail else ""),
         )
 
     def _pipeline_error(

--- a/src/afterworlds/services/context_builder.py
+++ b/src/afterworlds/services/context_builder.py
@@ -179,6 +179,8 @@ class _RollingSummaryServiceLike(Protocol):
 
 
 class _RulesPackageServiceLike(Protocol):
+    def resolve_slice_package(self, request: RuleSliceRequest) -> UUID: ...
+
     def get_active_rule_slice(
         self,
         package_id: UUID,
@@ -400,8 +402,16 @@ class ContextBuilderService:
                     "rule_slice_request provided but rules_package_service was not "
                     "injected into ContextBuilderService"
                 )
+            # The package reference resolves through the service's one
+            # code-owned path (CRD Issue 5d, ADR-005d Decision 9): a UUID passes
+            # through, a human-facing slug resolves, and a reference that does
+            # not resolve raises rather than yielding an empty slice that would
+            # read as "no rule applies".
+            package_id = self._rules_package_service.resolve_slice_package(
+                rule_slice_request
+            )
             rules_package_slice = self._rules_package_service.get_active_rule_slice(
-                package_id=rule_slice_request.package_id,
+                package_id=package_id,
                 subsystem_tags=rule_slice_request.subsystem_tags,
                 entity_refs=rule_slice_request.entity_refs,
                 include_non_published=rule_slice_request.include_non_published,

--- a/src/afterworlds/services/rules_authority/__init__.py
+++ b/src/afterworlds/services/rules_authority/__init__.py
@@ -49,6 +49,7 @@ from afterworlds.services.rules_authority.retention import (
 )
 from afterworlds.services.rules_authority.service import (
     AuthorityResult,
+    IncoherentBindingError,
     MechanicalRuleSlice,
     RulesAuthorityService,
 )
@@ -79,6 +80,7 @@ __all__ = [
     "GameMasterAuthorityView",
     "GameMasterComponent",
     "GoverningProse",
+    "IncoherentBindingError",
     "InvalidPatchError",
     "MechanicalPatch",
     "MechanicalRuleSlice",

--- a/src/afterworlds/services/rules_authority/__init__.py
+++ b/src/afterworlds/services/rules_authority/__init__.py
@@ -1,0 +1,105 @@
+"""Runtime mechanical authority — CRD Issue 5d, Decisions 9 and 10.
+
+The infrastructure planned in PR #139's delivery sequence: the exact
+four-component effective binding, one code-owned resolution path, deterministic
+selectors, typed record/component/fact overrides with immutable replayable
+override-set versions, and the two authority views.
+
+This is infrastructure, not completed CRD Issue 5d. No production mechanical
+projection is published yet, so every production resolution through this package
+currently reports ``UNPUBLISHED`` — honestly, and by construction.
+"""
+
+from afterworlds.services.rules_authority.application import (
+    AppliedOverride,
+    EffectiveAuthority,
+    EffectiveComponent,
+    EffectiveFact,
+    EffectiveRecord,
+    OverrideApplicationError,
+    apply_override_set,
+)
+from afterworlds.services.rules_authority.binding import (
+    BindingResolution,
+    PackageResolution,
+    package_slug,
+    resolve_effective_binding,
+    resolve_package_reference,
+)
+from afterworlds.services.rules_authority.outcomes import AuthorityOutcome
+from afterworlds.services.rules_authority.override_set import (
+    EMPTY_OVERRIDE_SET_UUID,
+    EffectiveOverrideEntry,
+    EffectiveOverrideSet,
+    OverrideStateError,
+    collect_current_override_state,
+    override_set_identity,
+)
+from afterworlds.services.rules_authority.patches import (
+    InvalidPatchError,
+    MechanicalPatch,
+    PatchFamily,
+    patch_from_payload,
+    patch_payload,
+)
+from afterworlds.services.rules_authority.retention import (
+    OverrideSetRetentionError,
+    load_override_set_version,
+    retain_override_set,
+)
+from afterworlds.services.rules_authority.service import (
+    AuthorityResult,
+    MechanicalRuleSlice,
+    RulesAuthorityService,
+)
+from afterworlds.services.rules_authority.targets import (
+    MechanicalTarget,
+    MechanicalTargetKind,
+    TargetShapeError,
+)
+from afterworlds.services.rules_authority.views import (
+    GameMasterAuthorityView,
+    GameMasterComponent,
+    GoverningProse,
+    TypedAuthorityView,
+)
+
+__all__ = [
+    "EMPTY_OVERRIDE_SET_UUID",
+    "AppliedOverride",
+    "AuthorityOutcome",
+    "AuthorityResult",
+    "BindingResolution",
+    "EffectiveAuthority",
+    "EffectiveComponent",
+    "EffectiveFact",
+    "EffectiveOverrideEntry",
+    "EffectiveOverrideSet",
+    "EffectiveRecord",
+    "GameMasterAuthorityView",
+    "GameMasterComponent",
+    "GoverningProse",
+    "InvalidPatchError",
+    "MechanicalPatch",
+    "MechanicalRuleSlice",
+    "MechanicalTarget",
+    "MechanicalTargetKind",
+    "OverrideApplicationError",
+    "OverrideSetRetentionError",
+    "OverrideStateError",
+    "PackageResolution",
+    "PatchFamily",
+    "RulesAuthorityService",
+    "TargetShapeError",
+    "TypedAuthorityView",
+    "apply_override_set",
+    "collect_current_override_state",
+    "load_override_set_version",
+    "override_set_identity",
+    "package_slug",
+    "patch_from_payload",
+    "patch_payload",
+    "resolve_effective_binding",
+    "resolve_package_reference",
+    "retain_override_set",
+]

--- a/src/afterworlds/services/rules_authority/application.py
+++ b/src/afterworlds/services/rules_authority/application.py
@@ -1,0 +1,613 @@
+"""Typed override application over the immutable base projection — Decision 10.
+
+The base projection is never modified. Application reads the reconstructed
+projection, layers the ordered override state on top of it, and returns a
+separate effective view; the ``rp_mech_*`` rows and the projection UUID are
+untouched by construction, because nothing here holds a database session.
+
+Existing precedence and operation semantics are preserved exactly as ADR-005d
+Decision 10 requires:
+
+* ordering is ascending ``(precedence, override_id)``, the same rule the chunk
+  override path applies;
+* ``DISABLE`` suppresses an exact target and **stops later applicable
+  processing** for that target — mirroring the chunk path's behaviour of
+  halting once a disable wins, rather than letting a later replace resurrect
+  suppressed authority;
+* ``REPLACE`` supplies a complete validated replacement; and
+* ``APPEND`` adds a complete typed component or fact, and only where the owning
+  schema permits multiplicity.
+
+Every refusal is typed. An override whose target does not exist, whose patch is
+outside the closed union, or whose patch is incompatible with the target's own
+type raises :class:`OverrideApplicationError`, which the service seam reports as
+``INVALID_OVERRIDE`` — never as a skipped override, and never as an effective
+view that silently omits a change someone authored.
+
+**Provenance is exact and source-linked.** A base element carries the 5c leaf
+subspans that were accepted as its provenance; an override-supplied element
+carries the stable identity and origin of the override record that supplied it.
+Those are different kinds of authority and the view says which is which rather
+than blurring them into one "source" string.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.projection import ProjectionCandidate
+from afterworlds.ingestion.mechanical.representation import (
+    MechanicalFact,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RecordKind,
+    fact_key,
+)
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.models.rules_package import RulesPackageBinding
+from afterworlds.services.rules_authority.override_set import (
+    EffectiveOverrideEntry,
+    EffectiveOverrideSet,
+)
+from afterworlds.services.rules_authority.patches import (
+    ComponentAdditionPatch,
+    ComponentBody,
+    ComponentReplacementPatch,
+    DisablePatch,
+    FactAdditionPatch,
+    FactReplacementPatch,
+    InvalidPatchError,
+    RecordReplacementPatch,
+    patch_from_payload,
+)
+from afterworlds.services.rules_authority.targets import (
+    MechanicalTarget,
+    MechanicalTargetKind,
+)
+
+__all__ = [
+    "AppliedOverride",
+    "EffectiveAuthority",
+    "EffectiveComponent",
+    "EffectiveFact",
+    "EffectiveRecord",
+    "OverrideApplicationError",
+    "apply_override_set",
+]
+
+
+class OverrideApplicationError(ValueError):
+    """Raised when an override cannot be applied to the bound projection."""
+
+    def __init__(self, override_id: str, detail: str) -> None:
+        super().__init__(f"override {override_id}: {detail}")
+        self.override_id = override_id
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class EffectiveFact:
+    """One typed fact in the effective view, with its exact provenance."""
+
+    fact_key: str
+    fact: MechanicalFact
+    #: 5c leaf subspans accepted as this fact's provenance. Empty exactly when
+    #: the fact came from an override rather than from the source corpus.
+    span_ids: tuple[str, ...] = ()
+    #: The override that supplied this fact, when one did.
+    supplied_by_override_id: str | None = None
+    supplied_by_origin: OverrideOriginEnum | None = None
+
+
+@dataclass(frozen=True)
+class EffectiveComponent:
+    """One component of the effective view."""
+
+    record_key: str
+    semantic_key: str
+    handling: ComponentHandling
+    irreducibility_reason_code: str | None
+    facts: tuple[EffectiveFact, ...]
+    #: Authoritative 5c chunks holding this component's exact governing prose.
+    prose_chunk_ids: tuple[str, ...] = ()
+    span_ids: tuple[str, ...] = ()
+    supplied_by_override_id: str | None = None
+    supplied_by_origin: OverrideOriginEnum | None = None
+
+
+@dataclass(frozen=True)
+class EffectiveRecord:
+    """One record of the effective view."""
+
+    semantic_key: str
+    kind: RecordKind
+    parent_key: str | None
+    components: tuple[EffectiveComponent, ...]
+    span_ids: tuple[str, ...] = ()
+    supplied_by_override_id: str | None = None
+    supplied_by_origin: OverrideOriginEnum | None = None
+
+
+@dataclass(frozen=True)
+class AppliedOverride:
+    """Ordered provenance for one entry of the override set.
+
+    ``applied`` is ``False`` for an entry that was reached but had no effect —
+    an entry disabled at authoring time, or one whose target an earlier
+    ``DISABLE`` already suppressed. Reporting it rather than dropping it is what
+    makes the provenance *ordered*: an auditor sees the whole set in the order
+    it was resolved, and why each entry did or did not change anything.
+    """
+
+    override_id: str
+    origin: OverrideOriginEnum
+    target: MechanicalTarget
+    operation: OverrideOperationEnum
+    precedence: int
+    apply_order: int
+    is_enabled: bool
+    payload: dict[str, object]
+    applied: bool
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class EffectiveAuthority:
+    """The complete effective mechanical authority of one binding."""
+
+    binding: RulesPackageBinding
+    records: tuple[EffectiveRecord, ...]
+    applied_overrides: tuple[AppliedOverride, ...]
+
+
+# ---------------------------------------------------------------------------
+# Base view assembly
+# ---------------------------------------------------------------------------
+
+
+def _provenance_index(
+    candidate: ProjectionCandidate,
+) -> dict[tuple[ProvenanceTargetKind, tuple[str, ...]], tuple[str, ...]]:
+    """Map each element's provenance key to the spans claimed for it.
+
+    Primary and contextual claims are both retained, in a stable order, because
+    a consumer explaining a value needs the text that states it *and* the text
+    that limits it. Their distinction is preserved by ordering primary claims
+    first rather than by discarding one kind.
+    """
+    grouped: dict[
+        tuple[ProvenanceTargetKind, tuple[str, ...]], list[tuple[int, str]]
+    ] = {}
+    for claim in candidate.representation.provenance:
+        rank = 0 if claim.role is ProvenanceRole.PRIMARY else 1
+        grouped.setdefault((claim.target_kind, claim.target_key), []).append(
+            (rank, claim.span_id)
+        )
+    return {
+        key: tuple(span for _, span in sorted(set(claims)))
+        for key, claims in grouped.items()
+    }
+
+
+def _base_records(candidate: ProjectionCandidate) -> dict[str, EffectiveRecord]:
+    """Assemble the immutable base projection as an effective view."""
+    draft = candidate.representation
+    spans = _provenance_index(candidate)
+    prose: dict[tuple[str, str], list[str]] = {}
+    for binding in draft.prose_bindings:
+        prose.setdefault((binding.record_key, binding.component_key), []).append(
+            binding.chunk_id
+        )
+
+    components: dict[str, list[EffectiveComponent]] = {}
+    for component in draft.components:
+        facts = tuple(
+            EffectiveFact(
+                fact_key=fact_key(fact),
+                fact=fact,
+                span_ids=spans.get(
+                    (
+                        ProvenanceTargetKind.FACT,
+                        (component.record_key, component.semantic_key, fact_key(fact)),
+                    ),
+                    (),
+                ),
+            )
+            for fact in component.facts
+        )
+        components.setdefault(component.record_key, []).append(
+            EffectiveComponent(
+                record_key=component.record_key,
+                semantic_key=component.semantic_key,
+                handling=component.handling,
+                irreducibility_reason_code=component.irreducibility_reason_code,
+                facts=facts,
+                prose_chunk_ids=tuple(
+                    sorted(
+                        prose.get((component.record_key, component.semantic_key), ())
+                    )
+                ),
+                span_ids=spans.get(
+                    (
+                        ProvenanceTargetKind.COMPONENT,
+                        (component.record_key, component.semantic_key),
+                    ),
+                    (),
+                ),
+            )
+        )
+
+    return {
+        record.semantic_key: EffectiveRecord(
+            semantic_key=record.semantic_key,
+            kind=record.kind,
+            parent_key=record.parent_key,
+            components=tuple(
+                sorted(
+                    components.get(record.semantic_key, []),
+                    key=lambda c: c.semantic_key,
+                )
+            ),
+            span_ids=spans.get(
+                (ProvenanceTargetKind.RECORD, (record.semantic_key,)), ()
+            ),
+        )
+        for record in draft.records
+    }
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+
+def _component_from_body(
+    body: ComponentBody,
+    record_key: str,
+    semantic_key: str,
+    entry: EffectiveOverrideEntry,
+) -> EffectiveComponent:
+    return EffectiveComponent(
+        record_key=record_key,
+        semantic_key=semantic_key,
+        handling=body.handling,
+        irreducibility_reason_code=None,
+        facts=tuple(
+            EffectiveFact(
+                fact_key=fact_key(f),
+                fact=f,
+                supplied_by_override_id=entry.override_id,
+                supplied_by_origin=entry.origin,
+            )
+            for f in body.facts
+        ),
+        supplied_by_override_id=entry.override_id,
+        supplied_by_origin=entry.origin,
+    )
+
+
+def _find_component(
+    record: EffectiveRecord, key: str
+) -> tuple[int, EffectiveComponent] | None:
+    for index, component in enumerate(record.components):
+        if component.semantic_key == key:
+            return index, component
+    return None
+
+
+def _find_fact(
+    component: EffectiveComponent, key: str
+) -> tuple[int, EffectiveFact] | None:
+    for index, fact in enumerate(component.facts):
+        if fact.fact_key == key:
+            return index, fact
+    return None
+
+
+def _suppressed_by(
+    target: MechanicalTarget,
+    disabled_records: set[str],
+    disabled_components: set[tuple[str, str]],
+    disabled_facts: set[tuple[str, str, str]],
+) -> str | None:
+    """Is this target already suppressed by an earlier ``DISABLE``?
+
+    Suppression is inherited downward: disabling a record disables the
+    components and facts beneath it, so a later override aimed at one of them
+    has nothing to change. That is the existing precedence rule — the first
+    winning disable stops later processing of that target — applied to the
+    record/component/fact hierarchy the chunk path never had.
+    """
+    if target.record_key in disabled_records:
+        return "record"
+    if target.kind is MechanicalTargetKind.RECORD:
+        return None
+    assert target.component_key is not None
+    if (target.record_key, target.component_key) in disabled_components:
+        return "component"
+    if target.kind is MechanicalTargetKind.COMPONENT:
+        return None
+    assert target.fact_key is not None
+    if (target.record_key, target.component_key, target.fact_key) in disabled_facts:
+        return "fact"
+    return None
+
+
+def apply_override_set(
+    candidate: ProjectionCandidate,
+    override_set: EffectiveOverrideSet,
+    binding: RulesPackageBinding,
+) -> EffectiveAuthority:
+    """Layer *override_set* over the reconstructed base projection.
+
+    Raises :class:`OverrideApplicationError` for any override that cannot be
+    applied. The caller turns that into ``INVALID_OVERRIDE``; nothing here
+    degrades a failure into a partially applied view, because a view missing one
+    authored change is indistinguishable from one where that change was never
+    authored.
+    """
+    records = _base_records(candidate)
+    disabled_records: set[str] = set()
+    disabled_components: set[tuple[str, str]] = set()
+    disabled_facts: set[tuple[str, str, str]] = set()
+    provenance: list[AppliedOverride] = []
+
+    for entry in override_set.entries:
+        note = ""
+        applied = False
+        if entry.is_enabled:
+            applied, note = _apply_entry(
+                entry,
+                records,
+                disabled_records,
+                disabled_components,
+                disabled_facts,
+            )
+        else:
+            note = "authored disabled"
+        provenance.append(
+            AppliedOverride(
+                override_id=entry.override_id,
+                origin=entry.origin,
+                target=entry.target,
+                operation=entry.operation,
+                precedence=entry.precedence,
+                apply_order=entry.apply_order,
+                is_enabled=entry.is_enabled,
+                payload=entry.payload,
+                applied=applied,
+                note=note,
+            )
+        )
+
+    surviving = tuple(
+        replace(
+            record,
+            components=tuple(
+                replace(
+                    component,
+                    facts=tuple(
+                        fact
+                        for fact in component.facts
+                        if (record.semantic_key, component.semantic_key, fact.fact_key)
+                        not in disabled_facts
+                    ),
+                )
+                for component in record.components
+                if (record.semantic_key, component.semantic_key)
+                not in disabled_components
+            ),
+        )
+        for key, record in sorted(records.items())
+        if key not in disabled_records
+    )
+    return EffectiveAuthority(
+        binding=binding,
+        records=surviving,
+        applied_overrides=tuple(provenance),
+    )
+
+
+def _apply_entry(
+    entry: EffectiveOverrideEntry,
+    records: dict[str, EffectiveRecord],
+    disabled_records: set[str],
+    disabled_components: set[tuple[str, str]],
+    disabled_facts: set[tuple[str, str, str]],
+) -> tuple[bool, str]:
+    """Apply one enabled entry, returning whether it changed anything."""
+    target = entry.target
+    try:
+        patch = patch_from_payload(
+            entry.payload, operation=entry.operation, target=target
+        )
+    except InvalidPatchError as exc:
+        raise OverrideApplicationError(entry.override_id, str(exc)) from exc
+
+    record = records.get(target.record_key)
+    if record is None:
+        raise OverrideApplicationError(
+            entry.override_id,
+            f"target {target.describe()} names no record in the bound projection",
+        )
+
+    suppressed = _suppressed_by(
+        target, disabled_records, disabled_components, disabled_facts
+    )
+    if suppressed is not None:
+        return False, f"target already suppressed by an earlier {suppressed} disable"
+
+    if isinstance(patch, DisablePatch):
+        if target.kind is MechanicalTargetKind.RECORD:
+            disabled_records.add(target.record_key)
+            return True, "record suppressed"
+        assert target.component_key is not None
+        found = _find_component(record, target.component_key)
+        if found is None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"target {target.describe()} names no component of "
+                f"{target.record_key!r}",
+            )
+        if target.kind is MechanicalTargetKind.COMPONENT:
+            disabled_components.add((target.record_key, target.component_key))
+            return True, "component suppressed"
+        assert target.fact_key is not None
+        if _find_fact(found[1], target.fact_key) is None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"target {target.describe()} names no fact of "
+                f"{target.component_key!r}",
+            )
+        disabled_facts.add((target.record_key, target.component_key, target.fact_key))
+        return True, "fact suppressed"
+
+    if isinstance(patch, RecordReplacementPatch):
+        if patch.record_kind is not record.kind:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"record replacement declares kind {patch.record_kind.value!r}, "
+                f"target record {target.record_key!r} is "
+                f"{record.kind.value!r}",
+            )
+        records[target.record_key] = replace(
+            record,
+            components=tuple(
+                _component_from_body(
+                    body, target.record_key, body.semantic_key or "", entry
+                )
+                for body in sorted(patch.components, key=lambda b: b.semantic_key or "")
+            ),
+            supplied_by_override_id=entry.override_id,
+            supplied_by_origin=entry.origin,
+        )
+        # A replaced record's previously suppressed children no longer exist;
+        # clearing them keeps suppression from applying to unrelated new
+        # components that happen to reuse a semantic key.
+        disabled_components.difference_update(
+            {k for k in disabled_components if k[0] == target.record_key}
+        )
+        disabled_facts.difference_update(
+            {k for k in disabled_facts if k[0] == target.record_key}
+        )
+        return True, "record replaced"
+
+    if isinstance(patch, ComponentAdditionPatch):
+        # Appending a component targets the *record*, so this branch comes
+        # before the component-key assertion below: the target legitimately
+        # carries no component key, because the patch is what names the
+        # component being added.
+        key = patch.body.semantic_key or ""
+        if _find_component(record, key) is not None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"appending component {key!r} to record {target.record_key!r} "
+                "would duplicate an existing component",
+            )
+        records[target.record_key] = replace(
+            record,
+            components=tuple(
+                sorted(
+                    [
+                        *record.components,
+                        _component_from_body(patch.body, target.record_key, key, entry),
+                    ],
+                    key=lambda c: c.semantic_key,
+                )
+            ),
+        )
+        return True, "component appended"
+
+    assert target.component_key is not None
+    if isinstance(patch, ComponentReplacementPatch):
+        found = _find_component(record, target.component_key)
+        if found is None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"target {target.describe()} names no component of "
+                f"{target.record_key!r}",
+            )
+        index, _existing = found
+        components = list(record.components)
+        components[index] = _component_from_body(
+            patch.body, target.record_key, target.component_key, entry
+        )
+        records[target.record_key] = replace(record, components=tuple(components))
+        disabled_facts.difference_update(
+            {
+                k
+                for k in disabled_facts
+                if k[0] == target.record_key and k[1] == target.component_key
+            }
+        )
+        return True, "component replaced"
+
+    found = _find_component(record, target.component_key)
+    if found is None:
+        raise OverrideApplicationError(
+            entry.override_id,
+            f"target {target.describe()} names no component of "
+            f"{target.record_key!r}",
+        )
+    index, component = found
+    new_fact = patch.fact
+    new_key = fact_key(new_fact)
+
+    if isinstance(patch, FactReplacementPatch):
+        assert target.fact_key is not None
+        position = _find_fact(component, target.fact_key)
+        if position is None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"target {target.describe()} names no fact of "
+                f"{target.component_key!r}",
+            )
+        fact_index, _old = position
+        if new_key != target.fact_key and _find_fact(component, new_key) is not None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"replacement fact {new_key} already exists in component "
+                f"{target.component_key!r}",
+            )
+        facts = list(component.facts)
+        facts[fact_index] = EffectiveFact(
+            fact_key=new_key,
+            fact=new_fact,
+            supplied_by_override_id=entry.override_id,
+            supplied_by_origin=entry.origin,
+        )
+        note = "fact replaced"
+    else:
+        assert isinstance(patch, FactAdditionPatch)
+        if _find_fact(component, new_key) is not None:
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"appending fact {new_key} to component {target.component_key!r} "
+                "would duplicate an existing fact",
+            )
+        if component.handling is ComponentHandling.PROSE_BOUND:
+            # A prose-bound component asserts its meaning cannot be reduced to
+            # typed facts. Appending one would contradict the published
+            # handling, which is a projection-level judgement an override may
+            # not quietly reverse.
+            raise OverrideApplicationError(
+                entry.override_id,
+                f"component {target.component_key!r} is prose-bound; a typed "
+                "fact cannot be appended to it",
+            )
+        facts = [
+            *component.facts,
+            EffectiveFact(
+                fact_key=new_key,
+                fact=new_fact,
+                supplied_by_override_id=entry.override_id,
+                supplied_by_origin=entry.origin,
+            ),
+        ]
+        note = "fact appended"
+
+    components = list(record.components)
+    components[index] = replace(component, facts=tuple(facts))
+    records[target.record_key] = replace(record, components=tuple(components))
+    return True, note

--- a/src/afterworlds/services/rules_authority/binding.py
+++ b/src/afterworlds/services/rules_authority/binding.py
@@ -1,0 +1,329 @@
+"""The one code-owned binding-resolution path — CRD Issue 5d, Decision 9.
+
+Everything that needs the effective mechanical authority of a package comes
+through here. There is one resolution function, and it produces the complete
+four-component binding or a typed refusal — never a partially populated binding,
+never ``None``, and never an empty result a caller could read as permission.
+
+Two resolutions, layered:
+
+* :func:`resolve_package_reference` turns a human-facing reference into a
+  package UUID. It is the *only* place a slug is interpreted. ADR-005d
+  Decision 9 allows a slug to resolve through one code-owned service but never
+  to serve as canonical authority, so what comes back is a UUID, and the
+  binding is built from that.
+* :func:`resolve_effective_binding` produces the binding itself: package UUID,
+  release version, the active base projection's UUID, and the override-set UUID
+  derived from current override state — which it also retains as an immutable
+  replayable version, because a binding whose override-set identity names
+  nothing retrievable is the exact defect ADR-005d rejected.
+
+**Runtime resolution and replay are different operations**, and the difference
+lives here. Runtime recomputes the override-set identity from current state; a
+recorded binding that no longer matches is ``STALE`` and fails, and is never
+silently re-resolved against current overrides. Replay does not come through
+this path at all — it resolves the retained version through
+:func:`afterworlds.services.rules_authority.retention.load_override_set_version`
+and must succeed.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    resolve_active_projection,
+)
+from afterworlds.models.enums import PublicationStatusEnum
+from afterworlds.models.rules_package import RulesPackageBinding
+from afterworlds.persistence.orm.mechanical import MechanicalProjectionORM
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority.outcomes import AuthorityOutcome
+from afterworlds.services.rules_authority.override_set import (
+    EffectiveOverrideSet,
+    OverrideStateError,
+    collect_current_override_state,
+)
+from afterworlds.services.rules_authority.retention import retain_override_set
+
+__all__ = [
+    "BindingResolution",
+    "PackageResolution",
+    "package_slug",
+    "resolve_effective_binding",
+    "resolve_package_reference",
+]
+
+_SLUG_SEPARATORS = re.compile(r"[^a-z0-9]+")
+
+
+def package_slug(name: str) -> str:
+    """The human-facing slug form of a package name.
+
+    Deliberately lossy and deliberately not authority: several package names can
+    slugify to the same value, which is precisely why an ambiguous slug is a
+    typed ``AMBIGUOUS`` refusal rather than a first match.
+    """
+    return _SLUG_SEPARATORS.sub("-", name.strip().lower()).strip("-")
+
+
+@dataclass(frozen=True)
+class PackageResolution:
+    """The typed result of resolving a human-facing package reference."""
+
+    outcome: AuthorityOutcome
+    package_uuid: UUID | None = None
+    detail: str = ""
+    #: Every package a slug matched. Populated on ``AMBIGUOUS`` so an operator
+    #: can see what to disambiguate between rather than being told only that
+    #: something was ambiguous.
+    candidates: tuple[UUID, ...] = ()
+
+
+@dataclass(frozen=True)
+class BindingResolution:
+    """The typed result of resolving an effective binding.
+
+    ``binding`` is populated only on ``RESOLVED``. ``current_binding`` is
+    populated on ``STALE`` and ``MISMATCHED_RELEASE`` as well, so a caller that
+    must report what superseded a recorded binding does not have to resolve a
+    second time to find out.
+    """
+
+    outcome: AuthorityOutcome
+    binding: RulesPackageBinding | None = None
+    current_binding: RulesPackageBinding | None = None
+    override_state: EffectiveOverrideSet | None = None
+    detail: str = ""
+
+
+def resolve_package_reference(session: Session, reference: str) -> PackageResolution:
+    """Resolve a UUID string or human-facing slug to one package UUID.
+
+    A reference that is neither a well-formed UUID nor a slug matching exactly
+    one enabled package is a typed refusal. The previous behaviour this
+    replaces — parse the reference as a UUID and, on ``ValueError``, quietly
+    proceed with no rules at all — is the fail-open path #137 contract 6
+    requires to have no surviving caller: a malformed reference and a package
+    with genuinely no rules produced the same silence.
+    """
+    raw = reference.strip()
+    if not raw:
+        return PackageResolution(
+            AuthorityOutcome.INVALID_SELECTOR, detail="package reference is blank"
+        )
+
+    try:
+        return PackageResolution(AuthorityOutcome.RESOLVED, package_uuid=UUID(raw))
+    except ValueError:
+        pass
+
+    slug = package_slug(raw)
+    if not slug:
+        return PackageResolution(
+            AuthorityOutcome.INVALID_SELECTOR,
+            detail=f"package reference {reference!r} is neither a UUID nor a slug",
+        )
+
+    rows = (
+        session.execute(
+            select(RulesPackageORM)
+            .where(RulesPackageORM.is_enabled == True)  # noqa: E712
+            .order_by(RulesPackageORM.rules_package_id)
+        )
+        .scalars()
+        .all()
+    )
+    matches = [row for row in rows if package_slug(row.name) == slug]
+    if not matches:
+        return PackageResolution(
+            AuthorityOutcome.ABSENT,
+            detail=f"no enabled package resolves the slug {slug!r}",
+        )
+    if len(matches) > 1:
+        return PackageResolution(
+            AuthorityOutcome.AMBIGUOUS,
+            detail=(
+                f"slug {slug!r} resolves to {len(matches)} packages; a slug is not "
+                "canonical authority"
+            ),
+            candidates=tuple(UUID(row.rules_package_id) for row in matches),
+        )
+    return PackageResolution(
+        AuthorityOutcome.RESOLVED, package_uuid=UUID(matches[0].rules_package_id)
+    )
+
+
+def _projection_header(
+    session: Session, projection_uuid: str
+) -> MechanicalProjectionORM | None:
+    return session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == projection_uuid
+        )
+    ).scalar_one_or_none()
+
+
+def resolve_effective_binding(
+    session: Session,
+    package_uuid: UUID,
+    *,
+    now: str,
+    expected_release: str | None = None,
+    recorded: RulesPackageBinding | None = None,
+    retain: bool = True,
+) -> BindingResolution:
+    """Resolve the complete four-component effective binding of a package.
+
+    The order of checks is the contract, because each earlier failure would make
+    a later one meaningless:
+
+    1. the package exists and is published;
+    2. it has an active, published mechanical projection — otherwise
+       ``UNPUBLISHED``, which is a typed answer and not an empty one;
+    3. the projection's release matches *expected_release* when one is supplied
+       — otherwise ``MISMATCHED_RELEASE``;
+    4. current override state parses and yields an override-set identity, which
+       is retained as an immutable version; and
+    5. when *recorded* is supplied, all four components must match — a
+       superseded projection or a superseded override set is ``STALE``.
+
+    *retain* exists for the one caller that must not write: a diagnostic read
+    that only wants to know whether a recorded binding is current. It defaults
+    to ``True`` because resolution is the point at which replay evidence has to
+    exist; skipping it silently would leave a binding whose override-set UUID
+    names nothing retrievable.
+    """
+    package = session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(package_uuid)
+        )
+    ).scalar_one_or_none()
+    if package is None:
+        return BindingResolution(
+            AuthorityOutcome.ABSENT, detail=f"no package {package_uuid}"
+        )
+    if not package.is_enabled:
+        return BindingResolution(
+            AuthorityOutcome.ABSENT, detail=f"package {package_uuid} is disabled"
+        )
+    if package.publication_status != PublicationStatusEnum.PUBLISHED.value:
+        return BindingResolution(
+            AuthorityOutcome.UNPUBLISHED,
+            detail=(
+                f"package {package_uuid} is {package.publication_status}, not "
+                "published"
+            ),
+        )
+
+    active = resolve_active_projection(session, str(package_uuid))
+    if active.outcome is PublicationOutcome.UNPUBLISHED:
+        return BindingResolution(
+            AuthorityOutcome.UNPUBLISHED,
+            detail=f"package {package_uuid} has no active mechanical projection",
+        )
+    if active.outcome is not PublicationOutcome.PUBLISHED:
+        # ``resolve_active_projection`` reports STALE for an activation row
+        # pointing at a draft, at another package's projection, or at one whose
+        # recorded evidence was cleared or edited. It is stale here too — the
+        # active authority is not what the record says it is.
+        return BindingResolution(
+            AuthorityOutcome.STALE,
+            detail=(
+                f"active projection {active.projection_uuid} of package "
+                f"{package_uuid} does not verify: {active.outcome.value}"
+            ),
+        )
+
+    assert active.projection_uuid is not None
+    header = _projection_header(session, active.projection_uuid)
+    if header is None:  # pragma: no cover - resolve_active_projection proves it
+        return BindingResolution(
+            AuthorityOutcome.STALE,
+            detail=f"active projection {active.projection_uuid} has no header",
+        )
+    release_version = header.release_version
+
+    if expected_release is not None and expected_release != release_version:
+        return BindingResolution(
+            AuthorityOutcome.MISMATCHED_RELEASE,
+            detail=(
+                f"package {package_uuid} publishes release {release_version!r}, "
+                f"caller expected {expected_release!r}"
+            ),
+        )
+
+    try:
+        state = collect_current_override_state(
+            session, str(package_uuid), release_version
+        )
+    except OverrideStateError as exc:
+        return BindingResolution(AuthorityOutcome.INVALID_OVERRIDE, detail=str(exc))
+
+    override_set_uuid = state.override_set_uuid
+    if retain:
+        retain_override_set(session, state, now=now)
+
+    current = RulesPackageBinding(
+        package_uuid=package_uuid,
+        release_version=release_version,
+        mechanical_projection_uuid=UUID(active.projection_uuid),
+        override_set_uuid=UUID(override_set_uuid),
+    )
+
+    if recorded is not None:
+        if recorded.package_uuid != current.package_uuid:
+            return BindingResolution(
+                AuthorityOutcome.INVALID_SELECTOR,
+                current_binding=current,
+                override_state=state,
+                detail=(
+                    f"recorded binding names package {recorded.package_uuid}, "
+                    f"resolution was requested for {current.package_uuid}"
+                ),
+            )
+        if recorded.release_version != current.release_version:
+            return BindingResolution(
+                AuthorityOutcome.MISMATCHED_RELEASE,
+                current_binding=current,
+                override_state=state,
+                detail=(
+                    f"recorded binding names release {recorded.release_version!r}, "
+                    f"the package now publishes {current.release_version!r}"
+                ),
+            )
+        if recorded.mechanical_projection_uuid != current.mechanical_projection_uuid:
+            return BindingResolution(
+                AuthorityOutcome.STALE,
+                current_binding=current,
+                override_state=state,
+                detail=(
+                    "recorded binding names base projection "
+                    f"{recorded.mechanical_projection_uuid}, the active projection "
+                    f"is {current.mechanical_projection_uuid}"
+                ),
+            )
+        if recorded.override_set_uuid != current.override_set_uuid:
+            return BindingResolution(
+                AuthorityOutcome.STALE,
+                current_binding=current,
+                override_state=state,
+                detail=(
+                    "recorded binding names override set "
+                    f"{recorded.override_set_uuid}, current override state is "
+                    f"{current.override_set_uuid}"
+                ),
+            )
+
+    return BindingResolution(
+        AuthorityOutcome.RESOLVED,
+        binding=current,
+        current_binding=current,
+        override_state=state,
+    )

--- a/src/afterworlds/services/rules_authority/binding.py
+++ b/src/afterworlds/services/rules_authority/binding.py
@@ -112,6 +112,15 @@ def resolve_package_reference(session: Session, reference: str) -> PackageResolu
     proceed with no rules at all — is the fail-open path #137 contract 6
     requires to have no surviving caller: a malformed reference and a package
     with genuinely no rules produced the same silence.
+
+    **Both branches resolve against the same enabled-package population.** A
+    well-formed UUID is a *reference*, not a resolution: returning it unchecked
+    would mean an unknown or disabled package UUID reported ``RESOLVED`` while
+    the equivalent slug reported ``ABSENT``, and a caller that treats
+    ``RESOLVED`` as "this package exists" — which is the only sane reading —
+    would proceed on a package that does not. That asymmetry is the same
+    fail-open shape this function exists to remove, so the syntactic check is
+    never the whole check.
     """
     raw = reference.strip()
     if not raw:
@@ -120,9 +129,24 @@ def resolve_package_reference(session: Session, reference: str) -> PackageResolu
         )
 
     try:
-        return PackageResolution(AuthorityOutcome.RESOLVED, package_uuid=UUID(raw))
+        package_uuid = UUID(raw)
     except ValueError:
         pass
+    else:
+        row = session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == str(package_uuid)
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return PackageResolution(
+                AuthorityOutcome.ABSENT, detail=f"no package {package_uuid}"
+            )
+        if not row.is_enabled:
+            return PackageResolution(
+                AuthorityOutcome.ABSENT, detail=f"package {package_uuid} is disabled"
+            )
+        return PackageResolution(AuthorityOutcome.RESOLVED, package_uuid=package_uuid)
 
     slug = package_slug(raw)
     if not slug:

--- a/src/afterworlds/services/rules_authority/outcomes.py
+++ b/src/afterworlds/services/rules_authority/outcomes.py
@@ -1,0 +1,52 @@
+"""Typed runtime authority states — CRD Issue 5d, contracts 5 and 6.
+
+#137 requires mechanical authority operations to distinguish ``ABSENT``,
+``AMBIGUOUS``, ``UNRESOLVED``, ``UNREVIEWED``, ``INCOMPLETE``, ``STALE``,
+``MISMATCHED_RELEASE``, ``INVALID_SELECTOR``, ``INVALID_REFERENCE``,
+``INVALID_OVERRIDE``, and ``UNPUBLISHED``, and forbids collapsing any of them
+into ``None``, an empty result, a generic exception, retrieval fallback, or
+model inference.
+
+Those states are owned by two stages, and this enum declares only the runtime
+half. ``UNRESOLVED``, ``UNREVIEWED``, and ``INCOMPLETE`` are judgements about a
+projection *candidate* — they can only be reached by the publication gate, and
+they live in
+:class:`afterworlds.ingestion.mechanical.publication.PublicationOutcome`.
+Declaring them here as members no runtime path can return would be a menu of
+states rather than a contract. ``STALE``, ``MISMATCHED_RELEASE``, and
+``UNPUBLISHED`` appear in both, because both stages can genuinely reach them.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+__all__ = ["AuthorityOutcome"]
+
+
+class AuthorityOutcome(StrEnum):
+    """The typed result of one runtime authority resolution."""
+
+    #: The complete four-component effective binding was resolved.
+    RESOLVED = "resolved"
+    #: No such package, or no such retained override-set version.
+    ABSENT = "absent"
+    #: A human-facing slug resolved to more than one package.
+    AMBIGUOUS = "ambiguous"
+    #: The package has no active published mechanical projection.
+    UNPUBLISHED = "unpublished"
+    #: A recorded binding no longer matches current authority — a superseded
+    #: projection or, equally, an override-set identity that no longer matches
+    #: the identity recomputed from current override state.
+    STALE = "stale"
+    #: The recorded release is not the release the package now publishes.
+    MISMATCHED_RELEASE = "mismatched_release"
+    #: A malformed package reference, or a selector set that selects nothing
+    #: without saying so — the accidentally-empty selector.
+    INVALID_SELECTOR = "invalid_selector"
+    #: An override that cannot be applied: outside the closed patch union,
+    #: authored against another release, aimed at a target that does not exist,
+    #: or type-incompatible with the target it names.
+    INVALID_OVERRIDE = "invalid_override"
+    #: A selector naming an element the bound projection does not contain.
+    INVALID_REFERENCE = "invalid_reference"

--- a/src/afterworlds/services/rules_authority/override_set.py
+++ b/src/afterworlds/services/rules_authority/override_set.py
@@ -49,6 +49,11 @@ from sqlalchemy.orm import Session
 from afterworlds.ingestion.corpus.hashing import content_id
 from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
 from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
+from afterworlds.services.rules_authority.patches import (
+    InvalidPatchError,
+    patch_from_payload,
+    patch_payload,
+)
 from afterworlds.services.rules_authority.targets import (
     MechanicalTarget,
     MechanicalTargetKind,
@@ -70,11 +75,15 @@ __all__ = [
 class OverrideStateError(ValueError):
     """Raised when a stored override row cannot be read as canonical state.
 
-    Distinct from a patch being invalid: this is a row whose *columns* do not
-    parse — an unknown origin, an unknown operation, a target whose key set
-    does not match its kind. Such a row cannot be ordered or identified at all,
-    so it cannot be silently skipped either: skipping it would make the
-    override-set identity depend on which rows happened to parse.
+    Covers a row whose typed columns do not parse — an unknown origin or
+    operation, a target whose key set does not match its kind, a release the
+    package does not publish — and a payload that is not a valid member of the
+    closed patch union, because a payload with no canonical form cannot
+    participate in a content-derived identity.
+
+    Such a row is never skipped. Skipping would make the override-set identity
+    depend on which rows happened to parse, so a package with a malformed
+    override would silently share the identity of one that never had it.
     """
 
 
@@ -82,10 +91,17 @@ class OverrideStateError(ValueError):
 class EffectiveOverrideEntry:
     """One override as it participates in identity, order, and provenance.
 
-    ``payload`` is the stored payload exactly as validated. It is kept as the
-    canonical mapping rather than as a rebuilt patch object so that identity
-    derivation never depends on a patch type's ``__eq__``; the typed patch is
-    rebuilt separately at application time.
+    ``payload`` is the **canonical form of the validated typed patch**, not the
+    bytes that happened to be stored. ADR-005d Decision 9 says the identity
+    covers the complete *validated* payload, and the difference is load-bearing:
+    a stored payload could list the same facts in a different order, and hashing
+    it directly would mint two identities for one patch. Canonicalizing first
+    means an equivalent patch is one authority, while any genuine content change
+    still moves the identity.
+
+    It is kept as the canonical mapping rather than as a rebuilt patch object so
+    that identity derivation never depends on a patch type's ``__eq__``; the
+    typed patch is rebuilt again at application time from this canonical form.
     """
 
     override_id: str
@@ -225,6 +241,10 @@ def collect_current_override_state(
                 f"{row.release_version!r}; the package publishes "
                 f"{release_version!r}"
             )
+        try:
+            patch = patch_from_payload(row.payload, operation=operation, target=target)
+        except InvalidPatchError as exc:
+            raise OverrideStateError(f"override {row.override_id}: {exc}") from exc
         entries.append(
             EffectiveOverrideEntry(
                 override_id=row.override_id,
@@ -234,7 +254,7 @@ def collect_current_override_state(
                 precedence=row.precedence,
                 apply_order=order,
                 is_enabled=bool(row.is_enabled),
-                payload=dict(row.payload),
+                payload=patch_payload(patch),
             )
         )
     return EffectiveOverrideSet(

--- a/src/afterworlds/services/rules_authority/override_set.py
+++ b/src/afterworlds/services/rules_authority/override_set.py
@@ -1,0 +1,244 @@
+"""Canonical override state and its content-derived identity — Decision 9.
+
+The ``override_set_uuid`` is derived from the **canonical ordered effective
+override state**, per entry:
+
+* stable override identity;
+* override origin;
+* exact typed target identity;
+* operation;
+* precedence and resolved apply order;
+* enablement state; and
+* the complete validated payload.
+
+Three consequences of that list are load-bearing and are each proven by a
+negative control:
+
+* Deleting and recreating an otherwise identical override under a different
+  ``override_id`` mints a different identity — the identity is
+  provenance-exact, not merely mechanically equivalent.
+* Changing only the origin — a house rule becoming a package patch — mints a
+  different identity, because those are not the same authority.
+* Disabling an override mints a different identity. **Disabled overrides stay
+  in the canonical state, carrying ``is_enabled=False``.** Enablement is a
+  per-entry field in ADR-005d Decision 9's enumeration, so it must be able to
+  vary; if disabled entries were filtered out instead, the field would be
+  constant ``True`` and would carry no information, and *authoring* a
+  disabled override — an addition that changes nothing yet — would leave the
+  identity unmoved. They are retained for identity and provenance and are
+  skipped at application time.
+
+What is deliberately **outside** the identity: creation timestamps, authors,
+comments, and proposal history. They are audit metadata and do not participate
+in applicability, ordering, or resolution. Package scope is not repeated inside
+an entry either — the enclosing binding already supplies it.
+
+The empty override set has its own deterministic identity, computed from an
+empty entry list. It is a value, not the absence of one, so a binding never has
+to represent "no overrides" as a null the next caller can misread as "not yet
+resolved".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.hashing import content_id
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
+from afterworlds.services.rules_authority.targets import (
+    MechanicalTarget,
+    MechanicalTargetKind,
+    TargetShapeError,
+    target_payload,
+)
+
+__all__ = [
+    "EMPTY_OVERRIDE_SET_UUID",
+    "EffectiveOverrideEntry",
+    "EffectiveOverrideSet",
+    "OverrideStateError",
+    "collect_current_override_state",
+    "override_set_identity",
+    "override_set_payload",
+]
+
+
+class OverrideStateError(ValueError):
+    """Raised when a stored override row cannot be read as canonical state.
+
+    Distinct from a patch being invalid: this is a row whose *columns* do not
+    parse — an unknown origin, an unknown operation, a target whose key set
+    does not match its kind. Such a row cannot be ordered or identified at all,
+    so it cannot be silently skipped either: skipping it would make the
+    override-set identity depend on which rows happened to parse.
+    """
+
+
+@dataclass(frozen=True)
+class EffectiveOverrideEntry:
+    """One override as it participates in identity, order, and provenance.
+
+    ``payload`` is the stored payload exactly as validated. It is kept as the
+    canonical mapping rather than as a rebuilt patch object so that identity
+    derivation never depends on a patch type's ``__eq__``; the typed patch is
+    rebuilt separately at application time.
+    """
+
+    override_id: str
+    origin: OverrideOriginEnum
+    target: MechanicalTarget
+    operation: OverrideOperationEnum
+    precedence: int
+    apply_order: int
+    is_enabled: bool
+    payload: dict[str, object]
+
+    def entry_payload(self) -> dict[str, object]:
+        """Canonical identity-bearing payload of this entry."""
+        return {
+            "override_id": self.override_id,
+            "origin": self.origin.value,
+            "target": target_payload(self.target),
+            "operation": self.operation.value,
+            "precedence": self.precedence,
+            "apply_order": self.apply_order,
+            "is_enabled": self.is_enabled,
+            "payload": self.payload,
+        }
+
+
+@dataclass(frozen=True)
+class EffectiveOverrideSet:
+    """The complete canonical ordered override state and its identity.
+
+    ``package_uuid`` and ``release_version`` are the scope this state was
+    collected for. They are retained for retrieval and diagnosis and are not
+    part of :meth:`identity`'s payload — see the module docstring for why the
+    empty set has one identity rather than one per package.
+    """
+
+    package_uuid: str
+    release_version: str
+    entries: tuple[EffectiveOverrideEntry, ...]
+
+    @property
+    def override_set_uuid(self) -> str:
+        return override_set_identity(self.entries)
+
+    def applicable(self) -> tuple[EffectiveOverrideEntry, ...]:
+        """The entries that actually apply, in resolved order."""
+        return tuple(e for e in self.entries if e.is_enabled)
+
+
+def override_set_payload(
+    entries: tuple[EffectiveOverrideEntry, ...],
+) -> dict[str, object]:
+    """The exact payload an override-set identity is derived from."""
+    return {"entries": [e.entry_payload() for e in entries]}
+
+
+def override_set_identity(entries: tuple[EffectiveOverrideEntry, ...]) -> str:
+    """Content-derived identity of one canonical ordered override state."""
+    return content_id("mechanical_override_set", override_set_payload(entries))
+
+
+#: The identity of the no-overrides state. A deterministic value, not a null.
+EMPTY_OVERRIDE_SET_UUID = override_set_identity(())
+
+
+def _parse_row(
+    row: MechanicalOverrideORM,
+) -> tuple[OverrideOriginEnum, OverrideOperationEnum, MechanicalTarget]:
+    """Parse one stored row's typed columns, refusing anything unreadable."""
+    try:
+        origin = OverrideOriginEnum(row.override_origin)
+    except ValueError as exc:
+        raise OverrideStateError(
+            f"override {row.override_id}: origin {row.override_origin!r} is not "
+            "a declared override origin"
+        ) from exc
+    try:
+        operation = OverrideOperationEnum(row.override_operation)
+    except ValueError as exc:
+        raise OverrideStateError(
+            f"override {row.override_id}: operation {row.override_operation!r} is "
+            "not a declared override operation"
+        ) from exc
+    try:
+        kind = MechanicalTargetKind(row.target_kind)
+    except ValueError as exc:
+        raise OverrideStateError(
+            f"override {row.override_id}: target kind {row.target_kind!r} is not "
+            "a declared target kind"
+        ) from exc
+    try:
+        target = MechanicalTarget(
+            kind=kind,
+            record_key=row.target_record_key,
+            component_key=row.target_component_key,
+            fact_key=row.target_fact_key,
+        )
+    except TargetShapeError as exc:
+        raise OverrideStateError(f"override {row.override_id}: {exc}") from exc
+    return origin, operation, target
+
+
+def collect_current_override_state(
+    session: Session, package_uuid: str, release_version: str
+) -> EffectiveOverrideSet:
+    """Read the package's current override rows as canonical ordered state.
+
+    Ordering is ``(precedence, override_id)`` — the same rule the existing
+    chunk-override path applies, preserved unchanged as ADR-005d Decision 10
+    requires. ``override_id`` is the tie-break rather than insertion order or a
+    row id, so two databases holding the same overrides resolve the same order
+    and therefore the same identity.
+
+    A row authored against a different release fails here, closed, rather than
+    being filtered out. Filtering would make a cross-release override invisible:
+    the identity would silently equal that of a package with no such override,
+    and the explicit failure #137 contract 6 requires for a cross-release patch
+    would never be reported.
+    """
+    rows = (
+        session.execute(
+            select(MechanicalOverrideORM)
+            .where(MechanicalOverrideORM.package_uuid == package_uuid)
+            .order_by(
+                MechanicalOverrideORM.precedence,
+                MechanicalOverrideORM.override_id,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    entries: list[EffectiveOverrideEntry] = []
+    for order, row in enumerate(rows):
+        origin, operation, target = _parse_row(row)
+        if row.release_version != release_version:
+            raise OverrideStateError(
+                f"override {row.override_id} was authored against release "
+                f"{row.release_version!r}; the package publishes "
+                f"{release_version!r}"
+            )
+        entries.append(
+            EffectiveOverrideEntry(
+                override_id=row.override_id,
+                origin=origin,
+                target=target,
+                operation=operation,
+                precedence=row.precedence,
+                apply_order=order,
+                is_enabled=bool(row.is_enabled),
+                payload=dict(row.payload),
+            )
+        )
+    return EffectiveOverrideSet(
+        package_uuid=package_uuid,
+        release_version=release_version,
+        entries=tuple(entries),
+    )

--- a/src/afterworlds/services/rules_authority/patches.py
+++ b/src/afterworlds/services/rules_authority/patches.py
@@ -1,0 +1,486 @@
+"""Closed typed override patch families — CRD Issue 5d, Decision 10.
+
+Six families, and the set is closed. Which family a payload must be is decided
+entirely by the pair *(operation, target kind)*:
+
+===========  ===========  ==========================================
+Operation    Target       Patch family
+===========  ===========  ==========================================
+``DISABLE``  any          :class:`DisablePatch`
+``REPLACE``  record       :class:`RecordReplacementPatch`
+``REPLACE``  component    :class:`ComponentReplacementPatch`
+``REPLACE``  fact         :class:`FactReplacementPatch`
+``APPEND``   record       :class:`ComponentAdditionPatch`
+``APPEND``   component    :class:`FactAdditionPatch`
+``APPEND``   fact         *not permitted*
+===========  ===========  ==========================================
+
+``APPEND`` onto a fact has no family because a fact is a single value, not a
+collection: ADR-005d Decision 10 permits ``APPEND`` "only where the owning
+schema permits multiplicity", and a record's components and a component's facts
+are the only two places multiplicity exists.
+
+Record replacement is **record-kind-specific**, never a generic whole-record
+overwrite: :class:`RecordReplacementPatch` declares the ``record_kind`` it
+replaces, and a patch whose declared kind is not the target record's kind is a
+type-incompatible patch that fails rather than reshaping the record into
+something else.
+
+Two things this module deliberately refuses to accept, because accepting them
+would reopen decisions this PR does not own:
+
+* **Prose-bound authority.** An override-supplied component must be
+  ``STRUCTURED``. ``PROSE_BOUND`` and ``MIXED`` handling require exact governing
+  prose bound to an authoritative 5c ``RuleChunk`` with span-exact provenance
+  (#137 contract 3), which is build-time evidence a runtime patch does not
+  have. Authoring prose here would create the second prose store ADR-005d
+  forbids, so a prose-bound override component is rejected. ``DISABLE``
+  remains available for a prose-bound base component.
+* **Anything outside the closed typed-fact union.** Facts are rebuilt through
+  CRD Issue 5d's own :func:`fact_from_payload`, so an unknown family, a missing
+  field, an extra field, or a mistyped value is rejected here exactly as it is
+  in persistence — there is no looser runtime door into the same union.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.representation import (
+    MalformedFactPayloadError,
+    MechanicalFact,
+    RecordKind,
+    UnknownFactFamilyError,
+    fact_from_payload,
+    fact_invariant_violations,
+    fact_key,
+    fact_payload,
+)
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.services.rules_authority.targets import (
+    MechanicalTarget,
+    MechanicalTargetKind,
+)
+
+__all__ = [
+    "ComponentAdditionPatch",
+    "ComponentBody",
+    "ComponentReplacementPatch",
+    "DisablePatch",
+    "FactAdditionPatch",
+    "FactReplacementPatch",
+    "InvalidPatchError",
+    "MechanicalPatch",
+    "PatchFamily",
+    "RecordReplacementPatch",
+    "patch_from_payload",
+    "patch_payload",
+    "required_patch_family",
+]
+
+
+class PatchFamily(StrEnum):
+    """The closed patch union's discriminator."""
+
+    DISABLE = "disable"
+    REPLACE_RECORD = "replace_record"
+    REPLACE_COMPONENT = "replace_component"
+    REPLACE_FACT = "replace_fact"
+    APPEND_COMPONENT = "append_component"
+    APPEND_FACT = "append_fact"
+
+
+class InvalidPatchError(ValueError):
+    """Raised when a payload is not a valid member of the closed patch union.
+
+    Every runtime caller turns this into the typed ``INVALID_OVERRIDE`` state
+    rather than letting it escape: a malformed patch is an authority failure to
+    report, not an exception to propagate into a turn.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Patch shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ComponentBody:
+    """The complete typed content of one override-supplied component.
+
+    ``semantic_key`` is ``None`` for a replacement, where the target already
+    names the component being replaced, and required for an addition, where the
+    patch is what names it. Carrying the key twice would let a patch disagree
+    with its own target.
+    """
+
+    handling: ComponentHandling
+    facts: tuple[MechanicalFact, ...]
+    semantic_key: str | None = None
+
+
+@dataclass(frozen=True)
+class DisablePatch:
+    """Suppress an exact target. Carries no content by construction."""
+
+    FAMILY = PatchFamily.DISABLE
+
+
+@dataclass(frozen=True)
+class RecordReplacementPatch:
+    """A complete replacement for one record of a declared kind."""
+
+    FAMILY = PatchFamily.REPLACE_RECORD
+
+    record_kind: RecordKind
+    components: tuple[ComponentBody, ...]
+
+
+@dataclass(frozen=True)
+class ComponentReplacementPatch:
+    """A complete replacement for one component."""
+
+    FAMILY = PatchFamily.REPLACE_COMPONENT
+
+    body: ComponentBody
+
+
+@dataclass(frozen=True)
+class FactReplacementPatch:
+    """A complete replacement for one typed fact."""
+
+    FAMILY = PatchFamily.REPLACE_FACT
+
+    fact: MechanicalFact
+
+
+@dataclass(frozen=True)
+class ComponentAdditionPatch:
+    """One complete additional component for a record."""
+
+    FAMILY = PatchFamily.APPEND_COMPONENT
+
+    body: ComponentBody
+
+
+@dataclass(frozen=True)
+class FactAdditionPatch:
+    """One complete additional typed fact for a component."""
+
+    FAMILY = PatchFamily.APPEND_FACT
+
+    fact: MechanicalFact
+
+
+MechanicalPatch = (
+    DisablePatch
+    | RecordReplacementPatch
+    | ComponentReplacementPatch
+    | FactReplacementPatch
+    | ComponentAdditionPatch
+    | FactAdditionPatch
+)
+
+
+#: The one family a payload may be, given what the override says it does. This
+#: mapping is the type-compatibility contract: a payload of any other family is
+#: rejected before it can touch authority, so a ``REPLACE`` never quietly
+#: behaves like an ``APPEND`` because its payload said so.
+_REQUIRED_FAMILY: dict[
+    tuple[OverrideOperationEnum, MechanicalTargetKind], PatchFamily
+] = {
+    (OverrideOperationEnum.DISABLE, MechanicalTargetKind.RECORD): PatchFamily.DISABLE,
+    (
+        OverrideOperationEnum.DISABLE,
+        MechanicalTargetKind.COMPONENT,
+    ): PatchFamily.DISABLE,
+    (OverrideOperationEnum.DISABLE, MechanicalTargetKind.FACT): PatchFamily.DISABLE,
+    (
+        OverrideOperationEnum.REPLACE,
+        MechanicalTargetKind.RECORD,
+    ): PatchFamily.REPLACE_RECORD,
+    (
+        OverrideOperationEnum.REPLACE,
+        MechanicalTargetKind.COMPONENT,
+    ): PatchFamily.REPLACE_COMPONENT,
+    (
+        OverrideOperationEnum.REPLACE,
+        MechanicalTargetKind.FACT,
+    ): PatchFamily.REPLACE_FACT,
+    (
+        OverrideOperationEnum.APPEND,
+        MechanicalTargetKind.RECORD,
+    ): PatchFamily.APPEND_COMPONENT,
+    (
+        OverrideOperationEnum.APPEND,
+        MechanicalTargetKind.COMPONENT,
+    ): PatchFamily.APPEND_FACT,
+    # (APPEND, FACT) is absent on purpose — a fact has no multiplicity to
+    # append into, so there is no honest family for it.
+}
+
+
+def required_patch_family(
+    operation: OverrideOperationEnum, target_kind: MechanicalTargetKind
+) -> PatchFamily:
+    """The single patch family this operation/target pair permits.
+
+    Raises :class:`InvalidPatchError` for the one pair with no family, which is
+    how ``APPEND`` onto a fact fails: explicitly, and before anything is
+    applied.
+    """
+    family = _REQUIRED_FAMILY.get((operation, target_kind))
+    if family is None:
+        raise InvalidPatchError(
+            f"{operation.value} is not permitted on a {target_kind.value} target: "
+            "the owning schema declares no multiplicity there"
+        )
+    return family
+
+
+# ---------------------------------------------------------------------------
+# Payload → patch
+# ---------------------------------------------------------------------------
+
+
+def _require_keys(payload: Mapping[str, Any], expected: set[str], what: str) -> None:
+    supplied = set(payload)
+    if missing := sorted(expected - supplied):
+        raise InvalidPatchError(f"{what} payload is missing {missing}")
+    if extra := sorted(supplied - expected):
+        raise InvalidPatchError(f"{what} payload carries extra {extra}")
+
+
+def _build_fact(value: object, what: str) -> MechanicalFact:
+    if not isinstance(value, Mapping):
+        raise InvalidPatchError(
+            f"{what} fact must be a payload object, got {type(value).__name__}"
+        )
+    try:
+        fact = fact_from_payload(value)
+    except (UnknownFactFamilyError, MalformedFactPayloadError) as exc:
+        raise InvalidPatchError(
+            f"{what} fact is not a valid typed fact: {exc}"
+        ) from exc
+    if violations := fact_invariant_violations(fact):
+        raise InvalidPatchError(
+            f"{what} fact violates its own family contract: {'; '.join(violations)}"
+        )
+    return fact
+
+
+def _build_component_body(value: object, what: str, *, keyed: bool) -> ComponentBody:
+    """Rebuild one component body, refusing anything the projection would.
+
+    *keyed* distinguishes an addition (which must name the component it adds)
+    from a replacement (whose target already names it).
+    """
+    if not isinstance(value, Mapping):
+        raise InvalidPatchError(
+            f"{what} component must be a payload object, got {type(value).__name__}"
+        )
+    expected = {"handling", "facts"} | ({"semantic_key"} if keyed else set())
+    _require_keys(value, expected, what)
+
+    raw_handling = value["handling"]
+    if type(raw_handling) is not str:
+        raise InvalidPatchError(f"{what} handling must be a string")
+    try:
+        handling = ComponentHandling(raw_handling)
+    except ValueError as exc:
+        raise InvalidPatchError(
+            f"{what} handling {raw_handling!r} is not a declared handling"
+        ) from exc
+    if handling is not ComponentHandling.STRUCTURED:
+        # Prose-bound authority needs an authoritative 5c chunk and span-exact
+        # provenance, which a runtime patch cannot supply. Rejecting it here is
+        # what keeps overrides from becoming a second prose store.
+        raise InvalidPatchError(
+            f"{what} declares {handling.value} handling; an override-supplied "
+            "component must be structured, because prose-bound authority "
+            "requires build-time 5c prose binding and provenance"
+        )
+
+    semantic_key: str | None = None
+    if keyed:
+        raw_key = value["semantic_key"]
+        if type(raw_key) is not str or not raw_key.strip():
+            raise InvalidPatchError(f"{what} semantic_key must be a non-blank string")
+        semantic_key = raw_key
+
+    raw_facts = value["facts"]
+    if not isinstance(raw_facts, list):
+        raise InvalidPatchError(f"{what} facts must be a list")
+    facts = tuple(
+        _build_fact(entry, f"{what} fact {index}")
+        for index, entry in enumerate(raw_facts)
+    )
+    if not facts:
+        # Structured handling with no facts is the dishonest declaration the
+        # projection validator already rejects; a patch may not introduce it.
+        raise InvalidPatchError(f"{what} declares structured handling with no facts")
+    keys = [fact_key(f) for f in facts]
+    if len(set(keys)) != len(keys):
+        raise InvalidPatchError(f"{what} repeats the same typed fact")
+    return ComponentBody(handling=handling, facts=facts, semantic_key=semantic_key)
+
+
+def _build_disable(payload: Mapping[str, Any]) -> DisablePatch:
+    _require_keys(payload, {"patch"}, "disable")
+    return DisablePatch()
+
+
+def _build_replace_record(payload: Mapping[str, Any]) -> RecordReplacementPatch:
+    _require_keys(payload, {"patch", "record_kind", "components"}, "replace_record")
+    raw_kind = payload["record_kind"]
+    if type(raw_kind) is not str:
+        raise InvalidPatchError("replace_record record_kind must be a string")
+    try:
+        kind = RecordKind(raw_kind)
+    except ValueError as exc:
+        raise InvalidPatchError(
+            f"replace_record record_kind {raw_kind!r} is not a declared record kind"
+        ) from exc
+    raw_components = payload["components"]
+    if not isinstance(raw_components, list) or not raw_components:
+        raise InvalidPatchError(
+            "replace_record components must be a non-empty list: a record "
+            "replacement is complete or it is not a replacement"
+        )
+    components = tuple(
+        _build_component_body(entry, f"replace_record component {index}", keyed=True)
+        for index, entry in enumerate(raw_components)
+    )
+    keys = [c.semantic_key for c in components]
+    if len(set(keys)) != len(keys):
+        raise InvalidPatchError("replace_record repeats a component semantic_key")
+    return RecordReplacementPatch(record_kind=kind, components=components)
+
+
+def _build_replace_component(payload: Mapping[str, Any]) -> ComponentReplacementPatch:
+    _require_keys(payload, {"patch", "component"}, "replace_component")
+    return ComponentReplacementPatch(
+        body=_build_component_body(
+            payload["component"], "replace_component", keyed=False
+        )
+    )
+
+
+def _build_replace_fact(payload: Mapping[str, Any]) -> FactReplacementPatch:
+    _require_keys(payload, {"patch", "fact"}, "replace_fact")
+    return FactReplacementPatch(fact=_build_fact(payload["fact"], "replace_fact"))
+
+
+def _build_append_component(payload: Mapping[str, Any]) -> ComponentAdditionPatch:
+    _require_keys(payload, {"patch", "component"}, "append_component")
+    return ComponentAdditionPatch(
+        body=_build_component_body(payload["component"], "append_component", keyed=True)
+    )
+
+
+def _build_append_fact(payload: Mapping[str, Any]) -> FactAdditionPatch:
+    _require_keys(payload, {"patch", "fact"}, "append_fact")
+    return FactAdditionPatch(fact=_build_fact(payload["fact"], "append_fact"))
+
+
+_PATCH_BUILDERS: dict[PatchFamily, Any] = {
+    PatchFamily.DISABLE: _build_disable,
+    PatchFamily.REPLACE_RECORD: _build_replace_record,
+    PatchFamily.REPLACE_COMPONENT: _build_replace_component,
+    PatchFamily.REPLACE_FACT: _build_replace_fact,
+    PatchFamily.APPEND_COMPONENT: _build_append_component,
+    PatchFamily.APPEND_FACT: _build_append_fact,
+}
+
+
+def patch_from_payload(
+    payload: object,
+    *,
+    operation: OverrideOperationEnum,
+    target: MechanicalTarget,
+) -> MechanicalPatch:
+    """Rebuild the typed patch a stored payload declares, or refuse it.
+
+    The declared ``patch`` discriminator must be exactly the family the
+    operation and target permit. A well-formed payload of the wrong family is
+    still refused — that is what makes a cross-family patch a typed failure
+    rather than a silently reinterpreted one.
+    """
+    if not isinstance(payload, Mapping):
+        raise InvalidPatchError(
+            f"override payload must be an object, got {type(payload).__name__}"
+        )
+    required = required_patch_family(operation, target.kind)
+    raw = payload.get("patch")
+    try:
+        family = PatchFamily(str(raw))
+    except ValueError as exc:
+        raise InvalidPatchError(
+            f"{raw!r} is not a member of the closed patch union"
+        ) from exc
+    if family is not required:
+        raise InvalidPatchError(
+            f"{operation.value} on a {target.kind.value} target requires a "
+            f"{required.value} patch, got {family.value}"
+        )
+    return _PATCH_BUILDERS[family](payload)  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Patch → payload
+# ---------------------------------------------------------------------------
+
+
+def _component_body_payload(body: ComponentBody) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    if body.semantic_key is not None:
+        payload["semantic_key"] = body.semantic_key
+    payload["handling"] = body.handling.value
+    # Facts are ordered by their content-derived key rather than by authoring
+    # order: two patches supplying the same facts in a different order are the
+    # same patch, and must not mint two override-set identities.
+    payload["facts"] = [fact_payload(f) for f in sorted(body.facts, key=fact_key)]
+    return payload
+
+
+def patch_payload(patch: MechanicalPatch) -> dict[str, object]:
+    """Canonical identity-bearing payload of one typed patch.
+
+    This is what the override-set identity is derived from, so it must be a
+    complete and order-stable statement of the patch's content — a payload that
+    dropped a field would let two different patches share an identity.
+    """
+    if isinstance(patch, DisablePatch):
+        return {"patch": PatchFamily.DISABLE.value}
+    if isinstance(patch, RecordReplacementPatch):
+        return {
+            "patch": PatchFamily.REPLACE_RECORD.value,
+            "record_kind": patch.record_kind.value,
+            "components": [
+                _component_body_payload(c)
+                for c in sorted(patch.components, key=lambda c: c.semantic_key or "")
+            ],
+        }
+    if isinstance(patch, ComponentReplacementPatch):
+        return {
+            "patch": PatchFamily.REPLACE_COMPONENT.value,
+            "component": _component_body_payload(patch.body),
+        }
+    if isinstance(patch, FactReplacementPatch):
+        return {
+            "patch": PatchFamily.REPLACE_FACT.value,
+            "fact": fact_payload(patch.fact),
+        }
+    if isinstance(patch, ComponentAdditionPatch):
+        return {
+            "patch": PatchFamily.APPEND_COMPONENT.value,
+            "component": _component_body_payload(patch.body),
+        }
+    return {
+        "patch": PatchFamily.APPEND_FACT.value,
+        "fact": fact_payload(patch.fact),
+    }

--- a/src/afterworlds/services/rules_authority/retention.py
+++ b/src/afterworlds/services/rules_authority/retention.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import Session
 from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
 from afterworlds.persistence.orm.rules_authority import (
     OverrideSetEntryORM,
+    OverrideSetScopeORM,
     OverrideSetVersionORM,
 )
 from afterworlds.services.rules_authority.override_set import (
@@ -88,6 +89,11 @@ def retain_override_set(
         )
     ).scalar_one_or_none()
     if existing is not None:
+        # The content is already retained, but *this* scope may not be: shared
+        # content is the normal case, so a second package reaching the same
+        # identity still has to record its own association before it may replay
+        # against it.
+        _retain_scope(session, identity, state, now=now)
         # Reconstruct rather than trust: this is the read path replay will take,
         # so proving it here means a retention defect surfaces at the write that
         # could still have fixed it.
@@ -127,7 +133,38 @@ def retain_override_set(
             )
         )
     session.flush()
+    _retain_scope(session, identity, state, now=now)
     return identity
+
+
+def _retain_scope(
+    session: Session, identity: str, state: EffectiveOverrideSet, *, now: str
+) -> None:
+    """Record that *state*'s package and release retained this content.
+
+    Idempotent, and separate from the version write because the two have
+    different grains: the version is shared content written once, while the
+    association is per package/release and may legitimately be the first thing a
+    second package adds to content that already exists.
+    """
+    already = session.execute(
+        select(OverrideSetScopeORM).where(
+            OverrideSetScopeORM.override_set_uuid == identity,
+            OverrideSetScopeORM.package_uuid == state.package_uuid,
+            OverrideSetScopeORM.release_version == state.release_version,
+        )
+    ).scalar_one_or_none()
+    if already is not None:
+        return
+    session.add(
+        OverrideSetScopeORM(
+            override_set_uuid=identity,
+            package_uuid=state.package_uuid,
+            release_version=state.release_version,
+            first_recorded_at=now,
+        )
+    )
+    session.flush()
 
 
 def _entry_from_row(row: OverrideSetEntryORM) -> EffectiveOverrideEntry:
@@ -177,11 +214,18 @@ def load_override_set_version(
     re-derived from them would reconstruct today's authority while claiming to
     reconstruct the recorded one.
 
-    *package_uuid* and *release_version* are supplied by the caller rather than
-    read from the version row, because the version is content-addressed and
-    package-independent: identical override state across packages is one row,
-    and the empty set is shared by every package. The scope comes from the
-    binding being replayed, which is the only place it is authoritative.
+    *package_uuid* and *release_version* come from the binding being replayed
+    rather than from the version row, because the version is content-addressed
+    and package-independent: identical override state across packages is one
+    row, and the empty set is shared by every package.
+
+    They are **verified, not trusted.** A retained version may only be applied
+    under a scope it was actually retained for, proven against
+    ``rp_override_set_scopes``. Without that check the caller's binding would be
+    self-certifying, and since semantic keys are stable across SRD-derived
+    releases by design, an override set retained for one package finds live
+    targets in another and replays with the wrong provenance rather than
+    failing.
 
     Raises :class:`OverrideSetRetentionError` when the version is absent, its
     entry count disagrees with what was retained, its apply order is not a
@@ -196,6 +240,19 @@ def load_override_set_version(
     if version is None:
         raise OverrideSetRetentionError(
             f"no retained override-set version {override_set_uuid}"
+        )
+
+    scope = session.execute(
+        select(OverrideSetScopeORM).where(
+            OverrideSetScopeORM.override_set_uuid == override_set_uuid,
+            OverrideSetScopeORM.package_uuid == package_uuid,
+            OverrideSetScopeORM.release_version == release_version,
+        )
+    ).scalar_one_or_none()
+    if scope is None:
+        raise OverrideSetRetentionError(
+            f"retained override-set version {override_set_uuid} was never retained "
+            f"for package {package_uuid} release {release_version!r}"
         )
 
     rows = (

--- a/src/afterworlds/services/rules_authority/retention.py
+++ b/src/afterworlds/services/rules_authority/retention.py
@@ -34,6 +34,15 @@ transaction the whole unit — version, entries, and scope association — is wr
 under one savepoint, so a partial failure unwinds all of it rather than leaving
 an orphan snapshot the next reader would have to reason about.
 
+That guarantee needs a physical transaction underneath it, which a read-only
+prelude does not produce: under ``sqlite3``'s legacy transaction control a
+session that has only read is still in SQLite autocommit, and a savepoint opened
+there is the outermost one — releasing it *commits*. Binding resolution reads
+before it retains, so this was exactly the shape that occurred. Retention
+therefore calls :func:`~afterworlds.persistence.database.ensure_physical_transaction`
+first, which makes the savepoint genuinely nested and leaves the commit boundary
+where the caller expects it.
+
 **Concurrency.** Retention runs on every binding resolution, so two sessions
 resolving the same package at the same time both try to retain the same content.
 That is the expected case, not an error, and it is handled by writing through
@@ -51,6 +60,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.persistence.database import ensure_physical_transaction
 from afterworlds.persistence.orm.rules_authority import (
     OverrideSetEntryORM,
     OverrideSetScopeORM,
@@ -116,8 +126,17 @@ def retain_override_set(
     verification is not ceremony — a version whose retained entries no longer
     reproduce their own identity would silently answer replay reads with the
     wrong authority.
+
+    Never commits. Everything written here is pending in the caller's
+    transaction and disappears if the caller rolls back, so a retention that
+    belongs to a larger unit of work cannot outlive that unit's failure.
     """
     identity = state.override_set_uuid
+
+    # Before the savepoint, not inside it. Resolution reads before it retains, so
+    # without this the savepoint below would be the outermost one and releasing
+    # it would commit these rows out of the caller's control.
+    ensure_physical_transaction(session)
 
     # One savepoint around the whole unit. Version, entries, and scope are one
     # piece of evidence: a version without its entries, or content without the

--- a/src/afterworlds/services/rules_authority/retention.py
+++ b/src/afterworlds/services/rules_authority/retention.py
@@ -91,14 +91,17 @@ def retain_override_set(
         # Reconstruct rather than trust: this is the read path replay will take,
         # so proving it here means a retention defect surfaces at the write that
         # could still have fixed it.
-        load_override_set_version(session, identity)
+        load_override_set_version(
+            session,
+            identity,
+            package_uuid=state.package_uuid,
+            release_version=state.release_version,
+        )
         return identity
 
     session.add(
         OverrideSetVersionORM(
             override_set_uuid=identity,
-            package_uuid=state.package_uuid,
-            release_version=state.release_version,
             entry_count=len(state.entries),
             recorded_at=now,
         )
@@ -161,7 +164,11 @@ def _entry_from_row(row: OverrideSetEntryORM) -> EffectiveOverrideEntry:
 
 
 def load_override_set_version(
-    session: Session, override_set_uuid: str
+    session: Session,
+    override_set_uuid: str,
+    *,
+    package_uuid: str,
+    release_version: str,
 ) -> EffectiveOverrideSet:
     """Resolve one retained override-set version for audit or replay.
 
@@ -169,6 +176,12 @@ def load_override_set_version(
     consulted — they are the authoring surface, and an implementation that
     re-derived from them would reconstruct today's authority while claiming to
     reconstruct the recorded one.
+
+    *package_uuid* and *release_version* are supplied by the caller rather than
+    read from the version row, because the version is content-addressed and
+    package-independent: identical override state across packages is one row,
+    and the empty set is shared by every package. The scope comes from the
+    binding being replayed, which is the only place it is authoritative.
 
     Raises :class:`OverrideSetRetentionError` when the version is absent, its
     entry count disagrees with what was retained, its apply order is not a
@@ -213,7 +226,7 @@ def load_override_set_version(
             f"{rederived}"
         )
     return EffectiveOverrideSet(
-        package_uuid=version.package_uuid,
-        release_version=version.release_version,
+        package_uuid=package_uuid,
+        release_version=release_version,
         entries=entries,
     )

--- a/src/afterworlds/services/rules_authority/retention.py
+++ b/src/afterworlds/services/rules_authority/retention.py
@@ -1,0 +1,219 @@
+"""Retained immutable override-set versions — CRD Issue 5d, Decision 9.
+
+ADR-005d rejected "record the override-set identity but retain only current
+override rows": the identifier would name state that no longer exists once an
+override is edited, disabled, reprioritized, retargeted, or deleted, leaving
+audit and replay able to detect divergence but not to reconstruct the authority
+actually applied. This module is the retention that closes that gap.
+
+The shape chosen here is a **content-addressed snapshot**: one immutable version
+row keyed by the ``override_set_uuid``, plus its complete ordered entries. ADR-
+005d explicitly leaves the shape open (snapshot, append-only version records, or
+an event log that reconstructs the canonical version); a snapshot is the
+lowest-complexity option that is already content-addressed, so its reconstructed
+canonical version reproducing the recorded identity is a property of how it is
+stored rather than a second mechanism to verify.
+
+Two operations, and they are deliberately different:
+
+* :func:`retain_override_set` is called at binding-resolution time. It is
+  idempotent by construction — the identity *is* the primary key, so recording
+  the same state twice writes nothing the second time. When a version already
+  exists it is verified rather than trusted: its retained entries must still
+  reproduce the identity they are stored under.
+* :func:`load_override_set_version` is the audit and replay read. It resolves
+  the retained version and must succeed. ``STALE`` is not a valid answer here —
+  a failure to reconstruct is a retention defect, which is why it raises
+  :class:`OverrideSetRetentionError` rather than returning an outcome a caller
+  could mistake for ordinary divergence.
+
+Retention writes into the caller's transaction and flushes rather than commits.
+The caller owns the commit boundary, so a resolution that is part of a larger
+failed unit of work does not leave a half-retained version behind.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.persistence.orm.rules_authority import (
+    OverrideSetEntryORM,
+    OverrideSetVersionORM,
+)
+from afterworlds.services.rules_authority.override_set import (
+    EffectiveOverrideEntry,
+    EffectiveOverrideSet,
+    override_set_identity,
+)
+from afterworlds.services.rules_authority.targets import (
+    MechanicalTarget,
+    MechanicalTargetKind,
+    TargetShapeError,
+)
+
+__all__ = [
+    "OverrideSetRetentionError",
+    "load_override_set_version",
+    "retain_override_set",
+]
+
+
+class OverrideSetRetentionError(RuntimeError):
+    """Raised when a retained override-set version cannot be reconstructed.
+
+    This is never a divergence signal. It means the replay evidence a recorded
+    binding depends on is missing, incomplete, or no longer derives its own
+    identity — a defect in retention, reported as such so it cannot be mistaken
+    for the ordinary "current overrides have moved on" case.
+    """
+
+
+def retain_override_set(
+    session: Session, state: EffectiveOverrideSet, *, now: str
+) -> str:
+    """Record *state* as an immutable version, returning its identity.
+
+    Idempotent: an identical state is the *same* identity, so re-recording it
+    verifies the existing version instead of writing a second one. The
+    verification is not ceremony — a version whose retained entries no longer
+    reproduce their own identity would silently answer replay reads with the
+    wrong authority.
+    """
+    identity = state.override_set_uuid
+    existing = session.execute(
+        select(OverrideSetVersionORM).where(
+            OverrideSetVersionORM.override_set_uuid == identity
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        # Reconstruct rather than trust: this is the read path replay will take,
+        # so proving it here means a retention defect surfaces at the write that
+        # could still have fixed it.
+        load_override_set_version(session, identity)
+        return identity
+
+    session.add(
+        OverrideSetVersionORM(
+            override_set_uuid=identity,
+            package_uuid=state.package_uuid,
+            release_version=state.release_version,
+            entry_count=len(state.entries),
+            recorded_at=now,
+        )
+    )
+    # Flushed before its entries: they carry a foreign key to it, and the unit
+    # of work is free to order two pending inserts either way.
+    session.flush()
+    for entry in state.entries:
+        session.add(
+            OverrideSetEntryORM(
+                override_set_uuid=identity,
+                apply_order=entry.apply_order,
+                override_id=entry.override_id,
+                override_origin=entry.origin.value,
+                target_kind=entry.target.kind.value,
+                target_record_key=entry.target.record_key,
+                target_component_key=entry.target.component_key,
+                target_fact_key=entry.target.fact_key,
+                override_operation=entry.operation.value,
+                precedence=entry.precedence,
+                is_enabled=entry.is_enabled,
+                payload=entry.payload,
+            )
+        )
+    session.flush()
+    return identity
+
+
+def _entry_from_row(row: OverrideSetEntryORM) -> EffectiveOverrideEntry:
+    try:
+        origin = OverrideOriginEnum(row.override_origin)
+        operation = OverrideOperationEnum(row.override_operation)
+        kind = MechanicalTargetKind(row.target_kind)
+        target = MechanicalTarget(
+            kind=kind,
+            record_key=row.target_record_key,
+            component_key=row.target_component_key,
+            fact_key=row.target_fact_key,
+        )
+    except (ValueError, TargetShapeError) as exc:
+        raise OverrideSetRetentionError(
+            f"retained override-set entry {row.override_set_uuid}/{row.apply_order} "
+            f"does not parse: {exc}"
+        ) from exc
+    if not isinstance(row.payload, dict):
+        raise OverrideSetRetentionError(
+            f"retained override-set entry {row.override_set_uuid}/{row.apply_order} "
+            "has no payload object"
+        )
+    return EffectiveOverrideEntry(
+        override_id=row.override_id,
+        origin=origin,
+        target=target,
+        operation=operation,
+        precedence=row.precedence,
+        apply_order=row.apply_order,
+        is_enabled=bool(row.is_enabled),
+        payload=dict(row.payload),
+    )
+
+
+def load_override_set_version(
+    session: Session, override_set_uuid: str
+) -> EffectiveOverrideSet:
+    """Resolve one retained override-set version for audit or replay.
+
+    Reads only the retained tables. Current ``rp_mech_overrides`` rows are never
+    consulted — they are the authoring surface, and an implementation that
+    re-derived from them would reconstruct today's authority while claiming to
+    reconstruct the recorded one.
+
+    Raises :class:`OverrideSetRetentionError` when the version is absent, its
+    entry count disagrees with what was retained, its apply order is not a
+    contiguous sequence, or its entries no longer derive the identity they are
+    stored under.
+    """
+    version = session.execute(
+        select(OverrideSetVersionORM).where(
+            OverrideSetVersionORM.override_set_uuid == override_set_uuid
+        )
+    ).scalar_one_or_none()
+    if version is None:
+        raise OverrideSetRetentionError(
+            f"no retained override-set version {override_set_uuid}"
+        )
+
+    rows = (
+        session.execute(
+            select(OverrideSetEntryORM)
+            .where(OverrideSetEntryORM.override_set_uuid == override_set_uuid)
+            .order_by(OverrideSetEntryORM.apply_order)
+        )
+        .scalars()
+        .all()
+    )
+    if len(rows) != version.entry_count:
+        raise OverrideSetRetentionError(
+            f"retained override-set version {override_set_uuid} records "
+            f"{version.entry_count} entries, {len(rows)} are present"
+        )
+    if [r.apply_order for r in rows] != list(range(len(rows))):
+        raise OverrideSetRetentionError(
+            f"retained override-set version {override_set_uuid} has a broken "
+            "apply order"
+        )
+
+    entries = tuple(_entry_from_row(row) for row in rows)
+    rederived = override_set_identity(entries)
+    if rederived != override_set_uuid:
+        raise OverrideSetRetentionError(
+            f"retained override-set version {override_set_uuid} reconstructs as "
+            f"{rederived}"
+        )
+    return EffectiveOverrideSet(
+        package_uuid=version.package_uuid,
+        release_version=version.release_version,
+        entries=entries,
+    )

--- a/src/afterworlds/services/rules_authority/retention.py
+++ b/src/afterworlds/services/rules_authority/retention.py
@@ -29,12 +29,25 @@ Two operations, and they are deliberately different:
 
 Retention writes into the caller's transaction and flushes rather than commits.
 The caller owns the commit boundary, so a resolution that is part of a larger
-failed unit of work does not leave a half-retained version behind.
+failed unit of work does not leave a half-retained version behind. Within that
+transaction the whole unit — version, entries, and scope association — is written
+under one savepoint, so a partial failure unwinds all of it rather than leaving
+an orphan snapshot the next reader would have to reason about.
+
+**Concurrency.** Retention runs on every binding resolution, so two sessions
+resolving the same package at the same time both try to retain the same content.
+That is the expected case, not an error, and it is handled by writing through
+``INSERT ... ON CONFLICT DO NOTHING`` against content-aware immutability guards
+rather than by querying for absence first and racing into the gap. See
+:func:`_insert_or_ignore` — the guard shape and the insert shape are one design
+and neither is safe alone.
 """
 
 from __future__ import annotations
 
 from sqlalchemy import select
+from sqlalchemy.dialects.sqlite import Insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
 from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
@@ -61,6 +74,28 @@ __all__ = [
 ]
 
 
+def _insert_or_ignore(model: type) -> Insert:
+    """An insert that treats an already-present identical row as done.
+
+    This is the idempotent half of a mechanism whose other half is the
+    content-aware ``BEFORE INSERT`` guards in migration ``0024``, and the two
+    only work together.
+
+    Query-then-insert cannot be made concurrency-safe here: two sessions both
+    observe absence, both insert, and the loser takes a uniqueness violation for
+    doing exactly what it was asked to. ``ON CONFLICT DO NOTHING`` removes that
+    race at the source instead of catching it afterwards — nothing is suppressed,
+    because for the loser there is genuinely nothing left to do.
+
+    It only works because the guards reject a re-insert that would *change*
+    retained content rather than one that merely repeats it. An existence-based
+    guard aborts the statement before conflict resolution is ever reached, which
+    was verified against the engine rather than assumed; under such a guard this
+    upsert would fail exactly where it needs to succeed.
+    """
+    return sqlite_insert(model).on_conflict_do_nothing()
+
+
 class OverrideSetRetentionError(RuntimeError):
     """Raised when a retained override-set version cannot be reconstructed.
 
@@ -83,88 +118,66 @@ def retain_override_set(
     wrong authority.
     """
     identity = state.override_set_uuid
-    existing = session.execute(
-        select(OverrideSetVersionORM).where(
-            OverrideSetVersionORM.override_set_uuid == identity
-        )
-    ).scalar_one_or_none()
-    if existing is not None:
-        # The content is already retained, but *this* scope may not be: shared
-        # content is the normal case, so a second package reaching the same
-        # identity still has to record its own association before it may replay
-        # against it.
-        _retain_scope(session, identity, state, now=now)
-        # Reconstruct rather than trust: this is the read path replay will take,
-        # so proving it here means a retention defect surfaces at the write that
-        # could still have fixed it.
-        load_override_set_version(
-            session,
-            identity,
-            package_uuid=state.package_uuid,
-            release_version=state.release_version,
-        )
-        return identity
 
-    session.add(
-        OverrideSetVersionORM(
-            override_set_uuid=identity,
-            entry_count=len(state.entries),
-            recorded_at=now,
-        )
-    )
-    # Flushed before its entries: they carry a foreign key to it, and the unit
-    # of work is free to order two pending inserts either way.
-    session.flush()
-    for entry in state.entries:
-        session.add(
-            OverrideSetEntryORM(
+    # One savepoint around the whole unit. Version, entries, and scope are one
+    # piece of evidence: a version without its entries, or content without the
+    # association proving whose it is, is not partial evidence but unusable
+    # evidence. A failure part-way therefore unwinds all of it and leaves the
+    # caller's transaction usable, rather than leaving an orphan snapshot behind
+    # for the next reader to trip over.
+    with session.begin_nested():
+        session.execute(
+            _insert_or_ignore(OverrideSetVersionORM).values(
                 override_set_uuid=identity,
-                apply_order=entry.apply_order,
-                override_id=entry.override_id,
-                override_origin=entry.origin.value,
-                target_kind=entry.target.kind.value,
-                target_record_key=entry.target.record_key,
-                target_component_key=entry.target.component_key,
-                target_fact_key=entry.target.fact_key,
-                override_operation=entry.operation.value,
-                precedence=entry.precedence,
-                is_enabled=entry.is_enabled,
-                payload=entry.payload,
+                entry_count=len(state.entries),
+                recorded_at=now,
             )
         )
-    session.flush()
-    _retain_scope(session, identity, state, now=now)
-    return identity
-
-
-def _retain_scope(
-    session: Session, identity: str, state: EffectiveOverrideSet, *, now: str
-) -> None:
-    """Record that *state*'s package and release retained this content.
-
-    Idempotent, and separate from the version write because the two have
-    different grains: the version is shared content written once, while the
-    association is per package/release and may legitimately be the first thing a
-    second package adds to content that already exists.
-    """
-    already = session.execute(
-        select(OverrideSetScopeORM).where(
-            OverrideSetScopeORM.override_set_uuid == identity,
-            OverrideSetScopeORM.package_uuid == state.package_uuid,
-            OverrideSetScopeORM.release_version == state.release_version,
+        # Flushed before its entries: they carry a foreign key to it, and the
+        # unit of work is free to order two pending inserts either way.
+        session.flush()
+        for entry in state.entries:
+            session.execute(
+                _insert_or_ignore(OverrideSetEntryORM).values(
+                    override_set_uuid=identity,
+                    apply_order=entry.apply_order,
+                    override_id=entry.override_id,
+                    override_origin=entry.origin.value,
+                    target_kind=entry.target.kind.value,
+                    target_record_key=entry.target.record_key,
+                    target_component_key=entry.target.component_key,
+                    target_fact_key=entry.target.fact_key,
+                    override_operation=entry.operation.value,
+                    precedence=entry.precedence,
+                    is_enabled=entry.is_enabled,
+                    payload=entry.payload,
+                )
+            )
+        # The content may already be retained while *this* scope is not: shared
+        # content is the normal case, so a second package reaching the same
+        # identity still records its own association before it may replay.
+        session.execute(
+            _insert_or_ignore(OverrideSetScopeORM).values(
+                override_set_uuid=identity,
+                package_uuid=state.package_uuid,
+                release_version=state.release_version,
+                first_recorded_at=now,
+            )
         )
-    ).scalar_one_or_none()
-    if already is not None:
-        return
-    session.add(
-        OverrideSetScopeORM(
-            override_set_uuid=identity,
-            package_uuid=state.package_uuid,
-            release_version=state.release_version,
-            first_recorded_at=now,
-        )
+        session.flush()
+
+    # Verify whatever is now there, whoever wrote it. This is the read path
+    # replay will take, so proving it at the write means a retention defect
+    # surfaces while it could still have been fixed — and after a lost race it
+    # is what confirms the winner's evidence is the valid one this caller can
+    # rely on, rather than assuming so because no error was raised.
+    load_override_set_version(
+        session,
+        identity,
+        package_uuid=state.package_uuid,
+        release_version=state.release_version,
     )
-    session.flush()
+    return identity
 
 
 def _entry_from_row(row: OverrideSetEntryORM) -> EffectiveOverrideEntry:

--- a/src/afterworlds/services/rules_authority/service.py
+++ b/src/afterworlds/services/rules_authority/service.py
@@ -67,9 +67,20 @@ from afterworlds.services.rules_authority.views import (
 
 __all__ = [
     "AuthorityResult",
+    "IncoherentBindingError",
     "MechanicalRuleSlice",
     "RulesAuthorityService",
 ]
+
+
+class IncoherentBindingError(RuntimeError):
+    """Raised when a recorded binding's four components describe two authorities.
+
+    Distinct from ``STALE``, which means the world moved on from a coherent
+    binding. This means the binding was never coherent: its projection was built
+    over a different package or release than the binding names, so replaying it
+    would label one package's mechanics with another's provenance.
+    """
 
 
 @dataclass(frozen=True)
@@ -349,13 +360,42 @@ class RulesAuthorityService:
         Raises rather than returning an outcome. ``STALE`` is not a valid answer
         to a replay: divergence from current state is expected and is the whole
         point. A version that cannot be resolved is a retention defect
-        (:class:`OverrideSetRetentionError`), and a projection that cannot be
-        reconstructed is a persistence defect; neither is a divergence signal.
+        (:class:`OverrideSetRetentionError`), a projection that cannot be
+        reconstructed is a persistence defect, and a binding whose components do
+        not describe one authority is an :class:`IncoherentBindingError`. None of
+        the three is a divergence signal.
+
+        **The four components are checked against each other, not just resolved
+        individually.** The override set and the projection are loaded from
+        different tables by different identities, so nothing about loading both
+        proves they belong together — and because the override-set identity is
+        content-derived and package-independent, the empty set is legitimately
+        shared by every package. A binding that paired package B with package A's
+        projection would otherwise replay A's mechanics under B's provenance,
+        which is exactly the ambiguity the four-component binding exists to
+        remove.
         """
+        candidate = self._reconstruct(recorded)
+        bound = candidate.binding
+        if bound.package_uuid != str(recorded.package_uuid):
+            raise IncoherentBindingError(
+                f"recorded binding names package {recorded.package_uuid}, but "
+                f"projection {recorded.mechanical_projection_uuid} was built over "
+                f"package {bound.package_uuid}"
+            )
+        if bound.release_version != recorded.release_version:
+            raise IncoherentBindingError(
+                f"recorded binding names release {recorded.release_version!r}, but "
+                f"projection {recorded.mechanical_projection_uuid} was built over "
+                f"release {bound.release_version!r}"
+            )
         state = load_override_set_version(
-            self._session, str(recorded.override_set_uuid)
+            self._session,
+            str(recorded.override_set_uuid),
+            package_uuid=str(recorded.package_uuid),
+            release_version=recorded.release_version,
         )
-        return apply_override_set(self._reconstruct(recorded), state, recorded)
+        return apply_override_set(candidate, state, recorded)
 
 
 def _select(

--- a/src/afterworlds/services/rules_authority/service.py
+++ b/src/afterworlds/services/rules_authority/service.py
@@ -1,0 +1,406 @@
+"""The runtime mechanical-authority seam — CRD Issue 5d, contract 6.
+
+One service, and every runtime read of mechanical authority goes through it:
+binding resolution, rule slices, the deterministic-consumer view, the GameMaster
+authority view, and audit replay. Each returns a typed result carrying the
+complete four-component effective binding that produced it, or a typed refusal.
+Nothing returns ``None``, an empty collection, or a bare exception to mean
+"no authority" (#137 contract 5).
+
+**Runtime and replay are different operations, and this is where that shows.**
+
+* :meth:`RulesAuthorityService.resolve` and the view methods recompute the
+  override-set identity from *current* override state. A recorded binding that
+  no longer matches is ``STALE`` and fails; it is never silently re-resolved
+  against current overrides.
+* :meth:`RulesAuthorityService.replay` resolves the *retained* immutable
+  override-set version named by the recorded binding and reconstructs the exact
+  effective authority originally applied — after the current override rows have
+  been edited, disabled, reprioritized, retargeted, or deleted. ``STALE`` is not
+  a possible answer there; a failure to reconstruct is a retention defect and
+  raises rather than returning an outcome an auditor could read as ordinary
+  divergence.
+
+The obsolete ``MechanicalEntity`` authority path is untouched by this module.
+Nothing here reads it, falls back to it, or combines with it: a caller resolves
+either the typed mechanical authority below or the legacy slice, never a mixture
+of the two.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.persistence import (
+    PersistedStateReconstructionError,
+    ProjectionNotPersistedError,
+    reconstruct_candidate,
+)
+from afterworlds.ingestion.mechanical.projection import ProjectionCandidate
+from afterworlds.models.rules_package import RuleSliceRequest, RulesPackageBinding
+from afterworlds.persistence.orm.rules_package import RuleChunkORM
+from afterworlds.services.rules_authority.application import (
+    EffectiveAuthority,
+    EffectiveComponent,
+    EffectiveRecord,
+    OverrideApplicationError,
+    apply_override_set,
+)
+from afterworlds.services.rules_authority.binding import (
+    BindingResolution,
+    resolve_effective_binding,
+    resolve_package_reference,
+)
+from afterworlds.services.rules_authority.outcomes import AuthorityOutcome
+from afterworlds.services.rules_authority.override_set import EffectiveOverrideSet
+from afterworlds.services.rules_authority.retention import load_override_set_version
+from afterworlds.services.rules_authority.views import (
+    GameMasterAuthorityView,
+    TypedAuthorityView,
+    build_gamemaster_view,
+    build_typed_view,
+)
+
+__all__ = [
+    "AuthorityResult",
+    "MechanicalRuleSlice",
+    "RulesAuthorityService",
+]
+
+
+@dataclass(frozen=True)
+class MechanicalRuleSlice:
+    """A deterministic selection of the effective mechanical authority.
+
+    Carries the complete effective binding, so a slice can always state which
+    base projection and which override set produced it — the ambiguity
+    ADR-005d Decision 9 exists to remove.
+    """
+
+    binding: RulesPackageBinding
+    records: tuple[EffectiveRecord, ...]
+    whole_package: bool
+
+
+@dataclass(frozen=True)
+class AuthorityResult:
+    """One typed authority read.
+
+    Exactly one of the payload fields is populated, and only when ``outcome`` is
+    ``RESOLVED``. ``binding`` is populated alongside every successful read and,
+    where resolution got far enough to know it, alongside a refusal too.
+    """
+
+    outcome: AuthorityOutcome
+    binding: RulesPackageBinding | None = None
+    slice: MechanicalRuleSlice | None = None
+    typed_view: TypedAuthorityView | None = None
+    gamemaster_view: GameMasterAuthorityView | None = None
+    detail: str = ""
+
+
+class RulesAuthorityService:
+    """Typed runtime reads of a package's effective mechanical authority."""
+
+    def __init__(self, session: Session, *, now: str) -> None:
+        self._session = session
+        # Retention records when a version was first observed. It is audit
+        # metadata on the version row and never reaches the identity, so a
+        # caller-supplied clock cannot change what a binding resolves to.
+        self._now = now
+
+    # -- Binding ------------------------------------------------------------
+
+    def resolve(
+        self,
+        *,
+        package_uuid: UUID | None = None,
+        package_reference: str | None = None,
+        expected_release: str | None = None,
+        recorded: RulesPackageBinding | None = None,
+        retain: bool = True,
+    ) -> BindingResolution:
+        """Resolve the effective binding from a UUID or a human-facing slug.
+
+        Both forms funnel into the same code-owned path: a slug is resolved to a
+        package UUID first and never becomes authority itself, so a valid slug
+        and the matching UUID resolve to the same exact binding.
+        """
+        if (package_uuid is None) == (package_reference is None):
+            return BindingResolution(
+                AuthorityOutcome.INVALID_SELECTOR,
+                detail=(
+                    "exactly one of package_uuid or package_reference must be "
+                    "supplied"
+                ),
+            )
+        if package_uuid is None:
+            assert package_reference is not None
+            resolved = resolve_package_reference(self._session, package_reference)
+            if resolved.outcome is not AuthorityOutcome.RESOLVED:
+                return BindingResolution(resolved.outcome, detail=resolved.detail)
+            assert resolved.package_uuid is not None
+            package_uuid = resolved.package_uuid
+
+        return resolve_effective_binding(
+            self._session,
+            package_uuid,
+            now=self._now,
+            expected_release=expected_release,
+            recorded=recorded,
+            retain=retain,
+        )
+
+    # -- Effective authority ------------------------------------------------
+
+    def _reconstruct(self, binding: RulesPackageBinding) -> ProjectionCandidate:
+        return reconstruct_candidate(
+            self._session, str(binding.mechanical_projection_uuid)
+        )
+
+    def _effective(
+        self, binding: RulesPackageBinding, state: EffectiveOverrideSet
+    ) -> EffectiveAuthority:
+        return apply_override_set(self._reconstruct(binding), state, binding)
+
+    def _resolve_authority(
+        self, request: RuleSliceRequest
+    ) -> tuple[AuthorityResult, EffectiveAuthority | None]:
+        """Shared front half: resolve the binding, then apply the override set.
+
+        Returns the refusal and no authority, or a placeholder result and the
+        effective authority. Both view methods and the slice method use it, so
+        all three refuse identically and none can drift into a softer failure.
+        """
+        if request.package_id is not None:
+            resolution = self.resolve(
+                package_uuid=request.package_id,
+                recorded=request.recorded_binding,
+            )
+        else:
+            assert request.package_slug is not None
+            resolution = self.resolve(
+                package_reference=request.package_slug,
+                recorded=request.recorded_binding,
+            )
+        if resolution.outcome is not AuthorityOutcome.RESOLVED:
+            return (
+                AuthorityResult(
+                    resolution.outcome,
+                    binding=resolution.current_binding,
+                    detail=resolution.detail,
+                ),
+                None,
+            )
+
+        assert resolution.binding is not None
+        assert resolution.override_state is not None
+        binding = resolution.binding
+        try:
+            authority = self._effective(binding, resolution.override_state)
+        except OverrideApplicationError as exc:
+            return (
+                AuthorityResult(
+                    AuthorityOutcome.INVALID_OVERRIDE,
+                    binding=binding,
+                    detail=exc.detail,
+                ),
+                None,
+            )
+        except (ProjectionNotPersistedError, PersistedStateReconstructionError) as exc:
+            # The activation row named a projection whose persisted state no
+            # longer rebuilds. That is exactly what STALE means here: the
+            # authority is not what the record says it is.
+            return (
+                AuthorityResult(
+                    AuthorityOutcome.STALE, binding=binding, detail=str(exc)
+                ),
+                None,
+            )
+        return AuthorityResult(AuthorityOutcome.RESOLVED, binding=binding), authority
+
+    # -- Rule slice ---------------------------------------------------------
+
+    def rule_slice(self, request: RuleSliceRequest) -> AuthorityResult:
+        """Resolve a deterministic slice of the effective mechanical authority.
+
+        Selection is deterministic lookup against the exact semantic keys the
+        request names, or the explicit ``whole_package`` flag. A selector naming
+        an element the bound projection does not contain is
+        ``INVALID_REFERENCE`` — not an empty slice, which would read as "that
+        rule does not apply".
+
+        The accidentally-empty selector cannot reach this method: the request
+        model refuses to construct without either a selector or the explicit
+        flag.
+        """
+        result, scoped = self._scoped_authority(request)
+        if scoped is None:
+            return result
+        assert result.binding is not None
+        return AuthorityResult(
+            AuthorityOutcome.RESOLVED,
+            binding=result.binding,
+            slice=MechanicalRuleSlice(
+                binding=result.binding,
+                records=scoped.records,
+                whole_package=request.whole_package,
+            ),
+        )
+
+    def _scoped_authority(
+        self, request: RuleSliceRequest
+    ) -> tuple[AuthorityResult, EffectiveAuthority | None]:
+        """Resolve the effective authority and narrow it to the request.
+
+        One resolution shared by the slice and both views, so a slice and the
+        views built for the same request cannot disagree — and so resolution,
+        which retains an override-set version, happens once per read rather than
+        once per surface.
+        """
+        result, authority = self._resolve_authority(request)
+        if authority is None:
+            return result, None
+        assert result.binding is not None
+        if request.whole_package:
+            return result, authority
+        selected, missing = _select(authority, request)
+        if missing:
+            return (
+                AuthorityResult(
+                    AuthorityOutcome.INVALID_REFERENCE,
+                    binding=result.binding,
+                    detail="the bound projection contains no "
+                    + "; ".join(sorted(missing)),
+                ),
+                None,
+            )
+        return result, replace(authority, records=selected)
+
+    # -- Views --------------------------------------------------------------
+
+    def typed_view(self, request: RuleSliceRequest) -> AuthorityResult:
+        """The deterministic-consumer view over the requested authority."""
+        result, scoped = self._scoped_authority(request)
+        if scoped is None:
+            return result
+        return AuthorityResult(
+            AuthorityOutcome.RESOLVED,
+            binding=result.binding,
+            typed_view=build_typed_view(scoped),
+        )
+
+    def gamemaster_view(self, request: RuleSliceRequest) -> AuthorityResult:
+        """The GameMaster authority view over the requested authority.
+
+        Governing prose is read from the authoritative 5c ``RuleChunk`` records
+        of the bound package, by the exact chunk identity the projection
+        recorded. No retrieval, similarity, or model selection participates.
+        """
+        result, scoped = self._scoped_authority(request)
+        if scoped is None:
+            return result
+        assert result.binding is not None
+        return AuthorityResult(
+            AuthorityOutcome.RESOLVED,
+            binding=result.binding,
+            gamemaster_view=build_gamemaster_view(
+                scoped, self._prose_for(result.binding, scoped)
+            ),
+        )
+
+    def _prose_for(
+        self, binding: RulesPackageBinding, authority: EffectiveAuthority
+    ) -> dict[str, str]:
+        chunk_ids = {
+            chunk_id
+            for record in authority.records
+            for component in record.components
+            for chunk_id in component.prose_chunk_ids
+        }
+        if not chunk_ids:
+            return {}
+        rows = (
+            self._session.execute(
+                select(RuleChunkORM).where(
+                    RuleChunkORM.rules_package_id == str(binding.package_uuid),
+                    RuleChunkORM.chunk_id.in_(sorted(chunk_ids)),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return {row.chunk_id: row.content for row in rows}
+
+    # -- Audit and replay ---------------------------------------------------
+
+    def replay(self, recorded: RulesPackageBinding) -> EffectiveAuthority:
+        """Reconstruct the exact effective authority a recorded binding named.
+
+        Resolves the retained immutable override-set version rather than current
+        override rows, so this keeps working — and keeps returning the *original*
+        authority — after those rows are edited, disabled, reprioritized,
+        retargeted, or deleted.
+
+        Raises rather than returning an outcome. ``STALE`` is not a valid answer
+        to a replay: divergence from current state is expected and is the whole
+        point. A version that cannot be resolved is a retention defect
+        (:class:`OverrideSetRetentionError`), and a projection that cannot be
+        reconstructed is a persistence defect; neither is a divergence signal.
+        """
+        state = load_override_set_version(
+            self._session, str(recorded.override_set_uuid)
+        )
+        return apply_override_set(self._reconstruct(recorded), state, recorded)
+
+
+def _select(
+    authority: EffectiveAuthority, request: RuleSliceRequest
+) -> tuple[tuple[EffectiveRecord, ...], set[str]]:
+    """Apply the request's deterministic selectors to *authority*.
+
+    A record selector takes the whole record; a component selector takes exactly
+    the named components. Selecting a record and one of its components yields
+    the whole record — the broader selector wins rather than the last one
+    written, so selector order cannot change what a slice contains.
+    """
+    by_key = {record.semantic_key: record for record in authority.records}
+    missing: set[str] = set()
+    whole: set[str] = set()
+    partial: dict[str, dict[str, EffectiveComponent]] = {}
+
+    for record_key in request.record_selectors:
+        if record_key not in by_key:
+            missing.add(f"record {record_key!r}")
+            continue
+        whole.add(record_key)
+
+    for record_key, component_key in request.component_selectors:
+        record = by_key.get(record_key)
+        if record is None:
+            missing.add(f"record {record_key!r}")
+            continue
+        chosen = [c for c in record.components if c.semantic_key == component_key]
+        if not chosen:
+            missing.add(f"component {component_key!r} of record {record_key!r}")
+            continue
+        partial.setdefault(record_key, {})[component_key] = chosen[0]
+
+    selected = tuple(
+        (
+            by_key[key]
+            if key in whole
+            else replace(
+                by_key[key],
+                components=tuple(
+                    sorted(partial[key].values(), key=lambda c: c.semantic_key)
+                ),
+            )
+        )
+        for key in sorted(whole | set(partial))
+    )
+    return selected, missing

--- a/src/afterworlds/services/rules_authority/targets.py
+++ b/src/afterworlds/services/rules_authority/targets.py
@@ -1,0 +1,106 @@
+"""Exact typed override targets — CRD Issue 5d, Decision 10.
+
+An override names one exact element of the mechanical projection: a record, one
+component of a record, or one fact of a component. Nothing else is addressable.
+There is deliberately no JSON path, no selector expression, and no wildcard —
+#137 contract 6 forbids them, and each of those would let an override reach
+authority nobody reviewed it against.
+
+**Semantic keys, not derived IDs.** A target names the committed semantic keys
+(``record_key``, ``component_key``, and the content-derived ``fact_key``) rather
+than the projection-scoped ``record_id``/``component_id``/``fact_id`` derived in
+:mod:`afterworlds.ingestion.mechanical.projection`. Derived IDs are minted from
+the projection UUID, so targeting them would expire every override the moment
+the same release is reprojected — an override would silently stop applying
+because an unrelated part of the projection changed. Semantic keys survive that;
+what does *not* survive is a change of release, which is why every override
+carries its authored ``release_version`` and a mismatch fails explicitly as
+``INVALID_OVERRIDE`` rather than being applied or skipped.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+__all__ = [
+    "MechanicalTarget",
+    "MechanicalTargetKind",
+    "TargetShapeError",
+    "target_payload",
+]
+
+
+class MechanicalTargetKind(StrEnum):
+    """What kind of element an override targets."""
+
+    RECORD = "record"
+    COMPONENT = "component"
+    FACT = "fact"
+
+
+class TargetShapeError(ValueError):
+    """Raised when a target's key set does not match its declared kind."""
+
+
+@dataclass(frozen=True)
+class MechanicalTarget:
+    """One exact typed target inside a mechanical projection.
+
+    The key set is exhaustively determined by ``kind``, and the constructor
+    refuses any other combination. A component target carrying a ``fact_key``,
+    or a fact target missing its component, is not a target that merely fails to
+    resolve later — it is a target that does not identify anything, and
+    accepting it would make the identity of an override set depend on fields
+    that mean nothing.
+    """
+
+    kind: MechanicalTargetKind
+    record_key: str
+    component_key: str | None = None
+    fact_key: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.record_key.strip():
+            raise TargetShapeError("target record_key is blank")
+        needs_component = self.kind in (
+            MechanicalTargetKind.COMPONENT,
+            MechanicalTargetKind.FACT,
+        )
+        if needs_component and not (self.component_key or "").strip():
+            raise TargetShapeError(f"{self.kind.value} target requires a component_key")
+        if not needs_component and self.component_key is not None:
+            raise TargetShapeError(
+                f"{self.kind.value} target must not carry a component_key"
+            )
+        if self.kind is MechanicalTargetKind.FACT:
+            if not (self.fact_key or "").strip():
+                raise TargetShapeError("fact target requires a fact_key")
+        elif self.fact_key is not None:
+            raise TargetShapeError(
+                f"{self.kind.value} target must not carry a fact_key"
+            )
+
+    def describe(self) -> str:
+        """Human-readable target, used in typed failure detail."""
+        parts = [self.record_key]
+        if self.component_key is not None:
+            parts.append(self.component_key)
+        if self.fact_key is not None:
+            parts.append(self.fact_key)
+        return f"{self.kind.value}:{'/'.join(parts)}"
+
+
+def target_payload(target: MechanicalTarget) -> dict[str, object]:
+    """Canonical identity-bearing payload of one target.
+
+    Absent keys are serialized as ``None`` rather than omitted, so a component
+    target and a fact target can never canonicalize to the same bytes through a
+    missing key.
+    """
+    return {
+        "kind": target.kind.value,
+        "record_key": target.record_key,
+        "component_key": target.component_key,
+        "fact_key": target.fact_key,
+    }

--- a/src/afterworlds/services/rules_authority/views.py
+++ b/src/afterworlds/services/rules_authority/views.py
@@ -1,0 +1,160 @@
+"""The two authority views — CRD Issue 5d, contract 6.
+
+#137 requires two exact source-linked read surfaces over the same effective
+authority:
+
+1. a **typed mechanical view** for deterministic consumers, carrying applied
+   override provenance; and
+2. a **GameMaster authority view** combining exact governing prose with
+   structured context and handling.
+
+Both are built from one :class:`EffectiveAuthority`, so they cannot disagree
+about what the authority is, and both carry the complete four-component
+effective binding that produced them.
+
+Two boundaries are enforced by what these views *do not* contain:
+
+* **Neither view implies adapter capability.** There is no "supported",
+  "executable", or "certified" field anywhere here, and there is no place a
+  consumer could read one. Representation and execution are independent
+  (ADR-005d Decision 1); the bounded-d20 adapter declares and proves what it can
+  execute, and that declaration is CRD Issue 15c's, not this view's.
+* **Retrieval never chooses a mechanical value.** The GameMaster view resolves
+  governing prose through the exact ``chunk_id`` recorded as the component's
+  build-time prose binding. A retrieval layer may locate *candidates* to look
+  at, but what comes back here is bound by identity, not by similarity, and a
+  chunk that is not the bound one is simply not in the view (ADR-018, ADR-005c
+  D4).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.representation import RecordKind
+from afterworlds.models.rules_package import RulesPackageBinding
+from afterworlds.services.rules_authority.application import (
+    AppliedOverride,
+    EffectiveAuthority,
+    EffectiveComponent,
+    EffectiveFact,
+    EffectiveRecord,
+)
+
+__all__ = [
+    "GameMasterAuthorityView",
+    "GameMasterComponent",
+    "GoverningProse",
+    "TypedAuthorityView",
+    "build_gamemaster_view",
+    "build_typed_view",
+]
+
+
+@dataclass(frozen=True)
+class TypedAuthorityView:
+    """Exact typed authority for a deterministic consumer.
+
+    ``records`` is the effective view after override application: base
+    authority with overrides layered on, each element carrying either its 5c
+    span provenance or the identity and origin of the override that supplied
+    it.
+    """
+
+    binding: RulesPackageBinding
+    records: tuple[EffectiveRecord, ...]
+    applied_overrides: tuple[AppliedOverride, ...]
+
+
+@dataclass(frozen=True)
+class GoverningProse:
+    """One passage of exact governing prose, bound by identity.
+
+    ``text`` is ``None`` when the bound chunk is not present in the store being
+    read — reported as an absent passage rather than substituted with a similar
+    one, because a nearby passage is not the governing passage.
+    """
+
+    chunk_id: str
+    text: str | None
+
+
+@dataclass(frozen=True)
+class GameMasterComponent:
+    """One component as a GameMaster reads it: prose, context, and handling."""
+
+    record_key: str
+    record_kind: RecordKind
+    component_key: str
+    handling: ComponentHandling
+    irreducibility_reason_code: str | None
+    governing_prose: tuple[GoverningProse, ...]
+    #: Typed facts, supplied as *context* for judgement. A GameMaster reading
+    #: this view is adjudicating, not executing; the facts are here so the
+    #: judgement is made against exact authority rather than recollection.
+    structured_context: tuple[EffectiveFact, ...]
+    span_ids: tuple[str, ...]
+    supplied_by_override_id: str | None
+
+
+@dataclass(frozen=True)
+class GameMasterAuthorityView:
+    """Exact governing authority for GameMaster adjudication."""
+
+    binding: RulesPackageBinding
+    components: tuple[GameMasterComponent, ...]
+    applied_overrides: tuple[AppliedOverride, ...]
+
+
+def build_typed_view(authority: EffectiveAuthority) -> TypedAuthorityView:
+    """The deterministic-consumer view of one effective authority."""
+    return TypedAuthorityView(
+        binding=authority.binding,
+        records=tuple(authority.records),
+        applied_overrides=authority.applied_overrides,
+    )
+
+
+def _gamemaster_component(
+    record_key: str,
+    record_kind: RecordKind,
+    component: EffectiveComponent,
+    prose: Mapping[str, str],
+) -> GameMasterComponent:
+    return GameMasterComponent(
+        record_key=record_key,
+        record_kind=record_kind,
+        component_key=component.semantic_key,
+        handling=component.handling,
+        irreducibility_reason_code=component.irreducibility_reason_code,
+        governing_prose=tuple(
+            GoverningProse(chunk_id=chunk_id, text=prose.get(chunk_id))
+            for chunk_id in component.prose_chunk_ids
+        ),
+        structured_context=component.facts,
+        span_ids=component.span_ids,
+        supplied_by_override_id=component.supplied_by_override_id,
+    )
+
+
+def build_gamemaster_view(
+    authority: EffectiveAuthority, prose: Mapping[str, str]
+) -> GameMasterAuthorityView:
+    """The GameMaster view of one effective authority.
+
+    *prose* maps an authoritative 5c ``chunk_id`` to its exact text. It is
+    supplied by the service seam, which reads it from the authoritative
+    ``RuleChunk`` records of the bound package — there is no second prose store
+    and no text is copied into the projection.
+    """
+    return GameMasterAuthorityView(
+        binding=authority.binding,
+        components=tuple(
+            _gamemaster_component(record.semantic_key, record.kind, component, prose)
+            for record in authority.records
+            for component in record.components
+        ),
+        applied_overrides=authority.applied_overrides,
+    )

--- a/src/afterworlds/services/rules_package.py
+++ b/src/afterworlds/services/rules_package.py
@@ -52,6 +52,7 @@ from afterworlds.models.rules_package import (
     MechanicalEntity,
     RuleChunk,
     RuleOverride,
+    RuleSliceRequest,
     RuleSource,
     RulesPackageDetail,
     SpellEntity,
@@ -64,6 +65,23 @@ from afterworlds.persistence.orm.rules_package import (
     RuleSourceORM,
     RulesPackageORM,
 )
+from afterworlds.services.rules_authority.binding import resolve_package_reference
+from afterworlds.services.rules_authority.outcomes import AuthorityOutcome
+
+
+class RuleSliceResolutionError(ValueError):
+    """Raised when a rule-slice request's package reference does not resolve.
+
+    Carries the typed :class:`AuthorityOutcome` so a caller reports *why* — an
+    invalid selector, an ambiguous slug, or an absent package — rather than
+    collapsing three distinct states into one failure string.
+    """
+
+    def __init__(self, outcome: AuthorityOutcome, detail: str) -> None:
+        super().__init__(detail)
+        self.outcome = outcome
+        self.detail = detail
+
 
 # ---------------------------------------------------------------------------
 # Module-level helpers — ORM row → Pydantic model conversion
@@ -428,6 +446,34 @@ class RulesPackageService:
             .all()
         )
         return [_orm_to_override(r) for r in rows]
+
+    def resolve_slice_package(self, request: RuleSliceRequest) -> UUID:
+        """Resolve a rule-slice request's package reference to one UUID.
+
+        The single code-owned resolution seam for callers holding a
+        ``RuleSliceRequest``: a UUID passes through, and a human-facing slug
+        resolves through
+        :func:`afterworlds.services.rules_authority.resolve_package_reference`,
+        which is the only place a slug is interpreted (ADR-005d Decision 9).
+
+        Raises :class:`RuleSliceResolutionError` when the reference does not
+        resolve. A malformed or ambiguous reference is an explicit failure, not
+        an empty slice — an empty slice reads as "no rule applies", which is a
+        different and far more dangerous claim.
+        """
+        if request.package_id is not None:
+            return request.package_id
+        assert request.package_slug is not None
+        resolution = resolve_package_reference(self._session, request.package_slug)
+        if resolution.outcome is not AuthorityOutcome.RESOLVED:
+            raise RuleSliceResolutionError(
+                resolution.outcome,
+                f"rules package reference {request.package_slug!r} did not "
+                f"resolve: {resolution.outcome.value}"
+                + (f" ({resolution.detail})" if resolution.detail else ""),
+            )
+        assert resolution.package_uuid is not None
+        return resolution.package_uuid
 
     def get_active_rule_slice(
         self,

--- a/tests/ingestion/mechanical/test_raw_state_closure.py
+++ b/tests/ingestion/mechanical/test_raw_state_closure.py
@@ -53,6 +53,7 @@ from afterworlds.persistence.orm.mechanical import (
     MechanicalRelationshipORM,
     MechanicalSpanORM,
 )
+from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
 from afterworlds.persistence.orm.rules_package import RulesPackageORM
 from tests.ingestion.mechanical.conftest import (
     SCOPED_REFERENCES,
@@ -86,7 +87,20 @@ TABLE_POLICY: dict[type, str] = {
     # deliberately outside the raw row set and the persisted-state digest. A
     # projection's content must not change when it is activated.
     MechanicalActiveProjectionORM: "activation",
+    # Package-scoped runtime state, not projection-scoped. Overrides never
+    # mutate the immutable base projection or remint its identity (ADR-005d
+    # Decision 10) — the applied ordered override state is identified separately
+    # by the override-set UUID of the effective binding. A projection's
+    # reconstructed meaning and its persisted-state digest must therefore not
+    # move when an override is authored, edited, or deleted, which is exactly
+    # what including this table would do.
+    MechanicalOverrideORM: "runtime_override",
 }
+
+#: Policies whose rows are deliberately outside a projection's raw row set.
+#: Named once so the two inventory tests below cannot drift apart about which
+#: tables reconstruction is supposed to load.
+_NON_PROJECTION_POLICIES = frozenset({"header", "activation", "runtime_override"})
 
 
 @pytest.fixture()
@@ -505,7 +519,7 @@ def test_every_scoped_table_is_loaded_into_the_raw_state(session: Session) -> No
     scoped = {
         model.__tablename__  # type: ignore[attr-defined]
         for model, policy in TABLE_POLICY.items()
-        if policy not in {"header", "activation"}
+        if policy not in _NON_PROJECTION_POLICIES
     }
     # The default batch-reviewed candidate populates every scoped table except
     # references, which the honest fixture leaves empty.

--- a/tests/ingestion/mechanical/test_runtime_production_release.py
+++ b/tests/ingestion/mechanical/test_runtime_production_release.py
@@ -1,0 +1,153 @@
+"""The real CRD Issue 5c release, through the runtime authority path.
+
+Everything else in this suite runs against a bounded fixture. This module runs
+against the *actual* published SRD 5.2.1 corpus — built from the committed PDF
+and finalized through CRD Issue 5c's own lifecycle — and proves the claim this
+PR must not overstate.
+
+The runtime binding path resolves the real release's package and reports
+``UNPUBLISHED``: no accepted oracle is committed for that release, so no
+mechanical projection over it has been published, so there is no active
+mechanical authority to bind. That is the honest state, and it is asserted here
+as a *typed* outcome rather than as an absence — a resolver that answered
+"nothing" would be indistinguishable from one that had lost the release.
+
+It also re-confirms the exact production release identity from current ``main``
+rather than restating a previously reported value.
+
+Session-scoped 5c fixtures are shared with the CRD Issue 5c and 5d suites
+through ``tests/ingestion/conftest.py``, so this costs no second corpus build.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from afterworlds.ingestion.corpus.persistence import persist_release
+from afterworlds.ingestion.corpus.pipeline import ReleaseArtifacts
+from afterworlds.ingestion.mechanical.oracle import committed_oracle_for
+from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority import (
+    EMPTY_OVERRIDE_SET_UUID,
+    AuthorityOutcome,
+    RulesAuthorityService,
+    collect_current_override_state,
+    resolve_package_reference,
+)
+
+NOW = "2026-08-08T00:00:00Z"
+
+#: The production identity last verified on ``main``. A drift canary, not
+#: authority: the assertions below read the identity from the release the
+#: committed source actually builds, and this constant only makes an unexpected
+#: change legible in the failure message.
+EXPECTED_PACKAGE_UUID = "4458fa10-4a66-5e0e-9ecc-ea37530ad2b4"
+EXPECTED_RELEASE_VERSION = "5.2.1-corpus.36b786d8-fa2"
+
+
+@pytest.fixture(scope="module")
+def production(full_release: ReleaseArtifacts):  # type: ignore[no-untyped-def]
+    """The real release re-persisted into a private store, marked published."""
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as session:
+        persist_release(session, full_release, now=NOW)
+        package_uuid = full_release.release.package_uuid
+        session.execute(
+            select(CorpusReleaseORM).where(
+                CorpusReleaseORM.package_uuid == package_uuid
+            )
+        ).scalar_one().publication_status = "published"
+        package = session.execute(
+            select(RulesPackageORM).where(
+                RulesPackageORM.rules_package_id == package_uuid
+            )
+        ).scalar_one()
+        package.publication_status = "published"
+        package.published_at = NOW
+        session.flush()
+        yield session, full_release
+    engine.dispose()
+
+
+def test_the_production_release_identity(production) -> None:  # type: ignore[no-untyped-def]
+    """Re-confirmed from the release the committed source builds."""
+    _session, release = production
+    assert release.release.package_uuid == EXPECTED_PACKAGE_UUID
+    assert release.release.release_version == EXPECTED_RELEASE_VERSION
+
+
+def test_no_mechanical_projection_is_published_for_the_real_release(
+    production,  # type: ignore[no-untyped-def]
+) -> None:
+    """Nothing judges the real SRD release yet, so nothing over it is active."""
+    _session, release = production
+    assert (
+        committed_oracle_for(
+            release.release.package_uuid, release.release.release_version
+        )
+        is None
+    )
+
+
+def test_the_production_binding_resolves_to_unpublished(
+    production,  # type: ignore[no-untyped-def]
+) -> None:
+    """Typed, not empty: this PR publishes no production mechanical authority."""
+    session, release = production
+    resolution = RulesAuthorityService(session, now=NOW).resolve(
+        package_uuid=UUID(release.release.package_uuid)
+    )
+    assert resolution.outcome is AuthorityOutcome.UNPUBLISHED
+    assert resolution.binding is None
+    assert "no active mechanical projection" in resolution.detail
+
+
+def test_the_production_package_reference_still_resolves(
+    production,  # type: ignore[no-untyped-def]
+) -> None:
+    """Package resolution and authority resolution are different questions.
+
+    The package is found; what it has no published mechanical projection for is
+    the authority. Collapsing the two would make "this package does not exist"
+    and "this package has no typed authority yet" the same answer.
+    """
+    session, release = production
+    resolved = resolve_package_reference(session, release.release.package_uuid)
+    assert resolved.outcome is AuthorityOutcome.RESOLVED
+    assert resolved.package_uuid == UUID(release.release.package_uuid)
+
+
+def test_the_production_package_has_the_empty_override_state(
+    production,  # type: ignore[no-untyped-def]
+) -> None:
+    """No typed overrides are authored against production authority here."""
+    session, release = production
+    state = collect_current_override_state(
+        session,
+        release.release.package_uuid,
+        release.release.release_version,
+    )
+    assert state.entries == ()
+    assert state.override_set_uuid == EMPTY_OVERRIDE_SET_UUID
+
+
+def test_a_production_rule_slice_is_typed_not_empty(
+    production,  # type: ignore[no-untyped-def]
+) -> None:
+    """A whole-package request over the real release refuses explicitly."""
+    session, release = production
+    result = RulesAuthorityService(session, now=NOW).rule_slice(
+        RuleSliceRequest(
+            package_id=UUID(release.release.package_uuid), whole_package=True
+        )
+    )
+    assert result.outcome is AuthorityOutcome.UNPUBLISHED
+    assert result.slice is None

--- a/tests/persistence/test_physical_transaction.py
+++ b/tests/persistence/test_physical_transaction.py
@@ -1,0 +1,127 @@
+"""``ensure_physical_transaction`` — the driver behaviour it exists to correct.
+
+``sqlite3`` is used with its legacy transaction control, which opens a
+transaction implicitly only before ``INSERT``/``UPDATE``/``DELETE``/``REPLACE``.
+A session that has only read is therefore inside a SQLAlchemy transaction while
+the connection is still in SQLite autocommit — and a ``SAVEPOINT`` opened there
+is the *outermost* one, so releasing it commits.
+
+These are characterization tests as much as unit tests: the first pair pins the
+driver behaviour the helper depends on, so if a future Python, SQLAlchemy, or
+driver-configuration change removes it, the reason this helper exists fails
+loudly here rather than silently somewhere downstream.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Session, sessionmaker
+
+from afterworlds.persistence.database import (
+    create_engine,
+    create_session_factory,
+    ensure_physical_transaction,
+)
+
+
+@pytest.fixture()
+def factory(tmp_path: Path) -> sessionmaker[Session]:
+    """A file-backed engine, so separate sessions are genuinely separate.
+
+    An in-memory URL would hand every session the same connection, which is
+    exactly what these tests must not do: "visible elsewhere" is the whole
+    assertion.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'txn.db'}")
+    with engine.begin() as conn:
+        conn.exec_driver_sql("CREATE TABLE t (k TEXT PRIMARY KEY)")
+    return create_session_factory(engine)
+
+
+def _raw(session: Session) -> sqlite3.Connection:
+    connection = session.connection().connection.dbapi_connection
+    assert isinstance(connection, sqlite3.Connection)
+    return connection
+
+
+def _visible(factory: sessionmaker[Session]) -> int:
+    with factory() as other:
+        return int(other.execute(sa.text("SELECT COUNT(*) FROM t")).scalar_one())
+
+
+def test_a_read_only_session_is_not_yet_in_a_physical_transaction(
+    factory: sessionmaker[Session],
+) -> None:
+    """The premise: SQLAlchemy's logical state does not imply a real BEGIN."""
+    with factory() as session:
+        session.execute(sa.text("SELECT COUNT(*) FROM t"))
+        assert session.in_transaction(), "SQLAlchemy considers itself in one"
+        assert not _raw(session).in_transaction, "SQLite does not"
+
+
+def test_ensure_opens_one_and_is_idempotent(factory: sessionmaker[Session]) -> None:
+    """Twice must be safe — SQLite refuses a transaction within a transaction."""
+    with factory() as session:
+        session.execute(sa.text("SELECT COUNT(*) FROM t"))
+        ensure_physical_transaction(session)
+        assert _raw(session).in_transaction
+        ensure_physical_transaction(session)
+        assert _raw(session).in_transaction
+
+
+def test_ensure_is_a_no_op_once_the_session_has_written(
+    factory: sessionmaker[Session],
+) -> None:
+    """A writing session already has one; issuing a second BEGIN would raise."""
+    with factory() as session:
+        session.execute(sa.text("INSERT INTO t VALUES ('pre')"))
+        assert _raw(session).in_transaction
+        ensure_physical_transaction(session)
+        session.rollback()
+    assert _visible(factory) == 0
+
+
+def test_without_it_releasing_a_savepoint_commits(
+    factory: sessionmaker[Session],
+) -> None:
+    """The defect, pinned. Not a recommendation — a property being relied upon.
+
+    A savepoint opened in autocommit is the outermost one, so releasing it ends
+    the transaction it implicitly started. The caller's later rollback has
+    nothing left to undo.
+    """
+    with factory() as session:
+        session.execute(sa.text("SELECT COUNT(*) FROM t"))
+        with session.begin_nested():
+            session.execute(sa.text("INSERT INTO t VALUES ('a')"))
+        session.rollback()
+    assert _visible(factory) == 1
+
+
+def test_with_it_the_savepoint_is_genuinely_nested(
+    factory: sessionmaker[Session],
+) -> None:
+    """The correction: the enclosing transaction owns the commit boundary."""
+    with factory() as session:
+        session.execute(sa.text("SELECT COUNT(*) FROM t"))
+        ensure_physical_transaction(session)
+        with session.begin_nested():
+            session.execute(sa.text("INSERT INTO t VALUES ('a')"))
+        session.rollback()
+    assert _visible(factory) == 0
+
+
+def test_it_does_not_take_over_the_commit(factory: sessionmaker[Session]) -> None:
+    """Committing still works, and the connection returns to autocommit."""
+    with factory() as session:
+        session.execute(sa.text("SELECT COUNT(*) FROM t"))
+        ensure_physical_transaction(session)
+        with session.begin_nested():
+            session.execute(sa.text("INSERT INTO t VALUES ('a')"))
+        session.commit()
+        assert not _raw(session).in_transaction
+    assert _visible(factory) == 1

--- a/tests/persistence/test_rules_authority_migration.py
+++ b/tests/persistence/test_rules_authority_migration.py
@@ -246,6 +246,119 @@ def test_an_identical_reinsert_is_permitted_on_the_migrated_schema(
         con.close()
 
 
+# ---------------------------------------------------------------------------
+# `INSERT OR REPLACE` at an *identical* entry_count
+# ---------------------------------------------------------------------------
+#
+# The content-aware guard lets that statement past on purpose — refusing it would
+# also refuse the service's `ON CONFLICT DO NOTHING`. What stops it from wiping
+# the version's children is a second mechanism, and the distinction is subtle
+# enough to be worth pinning: REPLACE's own conflict-resolution delete skips
+# BEFORE DELETE triggers while `recursive_triggers` is off, but the foreign-key
+# CASCADE it sets off does *not* — the children's own DELETE guards fire and
+# abort the statement. These assert that state by state instead of reasoning
+# about it.
+
+
+def _seed_state(
+    con: sqlite3.Connection, *, entries: int, scope: bool, live_package: bool
+) -> None:
+    con.execute("PRAGMA foreign_keys=ON")
+    if scope or live_package:
+        con.execute(
+            "INSERT INTO rp_packages (rules_package_id, name, system, version,"
+            " is_enabled, publication_status, published_at, created_at, updated_at)"
+            " VALUES ('pkg', 'p', 'd20', '1', 1, 'published', 't', 't', 't')"
+        )
+    con.execute(
+        "INSERT INTO rp_override_set_versions VALUES ('v1', ?, 't0')", (entries,)
+    )
+    for order in range(entries):
+        con.execute(
+            "INSERT INTO rp_override_set_entries (override_set_uuid, apply_order,"
+            " override_id, override_origin, target_kind, target_record_key,"
+            " target_component_key, target_fact_key, override_operation, precedence,"
+            " is_enabled, payload) VALUES ('v1', ?, 'o', 'house_rule', 'record',"
+            " 'r', NULL, NULL, 'disable', 1, 1, '{}')",
+            (order,),
+        )
+    if scope:
+        con.execute(
+            "INSERT INTO rp_override_set_scopes VALUES ('v1', 'pkg', 'rel', 't0')"
+        )
+    if not live_package:
+        con.execute("DELETE FROM rp_packages WHERE rules_package_id = 'pkg'")
+
+
+def _row_counts(con: sqlite3.Connection) -> tuple[int, int, int]:
+    return tuple(  # type: ignore[return-value]
+        con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        for table in RETAINED_TABLES[1:]
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "entries", "scope", "live_package"),
+    [
+        ("entries and scope, package live", 1, True, True),
+        ("entries and scope, package deleted", 1, True, False),
+        ("entries, association already gone", 1, False, False),
+        ("empty set with a scope", 0, True, True),
+    ],
+)
+def test_an_identical_count_replace_cannot_destroy_retained_evidence(
+    migrated: Path, label: str, entries: int, scope: bool, live_package: bool
+) -> None:
+    """Refused in every state where there is retained evidence to destroy."""
+    con = sqlite3.connect(migrated)
+    try:
+        _seed_state(con, entries=entries, scope=scope, live_package=live_package)
+        before = _row_counts(con)
+        with pytest.raises(sqlite3.IntegrityError):
+            con.execute(
+                "INSERT OR REPLACE INTO rp_override_set_versions"
+                " VALUES ('v1', ?, 'forged')",
+                (entries,),
+            )
+        assert _row_counts(con) == before
+        assert con.execute(
+            "SELECT recorded_at FROM rp_override_set_versions"
+        ).fetchone() == ("t0",)
+    finally:
+        con.close()
+
+
+def test_a_childless_header_is_the_only_replaceable_shape_and_is_inert(
+    migrated: Path,
+) -> None:
+    """The residue, stated exactly rather than left as an unknown.
+
+    A header with no entries and no association has nothing to cascade into, so
+    the replacement lands. It is inert: retention never produces this shape — the
+    scope is written in the same unit — the entry count cannot move without
+    tripping the content-aware guard, and the one column that does change is the
+    ``recorded_at`` audit stamp, which ADR-005d Decision 9 keeps outside identity.
+    Such a version already fails replay closed for want of a scope.
+    """
+    con = sqlite3.connect(migrated)
+    try:
+        _seed_state(con, entries=0, scope=False, live_package=False)
+        con.execute(
+            "INSERT OR REPLACE INTO rp_override_set_versions VALUES ('v1', 0, 'forged')"
+        )
+        assert con.execute(
+            "SELECT override_set_uuid, entry_count FROM rp_override_set_versions"
+        ).fetchall() == [("v1", 0)]
+        # And the count still cannot be moved, which is what identity rests on.
+        with pytest.raises(sqlite3.IntegrityError):
+            con.execute(
+                "INSERT OR REPLACE INTO rp_override_set_versions"
+                " VALUES ('v1', 3, 'forged')"
+            )
+    finally:
+        con.close()
+
+
 def test_package_deletion_cascades_the_scope_association(migrated: Path) -> None:
     """The contractual carve-out the delete guard is conditional on."""
     con = sqlite3.connect(migrated)

--- a/tests/persistence/test_rules_authority_migration.py
+++ b/tests/persistence/test_rules_authority_migration.py
@@ -1,0 +1,265 @@
+"""Migration 0024 against a real alembic run — CRD Issue 5d runtime authority.
+
+The runtime-authority suite installs the append-only triggers by hand, because
+``Base.metadata.create_all`` does not create triggers and a suite without them
+would prove nothing about the protection production actually has. Hand-mirroring
+is exactly how a fixture drifts away from the migration it stands in for, so this
+module runs the real migration and asserts the database ends up with the same
+trigger set the fixture installs — and that each guard actually refuses what it
+claims to.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from afterworlds.persistence.orm.base import Base
+from tests.services.rules_authority.conftest import _trigger_names
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RETAINED_TABLES = (
+    "rp_mech_overrides",
+    "rp_override_set_versions",
+    "rp_override_set_entries",
+    "rp_override_set_scopes",
+)
+
+
+def _alembic(db: Path, *args: str) -> None:
+    """Run alembic against *db* through the repository's own migration chain.
+
+    A temporary config is used rather than a ``-x`` argument because this
+    repository's ``env.py`` reads the URL from the ini file; pointing it at a
+    throwaway database is what keeps the test from migrating the developer's own.
+    """
+    ini = db.parent / "alembic.ini"
+    if not ini.exists():
+        source = (REPO_ROOT / "alembic.ini").read_text()
+        ini.write_text(
+            source.replace(
+                "script_location = alembic",
+                f"script_location = {REPO_ROOT / 'alembic'}",
+            ).replace(
+                "sqlalchemy.url = sqlite:///afterworlds.db",
+                f"sqlalchemy.url = sqlite:///{db}",
+            )
+        )
+    result = subprocess.run(
+        [sys.executable, "-m", "alembic", "-c", str(ini), *args],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")},
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:  # pragma: no cover - surfaced only on failure
+        raise AssertionError(
+            f"alembic {' '.join(args)} failed:\n{result.stdout}\n{result.stderr}"
+        )
+
+
+@pytest.fixture()
+def migrated(tmp_path: Path) -> Path:
+    """A database built by the real migration chain, not by ``create_all``."""
+    db = tmp_path / "migrated.db"
+    _alembic(db, "upgrade", "head")
+    return db
+
+
+def _names(db: Path, kind: str) -> set[str]:
+    con = sqlite3.connect(db)
+    try:
+        return {
+            row[0]
+            for row in con.execute(
+                "SELECT name FROM sqlite_master WHERE type = ?", (kind,)
+            )
+        }
+    finally:
+        con.close()
+
+
+def test_the_migration_creates_every_runtime_authority_table(
+    migrated: Path,
+) -> None:
+    assert set(RETAINED_TABLES) <= _names(migrated, "table")
+
+
+def test_migrated_columns_match_the_orm_exactly(migrated: Path) -> None:
+    """A column present in one and not the other is schema drift, not a detail."""
+    con = sqlite3.connect(migrated)
+    try:
+        for table in RETAINED_TABLES:
+            in_db = {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+            in_orm = {column.name for column in Base.metadata.tables[table].columns}
+            assert in_db == in_orm, f"{table}: {in_db ^ in_orm}"
+    finally:
+        con.close()
+
+
+def test_the_migration_installs_exactly_the_fixture_trigger_set(
+    migrated: Path,
+) -> None:
+    """The mirror the suite installs is the set the migration really creates."""
+    installed = {name for name in _names(migrated, "trigger") if "override_set" in name}
+    assert installed == set(_trigger_names())
+
+
+def test_the_version_table_has_no_owning_foreign_key(migrated: Path) -> None:
+    """Shared content must not be tied to one package's lifecycle."""
+    con = sqlite3.connect(migrated)
+    try:
+        fks = list(con.execute("PRAGMA foreign_key_list(rp_override_set_versions)"))
+    finally:
+        con.close()
+    assert fks == []
+
+
+def test_downgrade_removes_every_table_and_trigger(migrated: Path) -> None:
+    _alembic(migrated, "downgrade", "0023")
+    assert not (set(RETAINED_TABLES) & _names(migrated, "table"))
+    assert not {n for n in _names(migrated, "trigger") if "override_set" in n}
+    # The preceding migration's objects survive.
+    assert "rp_mech_active_projections" in _names(migrated, "table")
+    assert "rp_mech_projections" in _names(migrated, "table")
+
+
+def test_upgrade_downgrade_upgrade_is_clean(migrated: Path) -> None:
+    _alembic(migrated, "downgrade", "0023")
+    _alembic(migrated, "upgrade", "head")
+    assert set(RETAINED_TABLES) <= _names(migrated, "table")
+    assert {n for n in _names(migrated, "trigger") if "override_set" in n} == set(
+        _trigger_names()
+    )
+
+
+# ---------------------------------------------------------------------------
+# The guards, exercised against the migrated database itself
+# ---------------------------------------------------------------------------
+
+
+def _seed(con: sqlite3.Connection) -> None:
+    con.execute("PRAGMA foreign_keys=ON")
+    con.execute(
+        "INSERT INTO rp_packages (rules_package_id, name, system, version,"
+        " is_enabled, publication_status, published_at, created_at, updated_at)"
+        " VALUES ('pkg', 'p', 'd20', '1', 1, 'published', 't', 't', 't')"
+    )
+    con.execute("INSERT INTO rp_override_set_versions VALUES ('v1', 1, 't0')")
+    con.execute(
+        "INSERT INTO rp_override_set_entries (override_set_uuid, apply_order,"
+        " override_id, override_origin, target_kind, target_record_key,"
+        " target_component_key, target_fact_key, override_operation, precedence,"
+        " is_enabled, payload) VALUES ('v1', 0, 'o', 'house_rule', 'record',"
+        " 'r', NULL, NULL, 'disable', 1, 1, '{}')"
+    )
+    con.execute("INSERT INTO rp_override_set_scopes VALUES ('v1', 'pkg', 'rel', 't0')")
+
+
+@pytest.mark.parametrize(
+    ("label", "sql"),
+    [
+        ("version update", "UPDATE rp_override_set_versions SET entry_count = 9"),
+        ("version delete", "DELETE FROM rp_override_set_versions"),
+        (
+            "version differing replace",
+            "INSERT OR REPLACE INTO rp_override_set_versions VALUES ('v1', 9, 't1')",
+        ),
+        ("entry update", "UPDATE rp_override_set_entries SET precedence = 9"),
+        ("entry delete", "DELETE FROM rp_override_set_entries"),
+        (
+            "entry differing replace",
+            "INSERT OR REPLACE INTO rp_override_set_entries (override_set_uuid,"
+            " apply_order, override_id, override_origin, target_kind,"
+            " target_record_key, target_component_key, target_fact_key,"
+            " override_operation, precedence, is_enabled, payload) VALUES ('v1',"
+            " 0, 'forged', 'house_rule', 'record', 'r', NULL, NULL, 'disable',"
+            " 1, 1, '{}')",
+        ),
+        (
+            "entry appended past the seal",
+            "INSERT INTO rp_override_set_entries (override_set_uuid, apply_order,"
+            " override_id, override_origin, target_kind, target_record_key,"
+            " target_component_key, target_fact_key, override_operation,"
+            " precedence, is_enabled, payload) VALUES ('v1', 1, 'extra',"
+            " 'house_rule', 'record', 'r', NULL, NULL, 'disable', 1, 1, '{}')",
+        ),
+        ("scope update", "UPDATE rp_override_set_scopes SET package_uuid = 'other'"),
+        ("scope delete while package live", "DELETE FROM rp_override_set_scopes"),
+    ],
+)
+def test_the_migrated_guards_refuse_every_rewrite_path(
+    migrated: Path, label: str, sql: str
+) -> None:
+    """Asserted against the real migrated schema, not the fixture's mirror."""
+    con = sqlite3.connect(migrated)
+    try:
+        _seed(con)
+        with pytest.raises(sqlite3.IntegrityError):
+            con.execute(sql)
+    finally:
+        con.close()
+
+
+def test_an_identical_reinsert_is_permitted_on_the_migrated_schema(
+    migrated: Path,
+) -> None:
+    """The other half of the design: benign repeats must pass.
+
+    A guard that also refused these would make the service's
+    ``ON CONFLICT DO NOTHING`` retention fail under concurrency, which is the
+    coupling this migration and :mod:`retention` are designed around.
+    """
+    con = sqlite3.connect(migrated)
+    try:
+        _seed(con)
+        con.execute(
+            "INSERT INTO rp_override_set_versions VALUES ('v1', 1, 't9')"
+            " ON CONFLICT DO NOTHING"
+        )
+        con.execute(
+            "INSERT INTO rp_override_set_entries (override_set_uuid, apply_order,"
+            " override_id, override_origin, target_kind, target_record_key,"
+            " target_component_key, target_fact_key, override_operation,"
+            " precedence, is_enabled, payload) VALUES ('v1', 0, 'o',"
+            " 'house_rule', 'record', 'r', NULL, NULL, 'disable', 1, 1, '{}')"
+            " ON CONFLICT DO NOTHING"
+        )
+        con.execute(
+            "INSERT INTO rp_override_set_scopes VALUES ('v1', 'pkg', 'rel', 't9')"
+            " ON CONFLICT DO NOTHING"
+        )
+        assert con.execute(
+            "SELECT recorded_at FROM rp_override_set_versions"
+        ).fetchone() == ("t0",)
+        assert (
+            con.execute("SELECT COUNT(*) FROM rp_override_set_entries").fetchone()[0]
+            == 1
+        )
+    finally:
+        con.close()
+
+
+def test_package_deletion_cascades_the_scope_association(migrated: Path) -> None:
+    """The contractual carve-out the delete guard is conditional on."""
+    con = sqlite3.connect(migrated)
+    try:
+        _seed(con)
+        con.execute("DELETE FROM rp_packages WHERE rules_package_id = 'pkg'")
+        assert (
+            con.execute("SELECT COUNT(*) FROM rp_override_set_scopes").fetchone()[0]
+            == 0
+        )
+        # The shared content itself is untouched by that cascade.
+        assert (
+            con.execute("SELECT COUNT(*) FROM rp_override_set_versions").fetchone()[0]
+            == 1
+        )
+    finally:
+        con.close()

--- a/tests/pipeline/orchestrator/test_service.py
+++ b/tests/pipeline/orchestrator/test_service.py
@@ -113,6 +113,7 @@ from afterworlds.pipeline.safety.models import (
     SafetyVerdict,
 )
 from afterworlds.pipeline.writer.models import WriterResult
+from afterworlds.services.rules_authority import AuthorityOutcome
 from afterworlds.services.story_bible import StoryBibleService
 from tests.pipeline.orchestrator.conftest import (
     FakeContextBuilder,
@@ -5859,13 +5860,19 @@ class TestRuleSlicePreContext:
             rpg_visible_state_service=_FakeVisibleStateService(),  # type: ignore[arg-type]
         )
 
-    def test_uuid_binding_passes_rule_slice_request_to_context(
+    def test_uuid_binding_no_longer_builds_an_empty_selector_request(
         self, session_factory: object, seeded_story: tuple[object, object]
     ) -> None:
-        """Adjudicating intent + UUID rules_package_id → non-None RuleSliceRequest."""
-        from uuid import UUID, uuid4
+        """CRD Issue 5d (#137 contract 6): the empty-selector request is gone.
 
-        from afterworlds.models.rules_package import RuleSliceRequest
+        This used to build ``RuleSliceRequest(package_id=...)`` with no
+        selectors at all, which always produced an empty slice — the
+        accidentally-empty selector ADR-005d Decision 9 names. ``RuleSliceRequest``
+        now refuses to construct that way, and the orchestrator does not replace
+        it with a whole-package request: which mechanics an adjudicating turn
+        needs is CRD Issue 15c's selection contract.
+        """
+        from uuid import uuid4
 
         pkg_id = str(uuid4())
         story_id, node_id = seeded_story
@@ -5879,27 +5886,98 @@ class TestRuleSlicePreContext:
             RuntimeAccessPath.HOSTED,
         )
         assert len(spy.rule_slice_requests) == 1
-        rsr = spy.rule_slice_requests[0]
-        assert rsr is not None
-        assert isinstance(rsr, RuleSliceRequest)
-        assert rsr.package_id == UUID(pkg_id)
+        assert spy.rule_slice_requests[0] is None
 
-    def test_slug_binding_omits_rule_slice_request(
+    def test_slug_binding_without_a_resolver_is_not_swallowed(
         self, session_factory: object, seeded_story: tuple[object, object]
     ) -> None:
-        """Non-UUID slug binding → RuleSliceRequest is None (slug→UUID gap)."""
+        """No resolver wired → no resolution attempted, and no parse swallowed.
+
+        The removed path parsed the reference with ``UUID(...)`` and caught the
+        ``ValueError``, so a malformed reference and a package with no rules
+        produced the same silence. There is no such parse now: with no
+        code-owned resolver wired there is nothing to resolve against, and the
+        turn proceeds under ADR-015's ``undetermined`` behaviour.
+        """
         story_id, node_id = seeded_story
         spy = _SpyContextBuilder()
         orch = self._make_orch(session_factory, spy, rules_package_id="dnd5e-v1")
-        orch.orchestrate_turn(
+        result = orch.orchestrate_turn(
             story_id,  # type: ignore[arg-type]
             node_id,  # type: ignore[arg-type]
             "I attack the goblin.",
             _SOJOURNER,
             RuntimeAccessPath.HOSTED,
         )
+        assert result.disposition is not PipelineDisposition.PIPELINE_ERROR
         assert len(spy.rule_slice_requests) == 1
         assert spy.rule_slice_requests[0] is None
+
+    @pytest.mark.parametrize(
+        ("outcome", "expected"),
+        [
+            (AuthorityOutcome.AMBIGUOUS, "ambiguous"),
+            (AuthorityOutcome.INVALID_SELECTOR, "invalid_selector"),
+            (AuthorityOutcome.ABSENT, "absent"),
+        ],
+    )
+    def test_an_unresolvable_reference_fails_the_turn_explicitly(
+        self,
+        session_factory: object,
+        seeded_story: tuple[object, object],
+        outcome: AuthorityOutcome,
+        expected: str,
+    ) -> None:
+        """With the code-owned resolver wired, a refusal is a typed turn failure.
+
+        This is the half of the fail-open removal that changes behaviour: a
+        reference that genuinely does not resolve can no longer be dropped in
+        silence.
+        """
+        from afterworlds.services.rules_authority import PackageResolution
+
+        story_id, node_id = seeded_story
+        spy = _SpyContextBuilder()
+        orch = self._make_orch(session_factory, spy, rules_package_id="dnd5e-v1")
+        orch._rules_package_reference_resolver = (  # type: ignore[attr-defined]
+            lambda ref: PackageResolution(outcome, detail=f"{ref} did not resolve")
+        )
+        result = orch.orchestrate_turn(
+            story_id,  # type: ignore[arg-type]
+            node_id,  # type: ignore[arg-type]
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+        assert result.disposition is PipelineDisposition.PIPELINE_ERROR
+        assert result.pipeline_error_summary is not None
+        assert expected in result.pipeline_error_summary
+        assert "dnd5e-v1" in result.pipeline_error_summary
+
+    def test_a_resolving_reference_leaves_the_turn_alone(
+        self, session_factory: object, seeded_story: tuple[object, object]
+    ) -> None:
+        """A resolver that resolves does not, by itself, change the turn."""
+        from uuid import uuid4
+
+        from afterworlds.services.rules_authority import PackageResolution
+
+        story_id, node_id = seeded_story
+        spy = _SpyContextBuilder()
+        orch = self._make_orch(session_factory, spy, rules_package_id="dnd5e-v1")
+        orch._rules_package_reference_resolver = (  # type: ignore[attr-defined]
+            lambda _ref: PackageResolution(
+                AuthorityOutcome.RESOLVED, package_uuid=uuid4()
+            )
+        )
+        result = orch.orchestrate_turn(
+            story_id,  # type: ignore[arg-type]
+            node_id,  # type: ignore[arg-type]
+            "I attack the goblin.",
+            _SOJOURNER,
+            RuntimeAccessPath.HOSTED,
+        )
+        assert result.disposition is not PipelineDisposition.PIPELINE_ERROR
 
     def test_ooc_intent_omits_rule_slice_request(
         self, session_factory: object, seeded_story: tuple[object, object]

--- a/tests/services/rules_authority/conftest.py
+++ b/tests/services/rules_authority/conftest.py
@@ -131,13 +131,20 @@ NOW = "2026-08-08T00:00:00Z"
 _NS = UUID("2f2b6d9c-0e2a-5f31-9a44-6b0c1d2e3f40")
 PACKAGE_UUID = str(uuid5(_NS, "runtime-authority-primary"))
 RIVAL_PACKAGE_UUID = str(uuid5(_NS, "runtime-authority-rival"))
+#: A published 5c release carrying no mechanical projection at all, so
+#: ``UNPUBLISHED`` stays a reachable state now that the rival package has one.
+BARE_PACKAGE_UUID = str(uuid5(_NS, "runtime-authority-bare"))
 
 RELEASE_VERSION = "5.2.1-runtime.fixture"
 RIVAL_RELEASE_VERSION = "5.2.1-runtime.rival"
+BARE_RELEASE_VERSION = "5.2.1-runtime.bare"
 
 #: Both packages carry the same display name, so they slugify identically. That
 #: is what an ambiguous human-facing slug actually is.
 PACKAGE_NAME = "SRD 5.2.1 corpus"
+#: The bare package is deliberately named differently: the ambiguous-slug
+#: control needs exactly two packages sharing a slug, not three.
+BARE_PACKAGE_NAME = "Bare corpus with no projection"
 
 SPELL_LEAF = "leaf-spell"
 PROSE_LEAF = "leaf-prose"
@@ -270,7 +277,11 @@ _TRANSFORM_CONFIG: dict[str, object] = {
 
 
 def _seed_release(
-    session: Session, package_uuid: str, release_version: str, prefix: str = ""
+    session: Session,
+    package_uuid: str,
+    release_version: str,
+    prefix: str = "",
+    package_name: str = PACKAGE_NAME,
 ) -> str:
     """Persist one published 5c release, returning its bundle root hash.
 
@@ -343,11 +354,13 @@ def _seed_release(
             persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
         )
     )
-    _mark_published(session, package_uuid)
+    _mark_published(session, package_uuid, package_name)
     return bundle.bundle_root_hash
 
 
-def _mark_published(session: Session, package_uuid: str) -> None:
+def _mark_published(
+    session: Session, package_uuid: str, name: str = PACKAGE_NAME
+) -> None:
     """Transition a seeded release to published, as ``finalize_release`` does."""
     session.execute(
         select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == package_uuid)
@@ -357,7 +370,7 @@ def _mark_published(session: Session, package_uuid: str) -> None:
     ).scalar_one()
     package.publication_status = "published"
     package.published_at = NOW
-    package.name = PACKAGE_NAME
+    package.name = name
     session.flush()
 
 
@@ -365,12 +378,24 @@ def _mark_published(session: Session, package_uuid: str) -> None:
 # The bounded mechanical projection
 # ---------------------------------------------------------------------------
 
-WISH_BINDING = ProseBindingDraft(
-    component_key=OPEN_ENDED_KEY,
-    record_key=SPELL_KEY,
-    chunk_id=WISH_CHUNK,
-    irreducibility_reason_code="open_ended_effect",
-)
+
+def _wish_binding(prefix: str = "") -> ProseBindingDraft:
+    """The prose binding, scoped to the release's own chunk identities.
+
+    Chunk ids are release-scoped (``rp_chunks.chunk_id`` is globally unique), so
+    a projection over the rival release must bind that release's chunk. Semantic
+    *keys* stay identical across both — which is the point: shared keys are what
+    make a mis-scoped override set able to find live targets elsewhere.
+    """
+    return ProseBindingDraft(
+        component_key=OPEN_ENDED_KEY,
+        record_key=SPELL_KEY,
+        chunk_id=f"{prefix}{WISH_CHUNK}",
+        irreducibility_reason_code="open_ended_effect",
+    )
+
+
+WISH_BINDING = _wish_binding()
 
 
 def _classification(package_uuid: str, release_version: str) -> ClassificationLedger:
@@ -421,7 +446,7 @@ def _classification(package_uuid: str, release_version: str) -> ClassificationLe
     )
 
 
-def _representation() -> RepresentationDraft:
+def _representation(prefix: str = "") -> RepresentationDraft:
     """A spell with structured and prose-bound authority, plus a scoped creature.
 
     Small on purpose, but not degenerate: two records, three components across
@@ -458,7 +483,7 @@ def _representation() -> RepresentationDraft:
                 facts=(CHECK_FACT,),
             ),
         ),
-        prose_bindings=(WISH_BINDING,),
+        prose_bindings=(_wish_binding(prefix),),
         relationships=(),
         references=(),
         provenance=(
@@ -476,7 +501,7 @@ def _representation() -> RepresentationDraft:
             ),
             ProvenanceClaim(
                 ProvenanceTargetKind.PROSE_BINDING,
-                prose_binding_target_key(WISH_BINDING),
+                prose_binding_target_key(_wish_binding(prefix)),
                 PROSE_SPAN,
                 ProvenanceRole.PRIMARY,
             ),
@@ -515,6 +540,10 @@ class RuntimeFixture:
     release_version: str
     projection_uuid: UUID
     rival_package_uuid: UUID
+    rival_release_version: str
+    rival_projection_uuid: UUID
+    #: Published release, no mechanical projection.
+    bare_package_uuid: UUID
 
     def binding(self, override_set_uuid: UUID) -> RulesPackageBinding:
         return RulesPackageBinding(
@@ -525,24 +554,36 @@ class RuntimeFixture:
         )
 
 
-def _publish_bounded_projection(session: Session, bundle_root_hash: str) -> str:
+def _publish_bounded_projection(
+    session: Session,
+    bundle_root_hash: str,
+    package_uuid: str = PACKAGE_UUID,
+    release_version: str = RELEASE_VERSION,
+    chunk_prefix: str = "",
+) -> str:
     """Build, persist, gate, publish, and activate the bounded projection.
 
     Goes through :func:`_publish_projection` with an in-memory accepted oracle
     rather than writing the rows a publication would have left behind. Binding
     resolution reads the activation row and the recorded evidence, so a fixture
     that faked them would let this suite pass against state no gate accepted.
+
+    Parameterized by package so the rival package can carry its own published
+    projection. Both projections use the same representation, and deliberately
+    so: semantic keys are stable across SRD-derived releases by design, which is
+    exactly why an override set retained for one package can find live targets
+    in another and replay with false provenance if its scope is not verified.
     """
     binding = ReleaseBinding(
-        package_uuid=PACKAGE_UUID,
-        release_version=RELEASE_VERSION,
+        package_uuid=package_uuid,
+        release_version=release_version,
         authoritative_source_hash=AUTHORITATIVE_SOURCE_HASH,
         transform_config_hash=TRANSFORM_CONFIG_HASH,
         bundle_root_hash=bundle_root_hash,
         persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
     )
-    classification = _classification(PACKAGE_UUID, RELEASE_VERSION)
-    representation = _representation()
+    classification = _classification(package_uuid, release_version)
+    representation = _representation(chunk_prefix)
     identified = identify_projection(
         ProjectionCandidate(
             binding=binding,
@@ -580,10 +621,20 @@ def runtime(tmp_path) -> Iterator[RuntimeFixture]:  # type: ignore[no-untyped-de
     Base.metadata.create_all(engine)
     with create_session_factory(engine)() as session:
         bundle_root_hash = _seed_release(session, PACKAGE_UUID, RELEASE_VERSION)
-        _seed_release(
+        rival_root = _seed_release(
             session, RIVAL_PACKAGE_UUID, RIVAL_RELEASE_VERSION, prefix="rival-"
         )
         projection_uuid = _publish_bounded_projection(session, bundle_root_hash)
+        rival_projection_uuid = _publish_bounded_projection(
+            session, rival_root, RIVAL_PACKAGE_UUID, RIVAL_RELEASE_VERSION, "rival-"
+        )
+        _seed_release(
+            session,
+            BARE_PACKAGE_UUID,
+            BARE_RELEASE_VERSION,
+            prefix="bare-",
+            package_name=BARE_PACKAGE_NAME,
+        )
         install_append_only_triggers(session)
         yield RuntimeFixture(
             session=session,
@@ -591,6 +642,9 @@ def runtime(tmp_path) -> Iterator[RuntimeFixture]:  # type: ignore[no-untyped-de
             release_version=RELEASE_VERSION,
             projection_uuid=UUID(projection_uuid),
             rival_package_uuid=UUID(RIVAL_PACKAGE_UUID),
+            rival_release_version=RIVAL_RELEASE_VERSION,
+            rival_projection_uuid=UUID(rival_projection_uuid),
+            bare_package_uuid=UUID(BARE_PACKAGE_UUID),
         )
     engine.dispose()
 
@@ -742,23 +796,87 @@ def replace_record_payload(
 # tests/persistence/test_rpg_roll_audit_db.py and tests/entitlement/conftest.py
 # already use for the repository's other append-only evidence tables.
 
-_RETAINED_TABLES = ("rp_override_set_versions", "rp_override_set_entries")
+_RETAINED_TABLES = (
+    "rp_override_set_versions",
+    "rp_override_set_entries",
+    "rp_override_set_scopes",
+)
+
+#: Exactly migration 0024's trigger set, restated as (name, sql) so the fixture
+#: can drop and restore all of them. Scopes carry no DELETE guard, by design:
+#: their lifecycle is their package's.
+_GUARD_VERBS: dict[str, tuple[str, ...]] = {
+    "rp_override_set_versions": ("UPDATE", "DELETE"),
+    "rp_override_set_entries": ("UPDATE", "DELETE"),
+    "rp_override_set_scopes": ("UPDATE",),
+}
+
+_REINSERT_PREDICATE: dict[str, str] = {
+    "rp_override_set_versions": "override_set_uuid = NEW.override_set_uuid",
+    "rp_override_set_entries": (
+        "override_set_uuid = NEW.override_set_uuid AND apply_order = NEW.apply_order"
+    ),
+    "rp_override_set_scopes": (
+        "override_set_uuid = NEW.override_set_uuid"
+        " AND package_uuid = NEW.package_uuid"
+        " AND release_version = NEW.release_version"
+    ),
+}
+
+_SEAL_SQL = """
+CREATE TRIGGER seal_rp_override_set_entries
+BEFORE INSERT ON rp_override_set_entries
+WHEN (
+    SELECT COUNT(*) FROM rp_override_set_entries
+    WHERE override_set_uuid = NEW.override_set_uuid
+) >= (
+    SELECT entry_count FROM rp_override_set_versions
+    WHERE override_set_uuid = NEW.override_set_uuid
+)
+BEGIN
+    SELECT RAISE(ABORT, 'rp_override_set_entries is sealed: the retained
+version already holds every entry it declared');
+END
+"""
 
 
-def _trigger_sql(table: str, verb: str) -> str:
-    return (
-        f"CREATE TRIGGER prevent_{table}_{verb.lower()} "
-        f"BEFORE {verb} ON {table} "
-        f"BEGIN SELECT RAISE(ABORT, "
-        f"'{table} is append-only: {verb} is forbidden'); END"
-    )
+def _trigger_statements() -> list[str]:
+    statements: list[str] = []
+    for table, verbs in _GUARD_VERBS.items():
+        for verb in verbs:
+            statements.append(
+                f"CREATE TRIGGER prevent_{table}_{verb.lower()} "
+                f"BEFORE {verb} ON {table} "
+                f"BEGIN SELECT RAISE(ABORT, "
+                f"'{table} is append-only: {verb} is forbidden'); END"
+            )
+    for table, predicate in _REINSERT_PREDICATE.items():
+        statements.append(
+            f"CREATE TRIGGER prevent_{table}_reinsert "
+            f"BEFORE INSERT ON {table} "
+            f"WHEN EXISTS (SELECT 1 FROM {table} WHERE {predicate}) "
+            f"BEGIN SELECT RAISE(ABORT, "
+            f"'{table} is append-only: replacing a retained row is forbidden'); END"
+        )
+    statements.append(_SEAL_SQL)
+    return statements
+
+
+def _trigger_names() -> list[str]:
+    names = [
+        f"prevent_{table}_{verb.lower()}"
+        for table, verbs in _GUARD_VERBS.items()
+        for verb in verbs
+    ]
+    names += [f"prevent_{table}_reinsert" for table in _REINSERT_PREDICATE]
+    names.append("seal_rp_override_set_entries")
+    return names
 
 
 def install_append_only_triggers(session: Session) -> None:
     """Install the migration's append-only triggers on the retained tables."""
-    for table in _RETAINED_TABLES:
-        for verb in ("UPDATE", "DELETE"):
-            session.execute(sa_text(_trigger_sql(table, verb)))
+    for statement in _trigger_statements():
+        session.execute(sa_text(statement))
     session.flush()
 
 
@@ -772,9 +890,8 @@ def without_append_only_triggers(session: Session) -> Iterator[None]:
     edit — and asserts that reconstruction refuses it anyway. Belt and braces
     are both load-bearing, so both are tested.
     """
-    for table in _RETAINED_TABLES:
-        for verb in ("update", "delete"):
-            session.execute(sa_text(f"DROP TRIGGER IF EXISTS prevent_{table}_{verb}"))
+    for name in _trigger_names():
+        session.execute(sa_text(f"DROP TRIGGER IF EXISTS {name}"))
     session.flush()
     try:
         yield

--- a/tests/services/rules_authority/conftest.py
+++ b/tests/services/rules_authority/conftest.py
@@ -1,0 +1,729 @@
+"""Fixtures for the CRD Issue 5d runtime-authority suite.
+
+The runtime layer needs something the earlier 5d suites did not: an *activated*
+projection over a published 5c release, reached through the genuine
+publish → activate path rather than by writing the rows publication would have
+left behind. Activation is what binding resolution reads, so a fixture that
+faked it would prove the resolver can read rows nobody proved.
+
+The bounded release below is therefore built from real CRD Issue 5c model
+objects and persisted through 5c's own primitives, exactly as
+``tests/ingestion/mechanical/conftest.py`` does. It is a separate fixture rather
+than an import of that one for one reason: **package identities here are real
+UUIDs.** ``RulesPackageBinding`` types every component as a ``UUID``, which is
+what makes a slug structurally incapable of being canonical authority, and the
+bounded mechanical fixture uses the short string ``"pkg-5c"``. Changing that
+fixture's package identity would remint its committed accepted oracle, so this
+suite carries its own release instead.
+
+Two packages are seeded. The second exists so slug ambiguity is a real
+condition to resolve rather than a mocked one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from uuid import UUID, uuid5
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.corpus.bundle import build_bundle, reconciliation_hash
+from afterworlds.ingestion.corpus.concordance import ConcordanceResult
+from afterworlds.ingestion.corpus.ledger import ledger_hash
+from afterworlds.ingestion.corpus.models import (
+    CorpusBundleMembers,
+    CorpusChunk,
+    Disposition,
+    Leaf,
+    LeafDisposition,
+    LeafType,
+    ProjectionEdge,
+    ReconciliationFindings,
+    ReconciliationMember,
+    SourceLedger,
+)
+from afterworlds.ingestion.corpus.operational import (
+    CORPUS_CONTRACT_VERSION,
+    build_operational_corpus_snapshot,
+    operational_corpus_digest,
+)
+from afterworlds.ingestion.corpus.persistence import (
+    _persist_bundle_rows,
+    _persist_package_and_source,
+    _persist_release_record,
+)
+from afterworlds.ingestion.corpus.policy import (
+    FROZEN_POLICY,
+    policy_hash,
+    policy_payload,
+)
+from afterworlds.ingestion.corpus.report import (
+    EVIDENCE_REPORT_SCHEMA_VERSION as CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
+)
+from afterworlds.ingestion.corpus.report import build_report
+from afterworlds.ingestion.corpus.report import report_hash as corpus_report_hash
+from afterworlds.ingestion.mechanical.accounting import derive_span_id
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceRecord,
+    ClassificationLedger,
+    ComponentHandling,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.oracle import AcceptedOracle, RecordObligation
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+    record_persisted_state_digest,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    SEMANTIC_POLICY_VERSION,
+    semantic_policy_hash,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    ReleaseBinding,
+    identify_projection,
+)
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    _publish_projection,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    ComponentDraft,
+    DcKind,
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+    RecordDraft,
+    RecordKind,
+    RepresentationDraft,
+    SpellDescriptorFact,
+    SpellSchool,
+    fact_key,
+    fact_payload,
+    prose_binding_target_key,
+)
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.models.rules_package import RulesPackageBinding
+from afterworlds.persistence.database import create_engine, create_session_factory
+from afterworlds.persistence.orm.base import Base
+from afterworlds.persistence.orm.corpus import CorpusReleaseORM
+from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority.targets import (
+    MechanicalTarget,
+    MechanicalTargetKind,
+)
+
+NOW = "2026-08-08T00:00:00Z"
+
+#: Deterministic, and real UUIDs. Derived rather than literal so the two
+#: packages can never accidentally be written as the same value.
+_NS = UUID("2f2b6d9c-0e2a-5f31-9a44-6b0c1d2e3f40")
+PACKAGE_UUID = str(uuid5(_NS, "runtime-authority-primary"))
+RIVAL_PACKAGE_UUID = str(uuid5(_NS, "runtime-authority-rival"))
+
+RELEASE_VERSION = "5.2.1-runtime.fixture"
+RIVAL_RELEASE_VERSION = "5.2.1-runtime.rival"
+
+#: Both packages carry the same display name, so they slugify identically. That
+#: is what an ambiguous human-facing slug actually is.
+PACKAGE_NAME = "SRD 5.2.1 corpus"
+
+SPELL_LEAF = "leaf-spell"
+PROSE_LEAF = "leaf-prose"
+SUPPORT_LEAF = "leaf-support"
+CHECK_LEAF = "leaf-check"
+LEAF_LENGTHS = {SPELL_LEAF: 40, PROSE_LEAF: 30, SUPPORT_LEAF: 20, CHECK_LEAF: 25}
+
+WISH_CHUNK = "chunk-wish-0001"
+SUPPORT_CHUNK = "chunk-wish-0002"
+SPELL_CHUNK = "chunk-wish-spell"
+CHECK_CHUNK = "chunk-servant-check"
+
+SPELL_SPAN = derive_span_id(SPELL_LEAF, 0, 40)
+PROSE_SPAN = derive_span_id(PROSE_LEAF, 0, 30)
+SUPPORT_SPAN = derive_span_id(SUPPORT_LEAF, 0, 20)
+CHECK_SPAN = derive_span_id(CHECK_LEAF, 0, 25)
+
+SPELL_KEY = "spell:wish"
+CREATURE_KEY = "creature:wish-scoped-servant"
+DESCRIPTOR_KEY = "descriptor"
+OPEN_ENDED_KEY = "open-ended-clause"
+CHECK_KEY = "servant-check"
+
+DESCRIPTOR_FACT = SpellDescriptorFact(
+    level=9, school=SpellSchool.CONJURATION, ritual=False, concentration=False
+)
+DESCRIPTOR_FACT_KEY = fact_key(DESCRIPTOR_FACT)
+
+CHECK_FACT = AbilityCheckFact(
+    ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+)
+CHECK_FACT_KEY = fact_key(CHECK_FACT)
+
+AUTHORITATIVE_SOURCE_HASH = "a" * 64
+TRANSFORM_CONFIG_HASH = "b" * 64
+PERSISTED_CORPUS_DIGEST = "d" * 64
+
+PROSE_TEXT = "x" * 30
+
+
+def _ledger() -> SourceLedger:
+    return SourceLedger(
+        source_document="D&D SRD 5.2.1",
+        source_version="5.2.1",
+        source_sha256=AUTHORITATIVE_SOURCE_HASH,
+        extraction_config={"extractor": "runtime-authority-fixture"},
+        containers=(),
+        leaves=tuple(
+            Leaf(
+                leaf_id=leaf_id,
+                printed_page=1,
+                page_index=0,
+                leaf_type=LeafType.PARAGRAPH,
+                content="x" * length,
+                char_start=0,
+                char_end=length,
+                occurrence_index=index,
+                container_path=(),
+            )
+            for index, (leaf_id, length) in enumerate(sorted(LEAF_LENGTHS.items()))
+        ),
+    )
+
+
+_EDGE_PAIRS = (
+    (WISH_CHUNK, PROSE_LEAF),
+    (SUPPORT_CHUNK, SUPPORT_LEAF),
+    (SPELL_CHUNK, SPELL_LEAF),
+    (CHECK_CHUNK, CHECK_LEAF),
+)
+
+
+def _edges(prefix: str = "") -> tuple[ProjectionEdge, ...]:
+    return tuple(
+        ProjectionEdge(
+            projection_id=f"proj-{prefix}{chunk}",
+            leaf_id=leaf,
+            chunk_id=f"{prefix}{chunk}",
+            role="authoritative",
+            cover_start=0,
+            cover_end=LEAF_LENGTHS[leaf],
+        )
+        for chunk, leaf in _EDGE_PAIRS
+    )
+
+
+def _members(package_uuid: str, prefix: str = "") -> CorpusBundleMembers:
+    return CorpusBundleMembers(
+        chunks=tuple(
+            CorpusChunk(
+                chunk_id=f"{prefix}{chunk}",
+                subsystem="spells",
+                content="x" * LEAF_LENGTHS[leaf],
+                printed_page=1,
+                section_label=None,
+                container_path=(),
+                source_leaf_ids=(leaf,),
+                source_document="D&D SRD 5.2.1",
+                source_locator_type="page",
+                source_locator_value="p. 1",
+                source_id=package_uuid,
+            )
+            for chunk, leaf in _EDGE_PAIRS
+        ),
+        derivative_notes=(),
+    )
+
+
+def _reconciliation(ledger: SourceLedger, prefix: str = "") -> ReconciliationMember:
+    return ReconciliationMember(
+        policy_version=FROZEN_POLICY.policy_version,
+        policy_hash=policy_hash(FROZEN_POLICY),
+        dispositions=tuple(
+            LeafDisposition(leaf.leaf_id, Disposition.REPRESENTED, None)
+            for leaf in ledger.leaves
+        ),
+        projections=_edges(prefix),
+        findings=ReconciliationFindings((), (), (), (), ()),
+        inventoried_leaves=len(ledger.leaves),
+        represented_leaves=len(ledger.leaves),
+        excluded_leaves=0,
+        unresolved_leaves=0,
+    )
+
+
+_TRANSFORM_CONFIG: dict[str, object] = {
+    "reconciliation_policy": policy_payload(FROZEN_POLICY),
+    "evidence_report_schema_version": CORPUS_EVIDENCE_REPORT_SCHEMA_VERSION,
+}
+
+
+def _seed_release(
+    session: Session, package_uuid: str, release_version: str, prefix: str = ""
+) -> str:
+    """Persist one published 5c release, returning its bundle root hash.
+
+    *prefix* scopes chunk identities. ``rp_chunks.chunk_id`` is globally unique,
+    so two seeded packages cannot both carry a chunk called ``chunk-wish-0001``
+    — the rival release exists to be a second package, not a second copy of the
+    first one's authority.
+    """
+    ledger = _ledger()
+    members = _members(package_uuid, prefix)
+    recon = _reconciliation(ledger, prefix)
+    bundle = build_bundle(ledger, members, recon)
+    report = build_report(
+        ledger=ledger,
+        members=members,
+        recon=recon,
+        policy=FROZEN_POLICY,
+        authoritative_source_hash=AUTHORITATIVE_SOURCE_HASH,
+        transform_config_hash=TRANSFORM_CONFIG_HASH,
+        transform_config=_TRANSFORM_CONFIG,
+        bundle_root_hash=bundle.bundle_root_hash,
+        ledger_hash_value=ledger_hash(ledger),
+        persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
+        concordance=ConcordanceResult(
+            chunks_checked=len(members.chunks),
+            locator_failures=(),
+            content_failures=(),
+        ),
+        canaries=(),
+        persisted=True,
+    )
+
+    _persist_package_and_source(session, package_uuid, release_version, now=NOW)
+    _persist_release_record(
+        session,
+        package_uuid,
+        release_version=release_version,
+        authoritative_source_hash=AUTHORITATIVE_SOURCE_HASH,
+        transform_config_hash=TRANSFORM_CONFIG_HASH,
+        bundle_root_hash=bundle.bundle_root_hash,
+        evidence_report_hash=corpus_report_hash(report),
+        persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
+        corpus_contract_version=CORPUS_CONTRACT_VERSION,
+        operational_corpus_digest_value=None,
+        ledger_hash=ledger_hash(ledger),
+        policy_hash=policy_hash(FROZEN_POLICY),
+        reconciliation_hash=reconciliation_hash(recon),
+        corpus_report_reference=corpus_report_hash(report),
+        transform_config=_TRANSFORM_CONFIG,
+        report_payload=report.payload,
+        now=NOW,
+    )
+    _persist_bundle_rows(
+        session,
+        package_uuid,
+        package_uuid,
+        ledger=ledger,
+        recon=recon,
+        policy=FROZEN_POLICY,
+        members=members,
+        now=NOW,
+    )
+    release = session.get(CorpusReleaseORM, package_uuid)
+    assert release is not None
+    release.operational_corpus_digest = operational_corpus_digest(
+        build_operational_corpus_snapshot(
+            session,
+            package_uuid,
+            corpus_contract_version=CORPUS_CONTRACT_VERSION,
+            persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
+        )
+    )
+    _mark_published(session, package_uuid)
+    return bundle.bundle_root_hash
+
+
+def _mark_published(session: Session, package_uuid: str) -> None:
+    """Transition a seeded release to published, as ``finalize_release`` does."""
+    session.execute(
+        select(CorpusReleaseORM).where(CorpusReleaseORM.package_uuid == package_uuid)
+    ).scalar_one().publication_status = "published"
+    package = session.execute(
+        select(RulesPackageORM).where(RulesPackageORM.rules_package_id == package_uuid)
+    ).scalar_one()
+    package.publication_status = "published"
+    package.published_at = NOW
+    package.name = PACKAGE_NAME
+    session.flush()
+
+
+# ---------------------------------------------------------------------------
+# The bounded mechanical projection
+# ---------------------------------------------------------------------------
+
+WISH_BINDING = ProseBindingDraft(
+    component_key=OPEN_ENDED_KEY,
+    record_key=SPELL_KEY,
+    chunk_id=WISH_CHUNK,
+    irreducibility_reason_code="open_ended_effect",
+)
+
+
+def _classification(package_uuid: str, release_version: str) -> ClassificationLedger:
+    spans = (
+        SemanticSpan(
+            span_id=SPELL_SPAN,
+            leaf_id=SPELL_LEAF,
+            char_start=0,
+            char_end=40,
+            disposition=SemanticDisposition.SUBSTANTIVE,
+            review_state=ReviewState.ACCEPTED,
+        ),
+        SemanticSpan(
+            span_id=PROSE_SPAN,
+            leaf_id=PROSE_LEAF,
+            char_start=0,
+            char_end=30,
+            disposition=SemanticDisposition.SUBSTANTIVE,
+            review_state=ReviewState.ACCEPTED,
+        ),
+        SemanticSpan(
+            span_id=SUPPORT_SPAN,
+            leaf_id=SUPPORT_LEAF,
+            char_start=0,
+            char_end=20,
+            disposition=SemanticDisposition.SUPPORTING_AUTHORITY,
+            review_state=ReviewState.ACCEPTED,
+        ),
+        SemanticSpan(
+            span_id=CHECK_SPAN,
+            leaf_id=CHECK_LEAF,
+            char_start=0,
+            char_end=25,
+            disposition=SemanticDisposition.SUBSTANTIVE,
+            review_state=ReviewState.ACCEPTED,
+        ),
+    )
+    return ClassificationLedger(
+        package_uuid=package_uuid,
+        release_version=release_version,
+        policy_version=SEMANTIC_POLICY_VERSION,
+        policy_hash=semantic_policy_hash(),
+        spans=spans,
+        batches=(),
+        acceptances=tuple(
+            AcceptanceRecord(s.span_id, None, "owner", NOW) for s in spans
+        ),
+    )
+
+
+def _representation() -> RepresentationDraft:
+    """A spell with structured and prose-bound authority, plus a scoped creature.
+
+    Small on purpose, but not degenerate: two records, three components across
+    two handling dispositions, and two typed facts of different families — which
+    is the minimum that lets a replace, an append, and a disable each be aimed at
+    something distinguishable.
+    """
+    return RepresentationDraft(
+        records=(
+            RecordDraft(semantic_key=SPELL_KEY, kind=RecordKind.SPELL),
+            RecordDraft(
+                semantic_key=CREATURE_KEY,
+                kind=RecordKind.CREATURE,
+                parent_key=SPELL_KEY,
+            ),
+        ),
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(DESCRIPTOR_FACT,),
+            ),
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=OPEN_ENDED_KEY,
+                handling=ComponentHandling.PROSE_BOUND,
+                irreducibility_reason_code="open_ended_effect",
+            ),
+            ComponentDraft(
+                record_key=CREATURE_KEY,
+                semantic_key=CHECK_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(CHECK_FACT,),
+            ),
+        ),
+        prose_bindings=(WISH_BINDING,),
+        relationships=(),
+        references=(),
+        provenance=(
+            ProvenanceClaim(
+                ProvenanceTargetKind.FACT,
+                (SPELL_KEY, DESCRIPTOR_KEY, DESCRIPTOR_FACT_KEY),
+                SPELL_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.FACT,
+                (CREATURE_KEY, CHECK_KEY, CHECK_FACT_KEY),
+                CHECK_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.PROSE_BINDING,
+                prose_binding_target_key(WISH_BINDING),
+                PROSE_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.RECORD,
+                (SPELL_KEY,),
+                SUPPORT_SPAN,
+                ProvenanceRole.CONTEXTUAL,
+            ),
+        ),
+    )
+
+
+_OBLIGATIONS = (
+    RecordObligation(
+        record_key=SPELL_KEY,
+        kind=RecordKind.SPELL,
+        structured_fact_families=frozenset({DESCRIPTOR_FACT.FAMILY}),
+        prose_bound_components=frozenset({OPEN_ENDED_KEY}),
+    ),
+    RecordObligation(
+        record_key=CREATURE_KEY,
+        kind=RecordKind.CREATURE,
+        structured_fact_families=frozenset({CHECK_FACT.FAMILY}),
+        prose_bound_components=frozenset(),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class RuntimeFixture:
+    """One published release with one activated mechanical projection."""
+
+    session: Session
+    package_uuid: UUID
+    release_version: str
+    projection_uuid: UUID
+    rival_package_uuid: UUID
+
+    def binding(self, override_set_uuid: UUID) -> RulesPackageBinding:
+        return RulesPackageBinding(
+            package_uuid=self.package_uuid,
+            release_version=self.release_version,
+            mechanical_projection_uuid=self.projection_uuid,
+            override_set_uuid=override_set_uuid,
+        )
+
+
+def _publish_bounded_projection(session: Session, bundle_root_hash: str) -> str:
+    """Build, persist, gate, publish, and activate the bounded projection.
+
+    Goes through :func:`_publish_projection` with an in-memory accepted oracle
+    rather than writing the rows a publication would have left behind. Binding
+    resolution reads the activation row and the recorded evidence, so a fixture
+    that faked them would let this suite pass against state no gate accepted.
+    """
+    binding = ReleaseBinding(
+        package_uuid=PACKAGE_UUID,
+        release_version=RELEASE_VERSION,
+        authoritative_source_hash=AUTHORITATIVE_SOURCE_HASH,
+        transform_config_hash=TRANSFORM_CONFIG_HASH,
+        bundle_root_hash=bundle_root_hash,
+        persisted_corpus_digest=PERSISTED_CORPUS_DIGEST,
+    )
+    classification = _classification(PACKAGE_UUID, RELEASE_VERSION)
+    representation = _representation()
+    identified = identify_projection(
+        ProjectionCandidate(
+            binding=binding,
+            classification=classification,
+            representation=representation,
+        )
+    )
+    persist_draft(session, identified, now=NOW)
+    record_persisted_state_digest(session, identified.projection_uuid)
+    oracle = AcceptedOracle(
+        binding=binding,
+        policy_version=SEMANTIC_POLICY_VERSION,
+        policy_hash=semantic_policy_hash(),
+        spans=classification.spans,
+        representation=representation,
+        obligations=_OBLIGATIONS,
+    )
+    result = _publish_projection(session, identified.projection_uuid, oracle, now=NOW)
+    assert result.outcome is PublicationOutcome.PUBLISHED, (
+        result.outcome,
+        result.gate.failures if result.gate else (),
+    )
+    return identified.projection_uuid
+
+
+@pytest.fixture()
+def runtime(tmp_path) -> Iterator[RuntimeFixture]:  # type: ignore[no-untyped-def]
+    """A published release, an activated projection, and a rival package.
+
+    Per-test rather than session-scoped: publication commits, and these tests
+    author, edit, and delete override rows, so a shared database would let one
+    test's override state decide another's binding identity.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'runtime.db'}")
+    Base.metadata.create_all(engine)
+    with create_session_factory(engine)() as session:
+        bundle_root_hash = _seed_release(session, PACKAGE_UUID, RELEASE_VERSION)
+        _seed_release(
+            session, RIVAL_PACKAGE_UUID, RIVAL_RELEASE_VERSION, prefix="rival-"
+        )
+        projection_uuid = _publish_bounded_projection(session, bundle_root_hash)
+        yield RuntimeFixture(
+            session=session,
+            package_uuid=UUID(PACKAGE_UUID),
+            release_version=RELEASE_VERSION,
+            projection_uuid=UUID(projection_uuid),
+            rival_package_uuid=UUID(RIVAL_PACKAGE_UUID),
+        )
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Override authoring
+# ---------------------------------------------------------------------------
+
+
+def author_override(
+    session: Session,
+    *,
+    override_id: str,
+    target: MechanicalTarget,
+    operation: OverrideOperationEnum,
+    payload: dict[str, object],
+    precedence: int = 100,
+    origin: OverrideOriginEnum = OverrideOriginEnum.HOUSE_RULE,
+    is_enabled: bool = True,
+    package_uuid: str = PACKAGE_UUID,
+    release_version: str = RELEASE_VERSION,
+    created_at: str = NOW,
+    created_by: str | None = "owner",
+    note: str | None = None,
+) -> MechanicalOverrideORM:
+    """Author one typed override row on the mutable authoring surface."""
+    row = MechanicalOverrideORM(
+        override_id=override_id,
+        package_uuid=package_uuid,
+        release_version=release_version,
+        target_kind=target.kind.value,
+        target_record_key=target.record_key,
+        target_component_key=target.component_key,
+        target_fact_key=target.fact_key,
+        override_origin=origin.value,
+        override_operation=operation.value,
+        payload=payload,
+        precedence=precedence,
+        is_enabled=is_enabled,
+        created_at=created_at,
+        created_by=created_by,
+        note=note,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+#: The exact typed targets the bounded projection exposes.
+DESCRIPTOR_COMPONENT_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.COMPONENT,
+    record_key=SPELL_KEY,
+    component_key=DESCRIPTOR_KEY,
+)
+DESCRIPTOR_FACT_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.FACT,
+    record_key=SPELL_KEY,
+    component_key=DESCRIPTOR_KEY,
+    fact_key=DESCRIPTOR_FACT_KEY,
+)
+SPELL_RECORD_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.RECORD, record_key=SPELL_KEY
+)
+CREATURE_RECORD_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.RECORD, record_key=CREATURE_KEY
+)
+CHECK_COMPONENT_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.COMPONENT,
+    record_key=CREATURE_KEY,
+    component_key=CHECK_KEY,
+)
+PROSE_COMPONENT_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.COMPONENT,
+    record_key=SPELL_KEY,
+    component_key=OPEN_ENDED_KEY,
+)
+
+#: A different spell descriptor, used wherever a replacement must be visibly
+#: different from what it replaces.
+REPLACEMENT_DESCRIPTOR = SpellDescriptorFact(
+    level=7, school=SpellSchool.ILLUSION, ritual=True, concentration=True
+)
+ADDED_CHECK = AbilityCheckFact(
+    ability=AbilityScore.CHARISMA, dc_kind=DcKind.SPELL_SAVE_DC
+)
+
+DISABLE_PAYLOAD: dict[str, object] = {"patch": "disable"}
+
+
+def replace_fact_payload(fact: object = REPLACEMENT_DESCRIPTOR) -> dict[str, object]:
+    return {"patch": "replace_fact", "fact": fact_payload(fact)}
+
+
+def append_fact_payload(fact: object = ADDED_CHECK) -> dict[str, object]:
+    return {"patch": "append_fact", "fact": fact_payload(fact)}
+
+
+def replace_component_payload(
+    facts: tuple[object, ...] = (REPLACEMENT_DESCRIPTOR,),
+) -> dict[str, object]:
+    return {
+        "patch": "replace_component",
+        "component": {
+            "handling": "structured",
+            "facts": [fact_payload(f) for f in facts],
+        },
+    }
+
+
+def append_component_payload(
+    semantic_key: str = "house-rider",
+    facts: tuple[object, ...] = (ADDED_CHECK,),
+) -> dict[str, object]:
+    return {
+        "patch": "append_component",
+        "component": {
+            "semantic_key": semantic_key,
+            "handling": "structured",
+            "facts": [fact_payload(f) for f in facts],
+        },
+    }
+
+
+def replace_record_payload(
+    record_kind: str = "spell",
+    semantic_key: str = DESCRIPTOR_KEY,
+    facts: tuple[object, ...] = (REPLACEMENT_DESCRIPTOR,),
+) -> dict[str, object]:
+    return {
+        "patch": "replace_record",
+        "record_kind": record_kind,
+        "components": [
+            {
+                "semantic_key": semantic_key,
+                "handling": "structured",
+                "facts": [fact_payload(f) for f in facts],
+            }
+        ],
+    }

--- a/tests/services/rules_authority/conftest.py
+++ b/tests/services/rules_authority/conftest.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from uuid import UUID, uuid5
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import Engine, select
 from sqlalchemy import text as sa_text
 from sqlalchemy.orm import Session
 
@@ -536,6 +536,9 @@ class RuntimeFixture:
     """One published release with one activated mechanical projection."""
 
     session: Session
+    #: The engine behind :attr:`session`, so a test can open genuinely
+    #: independent connections for deterministic concurrency work.
+    engine: Engine
     package_uuid: UUID
     release_version: str
     projection_uuid: UUID
@@ -638,6 +641,7 @@ def runtime(tmp_path) -> Iterator[RuntimeFixture]:  # type: ignore[no-untyped-de
         install_append_only_triggers(session)
         yield RuntimeFixture(
             session=session,
+            engine=engine,
             package_uuid=UUID(PACKAGE_UUID),
             release_version=RELEASE_VERSION,
             projection_uuid=UUID(projection_uuid),
@@ -802,74 +806,95 @@ _RETAINED_TABLES = (
     "rp_override_set_scopes",
 )
 
-#: Exactly migration 0024's trigger set, restated as (name, sql) so the fixture
-#: can drop and restore all of them. Scopes carry no DELETE guard, by design:
-#: their lifecycle is their package's.
-_GUARD_VERBS: dict[str, tuple[str, ...]] = {
-    "rp_override_set_versions": ("UPDATE", "DELETE"),
-    "rp_override_set_entries": ("UPDATE", "DELETE"),
-    "rp_override_set_scopes": ("UPDATE",),
-}
-
-_REINSERT_PREDICATE: dict[str, str] = {
-    "rp_override_set_versions": "override_set_uuid = NEW.override_set_uuid",
-    "rp_override_set_entries": (
-        "override_set_uuid = NEW.override_set_uuid AND apply_order = NEW.apply_order"
-    ),
-    "rp_override_set_scopes": (
-        "override_set_uuid = NEW.override_set_uuid"
-        " AND package_uuid = NEW.package_uuid"
-        " AND release_version = NEW.release_version"
-    ),
-}
-
-_SEAL_SQL = """
-CREATE TRIGGER seal_rp_override_set_entries
-BEFORE INSERT ON rp_override_set_entries
-WHEN (
-    SELECT COUNT(*) FROM rp_override_set_entries
-    WHERE override_set_uuid = NEW.override_set_uuid
-) >= (
-    SELECT entry_count FROM rp_override_set_versions
-    WHERE override_set_uuid = NEW.override_set_uuid
+#: Migration 0024's trigger set, restated so the suite runs against the same
+#: protection production has (``create_all`` does not create triggers). A test
+#: asserts this set matches what the real migration installs, so the two cannot
+#: drift silently — hand-mirroring is what made drift possible before.
+_ENTRY_CONTENT_COLUMNS = (
+    "override_id",
+    "override_origin",
+    "target_kind",
+    "target_record_key",
+    "target_component_key",
+    "target_fact_key",
+    "override_operation",
+    "precedence",
+    "is_enabled",
+    "payload",
 )
-BEGIN
-    SELECT RAISE(ABORT, 'rp_override_set_entries is sealed: the retained
-version already holds every entry it declared');
-END
-"""
 
 
 def _trigger_statements() -> list[str]:
-    statements: list[str] = []
-    for table, verbs in _GUARD_VERBS.items():
-        for verb in verbs:
-            statements.append(
-                f"CREATE TRIGGER prevent_{table}_{verb.lower()} "
-                f"BEFORE {verb} ON {table} "
-                f"BEGIN SELECT RAISE(ABORT, "
-                f"'{table} is append-only: {verb} is forbidden'); END"
-            )
-    for table, predicate in _REINSERT_PREDICATE.items():
-        statements.append(
-            f"CREATE TRIGGER prevent_{table}_reinsert "
-            f"BEFORE INSERT ON {table} "
-            f"WHEN EXISTS (SELECT 1 FROM {table} WHERE {predicate}) "
-            f"BEGIN SELECT RAISE(ABORT, "
-            f"'{table} is append-only: replacing a retained row is forbidden'); END"
-        )
-    statements.append(_SEAL_SQL)
+    statements = [
+        f"CREATE TRIGGER prevent_{table}_update BEFORE UPDATE ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, "
+        f"'{table} is append-only: UPDATE is forbidden'); END"
+        for table in _RETAINED_TABLES
+    ]
+    statements += [
+        f"CREATE TRIGGER prevent_{table}_delete BEFORE DELETE ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, "
+        f"'{table} is append-only: DELETE is forbidden'); END"
+        for table in ("rp_override_set_versions", "rp_override_set_entries")
+    ]
+    statements.append(
+        "CREATE TRIGGER prevent_rp_override_set_scopes_delete "
+        "BEFORE DELETE ON rp_override_set_scopes "
+        "WHEN EXISTS (SELECT 1 FROM rp_packages "
+        "WHERE rules_package_id = OLD.package_uuid) "
+        "BEGIN SELECT RAISE(ABORT, "
+        "'rp_override_set_scopes is append-only while its package is live'); END"
+    )
+    statements.append(
+        "CREATE TRIGGER prevent_rp_override_set_versions_reinsert "
+        "BEFORE INSERT ON rp_override_set_versions "
+        "WHEN EXISTS (SELECT 1 FROM rp_override_set_versions "
+        "WHERE override_set_uuid = NEW.override_set_uuid "
+        "AND entry_count IS NOT NEW.entry_count) "
+        "BEGIN SELECT RAISE(ABORT, "
+        "'rp_override_set_versions is append-only: rewrite refused'); END"
+    )
+    differs = " OR ".join(f"{c} IS NOT NEW.{c}" for c in _ENTRY_CONTENT_COLUMNS)
+    statements.append(
+        "CREATE TRIGGER prevent_rp_override_set_entries_reinsert "
+        "BEFORE INSERT ON rp_override_set_entries "
+        "WHEN EXISTS (SELECT 1 FROM rp_override_set_entries "
+        "WHERE override_set_uuid = NEW.override_set_uuid "
+        f"AND apply_order = NEW.apply_order AND ({differs})) "
+        "BEGIN SELECT RAISE(ABORT, "
+        "'rp_override_set_entries is append-only: rewrite refused'); END"
+    )
+    statements.append(
+        "CREATE TRIGGER seal_rp_override_set_entries "
+        "BEFORE INSERT ON rp_override_set_entries "
+        "WHEN (SELECT COUNT(*) FROM rp_override_set_entries "
+        "WHERE override_set_uuid = NEW.override_set_uuid) >= "
+        "(SELECT entry_count FROM rp_override_set_versions "
+        "WHERE override_set_uuid = NEW.override_set_uuid) "
+        "AND NOT EXISTS (SELECT 1 FROM rp_override_set_entries "
+        "WHERE override_set_uuid = NEW.override_set_uuid "
+        "AND apply_order = NEW.apply_order) "
+        "BEGIN SELECT RAISE(ABORT, "
+        "'rp_override_set_entries is sealed: version already complete'); END"
+    )
     return statements
 
 
 def _trigger_names() -> list[str]:
-    names = [
-        f"prevent_{table}_{verb.lower()}"
-        for table, verbs in _GUARD_VERBS.items()
-        for verb in verbs
+    names = [f"prevent_{t}_update" for t in _RETAINED_TABLES]
+    names += [
+        f"prevent_{t}_delete"
+        for t in (
+            "rp_override_set_versions",
+            "rp_override_set_entries",
+            "rp_override_set_scopes",
+        )
     ]
-    names += [f"prevent_{table}_reinsert" for table in _REINSERT_PREDICATE]
-    names.append("seal_rp_override_set_entries")
+    names += [
+        "prevent_rp_override_set_versions_reinsert",
+        "prevent_rp_override_set_entries_reinsert",
+        "seal_rp_override_set_entries",
+    ]
     return names
 
 

--- a/tests/services/rules_authority/conftest.py
+++ b/tests/services/rules_authority/conftest.py
@@ -23,11 +23,13 @@ condition to resolve rather than a mocked one.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from uuid import UUID, uuid5
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy import text as sa_text
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.corpus.bundle import build_bundle, reconciliation_hash
@@ -582,6 +584,7 @@ def runtime(tmp_path) -> Iterator[RuntimeFixture]:  # type: ignore[no-untyped-de
             session, RIVAL_PACKAGE_UUID, RIVAL_RELEASE_VERSION, prefix="rival-"
         )
         projection_uuid = _publish_bounded_projection(session, bundle_root_hash)
+        install_append_only_triggers(session)
         yield RuntimeFixture(
             session=session,
             package_uuid=UUID(PACKAGE_UUID),
@@ -727,3 +730,53 @@ def replace_record_payload(
             }
         ],
     }
+
+
+# ---------------------------------------------------------------------------
+# Append-only enforcement
+# ---------------------------------------------------------------------------
+#
+# ``Base.metadata.create_all`` does not create triggers, so a suite built that
+# way would run without the protection production actually has and would prove
+# nothing about it. These mirror migration 0024 exactly, following the pattern
+# tests/persistence/test_rpg_roll_audit_db.py and tests/entitlement/conftest.py
+# already use for the repository's other append-only evidence tables.
+
+_RETAINED_TABLES = ("rp_override_set_versions", "rp_override_set_entries")
+
+
+def _trigger_sql(table: str, verb: str) -> str:
+    return (
+        f"CREATE TRIGGER prevent_{table}_{verb.lower()} "
+        f"BEFORE {verb} ON {table} "
+        f"BEGIN SELECT RAISE(ABORT, "
+        f"'{table} is append-only: {verb} is forbidden'); END"
+    )
+
+
+def install_append_only_triggers(session: Session) -> None:
+    """Install the migration's append-only triggers on the retained tables."""
+    for table in _RETAINED_TABLES:
+        for verb in ("UPDATE", "DELETE"):
+            session.execute(sa_text(_trigger_sql(table, verb)))
+    session.flush()
+
+
+@contextmanager
+def without_append_only_triggers(session: Session) -> Iterator[None]:
+    """Temporarily drop the append-only triggers, then restore them.
+
+    Used only by the controls that must prove *read-time* verification still
+    detects a rewritten retained row. The triggers stop the ordinary path; this
+    models what is left — a database restored without them, or an out-of-band
+    edit — and asserts that reconstruction refuses it anyway. Belt and braces
+    are both load-bearing, so both are tested.
+    """
+    for table in _RETAINED_TABLES:
+        for verb in ("update", "delete"):
+            session.execute(sa_text(f"DROP TRIGGER IF EXISTS prevent_{table}_{verb}"))
+    session.flush()
+    try:
+        yield
+    finally:
+        install_append_only_triggers(session)

--- a/tests/services/rules_authority/test_authority_views.py
+++ b/tests/services/rules_authority/test_authority_views.py
@@ -330,7 +330,7 @@ def test_a_slice_over_an_unpublished_package_is_typed(
     runtime: RuntimeFixture,
 ) -> None:
     result = service(runtime).rule_slice(
-        RuleSliceRequest(package_id=runtime.rival_package_uuid, whole_package=True)
+        RuleSliceRequest(package_id=runtime.bare_package_uuid, whole_package=True)
     )
     assert result.outcome is AuthorityOutcome.UNPUBLISHED
     assert result.slice is None

--- a/tests/services/rules_authority/test_authority_views.py
+++ b/tests/services/rules_authority/test_authority_views.py
@@ -1,0 +1,349 @@
+"""The two authority views and deterministic selection — #137 contract 6.
+
+Both views resolve the same effective authority, both identify the exact
+four-component binding that produced them, and neither implies adapter
+capability. Selection is deterministic lookup against exact semantic keys or the
+explicit ``whole_package`` flag; a selector naming something the projection does
+not contain is ``INVALID_REFERENCE``, never an empty slice.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    RulesAuthorityService,
+)
+from afterworlds.services.rules_authority.views import GameMasterComponent
+from tests.services.rules_authority.conftest import (
+    CHECK_KEY,
+    CREATURE_KEY,
+    DESCRIPTOR_FACT_TARGET,
+    DESCRIPTOR_KEY,
+    NOW,
+    OPEN_ENDED_KEY,
+    PROSE_TEXT,
+    SPELL_KEY,
+    WISH_CHUNK,
+    RuntimeFixture,
+    author_override,
+    replace_fact_payload,
+)
+
+
+def service(runtime: RuntimeFixture) -> RulesAuthorityService:
+    return RulesAuthorityService(runtime.session, now=NOW)
+
+
+def whole(runtime: RuntimeFixture) -> RuleSliceRequest:
+    return RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+
+
+# ---------------------------------------------------------------------------
+# Consistency between the views
+# ---------------------------------------------------------------------------
+
+
+def test_both_views_identify_the_same_complete_binding(
+    runtime: RuntimeFixture,
+) -> None:
+    """All four components, on every surface (#137 acceptance criterion 19)."""
+    binding = service(runtime).resolve(package_uuid=runtime.package_uuid).binding
+    assert binding is not None
+
+    sliced = service(runtime).rule_slice(whole(runtime))
+    typed = service(runtime).typed_view(whole(runtime))
+    gm = service(runtime).gamemaster_view(whole(runtime))
+
+    assert sliced.slice is not None
+    assert typed.typed_view is not None
+    assert gm.gamemaster_view is not None
+    assert (
+        sliced.slice.binding
+        == typed.typed_view.binding
+        == gm.gamemaster_view.binding
+        == binding
+    )
+
+
+def test_both_views_report_the_same_applied_override_provenance(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-shared",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    typed = service(runtime).typed_view(whole(runtime)).typed_view
+    gm = service(runtime).gamemaster_view(whole(runtime)).gamemaster_view
+    assert typed is not None and gm is not None
+    assert typed.applied_overrides == gm.applied_overrides
+    (applied,) = typed.applied_overrides
+    assert applied.override_id == "ov-shared"
+    assert applied.applied is True
+
+
+# ---------------------------------------------------------------------------
+# The typed view
+# ---------------------------------------------------------------------------
+
+
+def test_the_typed_view_carries_exact_source_linked_provenance(
+    runtime: RuntimeFixture,
+) -> None:
+    """Every base fact names the 5c leaf subspans it was accepted from."""
+    view = service(runtime).typed_view(whole(runtime)).typed_view
+    assert view is not None
+    facts = [
+        fact
+        for record in view.records
+        for component in record.components
+        for fact in component.facts
+    ]
+    assert facts
+    assert all(fact.span_ids for fact in facts)
+
+
+def test_the_typed_view_declares_no_adapter_capability(
+    runtime: RuntimeFixture,
+) -> None:
+    """Representation and execution are independent (ADR-005d Decision 1).
+
+    Asserted structurally rather than by inspection: no field on any view type
+    mentions support, execution, or certification, so there is nowhere for a
+    consumer to read a capability claim that this PR has no right to make.
+    """
+    view = service(runtime).typed_view(whole(runtime)).typed_view
+    assert view is not None
+    names = {
+        field.name
+        for record in view.records
+        for component in record.components
+        for field in dataclasses.fields(component)
+    } | {field.name for field in dataclasses.fields(GameMasterComponent)}
+    forbidden = ("support", "executable", "certif", "capab", "adapter")
+    assert not [n for n in names if any(f in n for f in forbidden)]
+
+
+# ---------------------------------------------------------------------------
+# The GameMaster view
+# ---------------------------------------------------------------------------
+
+
+def test_the_gamemaster_view_resolves_exact_governing_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    """Bound by chunk identity, read from the authoritative 5c RuleChunk."""
+    view = service(runtime).gamemaster_view(whole(runtime)).gamemaster_view
+    assert view is not None
+    (prose_bound,) = [c for c in view.components if c.component_key == OPEN_ENDED_KEY]
+    assert prose_bound.handling is ComponentHandling.PROSE_BOUND
+    assert prose_bound.irreducibility_reason_code == "open_ended_effect"
+    (passage,) = prose_bound.governing_prose
+    assert passage.chunk_id == WISH_CHUNK
+    assert passage.text == PROSE_TEXT
+
+
+def test_the_gamemaster_view_carries_structured_context_and_handling(
+    runtime: RuntimeFixture,
+) -> None:
+    view = service(runtime).gamemaster_view(whole(runtime)).gamemaster_view
+    assert view is not None
+    (descriptor,) = [c for c in view.components if c.component_key == DESCRIPTOR_KEY]
+    assert descriptor.handling is ComponentHandling.STRUCTURED
+    assert descriptor.governing_prose == ()
+    # Provenance lives where the projection puts it: a component's obligation is
+    # span coverage under the classification contract, while each fact carries
+    # its own edge (ADR-005d Decision 3). The view reports both as they are
+    # rather than inventing a component-level edge.
+    (fact,) = descriptor.structured_context
+    assert fact.span_ids
+
+
+def test_a_missing_bound_chunk_is_reported_not_substituted(
+    runtime: RuntimeFixture,
+) -> None:
+    """A nearby passage is not the governing passage.
+
+    The bound chunk is removed from the store; the view still names the exact
+    chunk it is bound to and reports the text as absent rather than resolving
+    something else in its place.
+    """
+    from sqlalchemy import delete
+
+    from afterworlds.persistence.orm.rules_package import RuleChunkORM
+
+    runtime.session.execute(
+        delete(RuleChunkORM).where(RuleChunkORM.chunk_id == WISH_CHUNK)
+    )
+    runtime.session.flush()
+
+    view = service(runtime).gamemaster_view(whole(runtime)).gamemaster_view
+    assert view is not None
+    (prose_bound,) = [c for c in view.components if c.component_key == OPEN_ENDED_KEY]
+    (passage,) = prose_bound.governing_prose
+    assert passage.chunk_id == WISH_CHUNK
+    assert passage.text is None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic selection
+# ---------------------------------------------------------------------------
+
+
+def test_whole_package_returns_every_record(runtime: RuntimeFixture) -> None:
+    sliced = service(runtime).rule_slice(whole(runtime))
+    assert sliced.slice is not None
+    assert sliced.slice.whole_package is True
+    assert {r.semantic_key for r in sliced.slice.records} == {
+        SPELL_KEY,
+        CREATURE_KEY,
+    }
+
+
+def test_a_record_selector_returns_that_record_whole(
+    runtime: RuntimeFixture,
+) -> None:
+    sliced = service(runtime).rule_slice(
+        RuleSliceRequest(package_id=runtime.package_uuid, record_selectors=(SPELL_KEY,))
+    )
+    assert sliced.slice is not None
+    (record,) = sliced.slice.records
+    assert record.semantic_key == SPELL_KEY
+    assert {c.semantic_key for c in record.components} == {
+        DESCRIPTOR_KEY,
+        OPEN_ENDED_KEY,
+    }
+
+
+def test_a_component_selector_narrows_to_that_component(
+    runtime: RuntimeFixture,
+) -> None:
+    sliced = service(runtime).rule_slice(
+        RuleSliceRequest(
+            package_id=runtime.package_uuid,
+            component_selectors=((SPELL_KEY, DESCRIPTOR_KEY),),
+        )
+    )
+    assert sliced.slice is not None
+    (record,) = sliced.slice.records
+    assert [c.semantic_key for c in record.components] == [DESCRIPTOR_KEY]
+
+
+def test_the_broader_selector_wins_regardless_of_order(
+    runtime: RuntimeFixture,
+) -> None:
+    """Selector order cannot change what a slice contains."""
+    both = RuleSliceRequest(
+        package_id=runtime.package_uuid,
+        record_selectors=(SPELL_KEY,),
+        component_selectors=((SPELL_KEY, DESCRIPTOR_KEY),),
+    )
+    sliced = service(runtime).rule_slice(both)
+    assert sliced.slice is not None
+    (record,) = sliced.slice.records
+    assert {c.semantic_key for c in record.components} == {
+        DESCRIPTOR_KEY,
+        OPEN_ENDED_KEY,
+    }
+
+
+def test_an_unknown_record_selector_is_an_invalid_reference(
+    runtime: RuntimeFixture,
+) -> None:
+    """Not an empty slice, which would read as "that rule does not apply"."""
+    result = service(runtime).rule_slice(
+        RuleSliceRequest(
+            package_id=runtime.package_uuid, record_selectors=("spell:nonesuch",)
+        )
+    )
+    assert result.outcome is AuthorityOutcome.INVALID_REFERENCE
+    assert "spell:nonesuch" in result.detail
+    assert result.slice is None
+
+
+def test_an_unknown_component_selector_is_an_invalid_reference(
+    runtime: RuntimeFixture,
+) -> None:
+    result = service(runtime).rule_slice(
+        RuleSliceRequest(
+            package_id=runtime.package_uuid,
+            component_selectors=((SPELL_KEY, "no-such-component"),),
+        )
+    )
+    assert result.outcome is AuthorityOutcome.INVALID_REFERENCE
+    assert "no-such-component" in result.detail
+
+
+def test_views_refuse_with_the_same_typed_outcome_as_the_slice(
+    runtime: RuntimeFixture,
+) -> None:
+    """One resolution behind all three surfaces, so none can be softer."""
+    bad = RuleSliceRequest(
+        package_id=runtime.package_uuid, record_selectors=("spell:nonesuch",)
+    )
+    assert (
+        service(runtime).rule_slice(bad).outcome
+        is service(runtime).typed_view(bad).outcome
+        is service(runtime).gamemaster_view(bad).outcome
+        is AuthorityOutcome.INVALID_REFERENCE
+    )
+
+
+def test_a_slug_request_resolves_to_the_same_slice(
+    runtime: RuntimeFixture,
+) -> None:
+    from sqlalchemy import select
+
+    from afterworlds.persistence.orm.rules_package import RulesPackageORM
+    from afterworlds.services.rules_authority import package_slug
+    from tests.services.rules_authority.conftest import (
+        PACKAGE_NAME,
+        RIVAL_PACKAGE_UUID,
+    )
+
+    rival = runtime.session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == RIVAL_PACKAGE_UUID
+        )
+    ).scalar_one()
+    rival.name = "Another corpus entirely"
+    runtime.session.flush()
+
+    by_uuid = service(runtime).rule_slice(whole(runtime))
+    by_slug = service(runtime).rule_slice(
+        RuleSliceRequest(package_slug=package_slug(PACKAGE_NAME), whole_package=True)
+    )
+    assert by_slug.outcome is AuthorityOutcome.RESOLVED
+    assert by_uuid.slice is not None and by_slug.slice is not None
+    assert by_slug.slice.binding == by_uuid.slice.binding
+    assert by_slug.slice.records == by_uuid.slice.records
+
+
+def test_a_slice_over_an_unpublished_package_is_typed(
+    runtime: RuntimeFixture,
+) -> None:
+    result = service(runtime).rule_slice(
+        RuleSliceRequest(package_id=runtime.rival_package_uuid, whole_package=True)
+    )
+    assert result.outcome is AuthorityOutcome.UNPUBLISHED
+    assert result.slice is None
+
+
+def test_selection_reaches_a_creature_component(runtime: RuntimeFixture) -> None:
+    sliced = service(runtime).rule_slice(
+        RuleSliceRequest(
+            package_id=runtime.package_uuid,
+            component_selectors=((CREATURE_KEY, CHECK_KEY),),
+        )
+    )
+    assert sliced.slice is not None
+    (record,) = sliced.slice.records
+    assert record.semantic_key == CREATURE_KEY
+    assert [c.semantic_key for c in record.components] == [CHECK_KEY]

--- a/tests/services/rules_authority/test_base_projection_unchanged.py
+++ b/tests/services/rules_authority/test_base_projection_unchanged.py
@@ -1,0 +1,181 @@
+"""Overrides never touch the immutable base projection — Decisions 6 and 10.
+
+ADR-005d is explicit that override state is outside projection identity: an
+override change mints a new override-set identity and leaves the base projection
+UUID and its rows exactly as published. These tests assert that against the
+database, not against the in-memory view — the failure worth catching is an
+application path that "helpfully" writes its result back.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from afterworlds.ingestion.mechanical.persistence import (
+    reconstruct_candidate,
+    verify_persisted_state,
+)
+from afterworlds.ingestion.mechanical.projection import projection_uuid
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.persistence.orm.mechanical import (
+    MechanicalComponentORM,
+    MechanicalFactORM,
+    MechanicalProjectionORM,
+    MechanicalRecordORM,
+)
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    RulesAuthorityService,
+)
+from tests.services.rules_authority.conftest import (
+    CREATURE_RECORD_TARGET,
+    DESCRIPTOR_COMPONENT_TARGET,
+    DESCRIPTOR_FACT_TARGET,
+    DISABLE_PAYLOAD,
+    NOW,
+    RuntimeFixture,
+    author_override,
+    replace_component_payload,
+    replace_fact_payload,
+)
+
+
+def _rows(runtime: RuntimeFixture) -> dict[str, list[tuple[str, ...]]]:
+    """Every persisted identity and semantic key of the base projection."""
+    uuid_ = str(runtime.projection_uuid)
+    records = (
+        runtime.session.execute(
+            select(MechanicalRecordORM)
+            .where(MechanicalRecordORM.projection_uuid == uuid_)
+            .order_by(MechanicalRecordORM.semantic_key)
+        )
+        .scalars()
+        .all()
+    )
+    components = (
+        runtime.session.execute(
+            select(MechanicalComponentORM)
+            .where(MechanicalComponentORM.projection_uuid == uuid_)
+            .order_by(
+                MechanicalComponentORM.record_key,
+                MechanicalComponentORM.semantic_key,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    facts = (
+        runtime.session.execute(
+            select(MechanicalFactORM)
+            .where(MechanicalFactORM.projection_uuid == uuid_)
+            .order_by(MechanicalFactORM.fact_key)
+        )
+        .scalars()
+        .all()
+    )
+    return {
+        "records": [(r.record_id, r.semantic_key, r.kind) for r in records],
+        "components": [
+            (c.component_id, c.record_key, c.semantic_key, c.handling)
+            for c in components
+        ],
+        "facts": [
+            (f.fact_id, f.record_key, f.component_key, f.fact_key, f.family)
+            for f in facts
+        ],
+    }
+
+
+def test_applying_overrides_leaves_the_projection_identity_unchanged(
+    runtime: RuntimeFixture,
+) -> None:
+    """The base projection UUID is not reminted by an override (Decision 6)."""
+    before = _rows(runtime)
+    service = RulesAuthorityService(runtime.session, now=NOW)
+
+    author_override(
+        runtime.session,
+        override_id="ov-a",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-b",
+        target=CREATURE_RECORD_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    result = service.typed_view(
+        RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+    )
+    assert result.outcome is AuthorityOutcome.RESOLVED
+    assert result.binding is not None
+    assert result.binding.mechanical_projection_uuid == runtime.projection_uuid
+
+    assert _rows(runtime) == before
+
+
+def test_the_persisted_projection_still_derives_its_own_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """Reconstructed persisted state still hashes to the published UUID."""
+    service = RulesAuthorityService(runtime.session, now=NOW)
+    author_override(
+        runtime.session,
+        override_id="ov-replace-component",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_component_payload(),
+    )
+    service.typed_view(
+        RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+    )
+
+    candidate = reconstruct_candidate(runtime.session, str(runtime.projection_uuid))
+    assert projection_uuid(candidate) == str(runtime.projection_uuid)
+    assert (
+        verify_persisted_state(
+            runtime.session,
+            str(runtime.projection_uuid),
+            expected_status="published",
+        )
+        == ()
+    )
+
+
+def test_the_published_header_is_untouched(runtime: RuntimeFixture) -> None:
+    header_before = _header_snapshot(runtime)
+    service = RulesAuthorityService(runtime.session, now=NOW)
+    author_override(
+        runtime.session,
+        override_id="ov-disable",
+        target=CREATURE_RECORD_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    service.gamemaster_view(
+        RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+    )
+    assert _header_snapshot(runtime) == header_before
+
+
+def _header_snapshot(runtime: RuntimeFixture) -> tuple[object, ...]:
+    header = runtime.session.execute(
+        select(MechanicalProjectionORM).where(
+            MechanicalProjectionORM.projection_uuid == str(runtime.projection_uuid)
+        )
+    ).scalar_one()
+    return (
+        header.projection_uuid,
+        header.payload_hash,
+        header.persisted_state_digest,
+        header.publication_status,
+        header.published_at,
+        header.evidence_report_hash,
+        header.oracle_identity,
+    )

--- a/tests/services/rules_authority/test_binding_resolution.py
+++ b/tests/services/rules_authority/test_binding_resolution.py
@@ -149,7 +149,7 @@ def test_a_package_without_an_active_projection_is_unpublished(
     runtime: RuntimeFixture,
 ) -> None:
     """``UNPUBLISHED`` is a typed answer, not an empty result."""
-    resolution = service(runtime).resolve(package_uuid=runtime.rival_package_uuid)
+    resolution = service(runtime).resolve(package_uuid=runtime.bare_package_uuid)
     assert resolution.outcome is AuthorityOutcome.UNPUBLISHED
     assert resolution.binding is None
 

--- a/tests/services/rules_authority/test_binding_resolution.py
+++ b/tests/services/rules_authority/test_binding_resolution.py
@@ -1,0 +1,308 @@
+"""Exact binding resolution and its typed refusals — #137 contract 6.
+
+Every state here is one #137 requires to stay distinct, and each is asserted as
+a *typed* outcome rather than as an absence: the failure mode this suite exists
+to prevent is a resolver that answers "no authority" and "malformed reference"
+with the same empty result.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.models.rules_package import RulesPackageBinding
+from afterworlds.persistence.orm.mechanical import MechanicalActiveProjectionORM
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    RulesAuthorityService,
+    package_slug,
+    resolve_package_reference,
+)
+from tests.services.rules_authority.conftest import (
+    DESCRIPTOR_FACT_TARGET,
+    DISABLE_PAYLOAD,
+    NOW,
+    PACKAGE_NAME,
+    RIVAL_PACKAGE_UUID,
+    RuntimeFixture,
+    author_override,
+)
+
+
+def service(runtime: RuntimeFixture) -> RulesAuthorityService:
+    return RulesAuthorityService(runtime.session, now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# The resolved binding
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_returns_all_four_components(runtime: RuntimeFixture) -> None:
+    """The binding is the exact four-component value, never three of four."""
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    binding = resolution.binding
+    assert binding is not None
+    assert binding.package_uuid == runtime.package_uuid
+    assert binding.release_version == runtime.release_version
+    assert binding.mechanical_projection_uuid == runtime.projection_uuid
+    # The override-set identity is a value even with no overrides authored.
+    assert isinstance(binding.override_set_uuid, UUID)
+
+
+def test_base_projection_and_override_identities_are_distinct(
+    runtime: RuntimeFixture,
+) -> None:
+    """ADR-005d Decision 9: the two identities are never collapsed into one."""
+    binding = service(runtime).resolve(package_uuid=runtime.package_uuid).binding
+    assert binding is not None
+    assert binding.mechanical_projection_uuid != binding.override_set_uuid
+
+
+def test_slug_and_uuid_resolve_to_the_same_binding(runtime: RuntimeFixture) -> None:
+    """#137 acceptance criterion 18, the positive half.
+
+    The rival package is renamed first so the slug is unambiguous; it is the
+    same fixture that makes the ambiguous case below real.
+    """
+    rival = runtime.session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == RIVAL_PACKAGE_UUID
+        )
+    ).scalar_one()
+    rival.name = "Some other corpus"
+    runtime.session.flush()
+
+    by_uuid = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    by_slug = service(runtime).resolve(package_reference=package_slug(PACKAGE_NAME))
+
+    assert by_slug.outcome is AuthorityOutcome.RESOLVED
+    assert by_slug.binding == by_uuid.binding
+
+
+def test_a_uuid_string_resolves_through_the_same_reference_path(
+    runtime: RuntimeFixture,
+) -> None:
+    """A UUID reference never reaches slug matching."""
+    resolved = resolve_package_reference(runtime.session, str(runtime.package_uuid))
+    assert resolved.outcome is AuthorityOutcome.RESOLVED
+    assert resolved.package_uuid == runtime.package_uuid
+
+
+# ---------------------------------------------------------------------------
+# Typed refusals
+# ---------------------------------------------------------------------------
+
+
+def test_an_ambiguous_slug_is_ambiguous_not_a_first_match(
+    runtime: RuntimeFixture,
+) -> None:
+    """Two packages share a display name, so the slug names neither of them."""
+    resolution = service(runtime).resolve(package_reference=package_slug(PACKAGE_NAME))
+    assert resolution.outcome is AuthorityOutcome.AMBIGUOUS
+    assert "not canonical authority" in resolution.detail
+
+    resolved = resolve_package_reference(runtime.session, PACKAGE_NAME)
+    assert resolved.outcome is AuthorityOutcome.AMBIGUOUS
+    assert set(resolved.candidates) == {
+        runtime.package_uuid,
+        runtime.rival_package_uuid,
+    }
+
+
+@pytest.mark.parametrize("reference", ["", "   ", "!!!", "///"])
+def test_a_malformed_reference_is_an_invalid_selector(
+    runtime: RuntimeFixture, reference: str
+) -> None:
+    """Neither a UUID nor a slug — refused, not silently dropped."""
+    resolution = service(runtime).resolve(package_reference=reference)
+    assert resolution.outcome is AuthorityOutcome.INVALID_SELECTOR
+
+
+def test_an_unknown_slug_is_absent(runtime: RuntimeFixture) -> None:
+    resolution = service(runtime).resolve(package_reference="no-such-package")
+    assert resolution.outcome is AuthorityOutcome.ABSENT
+
+
+def test_an_unknown_package_uuid_is_absent(runtime: RuntimeFixture) -> None:
+    resolution = service(runtime).resolve(package_uuid=uuid4())
+    assert resolution.outcome is AuthorityOutcome.ABSENT
+
+
+def test_supplying_both_reference_forms_is_an_invalid_selector(
+    runtime: RuntimeFixture,
+) -> None:
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, package_reference="anything"
+    )
+    assert resolution.outcome is AuthorityOutcome.INVALID_SELECTOR
+
+
+def test_a_package_without_an_active_projection_is_unpublished(
+    runtime: RuntimeFixture,
+) -> None:
+    """``UNPUBLISHED`` is a typed answer, not an empty result."""
+    resolution = service(runtime).resolve(package_uuid=runtime.rival_package_uuid)
+    assert resolution.outcome is AuthorityOutcome.UNPUBLISHED
+    assert resolution.binding is None
+
+
+def test_an_unpublished_package_row_is_unpublished(runtime: RuntimeFixture) -> None:
+    package = runtime.session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.package_uuid)
+        )
+    ).scalar_one()
+    package.publication_status = "draft"
+    runtime.session.flush()
+
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.UNPUBLISHED
+
+
+def test_a_disabled_package_is_absent(runtime: RuntimeFixture) -> None:
+    package = runtime.session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.package_uuid)
+        )
+    ).scalar_one()
+    package.is_enabled = False
+    runtime.session.flush()
+
+    assert (
+        service(runtime).resolve(package_uuid=runtime.package_uuid).outcome
+        is AuthorityOutcome.ABSENT
+    )
+
+
+def test_a_different_expected_release_is_a_mismatched_release(
+    runtime: RuntimeFixture,
+) -> None:
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, expected_release="5.2.1-something-else"
+    )
+    assert resolution.outcome is AuthorityOutcome.MISMATCHED_RELEASE
+    assert runtime.release_version in resolution.detail
+
+
+def test_a_recorded_binding_naming_another_release_is_mismatched(
+    runtime: RuntimeFixture,
+) -> None:
+    current = service(runtime).resolve(package_uuid=runtime.package_uuid).binding
+    assert current is not None
+    recorded = RulesPackageBinding(
+        package_uuid=current.package_uuid,
+        release_version="5.2.1-older",
+        mechanical_projection_uuid=current.mechanical_projection_uuid,
+        override_set_uuid=current.override_set_uuid,
+    )
+
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, recorded=recorded
+    )
+    assert resolution.outcome is AuthorityOutcome.MISMATCHED_RELEASE
+    # The refusal still reports what superseded it, so a caller need not
+    # resolve a second time to find out.
+    assert resolution.current_binding == current
+
+
+def test_a_recorded_binding_naming_another_projection_is_stale(
+    runtime: RuntimeFixture,
+) -> None:
+    current = service(runtime).resolve(package_uuid=runtime.package_uuid).binding
+    assert current is not None
+    recorded = RulesPackageBinding(
+        package_uuid=current.package_uuid,
+        release_version=current.release_version,
+        mechanical_projection_uuid=uuid4(),
+        override_set_uuid=current.override_set_uuid,
+    )
+
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, recorded=recorded
+    )
+    assert resolution.outcome is AuthorityOutcome.STALE
+
+
+def test_a_recorded_binding_naming_another_package_is_an_invalid_selector(
+    runtime: RuntimeFixture,
+) -> None:
+    """A binding for a different package is not stale — it is the wrong ask."""
+    current = service(runtime).resolve(package_uuid=runtime.package_uuid).binding
+    assert current is not None
+    recorded = RulesPackageBinding(
+        package_uuid=runtime.rival_package_uuid,
+        release_version=current.release_version,
+        mechanical_projection_uuid=current.mechanical_projection_uuid,
+        override_set_uuid=current.override_set_uuid,
+    )
+
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, recorded=recorded
+    )
+    assert resolution.outcome is AuthorityOutcome.INVALID_SELECTOR
+
+
+def test_an_activation_row_pointing_elsewhere_is_stale(
+    runtime: RuntimeFixture,
+) -> None:
+    """Activation is not self-certifying: a row alone is not authority."""
+    row = runtime.session.execute(
+        select(MechanicalActiveProjectionORM).where(
+            MechanicalActiveProjectionORM.package_uuid == str(runtime.package_uuid)
+        )
+    ).scalar_one()
+    runtime.session.delete(row)
+    runtime.session.flush()
+
+    assert (
+        service(runtime).resolve(package_uuid=runtime.package_uuid).outcome
+        is AuthorityOutcome.UNPUBLISHED
+    )
+
+
+def test_a_cross_release_override_is_an_invalid_override(
+    runtime: RuntimeFixture,
+) -> None:
+    """#137 contract 6: a cross-release patch fails explicitly.
+
+    Not filtered out, which would make the override invisible and let the
+    binding resolve to the identity of a package that never had it.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-cross-release",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        release_version="5.2.1-some-other-release",
+    )
+
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "authored against release" in resolution.detail
+
+
+def test_an_unreadable_override_row_is_an_invalid_override(
+    runtime: RuntimeFixture,
+) -> None:
+    """A row whose typed columns do not parse cannot be silently skipped."""
+    row = author_override(
+        runtime.session,
+        override_id="ov-bad-origin",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    row.override_origin = "not-an-origin"
+    runtime.session.flush()
+
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.INVALID_OVERRIDE

--- a/tests/services/rules_authority/test_override_identity.py
+++ b/tests/services/rules_authority/test_override_identity.py
@@ -1,0 +1,353 @@
+"""Override-set identity — ADR-005d Decision 9, #137 acceptance criterion 21.
+
+The identity is derived from the canonical ordered effective override state, and
+these tests are the contract for exactly what "effective override state" means:
+which changes must move it, and which must not.
+
+Every test here changes **one** thing. That is deliberate — an identity test
+that perturbs two fields at once proves only that something moved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from afterworlds.ingestion.mechanical.representation import (
+    SpellDescriptorFact,
+    SpellSchool,
+)
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
+from afterworlds.services.rules_authority import (
+    EMPTY_OVERRIDE_SET_UUID,
+    AuthorityOutcome,
+    MechanicalTarget,
+    MechanicalTargetKind,
+    RulesAuthorityService,
+    collect_current_override_state,
+    override_set_identity,
+)
+from tests.services.rules_authority.conftest import (
+    CHECK_COMPONENT_TARGET,
+    DESCRIPTOR_COMPONENT_TARGET,
+    DESCRIPTOR_FACT_TARGET,
+    DISABLE_PAYLOAD,
+    NOW,
+    PACKAGE_UUID,
+    RELEASE_VERSION,
+    SPELL_KEY,
+    RuntimeFixture,
+    append_fact_payload,
+    author_override,
+    replace_component_payload,
+    replace_fact_payload,
+)
+
+
+def identity(runtime: RuntimeFixture) -> str:
+    return collect_current_override_state(
+        runtime.session, PACKAGE_UUID, RELEASE_VERSION
+    ).override_set_uuid
+
+
+def resolved_identity(runtime: RuntimeFixture) -> str:
+    resolution = RulesAuthorityService(runtime.session, now=NOW).resolve(
+        package_uuid=runtime.package_uuid
+    )
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    assert resolution.binding is not None
+    return str(resolution.binding.override_set_uuid)
+
+
+# ---------------------------------------------------------------------------
+# The empty set
+# ---------------------------------------------------------------------------
+
+
+def test_the_empty_override_set_has_its_own_deterministic_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """ "No overrides" is a value, not the absence of one (Decision 9)."""
+    assert identity(runtime) == EMPTY_OVERRIDE_SET_UUID
+    assert override_set_identity(()) == EMPTY_OVERRIDE_SET_UUID
+    assert EMPTY_OVERRIDE_SET_UUID
+
+
+def test_the_resolved_binding_carries_the_empty_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """A package with no overrides still binds a real override-set UUID."""
+    assert resolved_identity(runtime) == EMPTY_OVERRIDE_SET_UUID
+
+
+def test_authoring_one_override_moves_the_identity(runtime: RuntimeFixture) -> None:
+    before = identity(runtime)
+    author_override(
+        runtime.session,
+        override_id="ov-1",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    assert identity(runtime) != before
+
+
+def test_removing_the_only_override_returns_to_the_empty_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    row = author_override(
+        runtime.session,
+        override_id="ov-1",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    assert identity(runtime) != EMPTY_OVERRIDE_SET_UUID
+    runtime.session.delete(row)
+    runtime.session.flush()
+    assert identity(runtime) == EMPTY_OVERRIDE_SET_UUID
+
+
+# ---------------------------------------------------------------------------
+# One change at a time
+# ---------------------------------------------------------------------------
+
+
+def _baseline(runtime: RuntimeFixture) -> str:
+    author_override(
+        runtime.session,
+        override_id="ov-baseline",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+        precedence=10,
+        origin=OverrideOriginEnum.HOUSE_RULE,
+    )
+    return identity(runtime)
+
+
+def test_recreating_an_identical_override_under_a_new_id_moves_the_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """#137 contract 5, negative control 1.
+
+    Provenance-exact, not merely mechanically equivalent: the same patch under a
+    different authoritative record is a different authority.
+    """
+    before = _baseline(runtime)
+    original = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert original is not None
+    runtime.session.delete(original)
+    runtime.session.flush()
+    author_override(
+        runtime.session,
+        override_id="ov-recreated",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+        precedence=10,
+        origin=OverrideOriginEnum.HOUSE_RULE,
+    )
+
+    assert identity(runtime) != before
+
+
+def test_changing_only_the_origin_moves_the_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """#137 contract 5, negative control 2.
+
+    A house rule and a package patch with identical mechanical contents are not
+    the same authority.
+    """
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    row.override_origin = OverrideOriginEnum.PACKAGE_PATCH.value
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_disabling_an_override_moves_the_identity(runtime: RuntimeFixture) -> None:
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    row.is_enabled = False
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_reprioritizing_an_override_moves_the_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    row.precedence = 999
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_reordering_two_overrides_moves_the_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """Order is part of the state, because order decides what wins."""
+    author_override(
+        runtime.session,
+        override_id="ov-a",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_component_payload(),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-b",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(),
+        precedence=20,
+    )
+    before = identity(runtime)
+
+    first = runtime.session.get(MechanicalOverrideORM, "ov-a")
+    second = runtime.session.get(MechanicalOverrideORM, "ov-b")
+    assert first is not None and second is not None
+    first.precedence, second.precedence = 20, 10
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_retargeting_an_override_moves_the_identity(runtime: RuntimeFixture) -> None:
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    row.target_component_key = "some-other-component"
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_changing_the_operation_moves_the_identity(runtime: RuntimeFixture) -> None:
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    row.override_operation = OverrideOperationEnum.DISABLE.value
+    row.payload = DISABLE_PAYLOAD
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_changing_the_payload_moves_the_identity(runtime: RuntimeFixture) -> None:
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    row.payload = replace_fact_payload(_other_descriptor())
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+# ---------------------------------------------------------------------------
+# What identity must *not* depend on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("created_at", "2027-01-01T00:00:00Z"),
+        ("created_by", "someone-else"),
+        ("note", "an operator comment added after the fact"),
+    ],
+)
+def test_incidental_audit_metadata_does_not_move_the_identity(
+    runtime: RuntimeFixture, field: str, value: str
+) -> None:
+    """Decision 9: audit metadata stays outside identity.
+
+    Creation timestamps, authors, and comments do not participate in
+    applicability, ordering, or resolution, so a re-annotated override is the
+    same authority.
+    """
+    before = _baseline(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-baseline")
+    assert row is not None
+    setattr(row, field, value)
+    runtime.session.flush()
+
+    assert identity(runtime) == before
+
+
+def test_package_scope_does_not_reach_inside_the_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """The enclosing binding supplies package scope (Decision 9).
+
+    Two packages with no overrides therefore share the empty identity — which is
+    what makes it *the* empty override set rather than one per package. The
+    binding still distinguishes them, because its other three components do.
+    """
+    primary = collect_current_override_state(
+        runtime.session, PACKAGE_UUID, RELEASE_VERSION
+    )
+    rival = collect_current_override_state(
+        runtime.session, str(runtime.rival_package_uuid), RELEASE_VERSION
+    )
+    assert primary.override_set_uuid == rival.override_set_uuid
+
+
+def test_identity_is_stable_across_repeated_derivation(
+    runtime: RuntimeFixture,
+) -> None:
+    """Content-derived means reproducible, not merely unique."""
+    _baseline(runtime)
+    assert identity(runtime) == identity(runtime) == resolved_identity(runtime)
+
+
+# ---------------------------------------------------------------------------
+# Target shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"kind": MechanicalTargetKind.COMPONENT, "record_key": SPELL_KEY},
+        {
+            "kind": MechanicalTargetKind.RECORD,
+            "record_key": SPELL_KEY,
+            "component_key": "c",
+        },
+        {
+            "kind": MechanicalTargetKind.FACT,
+            "record_key": SPELL_KEY,
+            "component_key": "c",
+        },
+        {
+            "kind": MechanicalTargetKind.COMPONENT,
+            "record_key": SPELL_KEY,
+            "component_key": "c",
+            "fact_key": "f",
+        },
+        {"kind": MechanicalTargetKind.RECORD, "record_key": "  "},
+    ],
+)
+def test_a_target_whose_keys_do_not_match_its_kind_is_refused(
+    kwargs: dict[str, object],
+) -> None:
+    """A target that identifies nothing cannot participate in an identity."""
+    with pytest.raises(Exception) as excinfo:
+        MechanicalTarget(**kwargs)  # type: ignore[arg-type]
+    assert "target" in str(excinfo.value)
+
+
+def _other_descriptor() -> SpellDescriptorFact:
+    return SpellDescriptorFact(
+        level=3, school=SpellSchool.EVOCATION, ritual=False, concentration=True
+    )

--- a/tests/services/rules_authority/test_override_identity.py
+++ b/tests/services/rules_authority/test_override_identity.py
@@ -28,6 +28,7 @@ from afterworlds.services.rules_authority import (
     override_set_identity,
 )
 from tests.services.rules_authority.conftest import (
+    ADDED_CHECK,
     CHECK_COMPONENT_TARGET,
     DESCRIPTOR_COMPONENT_TARGET,
     DESCRIPTOR_FACT_TARGET,
@@ -35,6 +36,7 @@ from tests.services.rules_authority.conftest import (
     NOW,
     PACKAGE_UUID,
     RELEASE_VERSION,
+    REPLACEMENT_DESCRIPTOR,
     SPELL_KEY,
     RuntimeFixture,
     append_fact_payload,
@@ -350,4 +352,53 @@ def test_a_target_whose_keys_do_not_match_its_kind_is_refused(
 def _other_descriptor() -> SpellDescriptorFact:
     return SpellDescriptorFact(
         level=3, school=SpellSchool.EVOCATION, ritual=False, concentration=True
+    )
+
+
+def test_identity_is_over_the_canonical_patch_not_the_stored_bytes(
+    runtime: RuntimeFixture,
+) -> None:
+    """Equivalent patches are one authority (ADR-005d Decision 9).
+
+    The identity covers the complete *validated* payload, so a payload that
+    lists the same facts in a different order canonicalizes to the same patch
+    and must not mint a second identity. Hashing the stored bytes directly is
+    the canonicalization gap this asserts against — the same defect family that
+    made partial sort keys leak authoring order into the projection UUID.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-order-a",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_component_payload((REPLACEMENT_DESCRIPTOR, ADDED_CHECK)),
+    )
+    forward = identity(runtime)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-order-a")
+    assert row is not None
+    row.payload = replace_component_payload((ADDED_CHECK, REPLACEMENT_DESCRIPTOR))
+    runtime.session.flush()
+
+    assert identity(runtime) == forward
+
+
+def test_a_payload_with_no_canonical_form_is_refused_not_identified(
+    runtime: RuntimeFixture,
+) -> None:
+    """A malformed override cannot be skipped into someone else's identity."""
+    author_override(
+        runtime.session,
+        override_id="ov-not-a-patch",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload={"patch": "replace_fact", "fact": {"family": "made_up"}},
+    )
+    with pytest.raises(Exception, match="closed typed-fact union"):
+        identity(runtime)
+    assert (
+        RulesAuthorityService(runtime.session, now=NOW)
+        .resolve(package_uuid=runtime.package_uuid)
+        .outcome
+        is AuthorityOutcome.INVALID_OVERRIDE
     )

--- a/tests/services/rules_authority/test_replay_and_staleness.py
+++ b/tests/services/rules_authority/test_replay_and_staleness.py
@@ -1,0 +1,325 @@
+"""Runtime staleness and historical replay — ADR-005d Decision 9.
+
+The two operations this module separates are the ones ADR-005d says are
+different, and the separation is the whole reason override-set versions are
+retained at all:
+
+* **Runtime** recomputes the override-set identity from current state. A
+  recorded binding that no longer matches is ``STALE`` and fails — never
+  silently re-resolved against whatever the overrides say now.
+* **Replay** resolves the retained immutable version and must succeed,
+  reconstructing what was originally applied, *after* the current rows are
+  edited, disabled, reprioritized, retargeted, or deleted. ``STALE`` is not a
+  valid answer here.
+
+The last test is the one ADR-005d's rejected-alternative 12 names directly: an
+implementation that retains only the identifier and re-derives from current rows
+must fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete, select
+
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.persistence.orm.rules_authority import (
+    MechanicalOverrideORM,
+    OverrideSetEntryORM,
+    OverrideSetVersionORM,
+)
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    OverrideSetRetentionError,
+    RulesAuthorityService,
+    load_override_set_version,
+)
+from tests.services.rules_authority.conftest import (
+    DESCRIPTOR_FACT_KEY,
+    DESCRIPTOR_FACT_TARGET,
+    DESCRIPTOR_KEY,
+    NOW,
+    SPELL_KEY,
+    RuntimeFixture,
+    author_override,
+    replace_fact_payload,
+)
+
+
+def service(runtime: RuntimeFixture) -> RulesAuthorityService:
+    return RulesAuthorityService(runtime.session, now=NOW)
+
+
+def _recorded_binding(runtime: RuntimeFixture):  # type: ignore[no-untyped-def]
+    """Author one override, resolve, and return the binding a consumer stores."""
+    author_override(
+        runtime.session,
+        override_id="ov-historic",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+        precedence=10,
+        origin=OverrideOriginEnum.HOUSE_RULE,
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    assert resolution.binding is not None
+    return resolution.binding
+
+
+# ---------------------------------------------------------------------------
+# Runtime staleness
+# ---------------------------------------------------------------------------
+
+
+def test_a_superseded_override_set_is_stale_at_runtime(
+    runtime: RuntimeFixture,
+) -> None:
+    """The recorded binding is refused, not quietly re-resolved."""
+    recorded = _recorded_binding(runtime)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-historic")
+    assert row is not None
+    row.precedence = 500
+    runtime.session.flush()
+
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, recorded=recorded
+    )
+    assert resolution.outcome is AuthorityOutcome.STALE
+    assert resolution.current_binding is not None
+    assert resolution.current_binding.override_set_uuid != recorded.override_set_uuid
+    # Everything else about the binding is unchanged: only the override set
+    # moved, and the base projection identity did not.
+    assert (
+        resolution.current_binding.mechanical_projection_uuid
+        == recorded.mechanical_projection_uuid
+    )
+
+
+def test_deleting_the_override_is_also_stale(runtime: RuntimeFixture) -> None:
+    recorded = _recorded_binding(runtime)
+    runtime.session.execute(
+        delete(MechanicalOverrideORM).where(
+            MechanicalOverrideORM.override_id == "ov-historic"
+        )
+    )
+    runtime.session.flush()
+
+    assert (
+        service(runtime)
+        .resolve(package_uuid=runtime.package_uuid, recorded=recorded)
+        .outcome
+        is AuthorityOutcome.STALE
+    )
+
+
+def test_a_current_binding_is_not_stale(runtime: RuntimeFixture) -> None:
+    """The check has to be capable of passing, or it proves nothing."""
+    recorded = _recorded_binding(runtime)
+    resolution = service(runtime).resolve(
+        package_uuid=runtime.package_uuid, recorded=recorded
+    )
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    assert resolution.binding == recorded
+
+
+# ---------------------------------------------------------------------------
+# Replay
+# ---------------------------------------------------------------------------
+
+
+def test_replay_reconstructs_the_original_authority_after_mutation(
+    runtime: RuntimeFixture,
+) -> None:
+    """#137 contract 5, negative control 3.
+
+    The recorded binding reconstructs the exact identities, origins, order,
+    targets, operations, enablement, and payloads originally applied — after the
+    current row has been retargeted, reprioritized, disabled, and re-originated.
+    """
+    recorded = _recorded_binding(runtime)
+    original = service(runtime).replay(recorded)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-historic")
+    assert row is not None
+    row.precedence = 900
+    row.is_enabled = False
+    row.override_origin = OverrideOriginEnum.PACKAGE_PATCH.value
+    row.target_component_key = "somewhere-else"
+    runtime.session.flush()
+
+    replayed = service(runtime).replay(recorded)
+
+    assert replayed.applied_overrides == original.applied_overrides
+    (applied,) = replayed.applied_overrides
+    assert applied.override_id == "ov-historic"
+    assert applied.origin is OverrideOriginEnum.HOUSE_RULE
+    assert applied.operation is OverrideOperationEnum.REPLACE
+    assert applied.precedence == 10
+    assert applied.apply_order == 0
+    assert applied.is_enabled is True
+    assert applied.target == DESCRIPTOR_FACT_TARGET
+    assert applied.payload == replace_fact_payload()
+    assert applied.applied is True
+    # And the reconstructed mechanical result is the original one too.
+    assert replayed.records == original.records
+
+
+def test_replay_survives_deletion_of_the_current_override(
+    runtime: RuntimeFixture,
+) -> None:
+    """Current rows are the authoring surface, not the replay evidence."""
+    recorded = _recorded_binding(runtime)
+    original = service(runtime).replay(recorded)
+
+    runtime.session.execute(
+        delete(MechanicalOverrideORM).where(
+            MechanicalOverrideORM.override_id == "ov-historic"
+        )
+    )
+    runtime.session.flush()
+    assert runtime.session.execute(select(MechanicalOverrideORM)).all() == []
+
+    replayed = service(runtime).replay(recorded)
+    assert replayed.applied_overrides == original.applied_overrides
+    assert replayed.records == original.records
+
+
+def test_replay_identifies_the_complete_effective_binding(
+    runtime: RuntimeFixture,
+) -> None:
+    """Replay evidence names all four components that produced it."""
+    recorded = _recorded_binding(runtime)
+    replayed = service(runtime).replay(recorded)
+    assert replayed.binding == recorded
+
+
+def test_replay_of_an_unretained_version_is_a_retention_defect(
+    runtime: RuntimeFixture,
+) -> None:
+    """Not ``STALE``: a missing version is a defect in retention itself."""
+    recorded = _recorded_binding(runtime)
+    runtime.session.execute(
+        delete(OverrideSetEntryORM).where(
+            OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+        )
+    )
+    runtime.session.execute(
+        delete(OverrideSetVersionORM).where(
+            OverrideSetVersionORM.override_set_uuid == str(recorded.override_set_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    with pytest.raises(OverrideSetRetentionError, match="no retained override-set"):
+        service(runtime).replay(recorded)
+
+
+def test_a_retained_version_that_no_longer_derives_its_identity_is_a_defect(
+    runtime: RuntimeFixture,
+) -> None:
+    """Retained evidence is verified on read, never trusted for being stored."""
+    recorded = _recorded_binding(runtime)
+    entry = runtime.session.execute(
+        select(OverrideSetEntryORM).where(
+            OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+        )
+    ).scalar_one()
+    entry.precedence = 77
+    runtime.session.flush()
+
+    with pytest.raises(OverrideSetRetentionError, match="reconstructs as"):
+        load_override_set_version(runtime.session, str(recorded.override_set_uuid))
+
+
+def test_a_retained_version_missing_an_entry_is_a_defect(
+    runtime: RuntimeFixture,
+) -> None:
+    recorded = _recorded_binding(runtime)
+    runtime.session.execute(
+        delete(OverrideSetEntryORM).where(
+            OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    with pytest.raises(OverrideSetRetentionError, match="entries"):
+        load_override_set_version(runtime.session, str(recorded.override_set_uuid))
+
+
+def test_retaining_the_same_state_twice_is_idempotent(
+    runtime: RuntimeFixture,
+) -> None:
+    """Identity is the primary key, so an identical state is the same version."""
+    recorded = _recorded_binding(runtime)
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+
+    versions = (
+        runtime.session.execute(
+            select(OverrideSetVersionORM).where(
+                OverrideSetVersionORM.override_set_uuid
+                == str(recorded.override_set_uuid)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(versions) == 1
+    entries = (
+        runtime.session.execute(
+            select(OverrideSetEntryORM).where(
+                OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(entries) == 1
+
+
+def test_current_rows_cannot_substitute_for_retained_provenance(
+    runtime: RuntimeFixture,
+) -> None:
+    """#137 contract 5, negative control 4 — stated as an equivalence failure.
+
+    An implementation that kept only the ``override_set_uuid`` and re-derived
+    from current rows would answer this replay with *today's* authority. The
+    assertion is that replay and a fresh derivation from current state disagree,
+    and that replay is the one that still matches what was recorded.
+    """
+    recorded = _recorded_binding(runtime)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-historic")
+    assert row is not None
+    row.payload = replace_fact_payload(_third_descriptor())
+    runtime.session.flush()
+
+    current = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert current.outcome is AuthorityOutcome.RESOLVED
+    assert current.binding is not None
+    assert current.binding.override_set_uuid != recorded.override_set_uuid
+
+    replayed = service(runtime).replay(recorded)
+    (applied,) = replayed.applied_overrides
+    assert applied.payload == replace_fact_payload()
+    assert applied.payload != replace_fact_payload(_third_descriptor())
+
+    # And the replayed mechanical value is the original one, not the current.
+    (record,) = [r for r in replayed.records if r.semantic_key == SPELL_KEY]
+    (component,) = [c for c in record.components if c.semantic_key == DESCRIPTOR_KEY]
+    (fact,) = component.facts
+    assert fact.fact.level == 7
+    assert fact.fact_key != DESCRIPTOR_FACT_KEY
+
+
+def _third_descriptor():  # type: ignore[no-untyped-def]
+    from afterworlds.ingestion.mechanical.representation import (
+        SpellDescriptorFact,
+        SpellSchool,
+    )
+
+    return SpellDescriptorFact(
+        level=2, school=SpellSchool.NECROMANCY, ritual=False, concentration=False
+    )

--- a/tests/services/rules_authority/test_replay_and_staleness.py
+++ b/tests/services/rules_authority/test_replay_and_staleness.py
@@ -23,6 +23,7 @@ import pytest
 from sqlalchemy import delete, select
 
 from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.models.rules_package import RulesPackageBinding
 from afterworlds.persistence.orm.rules_authority import (
     MechanicalOverrideORM,
     OverrideSetEntryORM,
@@ -43,11 +44,22 @@ from tests.services.rules_authority.conftest import (
     RuntimeFixture,
     author_override,
     replace_fact_payload,
+    without_append_only_triggers,
 )
 
 
 def service(runtime: RuntimeFixture) -> RulesAuthorityService:
     return RulesAuthorityService(runtime.session, now=NOW)
+
+
+def _load(runtime: RuntimeFixture, recorded: RulesPackageBinding):  # type: ignore[no-untyped-def]
+    """Load a retained version with the scope its binding supplies."""
+    return load_override_set_version(
+        runtime.session,
+        str(recorded.override_set_uuid),
+        package_uuid=str(recorded.package_uuid),
+        release_version=recorded.release_version,
+    )
 
 
 def _recorded_binding(runtime: RuntimeFixture):  # type: ignore[no-untyped-def]
@@ -200,17 +212,19 @@ def test_replay_of_an_unretained_version_is_a_retention_defect(
 ) -> None:
     """Not ``STALE``: a missing version is a defect in retention itself."""
     recorded = _recorded_binding(runtime)
-    runtime.session.execute(
-        delete(OverrideSetEntryORM).where(
-            OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+    with without_append_only_triggers(runtime.session):
+        runtime.session.execute(
+            delete(OverrideSetEntryORM).where(
+                OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+            )
         )
-    )
-    runtime.session.execute(
-        delete(OverrideSetVersionORM).where(
-            OverrideSetVersionORM.override_set_uuid == str(recorded.override_set_uuid)
+        runtime.session.execute(
+            delete(OverrideSetVersionORM).where(
+                OverrideSetVersionORM.override_set_uuid
+                == str(recorded.override_set_uuid)
+            )
         )
-    )
-    runtime.session.flush()
+        runtime.session.flush()
 
     with pytest.raises(OverrideSetRetentionError, match="no retained override-set"):
         service(runtime).replay(recorded)
@@ -226,26 +240,28 @@ def test_a_retained_version_that_no_longer_derives_its_identity_is_a_defect(
             OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
         )
     ).scalar_one()
-    entry.precedence = 77
-    runtime.session.flush()
+    with without_append_only_triggers(runtime.session):
+        entry.precedence = 77
+        runtime.session.flush()
 
     with pytest.raises(OverrideSetRetentionError, match="reconstructs as"):
-        load_override_set_version(runtime.session, str(recorded.override_set_uuid))
+        _load(runtime, recorded)
 
 
 def test_a_retained_version_missing_an_entry_is_a_defect(
     runtime: RuntimeFixture,
 ) -> None:
     recorded = _recorded_binding(runtime)
-    runtime.session.execute(
-        delete(OverrideSetEntryORM).where(
-            OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+    with without_append_only_triggers(runtime.session):
+        runtime.session.execute(
+            delete(OverrideSetEntryORM).where(
+                OverrideSetEntryORM.override_set_uuid == str(recorded.override_set_uuid)
+            )
         )
-    )
-    runtime.session.flush()
+        runtime.session.flush()
 
     with pytest.raises(OverrideSetRetentionError, match="entries"):
-        load_override_set_version(runtime.session, str(recorded.override_set_uuid))
+        _load(runtime, recorded)
 
 
 def test_retaining_the_same_state_twice_is_idempotent(

--- a/tests/services/rules_authority/test_retention_closure.py
+++ b/tests/services/rules_authority/test_retention_closure.py
@@ -21,6 +21,13 @@ Concurrency here is deterministic. Two real connections are driven through
 ``threading.Barrier`` so both are provably past the point where the old
 query-then-insert had already decided the row was absent; there are no sleeps and
 no timing assumptions.
+
+Round 4 added the transactionality half of the same family. The savepoint is
+only a *nested* savepoint if SQLite has issued a physical ``BEGIN``; after a
+read-only prelude it had not, so releasing the savepoint committed the retained
+rows out of the caller's control. Those controls assert from an independent
+session, since that is the only way to distinguish "committed" from "pending in
+this session's transaction".
 """
 
 from __future__ import annotations
@@ -38,6 +45,7 @@ from afterworlds.ingestion.mechanical.persistence import ProjectionNotPersistedE
 from afterworlds.models.enums import OverrideOperationEnum
 from afterworlds.persistence.database import create_session_factory
 from afterworlds.persistence.orm.rules_authority import (
+    MechanicalOverrideORM,
     OverrideSetEntryORM,
     OverrideSetScopeORM,
     OverrideSetVersionORM,
@@ -519,6 +527,170 @@ def test_an_identical_reinsert_is_a_no_op_and_a_differing_one_is_refused(
             {"i": identity, "n": count + 1},
         )
     runtime.session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Retention participates in the caller's *physical* transaction
+# ---------------------------------------------------------------------------
+#
+# Codex review round 4. The savepoint above is only a nested savepoint if SQLite
+# has actually issued ``BEGIN``. Under ``sqlite3``'s legacy transaction control
+# a session that has only read is still in autocommit, so the savepoint was the
+# outermost one and releasing it committed the retained rows — a caller's later
+# rollback could not take them back. These controls assert the boundary from a
+# separate session, because rows already committed are visible from anywhere and
+# rows merely pending in another session's transaction are visible from nowhere:
+# a same-session assertion cannot tell the two apart.
+
+
+def _retained_rows_elsewhere(engine: Engine, identity: str) -> tuple[int, int, int]:
+    """Count retained rows for *identity* on a genuinely independent session."""
+    with create_session_factory(engine)() as other:
+        return (
+            _count(other, OverrideSetVersionORM, identity),
+            _count(other, OverrideSetEntryORM, identity),
+            _count(other, OverrideSetScopeORM, identity),
+        )
+
+
+def _authored_state(session: Session, runtime: RuntimeFixture, override_id: str):  # type: ignore[no-untyped-def]
+    """Author one override on *session* and collect the state it implies."""
+    author_override(
+        session,
+        override_id=override_id,
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    return collect_current_override_state(
+        session, str(runtime.package_uuid), runtime.release_version
+    )
+
+
+def test_retention_after_a_read_only_prelude_rolls_back_with_the_caller(
+    runtime: RuntimeFixture,
+) -> None:
+    """The reported defect, asserted end to end on the ordinary path.
+
+    No DML precedes the resolution, so before this fix SQLite had issued no
+    ``BEGIN``, the retention savepoint was the outermost one, and releasing it
+    committed. The rollback below is the caller changing its mind; nothing
+    retained may survive it.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-txn",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    runtime.session.commit()
+
+    with create_session_factory(runtime.engine)() as session:
+        # A read-only prelude, exactly as binding resolution performs it.
+        result = service(session).resolve(package_uuid=runtime.package_uuid)
+        assert result.binding is not None
+        identity = str(result.binding.override_set_uuid)
+        # Pending in this session, and nowhere else.
+        assert _count(session, OverrideSetVersionORM, identity) == 1
+        assert _retained_rows_elsewhere(runtime.engine, identity) == (0, 0, 0)
+        session.rollback()
+
+    assert _retained_rows_elsewhere(runtime.engine, identity) == (0, 0, 0)
+
+
+def test_retention_rolls_back_when_later_work_in_an_explicit_block_raises(
+    runtime: RuntimeFixture,
+) -> None:
+    """``with session.begin():`` must own the boundary, not the savepoint."""
+    author_override(
+        runtime.session,
+        override_id="ov-txn-block",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    runtime.session.commit()
+
+    identity: str | None = None
+    with (
+        create_session_factory(runtime.engine)() as session,
+        pytest.raises(RuntimeError, match="later work fails"),
+        session.begin(),
+    ):
+        result = service(session).resolve(package_uuid=runtime.package_uuid)
+        assert result.binding is not None
+        identity = str(result.binding.override_set_uuid)
+        raise RuntimeError("later work fails")
+
+    assert identity is not None
+    assert _retained_rows_elsewhere(runtime.engine, identity) == (0, 0, 0)
+
+
+def test_retention_can_be_retried_and_committed_after_an_enclosing_rollback(
+    runtime: RuntimeFixture,
+) -> None:
+    """A rolled-back retention is genuinely absent, not a poisoned identity."""
+    author_override(
+        runtime.session,
+        override_id="ov-txn-retry",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    runtime.session.commit()
+
+    with create_session_factory(runtime.engine)() as session:
+        first = service(session).resolve(package_uuid=runtime.package_uuid)
+        assert first.binding is not None
+        identity = str(first.binding.override_set_uuid)
+        session.rollback()
+    assert _retained_rows_elsewhere(runtime.engine, identity) == (0, 0, 0)
+
+    with create_session_factory(runtime.engine)() as session:
+        again = service(session).resolve(package_uuid=runtime.package_uuid)
+        assert again.binding is not None
+        assert str(again.binding.override_set_uuid) == identity
+        session.commit()
+
+    assert _retained_rows_elsewhere(runtime.engine, identity) == (1, 1, 1)
+
+    # And the committed evidence replays, so the retry produced usable
+    # provenance rather than merely the right number of rows.
+    with create_session_factory(runtime.engine)() as session:
+        binding = _binding_for(runtime, identity)
+        assert service(session).replay(binding).binding == binding
+
+
+def test_retention_does_not_commit_the_callers_earlier_work(
+    runtime: RuntimeFixture,
+) -> None:
+    """Unrelated pending work must not be made durable by a retention.
+
+    Stated as an invariant rather than as a reproduction: authoring an override
+    is itself DML, so the driver has already opened a physical transaction by the
+    time retention runs and this held even while the defect existed. It is the
+    other half of the boundary — retention must neither commit its own rows nor
+    anyone else's — and it is asserted because a future change that reached for a
+    commit inside retention would break it and nothing else here would notice.
+    """
+    runtime.session.commit()
+    with create_session_factory(runtime.engine)() as session:
+        state = _authored_state(session, runtime, "ov-txn-bystander")
+        identity = state.override_set_uuid
+        retain_override_set(session, state, now=NOW)
+        session.rollback()
+
+    with create_session_factory(runtime.engine)() as other:
+        assert (
+            other.execute(
+                select(func.count())
+                .select_from(MechanicalOverrideORM)
+                .where(MechanicalOverrideORM.override_id == "ov-txn-bystander")
+            ).scalar_one()
+            == 0
+        )
+    assert _retained_rows_elsewhere(runtime.engine, identity) == (0, 0, 0)
 
 
 def test_the_fixture_installs_the_documented_trigger_set() -> None:

--- a/tests/services/rules_authority/test_retention_closure.py
+++ b/tests/services/rules_authority/test_retention_closure.py
@@ -1,0 +1,534 @@
+"""Retained-evidence persistence closure and transactional idempotency.
+
+Codex review round 3. Two symptoms, one architectural family: **retained
+evidence must be durable against every non-contractual path, and creating it
+must be safe when two sessions do it at once.**
+
+* A live scope association was directly deletable. Replay failed closed
+  afterwards, but the evidence proving which package a retained version belonged
+  to was gone and could not be reconstructed.
+* ``retain_override_set`` established idempotency by querying for absence and
+  inserting into the gap. Two sessions both observe absence, both insert, and the
+  loser takes a uniqueness violation, a trigger abort, or a lock error for doing
+  exactly what it was asked to.
+
+The fix is one design, not two patches: content-aware ``BEFORE INSERT`` guards
+plus ``INSERT ... ON CONFLICT DO NOTHING``, under one savepoint. Neither half is
+safe alone — an existence-based guard aborts the upsert before conflict
+resolution is reached, which is verified below rather than assumed.
+
+Concurrency here is deterministic. Two real connections are driven through
+``threading.Barrier`` so both are provably past the point where the old
+query-then-insert had already decided the row was absent; there are no sleeps and
+no timing assumptions.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from sqlalchemy import Engine, delete, func, select, text
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.persistence import ProjectionNotPersistedError
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.persistence.database import create_session_factory
+from afterworlds.persistence.orm.rules_authority import (
+    OverrideSetEntryORM,
+    OverrideSetScopeORM,
+    OverrideSetVersionORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority import (
+    OverrideSetRetentionError,
+    RulesAuthorityService,
+    collect_current_override_state,
+    retain_override_set,
+)
+from tests.services.rules_authority.conftest import (
+    DESCRIPTOR_FACT_TARGET,
+    NOW,
+    RuntimeFixture,
+    author_override,
+    replace_fact_payload,
+)
+
+#: Every trigger migration 0024 installs on the retained-evidence tables.
+EXPECTED_TRIGGERS = (
+    "prevent_rp_override_set_versions_update",
+    "prevent_rp_override_set_versions_delete",
+    "prevent_rp_override_set_versions_reinsert",
+    "prevent_rp_override_set_entries_update",
+    "prevent_rp_override_set_entries_delete",
+    "prevent_rp_override_set_entries_reinsert",
+    "prevent_rp_override_set_scopes_update",
+    "prevent_rp_override_set_scopes_delete",
+    "seal_rp_override_set_entries",
+)
+
+
+def service(session: Session) -> RulesAuthorityService:
+    return RulesAuthorityService(session, now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic concurrency harness
+# ---------------------------------------------------------------------------
+
+
+def _run_concurrently(
+    engine: Engine, work: list[Callable[[Session], Any]]
+) -> list[Any]:
+    """Run *work* on one fresh session each, synchronised by a barrier.
+
+    Each worker opens its own session, does its reads, waits at the barrier, and
+    only then writes. That makes the interleaving the defect needs — every worker
+    past its existence check before any worker inserts — a property of the test
+    rather than of the scheduler. Results are returned in submission order;
+    exceptions are returned rather than raised so a caller can assert on them.
+    """
+    factory = create_session_factory(engine)
+    results: list[Any] = [None] * len(work)
+
+    def _worker(index: int) -> None:
+        with factory() as session:
+            try:
+                results[index] = work[index](session)
+                session.commit()
+            except Exception as exc:  # noqa: BLE001 - returned for assertion
+                session.rollback()
+                results[index] = exc
+
+    threads = [
+        threading.Thread(target=_worker, args=(i,), name=f"retain-{i}")
+        for i in range(len(work))
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+    assert not any(t.is_alive() for t in threads), "concurrency harness deadlocked"
+    return results
+
+
+def _retain_after_barrier(
+    barrier: threading.Barrier, package_uuid: str, release_version: str
+) -> Callable[[Session], str]:
+    """Collect state, wait for every worker, then retain.
+
+    The read happens before the barrier and the write after it, so both workers
+    have provably observed the same absent state before either writes — the exact
+    interleaving the removed query-then-insert could not survive.
+    """
+
+    def _work(session: Session) -> str:
+        state = collect_current_override_state(session, package_uuid, release_version)
+        barrier.wait(timeout=30)
+        return retain_override_set(session, state, now=NOW)
+
+    return _work
+
+
+# ---------------------------------------------------------------------------
+# 1. Concurrent first retention of the same version and the same scope
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_first_retention_of_identical_content_and_scope(
+    runtime: RuntimeFixture,
+) -> None:
+    """Both callers converge on one valid result; neither sees a race error."""
+    author_override(
+        runtime.session,
+        override_id="ov-concurrent",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    runtime.session.commit()
+
+    package = str(runtime.package_uuid)
+    release = runtime.release_version
+    barrier = threading.Barrier(2)
+    results = _run_concurrently(
+        runtime.engine,
+        [_retain_after_barrier(barrier, package, release) for _ in range(2)],
+    )
+
+    for result in results:
+        assert not isinstance(result, Exception), f"race surfaced as failure: {result}"
+    assert results[0] == results[1]
+
+    identity = results[0]
+    runtime.session.rollback()
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 1
+    assert _count(runtime.session, OverrideSetScopeORM, identity) == 1
+    assert _count(runtime.session, OverrideSetEntryORM, identity) == 1
+    # And the converged evidence is usable, not merely present.
+    binding = _binding_for(runtime, identity)
+    assert service(runtime.session).replay(binding).binding == binding
+
+
+def _count(session: Session, model: type, identity: str) -> int:
+    return (
+        session.execute(
+            select(func.count())
+            .select_from(model)
+            .where(model.override_set_uuid == identity)  # type: ignore[attr-defined]
+        ).scalar_one()
+        or 0
+    )
+
+
+def _binding_for(runtime: RuntimeFixture, identity: str):  # type: ignore[no-untyped-def]
+    from uuid import UUID
+
+    from afterworlds.models.rules_package import RulesPackageBinding
+
+    return RulesPackageBinding(
+        package_uuid=runtime.package_uuid,
+        release_version=runtime.release_version,
+        mechanical_projection_uuid=runtime.projection_uuid,
+        override_set_uuid=UUID(identity),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Concurrent retention of shared content under different scopes
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_retention_of_shared_content_under_different_scopes(
+    runtime: RuntimeFixture,
+) -> None:
+    """One immutable version, both valid associations.
+
+    Both packages have no overrides, so both resolve the same empty override-set
+    identity — the sharing case that makes the association table necessary in the
+    first place.
+    """
+    runtime.session.commit()
+    barrier = threading.Barrier(2)
+    results = _run_concurrently(
+        runtime.engine,
+        [
+            _retain_after_barrier(
+                barrier, str(runtime.package_uuid), runtime.release_version
+            ),
+            _retain_after_barrier(
+                barrier,
+                str(runtime.rival_package_uuid),
+                runtime.rival_release_version,
+            ),
+        ],
+    )
+
+    for result in results:
+        assert not isinstance(result, Exception), f"race surfaced as failure: {result}"
+    assert results[0] == results[1], "shared content must converge on one identity"
+
+    identity = results[0]
+    runtime.session.rollback()
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 1
+    scopes = {
+        (row.package_uuid, row.release_version)
+        for row in runtime.session.execute(
+            select(OverrideSetScopeORM).where(
+                OverrideSetScopeORM.override_set_uuid == identity
+            )
+        )
+        .scalars()
+        .all()
+    }
+    assert scopes == {
+        (str(runtime.package_uuid), runtime.release_version),
+        (str(runtime.rival_package_uuid), runtime.rival_release_version),
+    }
+
+
+def test_repeated_sequential_retention_stays_idempotent(
+    runtime: RuntimeFixture,
+) -> None:
+    """The ordinary path must survive the guards that make the race safe.
+
+    Binding resolution retains on every read, so a guard that refused the second
+    identical write would break every second resolution. Asserted against the
+    row counts, not just the absence of an exception.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-repeat",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    identities = {
+        service(runtime.session)
+        .resolve(package_uuid=runtime.package_uuid)
+        .binding.override_set_uuid  # type: ignore[union-attr]
+        for _ in range(4)
+    }
+    assert len(identities) == 1
+    identity = str(next(iter(identities)))
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 1
+    assert _count(runtime.session, OverrideSetScopeORM, identity) == 1
+    assert _count(runtime.session, OverrideSetEntryORM, identity) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. A live scope association is not directly deletable
+# ---------------------------------------------------------------------------
+
+
+def test_direct_scope_deletion_is_rejected_while_the_package_lives(
+    runtime: RuntimeFixture,
+) -> None:
+    """The evidence a binding depends on cannot be destroyed out from under it."""
+    service(runtime.session).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(delete(OverrideSetScopeORM))
+    runtime.session.rollback()
+
+
+def test_direct_scope_deletion_by_raw_sql_is_rejected(
+    runtime: RuntimeFixture,
+) -> None:
+    """Guarded at the database, so an ORM-free path is refused too."""
+    service(runtime.session).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(text("DELETE FROM rp_override_set_scopes"))
+    runtime.session.rollback()
+
+
+def test_scope_mutation_is_rejected(runtime: RuntimeFixture) -> None:
+    """Relabelling an association onto another package is a rewrite, not a move."""
+    service(runtime.session).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(
+            text("UPDATE rp_override_set_scopes SET package_uuid = 'elsewhere'")
+        )
+    runtime.session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# 4. Intentional package deletion keeps its contractual cascade
+# ---------------------------------------------------------------------------
+
+
+def test_package_deletion_still_cascades_its_own_association(
+    runtime: RuntimeFixture,
+) -> None:
+    """The one contractual way an association goes away, still working.
+
+    SQLite removes the parent row before cascading, so the delete guard's
+    condition is already false by the time the child trigger fires. That is what
+    lets the guard block a direct delete without also blocking this.
+    """
+    primary = service(runtime.session).resolve(package_uuid=runtime.package_uuid)
+    rival = service(runtime.session).resolve(package_uuid=runtime.rival_package_uuid)
+    assert primary.binding is not None and rival.binding is not None
+    identity = str(primary.binding.override_set_uuid)
+    assert _count(runtime.session, OverrideSetScopeORM, identity) == 2
+
+    runtime.session.execute(
+        delete(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.rival_package_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    # Only the deleted package's association went; the shared version and the
+    # surviving package's association are untouched, and it still replays.
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 1
+    remaining = {
+        row.package_uuid
+        for row in runtime.session.execute(
+            select(OverrideSetScopeORM).where(
+                OverrideSetScopeORM.override_set_uuid == identity
+            )
+        )
+        .scalars()
+        .all()
+    }
+    assert remaining == {str(runtime.package_uuid)}
+    assert service(runtime.session).replay(primary.binding).binding == primary.binding
+
+
+def test_replay_for_a_deleted_package_fails_closed(
+    runtime: RuntimeFixture,
+) -> None:
+    """Its own bindings die with it — reported, never replayed unscoped.
+
+    Deleting a package cascades to its corpus release and therefore to its
+    mechanical projection as well, so replay refuses at whichever proof it
+    reaches first. The contract asserted here is that it *refuses*, never that a
+    particular layer is the one to notice: both are typed defects, and neither
+    returns authority.
+    """
+    rival = service(runtime.session).resolve(package_uuid=runtime.rival_package_uuid)
+    assert rival.binding is not None
+    runtime.session.execute(
+        delete(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.rival_package_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    with pytest.raises((OverrideSetRetentionError, ProjectionNotPersistedError)):
+        service(runtime.session).replay(rival.binding)
+
+
+# ---------------------------------------------------------------------------
+# 5. Partial failure rolls the whole retention unit back
+# ---------------------------------------------------------------------------
+
+
+def test_a_failure_part_way_through_retention_leaves_nothing_behind(
+    runtime: RuntimeFixture,
+) -> None:
+    """No orphan snapshot, and the caller's transaction survives.
+
+    The scope insert is made to fail by pointing the state at a package that does
+    not exist, so the foreign key rejects it *after* the version and its entries
+    have already been written inside the unit. Everything must unwind together.
+    """
+    from dataclasses import replace as dc_replace
+
+    author_override(
+        runtime.session,
+        override_id="ov-partial",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    state = collect_current_override_state(
+        runtime.session, str(runtime.package_uuid), runtime.release_version
+    )
+    identity = state.override_set_uuid
+    doomed = dc_replace(state, package_uuid="00000000-0000-0000-0000-000000000000")
+
+    with pytest.raises((IntegrityError, OperationalError)):
+        retain_override_set(runtime.session, doomed, now=NOW)
+
+    # No full rollback here on purpose: the savepoint must have unwound the
+    # retention unit *without* discarding the caller's transaction, so the
+    # override authored above is still pending and the counts below are read
+    # from a live session.
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 0
+    assert _count(runtime.session, OverrideSetEntryORM, identity) == 0
+    assert _count(runtime.session, OverrideSetScopeORM, identity) == 0
+
+    # The session is still usable, and a correct retention afterwards succeeds.
+    good = collect_current_override_state(
+        runtime.session, str(runtime.package_uuid), runtime.release_version
+    )
+    assert retain_override_set(runtime.session, good, now=NOW) == identity
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 1
+    assert _count(runtime.session, OverrideSetScopeORM, identity) == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Replay accepts only properly scoped retained evidence
+# ---------------------------------------------------------------------------
+
+
+def test_replay_accepts_only_properly_scoped_evidence(
+    runtime: RuntimeFixture,
+) -> None:
+    """Cross-package and cross-release refused; the correct scope accepted."""
+    from afterworlds.models.rules_package import RulesPackageBinding
+    from afterworlds.services.rules_authority import load_override_set_version
+
+    author_override(
+        runtime.session,
+        override_id="ov-scope-check",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    primary = service(runtime.session).resolve(package_uuid=runtime.package_uuid)
+    assert primary.binding is not None
+    identity = str(primary.binding.override_set_uuid)
+
+    # The scope it was retained under: accepted.
+    assert service(runtime.session).replay(primary.binding).binding == primary.binding
+
+    # Another package, carrying its own genuine projection: refused. Reachable
+    # end to end because both projections share semantic keys, so the override
+    # would otherwise find a live target and replay with the wrong provenance.
+    cross_package = RulesPackageBinding(
+        package_uuid=runtime.rival_package_uuid,
+        release_version=runtime.rival_release_version,
+        mechanical_projection_uuid=runtime.rival_projection_uuid,
+        override_set_uuid=primary.binding.override_set_uuid,
+    )
+    with pytest.raises(OverrideSetRetentionError, match="was never retained for"):
+        service(runtime.session).replay(cross_package)
+
+    # The right package under a release it was never retained for: refused.
+    # Asserted at the retention seam, because a binding naming a foreign release
+    # is stopped earlier still by the projection coherence check.
+    with pytest.raises(OverrideSetRetentionError, match="was never retained for"):
+        load_override_set_version(
+            runtime.session,
+            identity,
+            package_uuid=str(runtime.package_uuid),
+            release_version="5.2.1-never-retained",
+        )
+
+
+# ---------------------------------------------------------------------------
+# The guard shape and the insert shape are one design
+# ---------------------------------------------------------------------------
+
+
+def test_an_identical_reinsert_is_a_no_op_and_a_differing_one_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    """The property the whole concurrency fix rests on, asserted directly.
+
+    An existence-based guard would abort both of these. Only a content-aware one
+    distinguishes a benign repeat from a rewrite, which is what lets
+    ``ON CONFLICT DO NOTHING`` carry the idempotency.
+    """
+    service(runtime.session).resolve(package_uuid=runtime.package_uuid)
+    row = runtime.session.execute(select(OverrideSetVersionORM)).scalars().first()
+    assert row is not None
+    identity, count = row.override_set_uuid, row.entry_count
+
+    runtime.session.execute(
+        text(
+            "INSERT INTO rp_override_set_versions (override_set_uuid, entry_count,"
+            " recorded_at) VALUES (:i, :n, 'later') ON CONFLICT DO NOTHING"
+        ),
+        {"i": identity, "n": count},
+    )
+    runtime.session.flush()
+    assert _count(runtime.session, OverrideSetVersionORM, identity) == 1
+
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(
+            text(
+                "INSERT INTO rp_override_set_versions (override_set_uuid, entry_count,"
+                " recorded_at) VALUES (:i, :n, 'later') ON CONFLICT DO NOTHING"
+            ),
+            {"i": identity, "n": count + 1},
+        )
+    runtime.session.rollback()
+
+
+def test_the_fixture_installs_the_documented_trigger_set() -> None:
+    """The fixture's mirror is the full set, named explicitly.
+
+    ``create_all`` does not create triggers, so the suite installs them by hand
+    and hand-mirroring is how a fixture drifts from production. This pins the
+    names; ``tests/persistence/test_rules_authority_migration.py`` runs the real
+    migration and asserts the database ends up with exactly these.
+    """
+    from tests.services.rules_authority.conftest import _trigger_names
+
+    assert sorted(_trigger_names()) == sorted(EXPECTED_TRIGGERS)

--- a/tests/services/rules_authority/test_review_round_1_regressions.py
+++ b/tests/services/rules_authority/test_review_round_1_regressions.py
@@ -1,0 +1,297 @@
+"""Regression controls for Codex review round 1 (four P1 findings).
+
+Grouped here rather than scattered into the suites they touch, because the four
+findings are two defect *families* and the families are what the controls are
+about:
+
+* **A resolution that returns success without proving what it names.**
+  ``resolve_package_reference`` accepted any syntactically valid UUID, and
+  ``replay`` loaded an override set and a projection without checking they
+  describe one authority.
+* **Retained replay evidence that is not actually durable.** The retained
+  tables had no append-only enforcement, and a content-addressed version shared
+  by several packages was tied to one package's lifecycle by a cascading
+  foreign key.
+
+Each control fails against the pre-fix code and passes after it.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.models.rules_package import RuleSliceRequest, RulesPackageBinding
+from afterworlds.persistence.orm.rules_authority import (
+    OverrideSetEntryORM,
+    OverrideSetVersionORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority import (
+    EMPTY_OVERRIDE_SET_UUID,
+    AuthorityOutcome,
+    IncoherentBindingError,
+    RulesAuthorityService,
+    resolve_package_reference,
+)
+from afterworlds.services.rules_package import (
+    RuleSliceResolutionError,
+    RulesPackageService,
+)
+from tests.services.rules_authority.conftest import (
+    DESCRIPTOR_FACT_TARGET,
+    NOW,
+    RuntimeFixture,
+    author_override,
+    replace_fact_payload,
+)
+
+
+def service(runtime: RuntimeFixture) -> RulesAuthorityService:
+    return RulesAuthorityService(runtime.session, now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# Family 1 — success is never returned without proving what it names
+# ---------------------------------------------------------------------------
+
+
+def test_an_unknown_uuid_reference_is_absent_not_resolved(
+    runtime: RuntimeFixture,
+) -> None:
+    """Finding 1. A well-formed UUID is a reference, not a resolution.
+
+    It used to be returned unchecked, so an unknown package UUID reported
+    ``RESOLVED`` while the equivalent unknown slug reported ``ABSENT`` — and a
+    caller reading ``RESOLVED`` as "this package exists" proceeded on one that
+    did not.
+    """
+    resolved = resolve_package_reference(runtime.session, str(uuid4()))
+    assert resolved.outcome is AuthorityOutcome.ABSENT
+    assert resolved.package_uuid is None
+
+
+def test_a_disabled_package_uuid_reference_is_absent(
+    runtime: RuntimeFixture,
+) -> None:
+    """Both branches resolve against the same enabled-package population."""
+    package = runtime.session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.package_uuid)
+        )
+    ).scalar_one()
+    package.is_enabled = False
+    runtime.session.flush()
+
+    resolved = resolve_package_reference(runtime.session, str(runtime.package_uuid))
+    assert resolved.outcome is AuthorityOutcome.ABSENT
+
+
+def test_uuid_and_slug_branches_agree_on_an_absent_package(
+    runtime: RuntimeFixture,
+) -> None:
+    """The asymmetry itself is the defect, so the symmetry is the assertion."""
+    by_uuid = resolve_package_reference(runtime.session, str(uuid4()))
+    by_slug = resolve_package_reference(runtime.session, "no-such-package-at-all")
+    assert by_uuid.outcome is by_slug.outcome is AuthorityOutcome.ABSENT
+
+
+def test_the_rule_slice_seam_refuses_an_unknown_uuid(
+    runtime: RuntimeFixture,
+) -> None:
+    """The seam a Character Sheet reference reaches reports it too."""
+    unknown = uuid4()
+    resolver = RulesPackageService(runtime.session)
+    with pytest.raises(RuleSliceResolutionError) as excinfo:
+        resolver.resolve_slice_package(
+            RuleSliceRequest(package_slug=str(unknown), whole_package=True)
+        )
+    assert excinfo.value.outcome is AuthorityOutcome.ABSENT
+
+
+def test_replay_refuses_a_projection_from_another_package(
+    runtime: RuntimeFixture,
+) -> None:
+    """Finding 4. The four components must describe one authority.
+
+    The override set and the projection are loaded from different tables by
+    different identities, so loading both proves nothing about them belonging
+    together — and the empty override-set identity is legitimately shared, so it
+    cannot supply the link either.
+    """
+    incoherent = RulesPackageBinding(
+        package_uuid=runtime.rival_package_uuid,
+        release_version=runtime.release_version,
+        mechanical_projection_uuid=runtime.projection_uuid,
+        override_set_uuid=UUID(EMPTY_OVERRIDE_SET_UUID),
+    )
+    with pytest.raises(IncoherentBindingError, match="was built over package"):
+        service(runtime).replay(incoherent)
+
+
+def test_replay_refuses_a_projection_from_another_release(
+    runtime: RuntimeFixture,
+) -> None:
+    incoherent = RulesPackageBinding(
+        package_uuid=runtime.package_uuid,
+        release_version="5.2.1-some-other-release",
+        mechanical_projection_uuid=runtime.projection_uuid,
+        override_set_uuid=UUID(EMPTY_OVERRIDE_SET_UUID),
+    )
+    with pytest.raises(IncoherentBindingError, match="was built over release"):
+        service(runtime).replay(incoherent)
+
+
+def test_a_coherent_binding_still_replays(runtime: RuntimeFixture) -> None:
+    """The coherence check has to be capable of passing."""
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.binding is not None
+    assert service(runtime).replay(resolution.binding).binding == resolution.binding
+
+
+# ---------------------------------------------------------------------------
+# Family 2 — retained replay evidence is durable
+# ---------------------------------------------------------------------------
+
+
+def test_retained_versions_refuse_update(runtime: RuntimeFixture) -> None:
+    """Finding 2. Append-only is enforced by the database, not by discipline."""
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(
+            text("UPDATE rp_override_set_versions SET entry_count = 99")
+        )
+    runtime.session.rollback()
+
+
+def test_retained_versions_refuse_delete(runtime: RuntimeFixture) -> None:
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(text("DELETE FROM rp_override_set_versions"))
+    runtime.session.rollback()
+
+
+def test_retained_entries_refuse_update(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-durable",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(
+            text("UPDATE rp_override_set_entries SET precedence = 77")
+        )
+    runtime.session.rollback()
+
+
+def test_retained_entries_refuse_delete(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-durable",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(text("DELETE FROM rp_override_set_entries"))
+    runtime.session.rollback()
+
+
+def test_authoring_rows_remain_editable(runtime: RuntimeFixture) -> None:
+    """The authoring surface is deliberately *not* append-only.
+
+    Overrides are meant to be edited, disabled, and deleted; that is the whole
+    reason the retained versions exist separately. Locking both would make the
+    feature unusable, so the boundary between them is asserted rather than
+    assumed.
+    """
+    from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
+
+    row = author_override(
+        runtime.session,
+        override_id="ov-editable",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    row.precedence = 42
+    runtime.session.flush()
+    runtime.session.execute(
+        delete(MechanicalOverrideORM).where(
+            MechanicalOverrideORM.override_id == "ov-editable"
+        )
+    )
+    runtime.session.flush()
+    assert runtime.session.get(MechanicalOverrideORM, "ov-editable") is None
+
+
+def test_deleting_a_package_does_not_destroy_shared_replay_evidence(
+    runtime: RuntimeFixture,
+) -> None:
+    """Finding 3. A shared version is content, not one package's possession.
+
+    Both packages resolve the empty override set, which is one row by design.
+    Deleting the package that retained it first used to cascade that row away
+    and break replay for every recorded binding of every other package that
+    reused the identity.
+    """
+    first = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert first.binding is not None
+    assert str(first.binding.override_set_uuid) == EMPTY_OVERRIDE_SET_UUID
+
+    # The rival package has no active projection, so it reaches the same
+    # retained version through a direct retention call rather than a binding.
+    from afterworlds.services.rules_authority import (
+        collect_current_override_state,
+        retain_override_set,
+    )
+
+    rival_state = collect_current_override_state(
+        runtime.session, str(runtime.rival_package_uuid), runtime.release_version
+    )
+    assert retain_override_set(runtime.session, rival_state, now=NOW) == str(
+        EMPTY_OVERRIDE_SET_UUID
+    )
+
+    runtime.session.execute(
+        delete(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.rival_package_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    surviving = runtime.session.execute(
+        select(OverrideSetVersionORM).where(
+            OverrideSetVersionORM.override_set_uuid == EMPTY_OVERRIDE_SET_UUID
+        )
+    ).scalar_one_or_none()
+    assert surviving is not None
+    # And the other package's recorded binding still replays.
+    assert service(runtime).replay(first.binding).binding == first.binding
+
+
+def test_a_retained_version_carries_no_owning_package_column(
+    runtime: RuntimeFixture,
+) -> None:
+    """Stated structurally: there is no column to cascade from.
+
+    A fix that kept the column and only removed the cascade would leave a row
+    naming whichever package happened to retain it first, which is misleading
+    for shared content.
+    """
+    columns = {c.name for c in OverrideSetVersionORM.__table__.columns}
+    assert columns == {"override_set_uuid", "entry_count", "recorded_at"}
+    assert not OverrideSetVersionORM.__table__.foreign_keys
+    # The entries still cascade from their own version, which is correct: an
+    # entry has no meaning apart from the version it belongs to.
+    assert {
+        fk.column.table.name for fk in OverrideSetEntryORM.__table__.foreign_keys
+    } == {"rp_override_set_versions"}

--- a/tests/services/rules_authority/test_review_round_2_regressions.py
+++ b/tests/services/rules_authority/test_review_round_2_regressions.py
@@ -189,14 +189,22 @@ def test_deleting_a_package_drops_only_its_own_scope_association(
 def test_a_missing_scope_association_is_a_retention_defect(
     runtime: RuntimeFixture,
 ) -> None:
-    """Deleting the association fails replay closed, never falsely."""
+    """Absent evidence fails replay closed, never falsely.
+
+    Round 3 made a live association undeletable, so reaching this state now
+    requires bypassing the guard — which is what a database restored without its
+    triggers looks like. The refusal of the ordinary delete path is asserted
+    separately in the round-3 controls; this asserts that *if* the evidence is
+    gone anyway, replay still refuses rather than proceeding unscoped.
+    """
     primary = _binding_with_overrides(runtime)
-    runtime.session.execute(
-        delete(OverrideSetScopeORM).where(
-            OverrideSetScopeORM.override_set_uuid == str(primary.override_set_uuid)
+    with without_append_only_triggers(runtime.session):
+        runtime.session.execute(
+            delete(OverrideSetScopeORM).where(
+                OverrideSetScopeORM.override_set_uuid == str(primary.override_set_uuid)
+            )
         )
-    )
-    runtime.session.flush()
+        runtime.session.flush()
 
     with pytest.raises(OverrideSetRetentionError, match="was never retained for"):
         service(runtime).replay(primary)

--- a/tests/services/rules_authority/test_review_round_2_regressions.py
+++ b/tests/services/rules_authority/test_review_round_2_regressions.py
@@ -1,0 +1,333 @@
+"""Regression controls for Codex review round 2 (two P1 findings).
+
+Both findings landed in families this PR's stop condition already named, so they
+were reassessed as one structural question rather than patched where quoted:
+**what must be proven before a retained override-set version may be applied under
+a recorded binding, and what stops that evidence from being rewritten?**
+
+* **Scope was asserted, not proven.** Round 1 removed the version row's
+  `package_uuid` to stop a package deletion from destroying content shared with
+  other packages. That fixed the cascade and lost the only record of *which*
+  packages a version was ever retained for, so `load_override_set_version` took
+  the caller's word for it. Semantic keys are stable across SRD-derived releases
+  by design, so an override set retained for package A finds live targets in
+  package B and replays with B's provenance.
+* **Append-only was only half enforced.** `UPDATE` and `DELETE` were guarded;
+  `INSERT` was not. A plain insert appends an entry to a sealed version, and
+  because SQLite leaves `recursive_triggers` off by default, `INSERT OR REPLACE`
+  rewrites a header or an entry without firing the delete guard at all.
+
+Each control below fails against the round-1 code and passes after the round-2
+fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.models.rules_package import RuleSliceRequest, RulesPackageBinding
+from afterworlds.persistence.orm.rules_authority import (
+    OverrideSetScopeORM,
+    OverrideSetVersionORM,
+)
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    OverrideSetRetentionError,
+    RulesAuthorityService,
+    load_override_set_version,
+)
+from tests.services.rules_authority.conftest import (
+    DESCRIPTOR_FACT_TARGET,
+    NOW,
+    SPELL_KEY,
+    RuntimeFixture,
+    author_override,
+    replace_fact_payload,
+    without_append_only_triggers,
+)
+
+
+def service(runtime: RuntimeFixture) -> RulesAuthorityService:
+    return RulesAuthorityService(runtime.session, now=NOW)
+
+
+def _binding_with_overrides(runtime: RuntimeFixture) -> RulesPackageBinding:
+    """A recorded binding for the primary package carrying one real override."""
+    author_override(
+        runtime.session,
+        override_id="ov-scoped",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    assert resolution.binding is not None
+    return resolution.binding
+
+
+# ---------------------------------------------------------------------------
+# Finding A — a retained version may only be applied under a scope it was
+# actually retained for
+# ---------------------------------------------------------------------------
+
+
+def test_replay_refuses_a_version_retained_for_another_package(
+    runtime: RuntimeFixture,
+) -> None:
+    """The end-to-end false-provenance case, and it is reachable.
+
+    Both packages publish a projection over the same semantic keys — which is
+    what SRD-derived releases genuinely look like — so package A's override
+    finds a live target in package B. Every other check passes: B's projection
+    was built over B, and the retained entries reproduce their own identity.
+    Only the scope association can catch it.
+    """
+    primary = _binding_with_overrides(runtime)
+
+    mis_scoped = RulesPackageBinding(
+        package_uuid=runtime.rival_package_uuid,
+        release_version=runtime.rival_release_version,
+        mechanical_projection_uuid=runtime.rival_projection_uuid,
+        override_set_uuid=primary.override_set_uuid,
+    )
+    with pytest.raises(OverrideSetRetentionError, match="was never retained for"):
+        service(runtime).replay(mis_scoped)
+
+
+def test_replay_refuses_a_version_retained_for_another_release(
+    runtime: RuntimeFixture,
+) -> None:
+    """Release is part of the scope, not only the package."""
+    primary = _binding_with_overrides(runtime)
+    with pytest.raises(OverrideSetRetentionError, match="was never retained for"):
+        load_override_set_version(
+            runtime.session,
+            str(primary.override_set_uuid),
+            package_uuid=str(primary.package_uuid),
+            release_version="5.2.1-some-other-release",
+        )
+
+
+def test_a_version_replays_under_every_scope_it_was_retained_for(
+    runtime: RuntimeFixture,
+) -> None:
+    """Shared content stays shared — the check is scope, not exclusivity.
+
+    Both packages legitimately retain the empty override set, and each replays
+    its own binding against it. A fix that made versions single-owner would
+    break this, which is the round-1 defect in reverse.
+    """
+    primary = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    rival = service(runtime).resolve(package_uuid=runtime.rival_package_uuid)
+    assert primary.binding is not None and rival.binding is not None
+    assert primary.binding.override_set_uuid == rival.binding.override_set_uuid
+
+    assert service(runtime).replay(primary.binding).binding == primary.binding
+    assert service(runtime).replay(rival.binding).binding == rival.binding
+
+    versions = (
+        runtime.session.execute(
+            select(OverrideSetVersionORM).where(
+                OverrideSetVersionORM.override_set_uuid
+                == str(primary.binding.override_set_uuid)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(versions) == 1
+
+
+def test_the_scope_association_is_recorded_for_each_package(
+    runtime: RuntimeFixture,
+) -> None:
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    service(runtime).resolve(package_uuid=runtime.rival_package_uuid)
+
+    scopes = {
+        (row.package_uuid, row.release_version)
+        for row in runtime.session.execute(select(OverrideSetScopeORM)).scalars().all()
+    }
+    assert (str(runtime.package_uuid), runtime.release_version) in scopes
+    assert (str(runtime.rival_package_uuid), runtime.rival_release_version) in scopes
+
+
+def test_deleting_a_package_drops_only_its_own_scope_association(
+    runtime: RuntimeFixture,
+) -> None:
+    """Round 1's guarantee, now expressed through the association.
+
+    The shared content survives and the surviving package still replays; only
+    the deleted package's association goes with it.
+    """
+    primary = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    rival = service(runtime).resolve(package_uuid=runtime.rival_package_uuid)
+    assert primary.binding is not None and rival.binding is not None
+
+    runtime.session.execute(
+        delete(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == str(runtime.rival_package_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    surviving = runtime.session.execute(
+        select(OverrideSetVersionORM).where(
+            OverrideSetVersionORM.override_set_uuid
+            == str(primary.binding.override_set_uuid)
+        )
+    ).scalar_one_or_none()
+    assert surviving is not None
+    assert service(runtime).replay(primary.binding).binding == primary.binding
+
+
+def test_a_missing_scope_association_is_a_retention_defect(
+    runtime: RuntimeFixture,
+) -> None:
+    """Deleting the association fails replay closed, never falsely."""
+    primary = _binding_with_overrides(runtime)
+    runtime.session.execute(
+        delete(OverrideSetScopeORM).where(
+            OverrideSetScopeORM.override_set_uuid == str(primary.override_set_uuid)
+        )
+    )
+    runtime.session.flush()
+
+    with pytest.raises(OverrideSetRetentionError, match="was never retained for"):
+        service(runtime).replay(primary)
+
+
+# ---------------------------------------------------------------------------
+# Finding B — append-only means INSERT too
+# ---------------------------------------------------------------------------
+
+
+def test_a_sealed_version_refuses_an_appended_entry(
+    runtime: RuntimeFixture,
+) -> None:
+    """A plain INSERT used to extend a retained version past its entry count."""
+    _binding_with_overrides(runtime)
+    with pytest.raises((IntegrityError, OperationalError), match="sealed"):
+        runtime.session.execute(
+            text(
+                "INSERT INTO rp_override_set_entries (override_set_uuid, apply_order,"
+                " override_id, override_origin, target_kind, target_record_key,"
+                " target_component_key, target_fact_key, override_operation,"
+                " precedence, is_enabled, payload) "
+                "SELECT override_set_uuid, 1, 'ov-smuggled', override_origin,"
+                " target_kind, target_record_key, target_component_key,"
+                " target_fact_key, override_operation, precedence, is_enabled,"
+                " payload FROM rp_override_set_entries LIMIT 1"
+            )
+        )
+    runtime.session.rollback()
+
+
+def test_a_retained_version_refuses_insert_or_replace(
+    runtime: RuntimeFixture,
+) -> None:
+    """SQLite leaves ``recursive_triggers`` off, so REPLACE skips delete guards.
+
+    Verified rather than assumed: without a guard on INSERT itself, this
+    rewrites the header and the ``BEFORE DELETE`` trigger never fires.
+    """
+    _binding_with_overrides(runtime)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(
+            text(
+                "INSERT OR REPLACE INTO rp_override_set_versions "
+                "(override_set_uuid, entry_count, recorded_at) "
+                "SELECT override_set_uuid, 99, recorded_at "
+                "FROM rp_override_set_versions LIMIT 1"
+            )
+        )
+    runtime.session.rollback()
+
+
+def test_a_retained_entry_refuses_insert_or_replace(
+    runtime: RuntimeFixture,
+) -> None:
+    """Refused — by the seal guard or the re-insert guard, whichever fires first.
+
+    Both cover this write and the assertion accepts either, because the property
+    under test is that the retained entry cannot be rewritten, not which of the
+    two guards happens to reach it.
+    """
+    _binding_with_overrides(runtime)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only|sealed"):
+        runtime.session.execute(
+            text(
+                "INSERT OR REPLACE INTO rp_override_set_entries (override_set_uuid,"
+                " apply_order, override_id, override_origin, target_kind,"
+                " target_record_key, target_component_key, target_fact_key,"
+                " override_operation, precedence, is_enabled, payload) "
+                "SELECT override_set_uuid, apply_order, 'ov-swapped',"
+                " override_origin, target_kind, target_record_key,"
+                " target_component_key, target_fact_key, override_operation,"
+                " precedence, is_enabled, payload "
+                "FROM rp_override_set_entries LIMIT 1"
+            )
+        )
+    runtime.session.rollback()
+
+
+def test_the_scope_association_refuses_update(runtime: RuntimeFixture) -> None:
+    """An association may not be silently relabelled onto another package."""
+    service(runtime).resolve(package_uuid=runtime.package_uuid)
+    with pytest.raises((IntegrityError, OperationalError), match="append-only"):
+        runtime.session.execute(
+            text("UPDATE rp_override_set_scopes SET package_uuid = 'somewhere-else'")
+        )
+    runtime.session.rollback()
+
+
+def test_retention_remains_idempotent_under_the_insert_guards(
+    runtime: RuntimeFixture,
+) -> None:
+    """The guards must not break the ordinary repeated-resolution path.
+
+    Resolution retains on every read, so a guard that refused the second
+    identical retention would break every second binding resolution.
+    """
+    for _ in range(3):
+        assert (
+            service(runtime).resolve(package_uuid=runtime.package_uuid).outcome
+            is AuthorityOutcome.RESOLVED
+        )
+
+
+def test_read_time_verification_still_catches_a_bypassed_write(
+    runtime: RuntimeFixture,
+) -> None:
+    """Both layers stay load-bearing.
+
+    The triggers stop the ordinary path; this models a database restored without
+    them and asserts reconstruction still refuses the result rather than
+    replaying a rewritten version.
+    """
+    primary = _binding_with_overrides(runtime)
+    with without_append_only_triggers(runtime.session):
+        runtime.session.execute(
+            text("UPDATE rp_override_set_entries SET override_id = 'ov-forged'")
+        )
+        runtime.session.flush()
+
+    with pytest.raises(OverrideSetRetentionError, match="reconstructs as"):
+        service(runtime).replay(primary)
+
+
+def test_the_primary_record_is_still_reachable_after_all_of_this(
+    runtime: RuntimeFixture,
+) -> None:
+    """A sanity anchor: the fixture still describes real authority."""
+    result = service(runtime).typed_view(
+        RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+    )
+    assert result.outcome is AuthorityOutcome.RESOLVED
+    assert result.typed_view is not None
+    assert any(r.semantic_key == SPELL_KEY for r in result.typed_view.records)

--- a/tests/services/rules_authority/test_rule_slice_seam.py
+++ b/tests/services/rules_authority/test_rule_slice_seam.py
@@ -1,0 +1,145 @@
+"""The extended ``RuleSliceRequest`` seam — #137 contract 6.
+
+Two fail-open behaviours had to lose every surviving caller:
+
+* a package reference parsed with ``UUID(...)`` and, on ``ValueError``, silently
+  dropped; and
+* a request carrying no selectors at all, which always produced an empty slice
+  that read like "no rule applies".
+
+These tests assert the model itself now refuses both, so no caller can
+reintroduce either by construction, and that the code-owned resolution seam
+reports a typed reason instead of an empty result.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from afterworlds.models.enums import MechanicalEntityTypeEnum, RuleSubsystemEnum
+from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.persistence.orm.rules_package import RulesPackageORM
+from afterworlds.services.rules_authority import AuthorityOutcome, package_slug
+from afterworlds.services.rules_package import (
+    RuleSliceResolutionError,
+    RulesPackageService,
+)
+from tests.services.rules_authority.conftest import (
+    PACKAGE_NAME,
+    RIVAL_PACKAGE_UUID,
+    SPELL_KEY,
+    RuntimeFixture,
+)
+
+# ---------------------------------------------------------------------------
+# The accidentally-empty selector
+# ---------------------------------------------------------------------------
+
+
+def test_a_request_selecting_nothing_is_refused_at_construction(
+    runtime: RuntimeFixture,
+) -> None:
+    """The exact shape the orchestrator used to build, now unbuildable."""
+    with pytest.raises(ValueError, match="selects nothing"):
+        RuleSliceRequest(package_id=runtime.package_uuid)
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"whole_package": True},
+        {"subsystem_tags": [RuleSubsystemEnum.COMBAT]},
+        {"entity_refs": [(MechanicalEntityTypeEnum.SPELL, "Wish")]},
+        {"record_selectors": (SPELL_KEY,)},
+        {"component_selectors": ((SPELL_KEY, "descriptor"),)},
+    ],
+)
+def test_an_explicit_selection_is_accepted(
+    runtime: RuntimeFixture, selector: dict[str, object]
+) -> None:
+    """Every way of saying what is wanted, including saying "all of it"."""
+    request = RuleSliceRequest(package_id=runtime.package_uuid, **selector)
+    assert request.package_id == runtime.package_uuid
+
+
+# ---------------------------------------------------------------------------
+# The package reference
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_one_package_reference_form_is_required(
+    runtime: RuntimeFixture,
+) -> None:
+    with pytest.raises(ValueError, match="exactly one of package_id"):
+        RuleSliceRequest(whole_package=True)
+    with pytest.raises(ValueError, match="exactly one of package_id"):
+        RuleSliceRequest(
+            package_id=runtime.package_uuid,
+            package_slug="srd-5-2-1-corpus",
+            whole_package=True,
+        )
+
+
+def test_a_slug_request_resolves_through_the_code_owned_path(
+    runtime: RuntimeFixture,
+) -> None:
+    rival = runtime.session.execute(
+        select(RulesPackageORM).where(
+            RulesPackageORM.rules_package_id == RIVAL_PACKAGE_UUID
+        )
+    ).scalar_one()
+    rival.name = "Unrelated corpus"
+    runtime.session.flush()
+
+    service = RulesPackageService(runtime.session)
+    resolved = service.resolve_slice_package(
+        RuleSliceRequest(package_slug=package_slug(PACKAGE_NAME), whole_package=True)
+    )
+    assert resolved == runtime.package_uuid
+
+
+def test_a_uuid_request_passes_straight_through(runtime: RuntimeFixture) -> None:
+    service = RulesPackageService(runtime.session)
+    assert (
+        service.resolve_slice_package(
+            RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+        )
+        == runtime.package_uuid
+    )
+
+
+def test_an_ambiguous_slug_raises_a_typed_resolution_error(
+    runtime: RuntimeFixture,
+) -> None:
+    """Explicit failure, carrying which state it is — not an empty slice."""
+    service = RulesPackageService(runtime.session)
+    with pytest.raises(RuleSliceResolutionError) as excinfo:
+        service.resolve_slice_package(
+            RuleSliceRequest(
+                package_slug=package_slug(PACKAGE_NAME), whole_package=True
+            )
+        )
+    assert excinfo.value.outcome is AuthorityOutcome.AMBIGUOUS
+
+
+def test_an_unknown_slug_raises_a_typed_resolution_error(
+    runtime: RuntimeFixture,
+) -> None:
+    service = RulesPackageService(runtime.session)
+    with pytest.raises(RuleSliceResolutionError) as excinfo:
+        service.resolve_slice_package(
+            RuleSliceRequest(package_slug="nothing-here", whole_package=True)
+        )
+    assert excinfo.value.outcome is AuthorityOutcome.ABSENT
+
+
+def test_a_malformed_slug_raises_a_typed_resolution_error(
+    runtime: RuntimeFixture,
+) -> None:
+    service = RulesPackageService(runtime.session)
+    with pytest.raises(RuleSliceResolutionError) as excinfo:
+        service.resolve_slice_package(
+            RuleSliceRequest(package_slug="!!!", whole_package=True)
+        )
+    assert excinfo.value.outcome is AuthorityOutcome.INVALID_SELECTOR

--- a/tests/services/rules_authority/test_typed_overrides.py
+++ b/tests/services/rules_authority/test_typed_overrides.py
@@ -1,0 +1,572 @@
+"""Typed record/component/fact overrides — ADR-005d Decision 10.
+
+Existing precedence and operation semantics are preserved: ordering is
+ascending ``(precedence, override_id)``, ``DISABLE`` suppresses an exact target
+and stops later processing of it, ``REPLACE`` supplies a complete validated
+replacement, and ``APPEND`` adds only where the owning schema permits
+multiplicity.
+
+The negative controls are the point of the module. Each one is a patch that is
+*well-formed* and still refused: outside the closed union, aimed at a target that
+does not exist, incompatible with its target's type, or appended where nothing
+can be appended.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    MechanicalTarget,
+    MechanicalTargetKind,
+    RulesAuthorityService,
+)
+from tests.services.rules_authority.conftest import (
+    ADDED_CHECK,
+    CHECK_COMPONENT_TARGET,
+    CHECK_FACT_KEY,
+    CHECK_KEY,
+    CREATURE_KEY,
+    CREATURE_RECORD_TARGET,
+    DESCRIPTOR_COMPONENT_TARGET,
+    DESCRIPTOR_FACT_KEY,
+    DESCRIPTOR_FACT_TARGET,
+    DESCRIPTOR_KEY,
+    DISABLE_PAYLOAD,
+    NOW,
+    OPEN_ENDED_KEY,
+    PROSE_COMPONENT_TARGET,
+    REPLACEMENT_DESCRIPTOR,
+    SPELL_KEY,
+    SPELL_RECORD_TARGET,
+    RuntimeFixture,
+    append_component_payload,
+    append_fact_payload,
+    author_override,
+    replace_component_payload,
+    replace_fact_payload,
+    replace_record_payload,
+)
+
+
+def whole_package(runtime: RuntimeFixture) -> RuleSliceRequest:
+    return RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+
+
+def effective(runtime: RuntimeFixture):  # type: ignore[no-untyped-def]
+    result = RulesAuthorityService(runtime.session, now=NOW).typed_view(
+        whole_package(runtime)
+    )
+    assert result.outcome is AuthorityOutcome.RESOLVED, result.detail
+    assert result.typed_view is not None
+    return result.typed_view
+
+
+def refusal(runtime: RuntimeFixture):  # type: ignore[no-untyped-def]
+    return RulesAuthorityService(runtime.session, now=NOW).typed_view(
+        whole_package(runtime)
+    )
+
+
+def record(view, key: str):  # type: ignore[no-untyped-def]
+    matches = [r for r in view.records if r.semantic_key == key]
+    return matches[0] if matches else None
+
+
+def component(view, record_key: str, key: str):  # type: ignore[no-untyped-def]
+    found = record(view, record_key)
+    if found is None:
+        return None
+    matches = [c for c in found.components if c.semantic_key == key]
+    return matches[0] if matches else None
+
+
+# ---------------------------------------------------------------------------
+# The unpatched view
+# ---------------------------------------------------------------------------
+
+
+def test_the_base_view_is_the_projection(runtime: RuntimeFixture) -> None:
+    """Without overrides the effective view is the published authority."""
+    view = effective(runtime)
+    assert {r.semantic_key for r in view.records} == {SPELL_KEY, CREATURE_KEY}
+    descriptor = component(view, SPELL_KEY, DESCRIPTOR_KEY)
+    assert descriptor is not None
+    assert descriptor.handling is ComponentHandling.STRUCTURED
+    assert [f.fact_key for f in descriptor.facts] == [DESCRIPTOR_FACT_KEY]
+    # Base authority carries 5c span provenance and no override provenance.
+    assert descriptor.facts[0].span_ids
+    assert descriptor.facts[0].supplied_by_override_id is None
+    assert view.applied_overrides == ()
+
+
+# ---------------------------------------------------------------------------
+# DISABLE
+# ---------------------------------------------------------------------------
+
+
+def test_disable_suppresses_an_exact_fact(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-disable-fact",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    view = effective(runtime)
+
+    descriptor = component(view, SPELL_KEY, DESCRIPTOR_KEY)
+    assert descriptor is not None
+    assert descriptor.facts == ()
+    # Its sibling record is untouched.
+    check = component(view, CREATURE_KEY, CHECK_KEY)
+    assert check is not None
+    assert [f.fact_key for f in check.facts] == [CHECK_FACT_KEY]
+
+
+def test_disable_suppresses_an_exact_component(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-disable-component",
+        target=PROSE_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    view = effective(runtime)
+
+    assert component(view, SPELL_KEY, OPEN_ENDED_KEY) is None
+    assert component(view, SPELL_KEY, DESCRIPTOR_KEY) is not None
+
+
+def test_disable_suppresses_an_exact_record(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-disable-record",
+        target=CREATURE_RECORD_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    view = effective(runtime)
+
+    assert record(view, CREATURE_KEY) is None
+    assert record(view, SPELL_KEY) is not None
+
+
+def test_disable_stops_later_processing_of_the_same_target(
+    runtime: RuntimeFixture,
+) -> None:
+    """The existing precedence rule: the first winning disable ends the target.
+
+    A later replace does not resurrect suppressed authority, and the provenance
+    says why it did not.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-1-disable",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-2-replace",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_component_payload(),
+        precedence=20,
+    )
+    view = effective(runtime)
+
+    assert component(view, SPELL_KEY, DESCRIPTOR_KEY) is None
+    first, second = view.applied_overrides
+    assert (first.override_id, first.applied) == ("ov-1-disable", True)
+    assert (second.override_id, second.applied) == ("ov-2-replace", False)
+    assert "already suppressed" in second.note
+
+
+def test_disabling_a_record_suppresses_the_facts_beneath_it(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-1-disable-record",
+        target=SPELL_RECORD_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-2-replace-fact",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+        precedence=20,
+    )
+    view = effective(runtime)
+
+    assert record(view, SPELL_KEY) is None
+    assert view.applied_overrides[1].applied is False
+
+
+def test_an_override_authored_disabled_changes_nothing(
+    runtime: RuntimeFixture,
+) -> None:
+    """It still appears in the ordered provenance, marked as not applied."""
+    author_override(
+        runtime.session,
+        override_id="ov-inactive",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        is_enabled=False,
+    )
+    view = effective(runtime)
+
+    descriptor = component(view, SPELL_KEY, DESCRIPTOR_KEY)
+    assert descriptor is not None
+    assert [f.fact_key for f in descriptor.facts] == [DESCRIPTOR_FACT_KEY]
+    (entry,) = view.applied_overrides
+    assert entry.applied is False
+    assert entry.note == "authored disabled"
+
+
+# ---------------------------------------------------------------------------
+# REPLACE
+# ---------------------------------------------------------------------------
+
+
+def test_replace_supplies_a_complete_fact(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-replace-fact",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(),
+        origin=OverrideOriginEnum.PACKAGE_PATCH,
+    )
+    view = effective(runtime)
+
+    descriptor = component(view, SPELL_KEY, DESCRIPTOR_KEY)
+    assert descriptor is not None
+    (fact,) = descriptor.facts
+    assert fact.fact == REPLACEMENT_DESCRIPTOR
+    # Provenance-exact: the override record and its origin, not a source span.
+    assert fact.supplied_by_override_id == "ov-replace-fact"
+    assert fact.supplied_by_origin is OverrideOriginEnum.PACKAGE_PATCH
+    assert fact.span_ids == ()
+
+
+def test_replace_supplies_a_complete_component(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-replace-component",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_component_payload(),
+    )
+    view = effective(runtime)
+
+    descriptor = component(view, SPELL_KEY, DESCRIPTOR_KEY)
+    assert descriptor is not None
+    assert descriptor.supplied_by_override_id == "ov-replace-component"
+    assert [f.fact for f in descriptor.facts] == [REPLACEMENT_DESCRIPTOR]
+
+
+def test_replace_record_is_record_kind_specific(runtime: RuntimeFixture) -> None:
+    """A whole record is replaceable only through its own kind's patch."""
+    author_override(
+        runtime.session,
+        override_id="ov-replace-record",
+        target=SPELL_RECORD_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_record_payload(),
+    )
+    view = effective(runtime)
+
+    spell = record(view, SPELL_KEY)
+    assert spell is not None
+    assert [c.semantic_key for c in spell.components] == [DESCRIPTOR_KEY]
+    assert spell.supplied_by_override_id == "ov-replace-record"
+
+
+# ---------------------------------------------------------------------------
+# APPEND
+# ---------------------------------------------------------------------------
+
+
+def test_append_adds_a_fact_where_a_component_permits_multiplicity(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-append-fact",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(),
+    )
+    view = effective(runtime)
+
+    check = component(view, CREATURE_KEY, CHECK_KEY)
+    assert check is not None
+    assert {f.fact for f in check.facts} == {check.facts[0].fact, ADDED_CHECK}
+    added = [f for f in check.facts if f.supplied_by_override_id][0]
+    assert added.fact == ADDED_CHECK
+
+
+def test_append_adds_a_component_where_a_record_permits_multiplicity(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-append-component",
+        target=CREATURE_RECORD_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_component_payload(),
+    )
+    view = effective(runtime)
+
+    added = component(view, CREATURE_KEY, "house-rider")
+    assert added is not None
+    assert added.supplied_by_override_id == "ov-append-component"
+    assert component(view, CREATURE_KEY, CHECK_KEY) is not None
+
+
+# ---------------------------------------------------------------------------
+# Negative controls
+# ---------------------------------------------------------------------------
+
+
+def test_append_onto_a_fact_is_refused(runtime: RuntimeFixture) -> None:
+    """A fact is a single value; the owning schema declares no multiplicity."""
+    author_override(
+        runtime.session,
+        override_id="ov-append-fact-target",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "no multiplicity" in result.detail
+
+
+def test_a_type_incompatible_record_patch_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    """The declared record kind must be the target record's kind."""
+    author_override(
+        runtime.session,
+        override_id="ov-wrong-kind",
+        target=SPELL_RECORD_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_record_payload(record_kind="creature"),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "declares kind" in result.detail
+
+
+def test_a_patch_of_the_wrong_family_is_refused(runtime: RuntimeFixture) -> None:
+    """A well-formed payload of another family is still the wrong patch."""
+    author_override(
+        runtime.session,
+        override_id="ov-wrong-family",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_component_payload(),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "requires a replace_fact patch" in result.detail
+
+
+def test_a_fact_outside_the_closed_union_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-unknown-family",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_fact",
+            "fact": {"family": "damage_expression", "expression": "2d6+3"},
+        },
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "closed typed-fact union" in result.detail
+
+
+def test_a_mistyped_fact_field_is_refused(runtime: RuntimeFixture) -> None:
+    """No coercion: ``"9"`` is not 9, here or in persistence."""
+    author_override(
+        runtime.session,
+        override_id="ov-mistyped",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_fact",
+            "fact": {
+                "family": "spell_descriptor",
+                "level": "9",
+                "school": "illusion",
+                "ritual": False,
+                "concentration": False,
+            },
+        },
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+
+
+def test_a_prose_bound_override_component_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    """Runtime patches cannot author governing prose (#137 contract 3)."""
+    author_override(
+        runtime.session,
+        override_id="ov-prose",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {"handling": "prose_bound", "facts": []},
+        },
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "must be structured" in result.detail
+
+
+def test_an_override_targeting_a_missing_record_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-missing-record",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.RECORD, record_key="spell:no-such-spell"
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "names no record" in result.detail
+
+
+def test_an_override_targeting_a_missing_fact_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-missing-fact",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.FACT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+            fact_key="0" * 16,
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "names no fact" in result.detail
+
+
+def test_appending_a_duplicate_fact_is_refused(runtime: RuntimeFixture) -> None:
+    """Duplicate-as-coverage is refused at runtime as it is at publication."""
+    author_override(
+        runtime.session,
+        override_id="ov-duplicate",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(_existing_check()),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "would duplicate" in result.detail
+
+
+def test_appending_a_duplicate_component_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-duplicate-component",
+        target=CREATURE_RECORD_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_component_payload(semantic_key=CHECK_KEY),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "would duplicate" in result.detail
+
+
+def test_appending_a_fact_to_prose_bound_authority_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    """A published prose-bound judgement is not reversible by an override."""
+    author_override(
+        runtime.session,
+        override_id="ov-append-to-prose",
+        target=PROSE_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "prose-bound" in result.detail
+
+
+def test_a_structured_override_component_with_no_facts_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-empty-structured",
+        target=DESCRIPTOR_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {"handling": "structured", "facts": []},
+        },
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "no facts" in result.detail
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"patch": "disable", "extra": 1},
+        {"patch": "not-a-family"},
+        {"nothing": True},
+    ],
+)
+def test_a_payload_outside_the_closed_patch_union_is_refused(
+    runtime: RuntimeFixture, payload: dict[str, object]
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-malformed",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=payload,
+    )
+    assert refusal(runtime).outcome is AuthorityOutcome.INVALID_OVERRIDE
+
+
+def _existing_check():  # type: ignore[no-untyped-def]
+    from tests.services.rules_authority.conftest import CHECK_FACT
+
+    return CHECK_FACT

--- a/tests/services/test_context_builder.py
+++ b/tests/services/test_context_builder.py
@@ -1112,7 +1112,14 @@ def test_rule_slice_request_without_service_raises() -> None:
         retrieval_memory=_CountingRetrievalMemoryProvider(),
         rules_package_service=None,
     )
-    req = RuleSliceRequest(package_id=uuid4())
+    from afterworlds.models.enums import RuleSubsystemEnum as _RuleSubsystemEnum
+
+    # CRD Issue 5d (#137 contract 6): a rule-slice request must state what it
+    # selects, so the accidentally-empty form used here before is now refused
+    # at construction.
+    req = RuleSliceRequest(
+        package_id=uuid4(), subsystem_tags=[_RuleSubsystemEnum.COMBAT]
+    )
     with pytest.raises(ValueError, match="rules_package_service"):
         service.assemble(
             story_id=_STORY_ID,
@@ -1193,6 +1200,10 @@ def test_rule_slice_happy_path_wires_slice_and_covers_render() -> None:
             self.last_entity_refs: list[tuple[MechanicalEntityTypeEnum, str]] | None = (
                 None
             )
+
+        def resolve_slice_package(self, request: RuleSliceRequest) -> UUID:
+            assert request.package_id is not None
+            return request.package_id
 
         def get_active_rule_slice(
             self,
@@ -1294,6 +1305,10 @@ def test_rule_slice_mode_intent_policy(
         def __init__(self) -> None:
             self.call_count = 0
 
+        def resolve_slice_package(self, request: RuleSliceRequest) -> UUID:
+            assert request.package_id is not None
+            return request.package_id
+
         def get_active_rule_slice(
             self,
             package_id: UUID,
@@ -1312,7 +1327,14 @@ def test_rule_slice_mode_intent_policy(
         retrieval_memory=_CountingRetrievalMemoryProvider(),
         rules_package_service=stub_rules,
     )
-    req = RuleSliceRequest(package_id=uuid4())
+    from afterworlds.models.enums import RuleSubsystemEnum as _RuleSubsystemEnum
+
+    # CRD Issue 5d (#137 contract 6): a rule-slice request must state what it
+    # selects, so the accidentally-empty form used here before is now refused
+    # at construction.
+    req = RuleSliceRequest(
+        package_id=uuid4(), subsystem_tags=[_RuleSubsystemEnum.COMBAT]
+    )
 
     assembled = service.assemble(
         story_id=_STORY_ID,

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session
 
 import afterworlds.persistence.orm.corpus  # noqa: F401
 import afterworlds.persistence.orm.mechanical  # noqa: F401
+import afterworlds.persistence.orm.rules_authority  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 from afterworlds.models.enums import (
     MechanicalEntityTypeEnum,
@@ -258,6 +259,11 @@ class TestRpTablePrefix:
             "rp_mech_references",
             "rp_mech_provenance",
             "rp_mech_active_projections",
+            # CRD Issue 5d runtime authority: the typed override authoring
+            # surface and the retained immutable override-set versions.
+            "rp_mech_overrides",
+            "rp_override_set_versions",
+            "rp_override_set_entries",
         }
         actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
         assert (

--- a/tests/services/test_rules_package.py
+++ b/tests/services/test_rules_package.py
@@ -264,6 +264,7 @@ class TestRpTablePrefix:
             "rp_mech_overrides",
             "rp_override_set_versions",
             "rp_override_set_entries",
+            "rp_override_set_scopes",
         }
         actual = {n for n in Base.metadata.tables if n.startswith("rp_")}
         assert (

--- a/tests/services/test_schema_separation_invariant.py
+++ b/tests/services/test_schema_separation_invariant.py
@@ -20,6 +20,7 @@ import afterworlds.persistence.orm.character_sheet  # noqa: F401
 import afterworlds.persistence.orm.corpus  # noqa: F401
 import afterworlds.persistence.orm.mechanical  # noqa: F401
 import afterworlds.persistence.orm.node  # noqa: F401
+import afterworlds.persistence.orm.rules_authority  # noqa: F401
 import afterworlds.persistence.orm.rules_package  # noqa: F401
 import afterworlds.persistence.orm.session_state  # noqa: F401
 import afterworlds.persistence.orm.state  # noqa: F401
@@ -164,6 +165,10 @@ def test_rules_package_tables_exist_with_rp_prefix() -> None:
         "rp_mech_references",
         "rp_mech_provenance",
         "rp_mech_active_projections",
+        # CRD Issue 5d runtime authority (#137 contract 6).
+        "rp_mech_overrides",
+        "rp_override_set_versions",
+        "rp_override_set_entries",
     }
     actual = {name for name in Base.metadata.tables if name.startswith(_RP_PREFIX)}
     assert (

--- a/tests/services/test_schema_separation_invariant.py
+++ b/tests/services/test_schema_separation_invariant.py
@@ -169,6 +169,7 @@ def test_rules_package_tables_exist_with_rp_prefix() -> None:
         "rp_mech_overrides",
         "rp_override_set_versions",
         "rp_override_set_entries",
+        "rp_override_set_scopes",
     }
     actual = {name for name in Base.metadata.tables if name.startswith(_RP_PREFIX)}
     assert (


### PR DESCRIPTION
CRD Issue 5d (#137) PR 3 of the sequence stated in PR #139's Architecture Notes: the runtime-authority
infrastructure — effective binding, selectors, authority views, and typed overrides — wired *alongside* the
still-runnable `MechanicalEntity` path.

**This is infrastructure, not completed CRD Issue 5d.** No production mechanical projection is published,
no accepted content or production oracle is added, and no projection becomes active by merging this.

## What was built

**The exact four-component effective binding** (`models/rules_package.py`)
- `RulesPackageBinding(package_uuid, release_version, mechanical_projection_uuid, override_set_uuid)`,
  every component typed as a `UUID` or an exact release string. Base-projection identity and override-set
  identity are separate fields and are never collapsed into one value.
- A slug is therefore structurally incapable of being canonical authority: it cannot be a member of this
  type at all.

**One code-owned binding-resolution path** (`services/rules_authority/binding.py`)
- `resolve_package_reference()` is the only place a human-facing slug is interpreted. Both the UUID and slug
  branches resolve against the same enabled-package population, so a valid slug and the matching UUID
  resolve to the same exact binding and an unknown reference of either form is `ABSENT`.
- `resolve_effective_binding()` produces the binding itself, in a fixed order of checks: package exists and
  is published → active published projection (`UNPUBLISHED` otherwise) → release agreement
  (`MISMATCHED_RELEASE`) → current override state parses and is retained → recorded-binding comparison
  across all four components.
- Typed states stay distinct: `RESOLVED`, `ABSENT`, `AMBIGUOUS`, `UNPUBLISHED`, `STALE`,
  `MISMATCHED_RELEASE`, `INVALID_SELECTOR`, `INVALID_OVERRIDE`, `INVALID_REFERENCE`. `UNRESOLVED`,
  `UNREVIEWED`, and `INCOMPLETE` remain publication-stage states in `PublicationOutcome`.

**Deterministic selection on the existing seam** (`RuleSliceRequest`, extended — not replaced)
- Adds `package_slug`, `record_selectors`, `component_selectors`, `whole_package`, and `recorded_binding`
  to the same model Issue 8 introduced. Two model validators enforce exactly one package-reference form
  and refuse the accidentally-empty selector set at construction.
- A selector naming an element the bound projection does not contain is `INVALID_REFERENCE`, never an
  empty slice.

**Closed typed record/component/fact overrides** (`patches.py`, `targets.py`, `application.py`)
- Six patch families, closed, chosen entirely by *(operation, target kind)*. `APPEND` onto a fact has no
  family because a fact has no multiplicity. Record replacement is record-kind-specific and fails when the
  declared kind is not the target's.
- Existing precedence and operation semantics unchanged: ascending `(precedence, override_id)`, `DISABLE`
  suppresses an exact target and stops later processing of it (inherited downward through
  record → component → fact), `REPLACE` supplies a complete validated replacement, `APPEND` adds only into
  a declared multiplicity.
- Facts are rebuilt through CRD Issue 5d's own `fact_from_payload`, so there is no looser runtime door into
  the closed typed-fact union. No generic JSON paths, expressions, raw-string patches, or runtime rules
  language.

**Two authority views** (`views.py`, `service.py`)
- A typed deterministic-consumer view with applied override provenance, and a GameMaster view combining
  exact governing prose with structured context and handling.
- Both carry the complete four-component binding, both report the same ordered applied-override provenance,
  and both are built from one resolution so they cannot disagree.
- Governing prose resolves through the exact `chunk_id` the projection recorded, read from the
  authoritative 5c `RuleChunk`. A bound chunk that is missing is reported as absent, never substituted.
  Neither view has any field a consumer could read as an adapter-capability claim.

**Runtime and replay are different operations** (`service.py`)
- `resolve()` / the views recompute the override-set identity from current state; a recorded binding that
  no longer matches is `STALE` and fails, never silently re-resolved.
- `replay()` resolves the *retained* version and must succeed. It first proves the four components describe
  one authority, then raises rather than returning an outcome: `IncoherentBindingError` for a binding that
  was never coherent, `OverrideSetRetentionError` for a retention defect. Neither is a divergence signal.

**Fail-open removal**
- `orchestrator/service.py` no longer parses the sheet's `rules_package_id` with `UUID(...)` and swallows
  the `ValueError`. The reference goes through the code-owned resolver when one is wired, and an
  ambiguous / absent / malformed reference is a typed `PIPELINE_ERROR`.
- The empty-selector `RuleSliceRequest(package_id=...)` the orchestrator used to build is now unbuildable,
  and is not replaced by a whole-package request (see Architecture Notes).
- `context_builder.py` resolves its request's package through `RulesPackageService.resolve_slice_package()`,
  which raises a typed `RuleSliceResolutionError` carrying the `AuthorityOutcome`.

## Retention architecture (final)

Migration `0024`, additive only. **Four tables:**

| Table | Role | Mutability |
|---|---|---|
| `rp_mech_overrides` | the authoring surface for typed overrides | mutable by design — overrides are meant to be edited and deleted |
| `rp_override_set_versions` | content-addressed snapshot header, keyed by `override_set_uuid` | append-only; no `package_uuid`, no foreign key |
| `rp_override_set_entries` | the version's complete ordered entries | append-only, and sealed once the declared `entry_count` is present |
| `rp_override_set_scopes` | which `(package, release)` retained which content | append-only while its package is live; cascades on package deletion |

**Nine triggers**, all installed by `0024` and asserted against a real alembic run:

- `prevent_rp_override_set_{versions,entries,scopes}_update`
- `prevent_rp_override_set_{versions,entries}_delete`
- `prevent_rp_override_set_scopes_delete` — conditional on the owning package still existing
- `prevent_rp_override_set_{versions,entries}_reinsert` — **content-aware**
- `seal_rp_override_set_entries` — refuses a genuinely new position once the version is complete

Two SQLite behaviours the guard set is built on, each measured against the engine rather than assumed:
`recursive_triggers` is off by default, so `INSERT OR REPLACE`'s own conflict-resolution delete does **not**
fire `BEFORE DELETE` triggers — which is why the `BEFORE INSERT` guards exist at all. A foreign-key
`ON DELETE CASCADE` is a different mechanism and *does* fire them, which is what stops a REPLACE carrying an
identical `entry_count` from wiping a version's entries and association: the cascade raises from the
children's own guards and aborts the statement. Every evidence state is asserted in
`tests/persistence/test_rules_authority_migration.py`.

**Concurrency guarantee.** Retention runs on every binding resolution, so two sessions resolving the same
package concurrently both retain the same content. That is the expected case, not an error. Retention
writes through `INSERT ... ON CONFLICT DO NOTHING` inside **one savepoint** covering version, entries, and
scope together:

- concurrent first retention of identical content and scope converges on one valid retained result, with
  no race surfaced to either caller;
- concurrent retention of shared content under different scopes yields one immutable version with both
  valid associations;
- a partial failure unwinds the whole unit and leaves the caller's transaction usable — no orphan snapshot,
  no incomplete scope evidence;
- nothing is suppressed: no integrity, trigger, or lock error is caught and relabelled as idempotency. The
  losing writer genuinely has nothing left to do, and the final state is verified by the same read path
  replay uses.

The guard shape and the insert shape are **one design**. An existence-based guard aborts the statement
before conflict resolution is reached, so `ON CONFLICT DO NOTHING` would fail exactly where it must
succeed.

**Transaction boundary.** The savepoint above is only a *nested* savepoint if SQLite has actually issued
`BEGIN`. `sqlite3` is used here with its legacy transaction control, which opens a transaction implicitly
only before `INSERT`/`UPDATE`/`DELETE`/`REPLACE` — so a session that has only read is inside a SQLAlchemy
transaction while the connection is still in SQLite autocommit. Binding resolution reads before it retains,
which made the real sequence `SELECT → SAVEPOINT → writes → RELEASE`, and releasing an outermost savepoint
**commits**: a later rollback of the enclosing transaction, including one from an explicit
`with session.begin():`, could not take the retained rows back.

`persistence/database.py` therefore gains `ensure_physical_transaction()`, which asks the DBAPI connection
itself whether a transaction is open — SQLAlchemy's logical state cannot answer that — and emits `BEGIN`
only when it is not. Retention calls it before opening its savepoint. Release stops committing, the
enclosing transaction owns the commit boundary, `retain_override_set()` never commits, and partial-failure
rollback of the retention unit alone still works. It is deliberately scoped to this call site: making every
SQLAlchemy transaction physical would change lock acquisition for every service and migration in the
repository (see Architecture Notes).

## How this satisfies each acceptance criterion

| Criterion | Status in PR 3 |
|---|---|
| 16 — typed failure states distinct, never authorizing fallback | Met for the runtime path: nine typed outcomes, each asserted separately |
| 18 — slug and UUID resolve to the same binding; ambiguous/non-resolving inputs and empty selectors fail | Met |
| 19 — both views resolve consistent authority and binding, without implying adapter capability or letting retrieval choose values | Met |
| 20 — typed overrides preserve precedence, report ordered provenance, reject invalid/stale/cross-release/type-incompatible patches, leave base rows unchanged | Met |
| 21 — deterministic override-set identity incl. the empty one; identity moves on identity/origin/enablement/order/target/operation/payload and not on audit metadata; runtime `STALE`; replay reconstructs after mutation | Met, including all four #137 contract-5 negative controls |
| 23 — CRD Issue 2b can consume the four-component binding without 5d deciding sheet storage | Met: the binding is a standalone typed model |
| 1, 11, 14 | Unchanged from PRs 1–2; re-proved here only where runtime resolution depends on them |
| 17, 22, 24 (real-corpus canaries, legacy retirement, full-corpus acceptance) | **Not claimed by this PR** |

## Test coverage summary

**193 new tests**, of which **159** are in `tests/services/rules_authority/`:

| Module | Tests |
|---|---|
| `test_binding_resolution.py` | 22 |
| `test_override_identity.py` | 24 |
| `test_typed_overrides.py` | 27 |
| `test_authority_views.py` | 17 |
| `test_retention_closure.py` | 16 |
| `test_review_round_1_regressions.py` | 14 |
| `test_review_round_2_regressions.py` | 13 |
| `test_rule_slice_seam.py` | 12 |
| `test_replay_and_staleness.py` | 11 |
| `test_base_projection_unchanged.py` | 3 |
| `tests/persistence/test_rules_authority_migration.py` | 22 |
| `tests/persistence/test_physical_transaction.py` | 6 |
| `tests/ingestion/mechanical/test_runtime_production_release.py` | 6 |

Coverage by the required verification list — exact binding resolution and its failures; deterministic empty
and non-empty override-set identities; identity moving on override identity/origin/enablement/order/target/
operation/payload but not on audit metadata; runtime staleness plus exact historical replay after mutation
and deletion; both views returning consistent binding and provenance; typed `DISABLE`/`REPLACE`/permitted
`APPEND` with invalid, cross-release, and type-incompatible negative controls; and unchanged immutable
base-projection identity and rows.

**Retention closure (`test_retention_closure.py`)** covers the persistence-and-concurrency family with a
deterministic `threading.Barrier` harness over two real connections — no sleeps, no timing assumptions.
Both caller-visible results and final database state are asserted: concurrent first retention of identical
content and scope; concurrent retention of shared content under different scopes; repeated sequential
retention staying idempotent; direct scope deletion refused via ORM and raw SQL while the package lives;
scope mutation refused; package deletion still cascading its own association while the shared version and
the survivor's association remain; replay for a deleted package failing closed; partial-failure rollback
leaving no orphan snapshot and a usable transaction; replay accepting only properly scoped evidence
cross-package and cross-release; and the identical-vs-differing re-insert asymmetry the concurrency design
rests on.

Four of those assert the **transaction boundary** from a genuinely independent session — the only way to
distinguish "committed" from "pending in this session's transaction": retention after a read-only prelude
rolling back with its caller; the same inside an explicit `with session.begin():` whose later work raises;
retention retried and committed successfully after an enclosing rollback; and retention not committing the
caller's unrelated pending work. Three of the four fail without the fix (verified by disabling it).

**Physical transaction (`tests/persistence/test_physical_transaction.py`)** pins the driver behaviour the
helper depends on, so a future Python/SQLAlchemy/driver change that removes it fails loudly there rather
than silently downstream: a read-only session is in a SQLAlchemy transaction but not a SQLite one; the
helper opens one and is idempotent; it is a no-op once the session has written; without it a released
savepoint commits, with it the savepoint is genuinely nested; and it does not take over the commit.

**Migration (`tests/persistence/test_rules_authority_migration.py`)** runs the real alembic chain against a
throwaway database and asserts: all four tables created; migrated columns matching the ORM exactly; the
installed trigger set matching the fixture's mirror exactly (so the hand-installed fixture cannot drift);
the version table carrying no foreign key; `downgrade 0023` removing every table and trigger while leaving
0021/0023 intact; upgrade→downgrade→upgrade clean; nine parametrised rewrite paths each refused against the
migrated schema; identical re-inserts permitted; package deletion cascading the association; and an
identical-`entry_count` `INSERT OR REPLACE` refused in every state carrying retained evidence, with the one
childless shape pinned as inert.

**The exact CRD Issue 5c production release exercised:** package `4458fa10-4a66-5e0e-9ecc-ea37530ad2b4`,
release `5.2.1-corpus.36b786d8-fa2` — re-confirmed by building the release from the committed PDF through
CRD Issue 5c's own lifecycle, not assumed. Against it the runtime path reports `UNPUBLISHED`, and a
whole-package rule slice is `UNPUBLISHED` rather than empty.

### Verification on the final head `98c6428`

**CI on `98c6428` — [run #411](https://github.com/AfterworldsAI/afterworlds/actions/runs/31294214311),
all three jobs green:** *Lint, Type-check, Test, Audit* (Black, Ruff, strict mypy, `pytest --cov=src
--durations=25`, pip-audit) — success; *Frontend — Typecheck, Lint, Format, Test, Audit, Build* — success;
*E2E — minimal spine (Playwright, faked provider passes)* — success. That run is the full-suite evidence for
this head.

Locally on the same head:

```
black --check src/ tests/                 # 414 files unchanged
ruff check src/ tests/                    # All checks passed
mypy src/                                 # no issues in 222 source files
git diff --check                          # clean
pytest tests/persistence/ tests/services/rules_authority/   # 367 passed
pytest tests/persistence/test_rules_authority_migration.py  # 22 passed
```

The previous head `514cc6b` was additionally verified with a full local
`pytest --cov=src --durations=25` — 3267 passed, 10 skipped in 44:13, total coverage 93.44%. The local
full-suite repeat on `98c6428` was abandoned mid-run after a timing-sensitive API test
(`test_concurrent_submissions_different_stories_do_not_serialize`) flaked under concurrent load I had put on
the same machine; it passes on four consecutive clean runs and passed on the CI runner. Reported rather than
quietly re-run.

The savepoint defect was reproduced against the repository's own engine settings on Python 3.12.3 /
SQLAlchemy 2.0.51 / SQLite 3.45.1 before anything was changed, and the correction verified the same way.

Migration re-verified end to end from a clean database: `upgrade head` creates all four tables and installs
all nine triggers; every rewrite path is refused at the SQLite level; `downgrade 0023` removes them all;
re-upgrade matches the ORM exactly.

## Architecture Notes

**No drift from ADR-005d, ADR-005c (as amended), or #137.** ADR-005d Decision 9 explicitly leaves the
retention shape an implementation choice — "a content-addressed snapshot, … append-only version records, or
… append-only events" — and states that "the enclosing package UUID already supplies package scope," which
is exactly what the scope association records. Nothing here changes a claim either authority makes, so
neither is amended.

**Typed overrides live in their own table.** `rp_mech_overrides` is new rather than an extension of
`rp_overrides`: #137 contract 6 keeps chunk-targeting prose overrides distinct from typed mechanical
patches, and `rp_overrides` still carries the obsolete `target_entity_id` column the final
legacy-retirement PR removes.

**Overrides target semantic keys, not derived projection IDs.** Derived IDs are minted from the projection
UUID, so targeting them would expire every override the moment the same release is reprojected. Release
scope is enforced instead by the override's authored `release_version`.

**Identity is derived from the canonical validated patch, not the stored bytes**, so two payloads listing
the same facts in a different order are one authority while any genuine content change still moves the
identity.

**Retained versions are content, not one package's possession — and scope is a separate association.**
Because identity derives from the ordered entries alone, identical state across packages is one row and the
empty set is shared by every package. `rp_override_set_versions` therefore carries no `package_uuid` and no
foreign key; `rp_override_set_scopes` records which packages retained it. The two grains are what make both
properties true at once: shared content survives any one package's deletion, and a retained version may
only be replayed under a scope it was actually retained for.

**The scope delete guard is conditional, and that is the contract.** Deleting a package is the one
contractual way an association goes away, so the guard fires only while the owning package still exists.
SQLite removes the parent row before cascading, so the cascade proceeds and a direct delete is refused.
A removed association fails replay closed, never with false provenance.

**The physical-transaction fix is scoped to the retention call site, deliberately.** SQLAlchemy's documented
remedy for pysqlite's legacy transaction control is an engine-wide pair of `connect`/`begin` listeners that
makes *every* transaction physical. That would change when a write lock is taken for every service and
migration in the repository — a behavioural change well outside this issue, and one that would need its own
bounded audit. A one-call-site helper buys the guarantee this defect needs and nothing else.

**Sibling `begin_nested()` sites are surfaced, not changed.** `ingestion_service._upsert_package` /
`_upsert_source`, `rolling_summary`, and Story Bible's Extractor routing open savepoints in the same shape.
Whether any is actually exposed depends on whether DML precedes it — the orchestrator writes its turn row
before Extractor routing, for instance — and that was **not** audited here. Named as residue for a separate
bounded pass rather than swept into this PR.

**Disabled overrides participate in identity**, because ADR-005d Decision 9 lists enablement as a per-entry
field and requires both enabling and disabling to mint a different identity.

**A cross-release override fails the whole binding, closed**, rather than being filtered out and made
invisible.

**Binding resolution retains an override-set version, so a read path writes.** ADR-005d requires the
override-set UUID to name a retrievable immutable version. Resolution is the point at which that evidence
must exist, so it is recorded there — idempotently, inside the caller's transaction, flushing rather than
committing. A diagnostic caller that must not write can pass `retain=False`.

**An override-supplied component must be `STRUCTURED`.** Prose-bound handling requires build-time 5c prose
binding and span-exact provenance a runtime patch cannot supply; authoring prose here would create the
second prose store ADR-005d forbids. A prose-bound base component can be `DISABLE`d but not `REPLACE`d.
Surfaced rather than decided quietly — if runtime prose overrides are wanted, that is an ADR-005d change.

**The orchestrator's rule-slice request is removed rather than replaced.** It carried no selectors, so its
slice was always empty. It is not replaced with `whole_package=True`: which mechanics an adjudicating turn
needs is **CRD Issue 15c's** selection contract, and it would put whole-corpus authority into every turn's
stable prefix.

**The reference resolver is optional wiring.** Injecting it in production belongs with activation. How a
Character Sheet stores and revalidates its package reference remains **CRD Issue 2b's**.

**Nothing combines or falls back between old and new authority.** The legacy slice remains runnable and
separate until the final activation/legacy-retirement PR.

**Threat model.** Retained evidence is guarded against mutation, deletion, and rewrite through every
ordinary path, and verified again on read. Forging *new* evidence by direct SQL is outside the standard
CRD Issue 5c operational-reliability amendment §2.2 sets, which explicitly does not promise resistance to
an actor rewriting the database coherently. Stated so the boundary is explicit rather than implied.

### Legacy paths still pending

- `MechanicalEntity`, `SpellEntity`, `ConditionEntity`, `StatBlockEntity`, `ActionEntity`, `ItemEntity`,
  `EntityData`, `rp_mechanical_entities`, and `RuleOverride.target_entity_id` — all still present and
  runnable; removal is the final activation/legacy-retirement PR (#137 acceptance criterion 22).
- `RulesPackageService.get_active_rule_slice()`'s legacy chunk/entity path — retained unchanged.
- Production wiring of the reference resolver into `OrchestratorService`, and placement of the typed
  mechanical slice into `StablePrefix` — both belong with activation.

### Downstream seams touched

- **CRD Issue 2b** — `RulesPackageBinding` consumable as a standalone typed model; sheet storage remains 2b's.
- **CRD Issue 15c** — the two views expose exact authority with no capability surface; selector narrowing
  is 15c's.
- **CRD Issue 8 / Context Builder** — `RuleSliceRequest` extended in place; the service protocol gained
  `resolve_slice_package`. `StablePrefix` shape unchanged.
- **Orchestrator** — one new optional constructor parameter; no change to turn flow when unwired.
- **Persistence** — `persistence/database.py` gains `ensure_physical_transaction()`. Additive; no existing
  engine, session, or transaction behaviour is changed, and no other call site adopts it in this PR.
- **CRD Issue 5c** — read-only; no behaviour, identity, or seam modified.

## Review-Loop / Boundary Check

- [x] This PR still fits the intended scope of the issue.
- [ ] Repeated review churn has **not** accumulated on the same file or function.
- [x] The remaining work is still concrete implementation, not an ownership or boundary dispute.

Reported honestly: **five review rounds have now reached the retained-evidence seam**, and the
sibling-audit gate and stop condition fired at round 3. That round began by reconstructing the retention
invariant across snapshot, scope association, binding resolution, replay, deletion, rollback, and
concurrency before either symptom was touched — and found that round 2's own fix had created round 3's
first defect, by giving the association a delete path nothing guarded. Round 4 was the same seam one layer
down: the architecture rounds 2–3 arrived at was correct, but the physical transaction beneath its savepoint
did not exist on the read-then-retain path. Round 5 raised the identical-`entry_count` REPLACE path; that
one did not reproduce in any state carrying retained evidence, but the observation that the outcome rested
on reasoning rather than assertion was fair, and it is now asserted state by state.

**Sibling-audit dispositions (bounded to the representative parallel operations):**

| Operation | Disposition |
|---|---|
| Retained version creation | **patched** — upsert + savepoint over a real transaction |
| Scope-association creation | **patched** — upsert, and delete-guarded while live |
| Binding creation/resolution | **already safe** — scope is correct by construction; verified by the closure controls |
| Package deletion and cascades | **already safe**, now asserted — cascade preserved, direct delete refused |
| Replay reconstruction | **already safe** — scope verification from round 2, re-asserted end to end |
| Transaction rollback | **patched twice** — one savepoint over the whole unit (round 3), and a physical `BEGIN` beneath it so releasing that savepoint no longer commits (round 4) |
| `INSERT OR REPLACE` at an identical header | **already safe, now asserted** — FK cascade fires the children's DELETE guards and aborts; only a childless header is replaceable, and only its non-identity audit stamp moves |
| Other `begin_nested()` sites (ingestion, rolling summary, Story Bible) | **out of scope** — same shape, exposure unaudited, surfaced above |

Projection activation (`publication.py`) carries its own separate concurrency mechanism and is **out of
scope** for this family; it was not touched.

**No Owner decision, Known Unknown, Issue change, or ADR change was required.** Two boundaries remain
surfaced rather than decided: runtime prose-bound overrides, and which mechanics an adjudicating turn
selects.