### PR TITLE
feat(rules): first-class authored prose overlay for typed overrides (#137)

### DIFF
--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -5,7 +5,10 @@
 **Status:** Accepted — finalized by Owner 2026-07-30; amended by Owner Decision 2026-07-30 (PR #138
 review) so the effective runtime binding also carries an immutable override-set identity, and clarified
 in the same review so the contents that identity names are retained as immutable, provenance-exact replay
-evidence  
+evidence; further amended by Owner Decision 2026-08-08 so a runtime prose-bound override may resolve
+through a first-class authored-authority overlay distinct from 5c source prose, replacing this ADR's
+blanket prohibition on a second prose store with the narrower invariant that there is no duplicated store
+for what the SRD source says  
 **Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
 
 ---
@@ -100,6 +103,14 @@ Records and components use stable semantic keys rather than positional ordinals.
 and relationships carry exact many-to-many provenance to 5c leaf subspans. Primary and contextual roles
 are distinct; contextual overlap is permitted while conflicting primary claims fail.
 
+**Amended by Owner Decision 2026-08-08.** The many-to-many provenance required above binds the immutable
+base projection's prose bindings: those resolve exclusively to 5c leaf subspans and carry no other
+provenance. A distinct runtime authored-authority prose overlay, layered over a published record or
+component (Decision 10), is not a prose binding under this decision and does not participate in its
+many-to-many 5c subspan provenance. Authored prose is never assigned a 5c leaf subspan, a chunk identity,
+or an irreducibility claim copied from base-projection authority; its provenance is the authored override
+record and the retained override-set version that supplied it (Decision 9).
+
 ### Decision 4 — Closed typed facts, no generated rules engine
 
 Structured authority uses a closed, versioned discriminated union of fact families. A new mechanical
@@ -147,6 +158,12 @@ committed semantic keys, never local ordinals.
 This identity covers the immutable base projection only. `RuleOverride` state is deliberately outside it
 and carries its own separate identity under Decisions 9 and 10, so an override change never mutates or
 remints the base projection UUID.
+
+**Amended by Owner Decision 2026-08-08.** A runtime authored-authority prose overlay never contributes a
+component, fact, or prose binding to this identity. Whether zero or many authored prose overrides are
+applied at runtime, the projection they are applied over has exactly one `mechanical_projection_uuid`; the
+authored overlay's own complete canonical form participates instead in the override-set identity governed
+by Decision 9.
 
 ### Decision 7 — Build-time reference resolution
 
@@ -291,6 +308,14 @@ Every rule-slice request carries the exact effective binding plus deterministic 
 whole-package flag. Invalid slugs, accidentally empty selectors, stale bindings, and mismatched releases
 fail explicitly.
 
+**Amended by Owner Decision 2026-08-08.** The "complete validated payload" every canonical override entry
+already carries explicitly covers a prose-authority payload: the complete authored text of a `REPLACE` or
+`APPEND` against prose authority, or the empty payload of a `DISABLE`. Changing that authored text changes
+the override-set UUID exactly as changing any other enumerated field does; it never changes
+`mechanical_projection_uuid`. Prose authority is targeted at the same grain as a component — stable record
+and component identity — but is a distinct target kind (Decision 10), so a prose operation and a component
+operation against the same record/component pair are two different targets and never collide.
+
 ### Decision 10 — Typed override completion
 
 ADR-0007's entity-targeting override deferral is discharged by 5d.
@@ -316,6 +341,53 @@ never a generic JSON overwrite.
 
 The obsolete prose-only `MechanicalEntity` target is removed under ADR-005c's pre-release clean-baseline
 authority. Unmappable development targets are not guessed into new identities.
+
+**Amended by Owner Decision 2026-08-08 — a first-class authored-authority prose overlay.** `DISABLE`,
+`REPLACE`, and `APPEND` now also apply to prose authority: a fourth typed target grain scoped by stable
+record and component identity, never a raw chunk, a JSON path, or an unscoped selector. Their existing
+meanings extend without changing:
+
+- `DISABLE` on prose authority suppresses that exact component's effective governing prose without
+  deleting its base state — a structured or mixed component's typed facts are untouched, and a
+  prose-bound component's declared handling is untouched, even though it now presents no governing prose.
+- `REPLACE` on prose authority replaces the target's complete effective governing prose with exact
+  authored prose, superseding both the base projection's 5c-bound prose and any previously applied
+  authored prose for that target, resolved in the same ascending `(precedence, override_id)` order every
+  other override uses.
+- `APPEND` on prose authority preserves the target's existing effective governing prose — 5c-bound,
+  previously authored, or both — and adds one more authored passage after it, in that same order.
+
+Effective governing prose is represented as a closed discriminated form distinguishing at least:
+
+- **source prose** — an exact `chunk_id` and its resolved 5c text; and
+- **authored prose** — exact text plus the supplying override's stable identity and origin.
+
+Authored prose is never assigned a fake `chunk_id`, 5c span provenance, or an irreducibility claim copied
+from the base source; its provenance is the authored override and the retained override-set version
+(Decision 9). Attaching authored prose to a component the base projection classified `STRUCTURED` — which
+by definition carries no prose binding — makes that component's *effective* handling `MIXED` in every view
+built from it, honestly reflecting that structured facts and authored prose now coexist; the immutable base
+projection's own `STRUCTURED` classification and identity are untouched. A `DISABLE` of prose authority
+does not demote an effective `PROSE_BOUND` or `MIXED` component's handling merely because it now shows no
+prose — including a `MIXED` promotion that an earlier override in the same resolved set produced, which a
+later `DISABLE` of that same prose does not reverse; the suppression is visible in applied-override
+provenance instead. Complete component additions or
+replacements (this decision's existing `REPLACE`/`APPEND` component and record patches) may declare
+`PROSE_BOUND` or `MIXED` handling and carry authored prose where their own closed schema permits it, under
+the same non-fabricated-provenance rule.
+
+This discharges ADR-005d's blanket prohibition on a second prose store (recorded in this ADR's implementing
+code — `patches.py`'s prior docstring — and in #137 contract 3, rather than as a prior Decision clause in
+this document). The narrower invariant is: there is
+no duplicated store for what the SRD source says. 5c source prose remains immutable, resolves only from its
+exact `RuleChunk`, and is never copied and relabeled as source authority. A separately identified
+authored-authority overlay — carrying its own distinct provenance and never claiming 5c provenance — is
+intentional and is exactly what this amendment adds.
+
+Legacy chunk-targeting overrides (the pre-existing `rp_overrides` prose path) remain a distinct, obsolete
+pre-release mechanism. They are not a second concurrent mechanical or GameMaster truth: the typed authority
+path and views this ADR governs never read them, and their removal remains scheduled for the final
+activation/legacy-retirement PR, not the PR that introduces this overlay.
 
 ### Decision 11 — Downstream ownership remains downstream
 
@@ -413,6 +485,9 @@ narrowly scoped cross-reference as of this change.
   supplied each applied change. Runtime stale detection remains a separate fail-closed check against
   current override state.
 - 2b and 15c receive stable upstream contracts.
+- A house rule or package-patch author can supply exact authored governing prose through the same typed,
+  provenance-exact override path as any other mechanical patch, without corrupting or duplicating 5c
+  source authority (Owner Decision 2026-08-08).
 
 ### Costs
 
@@ -428,6 +503,9 @@ narrowly scoped cross-reference as of this change.
   mints a new override-set identity even when the mechanical result is unchanged, so authoring churn is
   visible in the binding rather than hidden by it.
 - Delivery requires multiple PRs before 5d is complete.
+- An effective component's governing prose can now be a mix of immutable 5c-bound passages and
+  mutable-until-retained authored passages, ordered by the same precedence rule as every other override;
+  operators and auditors reason about one more provenance-exact case (Owner Decision 2026-08-08).
 
 ### Rejected alternatives
 
@@ -465,6 +543,16 @@ narrowly scoped cross-reference as of this change.
     identity and origin as well. Identity is not broadened past that: creation timestamps, authors,
     comments, and proposal history stay non-identity audit metadata unless they participate in
     applicability, ordering, or resolution.
+14. **Integrate authored prose through the legacy `rp_overrides` chunk-targeting path.** Rejected by Owner
+    Decision 2026-08-08: that path targets a raw chunk directly, which is exactly the raw-chunk/unscoped-
+    selector targeting this ADR's typed override system exists to replace, and it would leave two
+    concurrent, differently-shaped override mechanisms both claiming to patch mechanical authority.
+    Authored prose extends the same typed record/component/fact target system instead, at a fourth grain
+    scoped by stable record and component identity.
+15. **Give authored prose its own irreducibility reason from the closed 5c catalog.** Rejected: that
+    catalog exists for 5c's build-time semantic classification of *source* text (Decision 2), a judgment an
+    override author is not making. An override-supplied component's `irreducibility_reason_code` stays
+    `None`, so it can never be confused with, or copied from, a base-projection classification.
 
 ---
 

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -358,7 +358,12 @@ meanings extend without changing:
 - `REPLACE` on prose authority replaces the target's complete effective governing prose with exact
   authored prose, superseding both the base projection's 5c-bound prose and any previously applied
   authored prose for that target, resolved in the same ascending `(precedence, override_id)` order every
-  other override uses.
+  other override uses. It also clears any source-derived irreducibility reason the component carried: that
+  reason was the base corpus's judgement about the source prose this operation just discarded, and keeping
+  it would be exactly the copied irreducibility claim the non-fabricated-provenance rule below forbids.
+  `APPEND` and `DISABLE` leave the reason untouched — `APPEND` only adds to existing governing prose, so
+  any source prose the reason describes remains effective, and `DISABLE`'s reason-preserving behavior on a
+  now-empty `PROSE_BOUND` component is the named exception directly below.
 - `APPEND` on prose authority preserves the target's existing effective governing prose — 5c-bound,
   previously authored, or both — and adds one more authored passage after it, in that same order.
 

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -8,7 +8,9 @@ in the same review so the contents that identity names are retained as immutable
 evidence; further amended by Owner Decision 2026-08-08 so a runtime prose-bound override may resolve
 through a first-class authored-authority overlay distinct from 5c source prose, replacing this ADR's
 blanket prohibition on a second prose store with the narrower invariant that there is no duplicated store
-for what the SRD source says  
+for what the SRD source says; further amended by Owner Decision 2026-08-09 so that overlay's effective
+`handling` is derived fresh from currently surviving facts and prose after each prose operation rather than
+remembered as a sticky promotion, correcting this ADR's prior text to the contrary  
 **Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
 
 ---
@@ -348,8 +350,9 @@ record and component identity, never a raw chunk, a JSON path, or an unscoped se
 meanings extend without changing:
 
 - `DISABLE` on prose authority suppresses that exact component's effective governing prose without
-  deleting its base state — a structured or mixed component's typed facts are untouched, and a
-  prose-bound component's declared handling is untouched, even though it now presents no governing prose.
+  deleting its base state or altering its typed facts. What that leaves the component's *effective*
+  handling as depends on what survives — see the effective-content classification below — not on what the
+  component's handling was before the disable.
 - `REPLACE` on prose authority replaces the target's complete effective governing prose with exact
   authored prose, superseding both the base projection's 5c-bound prose and any previously applied
   authored prose for that target, resolved in the same ascending `(precedence, override_id)` order every
@@ -367,14 +370,34 @@ from the base source; its provenance is the authored override and the retained o
 (Decision 9). Attaching authored prose to a component the base projection classified `STRUCTURED` — which
 by definition carries no prose binding — makes that component's *effective* handling `MIXED` in every view
 built from it, honestly reflecting that structured facts and authored prose now coexist; the immutable base
-projection's own `STRUCTURED` classification and identity are untouched. A `DISABLE` of prose authority
-does not demote an effective `PROSE_BOUND` or `MIXED` component's handling merely because it now shows no
-prose — including a `MIXED` promotion that an earlier override in the same resolved set produced, which a
-later `DISABLE` of that same prose does not reverse; the suppression is visible in applied-override
-provenance instead. Complete component additions or
+projection's own `STRUCTURED` classification and identity are untouched. Complete component additions or
 replacements (this decision's existing `REPLACE`/`APPEND` component and record patches) may declare
 `PROSE_BOUND` or `MIXED` handling and carry authored prose where their own closed schema permits it, under
 the same non-fabricated-provenance rule.
+
+**Amended by Owner Decision 2026-08-09 — effective-content classification, not historical/sticky.** An
+earlier draft of this decision stated that a `DISABLE` of prose authority "does not demote" an effective
+`PROSE_BOUND` or `MIXED` component's handling, including a `MIXED` promotion an earlier override in the
+same resolved set produced. That was wrong and is superseded: `EffectiveComponent.handling` describes the
+authority surviving *after* ordered override application, not authority that existed earlier in the
+sequence, so it is derived fresh from what survives each time a prose operation resolves rather than
+remembered as a sticky flag. Concretely:
+
+- effective facts plus effective prose → `MIXED`;
+- effective facts without effective prose → `STRUCTURED`;
+- effective prose without effective facts → `PROSE_BOUND`;
+- a prose-only component whose sole prose authority is suppressed remains `PROSE_BOUND`, with an empty
+  effective prose surface, because no other category honestly describes a component with no typed facts.
+
+So `STRUCTURED → authored prose → MIXED → DISABLE prose` finishes `STRUCTURED`, and a base `MIXED`
+component whose prose is suppressed while its facts survive finishes `STRUCTURED` the same way — a
+promotion to `MIXED` is never sticky. This recomputation affects only the effective runtime view: the
+immutable base projection's own classification and identity, and every applied-override's provenance, are
+unaffected either way. It does not loosen the unchanged suppression rule directly above — a later override
+aimed at the *exact same* already-disabled prose target still does not apply; re-promotion after a
+suppression can only come from a different target (a whole-component or whole-record replacement clears
+the stale suppression for the semantic key it replaces, exactly as it already does for facts and
+components).
 
 This discharges ADR-005d's blanket prohibition on a second prose store (recorded in this ADR's implementing
 code — `patches.py`'s prior docstring — and in #137 contract 3, rather than as a prior Decision clause in

--- a/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
+++ b/docs/decisions/adr-005d-complete-typed-mechanical-authority.md
@@ -9,8 +9,10 @@ evidence; further amended by Owner Decision 2026-08-08 so a runtime prose-bound 
 through a first-class authored-authority overlay distinct from 5c source prose, replacing this ADR's
 blanket prohibition on a second prose store with the narrower invariant that there is no duplicated store
 for what the SRD source says; further amended by Owner Decision 2026-08-09 so that overlay's effective
-`handling` is derived fresh from currently surviving facts and prose after each prose operation rather than
-remembered as a sticky promotion, correcting this ADR's prior text to the contrary  
+`handling` is a final classification of each component's own surviving facts and prose, derived once at
+final assembly for every component regardless of which override family supplied its authority or which
+operation resolved last, rather than remembered as a sticky promotion, correcting this ADR's prior text to
+the contrary  
 **Amends/clarifies:** ADR-005c, ADR-0007, ADR-015, ADR-018
 
 ---
@@ -375,28 +377,38 @@ replacements (this decision's existing `REPLACE`/`APPEND` component and record p
 `PROSE_BOUND` or `MIXED` handling and carry authored prose where their own closed schema permits it, under
 the same non-fabricated-provenance rule.
 
-**Amended by Owner Decision 2026-08-09 — effective-content classification, not historical/sticky.** An
-earlier draft of this decision stated that a `DISABLE` of prose authority "does not demote" an effective
-`PROSE_BOUND` or `MIXED` component's handling, including a `MIXED` promotion an earlier override in the
-same resolved set produced. That was wrong and is superseded: `EffectiveComponent.handling` describes the
-authority surviving *after* ordered override application, not authority that existed earlier in the
-sequence, so it is derived fresh from what survives each time a prose operation resolves rather than
-remembered as a sticky flag. Concretely:
+**Amended by Owner Decision 2026-08-09 — final effective-state classification, not historical/sticky or
+path-dependent.** An earlier draft of this decision stated that a `DISABLE` of prose authority "does not
+demote" an effective `PROSE_BOUND` or `MIXED` component's handling, including a `MIXED` promotion an
+earlier override in the same resolved set produced. That was wrong and is superseded:
+`EffectiveComponent.handling` describes the authority surviving *after* ordered override application, not
+authority that existed earlier in the sequence. It is a classification of each component's own final
+`facts` and `governing_prose`, computed once at final assembly, for every component alike — whether its
+authority came from a prose operation, a whole-component or whole-record `REPLACE`/`APPEND` declaring
+`handling` directly, or the immutable base projection — never remembered as a sticky flag and never
+dependent on which of those override families supplied the authority or which operation resolved last.
+Concretely, for every component with surviving facts or surviving prose after override application:
 
 - effective facts plus effective prose → `MIXED`;
 - effective facts without effective prose → `STRUCTURED`;
-- effective prose without effective facts → `PROSE_BOUND`;
-- a prose-only component whose sole prose authority is suppressed remains `PROSE_BOUND`, with an empty
-  effective prose surface, because no other category honestly describes a component with no typed facts.
+- effective prose without effective facts → `PROSE_BOUND`.
 
-So `STRUCTURED → authored prose → MIXED → DISABLE prose` finishes `STRUCTURED`, and a base `MIXED`
-component whose prose is suppressed while its facts survive finishes `STRUCTURED` the same way — a
-promotion to `MIXED` is never sticky. This recomputation affects only the effective runtime view: the
-immutable base projection's own classification and identity, and every applied-override's provenance, are
-unaffected either way. It does not loosen the unchanged suppression rule directly above — a later override
-aimed at the *exact same* already-disabled prose target still does not apply; re-promotion after a
-suppression can only come from a different target (a whole-component or whole-record replacement clears
-the stale suppression for the semantic key it replaces, exactly as it already does for facts and
+A component left with neither is not content-bearing; classifying that state is out of this decision's
+scope. The one settled exception is a prose-only component whose sole prose authority is suppressed: it
+remains `PROSE_BOUND`, with an empty effective prose surface, because no other category honestly describes
+a component with no typed facts — this is the component's already-declared handling, unmutated by the
+suppression itself, so it is unaffected by whether the prose or a sibling fact was suppressed first.
+
+So `STRUCTURED → authored prose → MIXED → DISABLE prose` finishes `STRUCTURED`, and a `MIXED` component —
+however its facts and prose were supplied — whose prose is suppressed while its facts survive finishes
+`STRUCTURED` the same way; a `MIXED` component whose facts are removed while its prose survives finishes
+`PROSE_BOUND` the same way. A promotion to `MIXED` is never sticky, and none of this depends on the order in
+which the surviving facts and prose were established. This classification affects only the effective
+runtime view: the immutable base projection's own classification and identity, and every applied-override's
+provenance, are unaffected either way. It does not loosen the unchanged suppression rule directly above — a
+later override aimed at the *exact same* already-disabled prose target still does not apply; re-promotion
+after a suppression can only come from a different target (a whole-component or whole-record replacement
+clears the stale suppression for the semantic key it replaces, exactly as it already does for facts and
 components).
 
 This discharges ADR-005d's blanket prohibition on a second prose store (recorded in this ADR's implementing

--- a/src/afterworlds/services/rules_authority/__init__.py
+++ b/src/afterworlds/services/rules_authority/__init__.py
@@ -12,11 +12,14 @@ currently reports ``UNPUBLISHED`` — honestly, and by construction.
 
 from afterworlds.services.rules_authority.application import (
     AppliedOverride,
+    AuthoredProse,
     EffectiveAuthority,
     EffectiveComponent,
     EffectiveFact,
     EffectiveRecord,
+    GoverningProseEntry,
     OverrideApplicationError,
+    SourceProse,
     apply_override_set,
 )
 from afterworlds.services.rules_authority.binding import (
@@ -61,13 +64,13 @@ from afterworlds.services.rules_authority.targets import (
 from afterworlds.services.rules_authority.views import (
     GameMasterAuthorityView,
     GameMasterComponent,
-    GoverningProse,
     TypedAuthorityView,
 )
 
 __all__ = [
     "EMPTY_OVERRIDE_SET_UUID",
     "AppliedOverride",
+    "AuthoredProse",
     "AuthorityOutcome",
     "AuthorityResult",
     "BindingResolution",
@@ -79,7 +82,7 @@ __all__ = [
     "EffectiveRecord",
     "GameMasterAuthorityView",
     "GameMasterComponent",
-    "GoverningProse",
+    "GoverningProseEntry",
     "IncoherentBindingError",
     "InvalidPatchError",
     "MechanicalPatch",
@@ -92,6 +95,7 @@ __all__ = [
     "PackageResolution",
     "PatchFamily",
     "RulesAuthorityService",
+    "SourceProse",
     "TargetShapeError",
     "TypedAuthorityView",
     "apply_override_set",

--- a/src/afterworlds/services/rules_authority/application.py
+++ b/src/afterworlds/services/rules_authority/application.py
@@ -405,19 +405,25 @@ def _finalize_component(
     record: EffectiveRecord,
     component: EffectiveComponent,
     disabled_facts: set[tuple[str, str, str]],
-    prose_touched: set[tuple[str, str]],
 ) -> EffectiveComponent:
-    """Filter disabled facts and, for components a prose operation touched,
-    re-derive handling from what survives.
+    """Filter disabled facts and derive final effective handling from what
+    survives — unconditionally, for every component, from its own final
+    ``facts``/``governing_prose`` (Owner Decision 2026-08-09, generalized).
+    This is the single derivation seam: nothing upstream sets ``handling`` for
+    a component a prose or fact operation touched, so there is no tracking
+    set whose membership could go stale if a semantic key is later
+    reincarnated by a replacement, and the result cannot depend on which
+    override family supplied the authority or which operation resolved last.
 
-    A prose operation derives ``handling`` from ``component.facts`` as it
-    stands *at that point* in the resolution order (Owner Decision
-    2026-08-09). A later FACT-kind ``DISABLE`` on the same component is only
-    reflected in ``component.facts`` here, at final assembly — so without this
-    second derivation, a component promoted to ``MIXED`` by an earlier prose
-    ``APPEND``/``REPLACE`` would keep reporting facts it no longer has once a
-    later override strips its last one. Components no prose operation ever
-    touched keep their already-correct handling untouched.
+    A component with neither surviving facts nor surviving prose is not
+    content-bearing; this derivation does not invent a policy for that
+    unrelated state and leaves ``handling`` exactly as declared — by the base
+    projection, or by whichever REPLACE/APPEND most recently (re)created this
+    component version. That declared value is never mutated mid-resolution by
+    any prose or fact operation (only by a component/record replacement
+    actually re-declaring it), so this fallback is itself order-independent
+    between a fact ``DISABLE`` and a prose ``DISABLE`` racing to empty the
+    same component out.
     """
     facts = tuple(
         fact
@@ -425,11 +431,16 @@ def _finalize_component(
         if (record.semantic_key, component.semantic_key, fact.fact_key)
         not in disabled_facts
     )
-    if (record.semantic_key, component.semantic_key) not in prose_touched:
-        return replace(component, facts=facts)
-    handling = _derive_prose_driven_handling(
-        facts_present=bool(facts), governing_prose=component.governing_prose
-    )
+    facts_present = bool(facts)
+    prose_present = bool(component.governing_prose)
+    if facts_present and prose_present:
+        handling = ComponentHandling.MIXED
+    elif facts_present:
+        handling = ComponentHandling.STRUCTURED
+    elif prose_present:
+        handling = ComponentHandling.PROSE_BOUND
+    else:
+        handling = component.handling
     reason = (
         None
         if handling is ComponentHandling.STRUCTURED
@@ -458,7 +469,6 @@ def apply_override_set(
     disabled_components: set[tuple[str, str]] = set()
     disabled_facts: set[tuple[str, str, str]] = set()
     disabled_prose: set[tuple[str, str]] = set()
-    prose_touched: set[tuple[str, str]] = set()
     provenance: list[AppliedOverride] = []
 
     for entry in override_set.entries:
@@ -472,7 +482,6 @@ def apply_override_set(
                 disabled_components,
                 disabled_facts,
                 disabled_prose,
-                prose_touched,
             )
         else:
             note = "authored disabled"
@@ -495,7 +504,7 @@ def apply_override_set(
         replace(
             record,
             components=tuple(
-                _finalize_component(record, component, disabled_facts, prose_touched)
+                _finalize_component(record, component, disabled_facts)
                 for component in record.components
                 if (record.semantic_key, component.semantic_key)
                 not in disabled_components
@@ -511,31 +520,6 @@ def apply_override_set(
     )
 
 
-def _derive_prose_driven_handling(
-    *, facts_present: bool, governing_prose: tuple[GoverningProseEntry, ...]
-) -> ComponentHandling:
-    """Effective handling for the authority that survives a prose operation.
-
-    Owner Decision 2026-08-09: effective-content classification. ``handling``
-    describes the authority surviving *after* this operation, never authority
-    that existed earlier in the sequence — so this is a pure function of what
-    remains right now, not a sticky flag remembering an earlier promotion.
-
-    * facts and prose both present -> ``MIXED``;
-    * facts only -> ``STRUCTURED``;
-    * prose only, or neither -> ``PROSE_BOUND``, because no other category
-      honestly describes a component with no typed facts, whether or not its
-      remaining prose is also empty (a suppressed prose-only component stays
-      ``PROSE_BOUND`` with an empty prose surface rather than inventing a
-      fourth state for "nothing").
-    """
-    if facts_present and governing_prose:
-        return ComponentHandling.MIXED
-    if facts_present:
-        return ComponentHandling.STRUCTURED
-    return ComponentHandling.PROSE_BOUND
-
-
 def _apply_prose_entry(
     entry: EffectiveOverrideEntry,
     patch: DisablePatch | ProseReplacementPatch | ProseAdditionPatch,
@@ -543,27 +527,19 @@ def _apply_prose_entry(
     record: EffectiveRecord,
     records: dict[str, EffectiveRecord],
     disabled_prose: set[tuple[str, str]],
-    disabled_facts: set[tuple[str, str, str]],
-    prose_touched: set[tuple[str, str]],
 ) -> tuple[bool, str]:
     """Apply one entry targeting prose authority (Owner Decision 2026-08-08).
 
     Prose is a sibling of a component's typed facts, never nested inside their
-    application: this never adds, removes, or reorders ``facts`` — only
-    ``governing_prose`` and the ``handling``/``irreducibility_reason_code``
-    pair derived fresh from what survives (Owner Decision 2026-08-09).
-
-    ``facts_present`` reads against ``disabled_facts`` rather than trusting
-    ``component.facts`` directly: a FACT-kind ``DISABLE`` earlier in this same
-    resolution order is recorded there immediately but is only filtered out of
-    ``component.facts`` once, at final assembly (see ``apply_override_set``),
-    so reading ``component.facts`` alone here could see a fact that is already
-    suppressed and about to disappear.
-
-    Recording this target in ``prose_touched`` is what lets final assembly
-    (``_finalize_component``) re-derive ``handling`` again if a *later* FACT
-    ``DISABLE`` on this same component changes what survives after this call
-    returns.
+    application: this touches only ``governing_prose``. It never touches
+    ``handling`` or ``irreducibility_reason_code`` — those are derived exactly
+    once, at final assembly, from each component's own final ``facts`` and
+    ``governing_prose`` (``_finalize_component``, Owner Decision 2026-08-09,
+    generalized), the same way regardless of which override family supplied
+    the authority or what order it resolved in. Leaving ``handling`` alone
+    here also keeps ``_apply_entry``'s ``FactAdditionPatch`` refusal reading
+    the component's actual *declared* handling, as it did before this overlay
+    existed, rather than a value a prose operation computed mid-sequence.
     """
     assert target.component_key is not None
     found = _find_component(record, target.component_key)
@@ -573,34 +549,11 @@ def _apply_prose_entry(
             f"target {target.describe()} names no component of {target.record_key!r}",
         )
     index, component = found
-    prose_touched.add((target.record_key, target.component_key))
     components = list(record.components)
-    facts_present = any(
-        (target.record_key, target.component_key, fact.fact_key) not in disabled_facts
-        for fact in component.facts
-    )
 
     if isinstance(patch, DisablePatch):
         disabled_prose.add((target.record_key, target.component_key))
-        handling = _derive_prose_driven_handling(
-            facts_present=facts_present, governing_prose=()
-        )
-        # STRUCTURED must never carry an irreducibility reason — the same
-        # honesty invariant the build-time projection validator enforces on
-        # the base corpus. A reason surviving from a demoted MIXED/PROSE_BOUND
-        # component would otherwise cite a prose authority that no longer
-        # exists in this effective view.
-        reason = (
-            None
-            if handling is ComponentHandling.STRUCTURED
-            else component.irreducibility_reason_code
-        )
-        components[index] = replace(
-            component,
-            handling=handling,
-            irreducibility_reason_code=reason,
-            governing_prose=(),
-        )
+        components[index] = replace(component, governing_prose=())
         records[target.record_key] = replace(record, components=tuple(components))
         return True, "prose suppressed"
 
@@ -617,15 +570,7 @@ def _apply_prose_entry(
         governing_prose = (*component.governing_prose, authored)
         note = "prose appended"
 
-    # REPLACE/APPEND always leave governing_prose non-empty, so the derived
-    # handling here is MIXED or PROSE_BOUND, never STRUCTURED — no reason-code
-    # clearing is needed on this branch.
-    handling = _derive_prose_driven_handling(
-        facts_present=facts_present, governing_prose=governing_prose
-    )
-    components[index] = replace(
-        component, handling=handling, governing_prose=governing_prose
-    )
+    components[index] = replace(component, governing_prose=governing_prose)
     records[target.record_key] = replace(record, components=tuple(components))
     return True, note
 
@@ -637,7 +582,6 @@ def _apply_entry(
     disabled_components: set[tuple[str, str]],
     disabled_facts: set[tuple[str, str, str]],
     disabled_prose: set[tuple[str, str]],
-    prose_touched: set[tuple[str, str]],
 ) -> tuple[bool, str]:
     """Apply one enabled entry, returning whether it changed anything."""
     target = entry.target
@@ -675,8 +619,6 @@ def _apply_entry(
             record,
             records,
             disabled_prose,
-            disabled_facts,
-            prose_touched,
         )
 
     if isinstance(patch, DisablePatch):

--- a/src/afterworlds/services/rules_authority/application.py
+++ b/src/afterworlds/services/rules_authority/application.py
@@ -531,15 +531,29 @@ def _apply_prose_entry(
     """Apply one entry targeting prose authority (Owner Decision 2026-08-08).
 
     Prose is a sibling of a component's typed facts, never nested inside their
-    application: this touches only ``governing_prose``. It never touches
-    ``handling`` or ``irreducibility_reason_code`` — those are derived exactly
-    once, at final assembly, from each component's own final ``facts`` and
-    ``governing_prose`` (``_finalize_component``, Owner Decision 2026-08-09,
-    generalized), the same way regardless of which override family supplied
-    the authority or what order it resolved in. Leaving ``handling`` alone
-    here also keeps ``_apply_entry``'s ``FactAdditionPatch`` refusal reading
-    the component's actual *declared* handling, as it did before this overlay
-    existed, rather than a value a prose operation computed mid-sequence.
+    application: this never touches ``facts`` or ``handling`` — those are
+    derived exactly once, at final assembly, from each component's own final
+    ``facts`` and ``governing_prose`` (``_finalize_component``, Owner Decision
+    2026-08-09, generalized), the same way regardless of which override
+    family supplied the authority or what order it resolved in. Leaving
+    ``handling`` alone here also keeps ``_apply_entry``'s ``FactAdditionPatch``
+    refusal reading the component's actual *declared* handling, as it did
+    before this overlay existed, rather than a value a prose operation
+    computed mid-sequence.
+
+    ``irreducibility_reason_code`` is the one field this does touch, and only
+    on ``REPLACE``: that operation discards every prior governing-prose entry
+    — source or authored — for exactly one new authored passage, so a reason
+    the base corpus recorded to justify the now-discarded *source* prose's
+    irreducibility can no longer honestly describe what governs this
+    component. Carrying it forward would present authored-only authority
+    under a source-derived irreducibility claim, which ADR-005d forbids the
+    same way it forbids a fabricated ``chunk_id`` or copied span provenance.
+    ``APPEND`` and ``DISABLE`` leave it untouched: ``APPEND`` only adds to
+    existing governing prose, so any source prose the reason describes
+    remains effective; ``DISABLE``'s reason-preserving behavior for a
+    now-empty ``PROSE_BOUND`` component is the already-settled exception
+    Decision 10 names and is unchanged by this fix.
     """
     assert target.component_key is not None
     found = _find_component(record, target.component_key)
@@ -563,16 +577,17 @@ def _apply_prose_entry(
         supplied_by_origin=entry.origin,
     )
     if isinstance(patch, ProseReplacementPatch):
-        governing_prose: tuple[GoverningProseEntry, ...] = (authored,)
-        note = "prose replaced"
-    else:
-        assert isinstance(patch, ProseAdditionPatch)
-        governing_prose = (*component.governing_prose, authored)
-        note = "prose appended"
+        components[index] = replace(
+            component, governing_prose=(authored,), irreducibility_reason_code=None
+        )
+        records[target.record_key] = replace(record, components=tuple(components))
+        return True, "prose replaced"
 
+    assert isinstance(patch, ProseAdditionPatch)
+    governing_prose = (*component.governing_prose, authored)
     components[index] = replace(component, governing_prose=governing_prose)
     records[target.record_key] = replace(record, components=tuple(components))
-    return True, note
+    return True, "prose appended"
 
 
 def _apply_entry(

--- a/src/afterworlds/services/rules_authority/application.py
+++ b/src/afterworlds/services/rules_authority/application.py
@@ -401,6 +401,45 @@ def _suppressed_by(
     return None
 
 
+def _finalize_component(
+    record: EffectiveRecord,
+    component: EffectiveComponent,
+    disabled_facts: set[tuple[str, str, str]],
+    prose_touched: set[tuple[str, str]],
+) -> EffectiveComponent:
+    """Filter disabled facts and, for components a prose operation touched,
+    re-derive handling from what survives.
+
+    A prose operation derives ``handling`` from ``component.facts`` as it
+    stands *at that point* in the resolution order (Owner Decision
+    2026-08-09). A later FACT-kind ``DISABLE`` on the same component is only
+    reflected in ``component.facts`` here, at final assembly — so without this
+    second derivation, a component promoted to ``MIXED`` by an earlier prose
+    ``APPEND``/``REPLACE`` would keep reporting facts it no longer has once a
+    later override strips its last one. Components no prose operation ever
+    touched keep their already-correct handling untouched.
+    """
+    facts = tuple(
+        fact
+        for fact in component.facts
+        if (record.semantic_key, component.semantic_key, fact.fact_key)
+        not in disabled_facts
+    )
+    if (record.semantic_key, component.semantic_key) not in prose_touched:
+        return replace(component, facts=facts)
+    handling = _derive_prose_driven_handling(
+        facts_present=bool(facts), governing_prose=component.governing_prose
+    )
+    reason = (
+        None
+        if handling is ComponentHandling.STRUCTURED
+        else component.irreducibility_reason_code
+    )
+    return replace(
+        component, facts=facts, handling=handling, irreducibility_reason_code=reason
+    )
+
+
 def apply_override_set(
     candidate: ProjectionCandidate,
     override_set: EffectiveOverrideSet,
@@ -419,6 +458,7 @@ def apply_override_set(
     disabled_components: set[tuple[str, str]] = set()
     disabled_facts: set[tuple[str, str, str]] = set()
     disabled_prose: set[tuple[str, str]] = set()
+    prose_touched: set[tuple[str, str]] = set()
     provenance: list[AppliedOverride] = []
 
     for entry in override_set.entries:
@@ -432,6 +472,7 @@ def apply_override_set(
                 disabled_components,
                 disabled_facts,
                 disabled_prose,
+                prose_touched,
             )
         else:
             note = "authored disabled"
@@ -454,15 +495,7 @@ def apply_override_set(
         replace(
             record,
             components=tuple(
-                replace(
-                    component,
-                    facts=tuple(
-                        fact
-                        for fact in component.facts
-                        if (record.semantic_key, component.semantic_key, fact.fact_key)
-                        not in disabled_facts
-                    ),
-                )
+                _finalize_component(record, component, disabled_facts, prose_touched)
                 for component in record.components
                 if (record.semantic_key, component.semantic_key)
                 not in disabled_components
@@ -478,6 +511,31 @@ def apply_override_set(
     )
 
 
+def _derive_prose_driven_handling(
+    *, facts_present: bool, governing_prose: tuple[GoverningProseEntry, ...]
+) -> ComponentHandling:
+    """Effective handling for the authority that survives a prose operation.
+
+    Owner Decision 2026-08-09: effective-content classification. ``handling``
+    describes the authority surviving *after* this operation, never authority
+    that existed earlier in the sequence — so this is a pure function of what
+    remains right now, not a sticky flag remembering an earlier promotion.
+
+    * facts and prose both present -> ``MIXED``;
+    * facts only -> ``STRUCTURED``;
+    * prose only, or neither -> ``PROSE_BOUND``, because no other category
+      honestly describes a component with no typed facts, whether or not its
+      remaining prose is also empty (a suppressed prose-only component stays
+      ``PROSE_BOUND`` with an empty prose surface rather than inventing a
+      fourth state for "nothing").
+    """
+    if facts_present and governing_prose:
+        return ComponentHandling.MIXED
+    if facts_present:
+        return ComponentHandling.STRUCTURED
+    return ComponentHandling.PROSE_BOUND
+
+
 def _apply_prose_entry(
     entry: EffectiveOverrideEntry,
     patch: DisablePatch | ProseReplacementPatch | ProseAdditionPatch,
@@ -485,13 +543,27 @@ def _apply_prose_entry(
     record: EffectiveRecord,
     records: dict[str, EffectiveRecord],
     disabled_prose: set[tuple[str, str]],
+    disabled_facts: set[tuple[str, str, str]],
+    prose_touched: set[tuple[str, str]],
 ) -> tuple[bool, str]:
     """Apply one entry targeting prose authority (Owner Decision 2026-08-08).
 
     Prose is a sibling of a component's typed facts, never nested inside their
-    application: ``DISABLE`` here clears only ``governing_prose`` and leaves
-    ``facts``/``handling`` — except for the honest ``STRUCTURED`` -> ``MIXED``
-    promotion below — completely untouched.
+    application: this never adds, removes, or reorders ``facts`` — only
+    ``governing_prose`` and the ``handling``/``irreducibility_reason_code``
+    pair derived fresh from what survives (Owner Decision 2026-08-09).
+
+    ``facts_present`` reads against ``disabled_facts`` rather than trusting
+    ``component.facts`` directly: a FACT-kind ``DISABLE`` earlier in this same
+    resolution order is recorded there immediately but is only filtered out of
+    ``component.facts`` once, at final assembly (see ``apply_override_set``),
+    so reading ``component.facts`` alone here could see a fact that is already
+    suppressed and about to disappear.
+
+    Recording this target in ``prose_touched`` is what lets final assembly
+    (``_finalize_component``) re-derive ``handling`` again if a *later* FACT
+    ``DISABLE`` on this same component changes what survives after this call
+    returns.
     """
     assert target.component_key is not None
     found = _find_component(record, target.component_key)
@@ -501,11 +573,34 @@ def _apply_prose_entry(
             f"target {target.describe()} names no component of {target.record_key!r}",
         )
     index, component = found
+    prose_touched.add((target.record_key, target.component_key))
     components = list(record.components)
+    facts_present = any(
+        (target.record_key, target.component_key, fact.fact_key) not in disabled_facts
+        for fact in component.facts
+    )
 
     if isinstance(patch, DisablePatch):
         disabled_prose.add((target.record_key, target.component_key))
-        components[index] = replace(component, governing_prose=())
+        handling = _derive_prose_driven_handling(
+            facts_present=facts_present, governing_prose=()
+        )
+        # STRUCTURED must never carry an irreducibility reason — the same
+        # honesty invariant the build-time projection validator enforces on
+        # the base corpus. A reason surviving from a demoted MIXED/PROSE_BOUND
+        # component would otherwise cite a prose authority that no longer
+        # exists in this effective view.
+        reason = (
+            None
+            if handling is ComponentHandling.STRUCTURED
+            else component.irreducibility_reason_code
+        )
+        components[index] = replace(
+            component,
+            handling=handling,
+            irreducibility_reason_code=reason,
+            governing_prose=(),
+        )
         records[target.record_key] = replace(record, components=tuple(components))
         return True, "prose suppressed"
 
@@ -513,16 +608,6 @@ def _apply_prose_entry(
         text=patch.text,
         supplied_by_override_id=entry.override_id,
         supplied_by_origin=entry.origin,
-    )
-    # Authored prose landing on a purely structured component makes its
-    # effective handling honestly MIXED: structured facts and authored prose
-    # now coexist, which is exactly what MIXED means. The base projection's
-    # own STRUCTURED classification and identity are untouched — only this
-    # runtime effective view changes.
-    handling = (
-        ComponentHandling.MIXED
-        if component.handling is ComponentHandling.STRUCTURED
-        else component.handling
     )
     if isinstance(patch, ProseReplacementPatch):
         governing_prose: tuple[GoverningProseEntry, ...] = (authored,)
@@ -532,6 +617,12 @@ def _apply_prose_entry(
         governing_prose = (*component.governing_prose, authored)
         note = "prose appended"
 
+    # REPLACE/APPEND always leave governing_prose non-empty, so the derived
+    # handling here is MIXED or PROSE_BOUND, never STRUCTURED — no reason-code
+    # clearing is needed on this branch.
+    handling = _derive_prose_driven_handling(
+        facts_present=facts_present, governing_prose=governing_prose
+    )
     components[index] = replace(
         component, handling=handling, governing_prose=governing_prose
     )
@@ -546,6 +637,7 @@ def _apply_entry(
     disabled_components: set[tuple[str, str]],
     disabled_facts: set[tuple[str, str, str]],
     disabled_prose: set[tuple[str, str]],
+    prose_touched: set[tuple[str, str]],
 ) -> tuple[bool, str]:
     """Apply one enabled entry, returning whether it changed anything."""
     target = entry.target
@@ -576,7 +668,16 @@ def _apply_entry(
         assert isinstance(
             patch, (DisablePatch, ProseReplacementPatch, ProseAdditionPatch)
         )
-        return _apply_prose_entry(entry, patch, target, record, records, disabled_prose)
+        return _apply_prose_entry(
+            entry,
+            patch,
+            target,
+            record,
+            records,
+            disabled_prose,
+            disabled_facts,
+            prose_touched,
+        )
 
     if isinstance(patch, DisablePatch):
         if target.kind is MechanicalTargetKind.RECORD:

--- a/src/afterworlds/services/rules_authority/application.py
+++ b/src/afterworlds/services/rules_authority/application.py
@@ -58,6 +58,8 @@ from afterworlds.services.rules_authority.patches import (
     FactAdditionPatch,
     FactReplacementPatch,
     InvalidPatchError,
+    ProseAdditionPatch,
+    ProseReplacementPatch,
     RecordReplacementPatch,
     patch_from_payload,
 )
@@ -68,11 +70,14 @@ from afterworlds.services.rules_authority.targets import (
 
 __all__ = [
     "AppliedOverride",
+    "AuthoredProse",
     "EffectiveAuthority",
     "EffectiveComponent",
     "EffectiveFact",
     "EffectiveRecord",
+    "GoverningProseEntry",
     "OverrideApplicationError",
+    "SourceProse",
     "apply_override_set",
 ]
 
@@ -101,6 +106,43 @@ class EffectiveFact:
 
 
 @dataclass(frozen=True)
+class SourceProse:
+    """One passage of exact 5c source prose, identified by its chunk.
+
+    ``text`` is resolved later, by the GameMaster view, from the authoritative
+    ``RuleChunk`` the service reads by this exact ``chunk_id``; it is ``None``
+    here because this type is built before that resolution happens. It is
+    never anything but an exact 5c chunk — never a fabricated id, never a
+    stand-in for authored text.
+    """
+
+    chunk_id: str
+    text: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthoredProse:
+    """One passage of authored governing prose (Owner Decision 2026-08-08).
+
+    A distinct runtime authority layer, not a second copy of 5c source
+    authority: ``text`` is exact and already resolved (it came from the
+    override's own validated payload, not from a lookup), and its provenance
+    is the supplying override's stable identity and origin — never a
+    fabricated ``chunk_id``, never 5c span provenance, and never an
+    irreducibility claim copied from base-projection authority.
+    """
+
+    text: str
+    supplied_by_override_id: str
+    supplied_by_origin: OverrideOriginEnum
+
+
+#: Effective governing prose is one of exactly these two kinds. Closed so a
+#: consumer switching on kind cannot silently miss a third one appearing later.
+GoverningProseEntry = SourceProse | AuthoredProse
+
+
+@dataclass(frozen=True)
 class EffectiveComponent:
     """One component of the effective view."""
 
@@ -109,8 +151,10 @@ class EffectiveComponent:
     handling: ComponentHandling
     irreducibility_reason_code: str | None
     facts: tuple[EffectiveFact, ...]
-    #: Authoritative 5c chunks holding this component's exact governing prose.
-    prose_chunk_ids: tuple[str, ...] = ()
+    #: Exact ordered governing prose: 5c-bound, authored, or both, in the
+    #: order overrides resolve in. Empty for a purely structured component
+    #: that has never had authored prose attached to it.
+    governing_prose: tuple[GoverningProseEntry, ...] = ()
     span_ids: tuple[str, ...] = ()
     supplied_by_override_id: str | None = None
     supplied_by_origin: OverrideOriginEnum | None = None
@@ -223,8 +267,9 @@ def _base_records(candidate: ProjectionCandidate) -> dict[str, EffectiveRecord]:
                 handling=component.handling,
                 irreducibility_reason_code=component.irreducibility_reason_code,
                 facts=facts,
-                prose_chunk_ids=tuple(
-                    sorted(
+                governing_prose=tuple(
+                    SourceProse(chunk_id=chunk_id)
+                    for chunk_id in sorted(
                         prose.get((component.record_key, component.semantic_key), ())
                     )
                 ),
@@ -282,6 +327,17 @@ def _component_from_body(
             )
             for f in body.facts
         ),
+        governing_prose=(
+            (
+                AuthoredProse(
+                    text=body.authored_prose,
+                    supplied_by_override_id=entry.override_id,
+                    supplied_by_origin=entry.origin,
+                ),
+            )
+            if body.authored_prose is not None
+            else ()
+        ),
         supplied_by_override_id=entry.override_id,
         supplied_by_origin=entry.origin,
     )
@@ -310,14 +366,20 @@ def _suppressed_by(
     disabled_records: set[str],
     disabled_components: set[tuple[str, str]],
     disabled_facts: set[tuple[str, str, str]],
+    disabled_prose: set[tuple[str, str]],
 ) -> str | None:
     """Is this target already suppressed by an earlier ``DISABLE``?
 
     Suppression is inherited downward: disabling a record disables the
-    components and facts beneath it, so a later override aimed at one of them
-    has nothing to change. That is the existing precedence rule — the first
-    winning disable stops later processing of that target — applied to the
-    record/component/fact hierarchy the chunk path never had.
+    components, facts, and prose beneath it, so a later override aimed at one
+    of them has nothing to change. That is the existing precedence rule — the
+    first winning disable stops later processing of that target — applied to
+    the record/component/fact/prose hierarchy the chunk path never had.
+
+    Prose and facts are siblings under a component, not one nested inside the
+    other: disabling a component's prose does not suppress its facts, and
+    disabling a fact does not touch its prose. Only a component- or
+    record-level ``DISABLE`` reaches both.
     """
     if target.record_key in disabled_records:
         return "record"
@@ -328,6 +390,11 @@ def _suppressed_by(
         return "component"
     if target.kind is MechanicalTargetKind.COMPONENT:
         return None
+    if target.kind is MechanicalTargetKind.PROSE:
+        if (target.record_key, target.component_key) in disabled_prose:
+            return "prose"
+        return None
+    assert target.kind is MechanicalTargetKind.FACT
     assert target.fact_key is not None
     if (target.record_key, target.component_key, target.fact_key) in disabled_facts:
         return "fact"
@@ -351,6 +418,7 @@ def apply_override_set(
     disabled_records: set[str] = set()
     disabled_components: set[tuple[str, str]] = set()
     disabled_facts: set[tuple[str, str, str]] = set()
+    disabled_prose: set[tuple[str, str]] = set()
     provenance: list[AppliedOverride] = []
 
     for entry in override_set.entries:
@@ -363,6 +431,7 @@ def apply_override_set(
                 disabled_records,
                 disabled_components,
                 disabled_facts,
+                disabled_prose,
             )
         else:
             note = "authored disabled"
@@ -409,12 +478,74 @@ def apply_override_set(
     )
 
 
+def _apply_prose_entry(
+    entry: EffectiveOverrideEntry,
+    patch: DisablePatch | ProseReplacementPatch | ProseAdditionPatch,
+    target: MechanicalTarget,
+    record: EffectiveRecord,
+    records: dict[str, EffectiveRecord],
+    disabled_prose: set[tuple[str, str]],
+) -> tuple[bool, str]:
+    """Apply one entry targeting prose authority (Owner Decision 2026-08-08).
+
+    Prose is a sibling of a component's typed facts, never nested inside their
+    application: ``DISABLE`` here clears only ``governing_prose`` and leaves
+    ``facts``/``handling`` — except for the honest ``STRUCTURED`` -> ``MIXED``
+    promotion below — completely untouched.
+    """
+    assert target.component_key is not None
+    found = _find_component(record, target.component_key)
+    if found is None:
+        raise OverrideApplicationError(
+            entry.override_id,
+            f"target {target.describe()} names no component of {target.record_key!r}",
+        )
+    index, component = found
+    components = list(record.components)
+
+    if isinstance(patch, DisablePatch):
+        disabled_prose.add((target.record_key, target.component_key))
+        components[index] = replace(component, governing_prose=())
+        records[target.record_key] = replace(record, components=tuple(components))
+        return True, "prose suppressed"
+
+    authored = AuthoredProse(
+        text=patch.text,
+        supplied_by_override_id=entry.override_id,
+        supplied_by_origin=entry.origin,
+    )
+    # Authored prose landing on a purely structured component makes its
+    # effective handling honestly MIXED: structured facts and authored prose
+    # now coexist, which is exactly what MIXED means. The base projection's
+    # own STRUCTURED classification and identity are untouched — only this
+    # runtime effective view changes.
+    handling = (
+        ComponentHandling.MIXED
+        if component.handling is ComponentHandling.STRUCTURED
+        else component.handling
+    )
+    if isinstance(patch, ProseReplacementPatch):
+        governing_prose: tuple[GoverningProseEntry, ...] = (authored,)
+        note = "prose replaced"
+    else:
+        assert isinstance(patch, ProseAdditionPatch)
+        governing_prose = (*component.governing_prose, authored)
+        note = "prose appended"
+
+    components[index] = replace(
+        component, handling=handling, governing_prose=governing_prose
+    )
+    records[target.record_key] = replace(record, components=tuple(components))
+    return True, note
+
+
 def _apply_entry(
     entry: EffectiveOverrideEntry,
     records: dict[str, EffectiveRecord],
     disabled_records: set[str],
     disabled_components: set[tuple[str, str]],
     disabled_facts: set[tuple[str, str, str]],
+    disabled_prose: set[tuple[str, str]],
 ) -> tuple[bool, str]:
     """Apply one enabled entry, returning whether it changed anything."""
     target = entry.target
@@ -433,10 +564,19 @@ def _apply_entry(
         )
 
     suppressed = _suppressed_by(
-        target, disabled_records, disabled_components, disabled_facts
+        target, disabled_records, disabled_components, disabled_facts, disabled_prose
     )
     if suppressed is not None:
         return False, f"target already suppressed by an earlier {suppressed} disable"
+
+    if target.kind is MechanicalTargetKind.PROSE:
+        # required_patch_family guarantees only these three families pair with
+        # a PROSE target; narrowed explicitly because that guarantee is a
+        # runtime invariant mypy cannot see through target.kind alone.
+        assert isinstance(
+            patch, (DisablePatch, ProseReplacementPatch, ProseAdditionPatch)
+        )
+        return _apply_prose_entry(entry, patch, target, record, records, disabled_prose)
 
     if isinstance(patch, DisablePatch):
         if target.kind is MechanicalTargetKind.RECORD:
@@ -491,6 +631,9 @@ def _apply_entry(
         disabled_facts.difference_update(
             {k for k in disabled_facts if k[0] == target.record_key}
         )
+        disabled_prose.difference_update(
+            {k for k in disabled_prose if k[0] == target.record_key}
+        )
         return True, "record replaced"
 
     if isinstance(patch, ComponentAdditionPatch):
@@ -541,6 +684,7 @@ def _apply_entry(
                 if k[0] == target.record_key and k[1] == target.component_key
             }
         )
+        disabled_prose.discard((target.record_key, target.component_key))
         return True, "component replaced"
 
     found = _find_component(record, target.component_key)
@@ -551,6 +695,9 @@ def _apply_entry(
             f"{target.record_key!r}",
         )
     index, component = found
+    # Reachable only for a FACT target: PROSE returned above, and RECORD/
+    # COMPONENT patches were each handled and returned by their own branch.
+    assert isinstance(patch, (FactReplacementPatch, FactAdditionPatch))
     new_fact = patch.fact
     new_key = fact_key(new_fact)
 

--- a/src/afterworlds/services/rules_authority/patches.py
+++ b/src/afterworlds/services/rules_authority/patches.py
@@ -1,7 +1,7 @@
 """Closed typed override patch families — CRD Issue 5d, Decision 10.
 
-Six families, and the set is closed. Which family a payload must be is decided
-entirely by the pair *(operation, target kind)*:
+Eight families, and the set is closed. Which family a payload must be is
+decided entirely by the pair *(operation, target kind)*:
 
 ===========  ===========  ==========================================
 Operation    Target       Patch family
@@ -10,15 +10,17 @@ Operation    Target       Patch family
 ``REPLACE``  record       :class:`RecordReplacementPatch`
 ``REPLACE``  component    :class:`ComponentReplacementPatch`
 ``REPLACE``  fact         :class:`FactReplacementPatch`
+``REPLACE``  prose        :class:`ProseReplacementPatch`
 ``APPEND``   record       :class:`ComponentAdditionPatch`
 ``APPEND``   component    :class:`FactAdditionPatch`
+``APPEND``   prose        :class:`ProseAdditionPatch`
 ``APPEND``   fact         *not permitted*
 ===========  ===========  ==========================================
 
 ``APPEND`` onto a fact has no family because a fact is a single value, not a
 collection: ADR-005d Decision 10 permits ``APPEND`` "only where the owning
-schema permits multiplicity", and a record's components and a component's facts
-are the only two places multiplicity exists.
+schema permits multiplicity", and a record's components, a component's facts,
+and a component's governing prose are the only places multiplicity exists.
 
 Record replacement is **record-kind-specific**, never a generic whole-record
 overwrite: :class:`RecordReplacementPatch` declares the ``record_kind`` it
@@ -26,16 +28,24 @@ replaces, and a patch whose declared kind is not the target record's kind is a
 type-incompatible patch that fails rather than reshaping the record into
 something else.
 
-Two things this module deliberately refuses to accept, because accepting them
-would reopen decisions this PR does not own:
+**Authored prose is a distinct runtime authority layer (Owner Decision
+2026-08-08), not a second copy of source authority.** ADR-005d's prohibition on
+a second *prose store* binds the base projection: its prose bindings resolve
+only to an authoritative 5c ``RuleChunk`` with span-exact provenance
+(#137 contract 3), and nothing here duplicates that. An override-supplied
+whole component may now declare ``PROSE_BOUND`` or ``MIXED`` handling and carry
+its own authored text — but that text is never bound to a chunk id, never
+claims 5c span provenance, and never copies an irreducibility reason from base
+authority; its provenance is the supplying override and the retained
+override-set version, and application-layer code enforces that by construction
+rather than by convention. The dedicated ``prose`` target kind
+(:mod:`afterworlds.services.rules_authority.targets`) exists for exactly the
+narrower case: patching *only* a component's governing prose without touching
+its typed facts at all.
 
-* **Prose-bound authority.** An override-supplied component must be
-  ``STRUCTURED``. ``PROSE_BOUND`` and ``MIXED`` handling require exact governing
-  prose bound to an authoritative 5c ``RuleChunk`` with span-exact provenance
-  (#137 contract 3), which is build-time evidence a runtime patch does not
-  have. Authoring prose here would create the second prose store ADR-005d
-  forbids, so a prose-bound override component is rejected. ``DISABLE``
-  remains available for a prose-bound base component.
+One thing this module still deliberately refuses to accept, because accepting
+it would reopen a decision this PR does not own:
+
 * **Anything outside the closed typed-fact union.** Facts are rebuilt through
   CRD Issue 5d's own :func:`fact_from_payload`, so an unknown family, a missing
   field, an extra field, or a mistyped value is rejected here exactly as it is
@@ -76,6 +86,8 @@ __all__ = [
     "InvalidPatchError",
     "MechanicalPatch",
     "PatchFamily",
+    "ProseAdditionPatch",
+    "ProseReplacementPatch",
     "RecordReplacementPatch",
     "patch_from_payload",
     "patch_payload",
@@ -90,8 +102,10 @@ class PatchFamily(StrEnum):
     REPLACE_RECORD = "replace_record"
     REPLACE_COMPONENT = "replace_component"
     REPLACE_FACT = "replace_fact"
+    REPLACE_PROSE = "replace_prose"
     APPEND_COMPONENT = "append_component"
     APPEND_FACT = "append_fact"
+    APPEND_PROSE = "append_prose"
 
 
 class InvalidPatchError(ValueError):
@@ -116,11 +130,19 @@ class ComponentBody:
     names the component being replaced, and required for an addition, where the
     patch is what names it. Carrying the key twice would let a patch disagree
     with its own target.
+
+    ``authored_prose`` is the component's own authored governing prose — never
+    a 5c chunk id, never span provenance, never an irreducibility reason copied
+    from base authority (Owner Decision 2026-08-08). It is required exactly
+    when ``handling`` is ``PROSE_BOUND`` or ``MIXED`` and forbidden for
+    ``STRUCTURED``, mirroring the honesty invariant the build-time projection
+    validator already enforces for the base corpus.
     """
 
     handling: ComponentHandling
     facts: tuple[MechanicalFact, ...]
     semantic_key: str | None = None
+    authored_prose: str | None = None
 
 
 @dataclass(frozen=True)
@@ -176,6 +198,35 @@ class FactAdditionPatch:
     fact: MechanicalFact
 
 
+@dataclass(frozen=True)
+class ProseReplacementPatch:
+    """Replace a component's complete effective governing prose.
+
+    Supersedes both the base projection's 5c-bound prose and any previously
+    applied authored prose for that target (ADR-005d Decision 10, amended
+    2026-08-08) — it is a replacement of everything shown, not one more
+    passage added to it.
+    """
+
+    FAMILY = PatchFamily.REPLACE_PROSE
+
+    text: str
+
+
+@dataclass(frozen=True)
+class ProseAdditionPatch:
+    """Add one authored passage after a component's existing effective prose.
+
+    The existing effective prose — 5c-bound, previously authored, or both — is
+    preserved; this adds one more passage in the same resolution order every
+    other override uses.
+    """
+
+    FAMILY = PatchFamily.APPEND_PROSE
+
+    text: str
+
+
 MechanicalPatch = (
     DisablePatch
     | RecordReplacementPatch
@@ -183,6 +234,8 @@ MechanicalPatch = (
     | FactReplacementPatch
     | ComponentAdditionPatch
     | FactAdditionPatch
+    | ProseReplacementPatch
+    | ProseAdditionPatch
 )
 
 
@@ -199,6 +252,7 @@ _REQUIRED_FAMILY: dict[
         MechanicalTargetKind.COMPONENT,
     ): PatchFamily.DISABLE,
     (OverrideOperationEnum.DISABLE, MechanicalTargetKind.FACT): PatchFamily.DISABLE,
+    (OverrideOperationEnum.DISABLE, MechanicalTargetKind.PROSE): PatchFamily.DISABLE,
     (
         OverrideOperationEnum.REPLACE,
         MechanicalTargetKind.RECORD,
@@ -212,6 +266,10 @@ _REQUIRED_FAMILY: dict[
         MechanicalTargetKind.FACT,
     ): PatchFamily.REPLACE_FACT,
     (
+        OverrideOperationEnum.REPLACE,
+        MechanicalTargetKind.PROSE,
+    ): PatchFamily.REPLACE_PROSE,
+    (
         OverrideOperationEnum.APPEND,
         MechanicalTargetKind.RECORD,
     ): PatchFamily.APPEND_COMPONENT,
@@ -219,6 +277,10 @@ _REQUIRED_FAMILY: dict[
         OverrideOperationEnum.APPEND,
         MechanicalTargetKind.COMPONENT,
     ): PatchFamily.APPEND_FACT,
+    (
+        OverrideOperationEnum.APPEND,
+        MechanicalTargetKind.PROSE,
+    ): PatchFamily.APPEND_PROSE,
     # (APPEND, FACT) is absent on purpose — a fact has no multiplicity to
     # append into, so there is no honest family for it.
 }
@@ -247,11 +309,17 @@ def required_patch_family(
 # ---------------------------------------------------------------------------
 
 
-def _require_keys(payload: Mapping[str, Any], expected: set[str], what: str) -> None:
+def _require_keys(
+    payload: Mapping[str, Any],
+    expected: set[str],
+    what: str,
+    *,
+    optional: frozenset[str] = frozenset(),
+) -> None:
     supplied = set(payload)
     if missing := sorted(expected - supplied):
         raise InvalidPatchError(f"{what} payload is missing {missing}")
-    if extra := sorted(supplied - expected):
+    if extra := sorted(supplied - expected - optional):
         raise InvalidPatchError(f"{what} payload carries extra {extra}")
 
 
@@ -278,13 +346,27 @@ def _build_component_body(value: object, what: str, *, keyed: bool) -> Component
 
     *keyed* distinguishes an addition (which must name the component it adds)
     from a replacement (whose target already names it).
+
+    ``handling`` may now be ``PROSE_BOUND`` or ``MIXED`` as well as
+    ``STRUCTURED`` (Owner Decision 2026-08-08): the same facts/prose honesty
+    invariant the build-time projection validator enforces for the base corpus
+    (``ingestion.mechanical.validation``) is enforced here for an
+    override-supplied component — structured handling has facts and no
+    authored prose; prose-bound handling has authored prose and no facts;
+    mixed handling has both. Unlike the base corpus, an override-supplied
+    component never carries an irreducibility reason: that catalog is 5c's own
+    build-time semantic judgment, not one a runtime override author makes.
     """
     if not isinstance(value, Mapping):
         raise InvalidPatchError(
             f"{what} component must be a payload object, got {type(value).__name__}"
         )
     expected = {"handling", "facts"} | ({"semantic_key"} if keyed else set())
-    _require_keys(value, expected, what)
+    # authored_prose is optional on the way in — existing STRUCTURED payloads
+    # that predate Owner Decision 2026-08-08 never mention it — but
+    # _component_body_payload always emits it explicitly, so the canonical
+    # form is never ambiguous about whether it was "omitted" or "null".
+    _require_keys(value, expected, what, optional=frozenset({"authored_prose"}))
 
     raw_handling = value["handling"]
     if type(raw_handling) is not str:
@@ -295,15 +377,6 @@ def _build_component_body(value: object, what: str, *, keyed: bool) -> Component
         raise InvalidPatchError(
             f"{what} handling {raw_handling!r} is not a declared handling"
         ) from exc
-    if handling is not ComponentHandling.STRUCTURED:
-        # Prose-bound authority needs an authoritative 5c chunk and span-exact
-        # provenance, which a runtime patch cannot supply. Rejecting it here is
-        # what keeps overrides from becoming a second prose store.
-        raise InvalidPatchError(
-            f"{what} declares {handling.value} handling; an override-supplied "
-            "component must be structured, because prose-bound authority "
-            "requires build-time 5c prose binding and provenance"
-        )
 
     semantic_key: str | None = None
     if keyed:
@@ -312,6 +385,13 @@ def _build_component_body(value: object, what: str, *, keyed: bool) -> Component
             raise InvalidPatchError(f"{what} semantic_key must be a non-blank string")
         semantic_key = raw_key
 
+    raw_prose = value.get("authored_prose")
+    if raw_prose is not None and (type(raw_prose) is not str or not raw_prose.strip()):
+        raise InvalidPatchError(
+            f"{what} authored_prose must be a non-blank string or null"
+        )
+    authored_prose: str | None = raw_prose
+
     raw_facts = value["facts"]
     if not isinstance(raw_facts, list):
         raise InvalidPatchError(f"{what} facts must be a list")
@@ -319,14 +399,40 @@ def _build_component_body(value: object, what: str, *, keyed: bool) -> Component
         _build_fact(entry, f"{what} fact {index}")
         for index, entry in enumerate(raw_facts)
     )
-    if not facts:
-        # Structured handling with no facts is the dishonest declaration the
-        # projection validator already rejects; a patch may not introduce it.
-        raise InvalidPatchError(f"{what} declares structured handling with no facts")
     keys = [fact_key(f) for f in facts]
     if len(set(keys)) != len(keys):
         raise InvalidPatchError(f"{what} repeats the same typed fact")
-    return ComponentBody(handling=handling, facts=facts, semantic_key=semantic_key)
+
+    if handling is ComponentHandling.PROSE_BOUND:
+        if facts:
+            raise InvalidPatchError(f"{what} declares prose_bound handling with facts")
+        if authored_prose is None:
+            raise InvalidPatchError(
+                f"{what} declares prose_bound handling with no authored prose"
+            )
+    else:
+        if not facts:
+            # Structured/mixed handling with no facts is the dishonest
+            # declaration the projection validator already rejects for the
+            # base corpus; a patch may not introduce it either.
+            raise InvalidPatchError(
+                f"{what} declares {handling.value} handling with no facts"
+            )
+        if handling is ComponentHandling.STRUCTURED:
+            if authored_prose is not None:
+                raise InvalidPatchError(
+                    f"{what} declares structured handling with authored prose"
+                )
+        elif authored_prose is None:
+            raise InvalidPatchError(
+                f"{what} declares mixed handling with no authored prose"
+            )
+    return ComponentBody(
+        handling=handling,
+        facts=facts,
+        semantic_key=semantic_key,
+        authored_prose=authored_prose,
+    )
 
 
 def _build_disable(payload: Mapping[str, Any]) -> DisablePatch:
@@ -387,13 +493,32 @@ def _build_append_fact(payload: Mapping[str, Any]) -> FactAdditionPatch:
     return FactAdditionPatch(fact=_build_fact(payload["fact"], "append_fact"))
 
 
+def _build_prose_text(payload: Mapping[str, Any], what: str) -> str:
+    raw = payload["text"]
+    if type(raw) is not str or not raw.strip():
+        raise InvalidPatchError(f"{what} text must be a non-blank string")
+    return raw
+
+
+def _build_replace_prose(payload: Mapping[str, Any]) -> ProseReplacementPatch:
+    _require_keys(payload, {"patch", "text"}, "replace_prose")
+    return ProseReplacementPatch(text=_build_prose_text(payload, "replace_prose"))
+
+
+def _build_append_prose(payload: Mapping[str, Any]) -> ProseAdditionPatch:
+    _require_keys(payload, {"patch", "text"}, "append_prose")
+    return ProseAdditionPatch(text=_build_prose_text(payload, "append_prose"))
+
+
 _PATCH_BUILDERS: dict[PatchFamily, Any] = {
     PatchFamily.DISABLE: _build_disable,
     PatchFamily.REPLACE_RECORD: _build_replace_record,
     PatchFamily.REPLACE_COMPONENT: _build_replace_component,
     PatchFamily.REPLACE_FACT: _build_replace_fact,
+    PatchFamily.REPLACE_PROSE: _build_replace_prose,
     PatchFamily.APPEND_COMPONENT: _build_append_component,
     PatchFamily.APPEND_FACT: _build_append_fact,
+    PatchFamily.APPEND_PROSE: _build_append_prose,
 }
 
 
@@ -444,6 +569,10 @@ def _component_body_payload(body: ComponentBody) -> dict[str, object]:
     # order: two patches supplying the same facts in a different order are the
     # same patch, and must not mint two override-set identities.
     payload["facts"] = [fact_payload(f) for f in sorted(body.facts, key=fact_key)]
+    # Load-bearing: omitting authored_prose here would let two REPLACE/APPEND
+    # component patches differing only in authored text canonicalize to
+    # identical bytes and silently share an override-set UUID.
+    payload["authored_prose"] = body.authored_prose
     return payload
 
 
@@ -452,7 +581,9 @@ def patch_payload(patch: MechanicalPatch) -> dict[str, object]:
 
     This is what the override-set identity is derived from, so it must be a
     complete and order-stable statement of the patch's content — a payload that
-    dropped a field would let two different patches share an identity.
+    dropped a field would let two different patches share an identity. Every
+    branch is explicit, with no bare fallthrough, so the closed union stays
+    exhaustive as a type-checking property rather than an implicit one.
     """
     if isinstance(patch, DisablePatch):
         return {"patch": PatchFamily.DISABLE.value}
@@ -475,12 +606,18 @@ def patch_payload(patch: MechanicalPatch) -> dict[str, object]:
             "patch": PatchFamily.REPLACE_FACT.value,
             "fact": fact_payload(patch.fact),
         }
+    if isinstance(patch, ProseReplacementPatch):
+        return {"patch": PatchFamily.REPLACE_PROSE.value, "text": patch.text}
     if isinstance(patch, ComponentAdditionPatch):
         return {
             "patch": PatchFamily.APPEND_COMPONENT.value,
             "component": _component_body_payload(patch.body),
         }
-    return {
-        "patch": PatchFamily.APPEND_FACT.value,
-        "fact": fact_payload(patch.fact),
-    }
+    if isinstance(patch, FactAdditionPatch):
+        return {
+            "patch": PatchFamily.APPEND_FACT.value,
+            "fact": fact_payload(patch.fact),
+        }
+    if isinstance(patch, ProseAdditionPatch):
+        return {"patch": PatchFamily.APPEND_PROSE.value, "text": patch.text}
+    raise AssertionError(f"unhandled patch type {type(patch).__name__}")

--- a/src/afterworlds/services/rules_authority/service.py
+++ b/src/afterworlds/services/rules_authority/service.py
@@ -48,6 +48,7 @@ from afterworlds.services.rules_authority.application import (
     EffectiveComponent,
     EffectiveRecord,
     OverrideApplicationError,
+    SourceProse,
     apply_override_set,
 )
 from afterworlds.services.rules_authority.binding import (
@@ -327,11 +328,14 @@ class RulesAuthorityService:
     def _prose_for(
         self, binding: RulesPackageBinding, authority: EffectiveAuthority
     ) -> dict[str, str]:
+        # Only SourceProse entries name a 5c chunk to resolve; AuthoredProse
+        # entries already carry their exact text (Owner Decision 2026-08-08).
         chunk_ids = {
-            chunk_id
+            entry.chunk_id
             for record in authority.records
             for component in record.components
-            for chunk_id in component.prose_chunk_ids
+            for entry in component.governing_prose
+            if isinstance(entry, SourceProse)
         }
         if not chunk_ids:
             return {}

--- a/src/afterworlds/services/rules_authority/targets.py
+++ b/src/afterworlds/services/rules_authority/targets.py
@@ -1,10 +1,18 @@
 """Exact typed override targets — CRD Issue 5d, Decision 10.
 
 An override names one exact element of the mechanical projection: a record, one
-component of a record, or one fact of a component. Nothing else is addressable.
-There is deliberately no JSON path, no selector expression, and no wildcard —
-#137 contract 6 forbids them, and each of those would let an override reach
-authority nobody reviewed it against.
+component of a record, one fact of a component, or the prose authority of one
+component. Nothing else is addressable. There is deliberately no JSON path, no
+selector expression, and no wildcard — #137 contract 6 forbids them, and each
+of those would let an override reach authority nobody reviewed it against.
+
+**Prose is its own grain, not a component subtype.** A ``COMPONENT``-kind
+``DISABLE`` already means "remove the whole component" (Decision 10). Prose
+authority needs to be suppressible, replaceable, or extensible on its own —
+Owner Decision 2026-08-08's authored-authority overlay — without disturbing
+that component's typed facts, so it is a fourth ``MechanicalTargetKind``
+scoped the same way a component is (record + component key), never a raw
+chunk id.
 
 **Semantic keys, not derived IDs.** A target names the committed semantic keys
 (``record_key``, ``component_key``, and the content-derived ``fact_key``) rather
@@ -37,6 +45,7 @@ class MechanicalTargetKind(StrEnum):
     RECORD = "record"
     COMPONENT = "component"
     FACT = "fact"
+    PROSE = "prose"
 
 
 class TargetShapeError(ValueError):
@@ -66,6 +75,7 @@ class MechanicalTarget:
         needs_component = self.kind in (
             MechanicalTargetKind.COMPONENT,
             MechanicalTargetKind.FACT,
+            MechanicalTargetKind.PROSE,
         )
         if needs_component and not (self.component_key or "").strip():
             raise TargetShapeError(f"{self.kind.value} target requires a component_key")

--- a/src/afterworlds/services/rules_authority/views.py
+++ b/src/afterworlds/services/rules_authority/views.py
@@ -19,18 +19,28 @@ Two boundaries are enforced by what these views *do not* contain:
   consumer could read one. Representation and execution are independent
   (ADR-005d Decision 1); the bounded-d20 adapter declares and proves what it can
   execute, and that declaration is CRD Issue 15c's, not this view's.
-* **Retrieval never chooses a mechanical value.** The GameMaster view resolves
-  governing prose through the exact ``chunk_id`` recorded as the component's
+* **Retrieval never chooses a mechanical value.** Source governing prose
+  resolves through the exact ``chunk_id`` recorded as the component's
   build-time prose binding. A retrieval layer may locate *candidates* to look
   at, but what comes back here is bound by identity, not by similarity, and a
   chunk that is not the bound one is simply not in the view (ADR-018, ADR-005c
   D4).
+
+**Authored prose (Owner Decision 2026-08-08).** Governing prose is a closed
+discriminated form: exact 5c source prose (:class:`~.application.SourceProse`,
+resolved here from the bound package's own ``RuleChunk`` rows) ordered
+alongside a distinct authored-authority overlay
+(:class:`~.application.AuthoredProse`), whose text and provenance were already
+resolved when the override was applied — see
+:mod:`afterworlds.services.rules_authority.application`. Both views surface the
+same ordered entries; only source entries need a text lookup here, because
+authored text is already exact.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from afterworlds.ingestion.mechanical.models import ComponentHandling
 from afterworlds.ingestion.mechanical.representation import RecordKind
@@ -41,12 +51,13 @@ from afterworlds.services.rules_authority.application import (
     EffectiveComponent,
     EffectiveFact,
     EffectiveRecord,
+    GoverningProseEntry,
+    SourceProse,
 )
 
 __all__ = [
     "GameMasterAuthorityView",
     "GameMasterComponent",
-    "GoverningProse",
     "TypedAuthorityView",
     "build_gamemaster_view",
     "build_typed_view",
@@ -69,28 +80,24 @@ class TypedAuthorityView:
 
 
 @dataclass(frozen=True)
-class GoverningProse:
-    """One passage of exact governing prose, bound by identity.
-
-    ``text`` is ``None`` when the bound chunk is not present in the store being
-    read — reported as an absent passage rather than substituted with a similar
-    one, because a nearby passage is not the governing passage.
-    """
-
-    chunk_id: str
-    text: str | None
-
-
-@dataclass(frozen=True)
 class GameMasterComponent:
-    """One component as a GameMaster reads it: prose, context, and handling."""
+    """One component as a GameMaster reads it: prose, context, and handling.
+
+    ``governing_prose`` is exact ordered source-and-authored authority. A
+    :class:`~.application.SourceProse` entry's ``text`` is ``None`` when the
+    bound chunk is not present in the store being read — reported as an
+    absent passage rather than substituted with a similar one, because a
+    nearby passage is not the governing passage. A
+    :class:`~.application.AuthoredProse` entry's ``text`` is never ``None``:
+    it is exact authored text, already resolved when the override applied.
+    """
 
     record_key: str
     record_kind: RecordKind
     component_key: str
     handling: ComponentHandling
     irreducibility_reason_code: str | None
-    governing_prose: tuple[GoverningProse, ...]
+    governing_prose: tuple[GoverningProseEntry, ...]
     #: Typed facts, supplied as *context* for judgement. A GameMaster reading
     #: this view is adjudicating, not executing; the facts are here so the
     #: judgement is made against exact authority rather than recollection.
@@ -117,6 +124,21 @@ def build_typed_view(authority: EffectiveAuthority) -> TypedAuthorityView:
     )
 
 
+def _resolve_prose(
+    entry: GoverningProseEntry, prose: Mapping[str, str]
+) -> GoverningProseEntry:
+    """Resolve one prose entry's text for the GameMaster view.
+
+    A :class:`SourceProse` entry is resolved by its exact ``chunk_id`` against
+    *prose*. An :class:`AuthoredProse` entry already carries exact text — it
+    came from the override's own validated payload, not from a lookup — so it
+    passes through unchanged.
+    """
+    if isinstance(entry, SourceProse):
+        return replace(entry, text=prose.get(entry.chunk_id))
+    return entry
+
+
 def _gamemaster_component(
     record_key: str,
     record_kind: RecordKind,
@@ -130,8 +152,7 @@ def _gamemaster_component(
         handling=component.handling,
         irreducibility_reason_code=component.irreducibility_reason_code,
         governing_prose=tuple(
-            GoverningProse(chunk_id=chunk_id, text=prose.get(chunk_id))
-            for chunk_id in component.prose_chunk_ids
+            _resolve_prose(entry, prose) for entry in component.governing_prose
         ),
         structured_context=component.facts,
         span_ids=component.span_ids,
@@ -146,8 +167,10 @@ def build_gamemaster_view(
 
     *prose* maps an authoritative 5c ``chunk_id`` to its exact text. It is
     supplied by the service seam, which reads it from the authoritative
-    ``RuleChunk`` records of the bound package — there is no second prose store
-    and no text is copied into the projection.
+    ``RuleChunk`` records of the bound package. Source prose is never copied
+    into the projection; a distinct authored-authority overlay (Owner Decision
+    2026-08-08) already carries its own exact text and never claims 5c
+    provenance — see :mod:`afterworlds.services.rules_authority.application`.
     """
     return GameMasterAuthorityView(
         binding=authority.binding,

--- a/tests/services/rules_authority/conftest.py
+++ b/tests/services/rules_authority/conftest.py
@@ -150,23 +150,41 @@ SPELL_LEAF = "leaf-spell"
 PROSE_LEAF = "leaf-prose"
 SUPPORT_LEAF = "leaf-support"
 CHECK_LEAF = "leaf-check"
-LEAF_LENGTHS = {SPELL_LEAF: 40, PROSE_LEAF: 30, SUPPORT_LEAF: 20, CHECK_LEAF: 25}
+#: Dedicated leaves for the base MIXED component's own fact and prose
+#: provenance — a span can carry only one PRIMARY claim, so this component
+#: cannot share CHECK_SPAN or PROSE_SPAN with the components that already
+#: claim them.
+MIXED_FACT_LEAF = "leaf-mixed-fact"
+MIXED_PROSE_LEAF = "leaf-mixed-prose"
+LEAF_LENGTHS = {
+    SPELL_LEAF: 40,
+    PROSE_LEAF: 30,
+    SUPPORT_LEAF: 20,
+    CHECK_LEAF: 25,
+    MIXED_FACT_LEAF: 22,
+    MIXED_PROSE_LEAF: 28,
+}
 
 WISH_CHUNK = "chunk-wish-0001"
 SUPPORT_CHUNK = "chunk-wish-0002"
 SPELL_CHUNK = "chunk-wish-spell"
 CHECK_CHUNK = "chunk-servant-check"
+MIXED_FACT_CHUNK = "chunk-servant-mixed-fact"
+MIXED_PROSE_CHUNK = "chunk-servant-mixed-prose"
 
 SPELL_SPAN = derive_span_id(SPELL_LEAF, 0, 40)
 PROSE_SPAN = derive_span_id(PROSE_LEAF, 0, 30)
 SUPPORT_SPAN = derive_span_id(SUPPORT_LEAF, 0, 20)
 CHECK_SPAN = derive_span_id(CHECK_LEAF, 0, 25)
+MIXED_FACT_SPAN = derive_span_id(MIXED_FACT_LEAF, 0, 22)
+MIXED_PROSE_SPAN = derive_span_id(MIXED_PROSE_LEAF, 0, 28)
 
 SPELL_KEY = "spell:wish"
 CREATURE_KEY = "creature:wish-scoped-servant"
 DESCRIPTOR_KEY = "descriptor"
 OPEN_ENDED_KEY = "open-ended-clause"
 CHECK_KEY = "servant-check"
+MIXED_KEY = "servant-mixed-clause"
 
 DESCRIPTOR_FACT = SpellDescriptorFact(
     level=9, school=SpellSchool.CONJURATION, ritual=False, concentration=False
@@ -214,6 +232,8 @@ _EDGE_PAIRS = (
     (SUPPORT_CHUNK, SUPPORT_LEAF),
     (SPELL_CHUNK, SPELL_LEAF),
     (CHECK_CHUNK, CHECK_LEAF),
+    (MIXED_FACT_CHUNK, MIXED_FACT_LEAF),
+    (MIXED_PROSE_CHUNK, MIXED_PROSE_LEAF),
 )
 
 
@@ -398,6 +418,16 @@ def _wish_binding(prefix: str = "") -> ProseBindingDraft:
 WISH_BINDING = _wish_binding()
 
 
+def _mixed_clause_binding(prefix: str = "") -> ProseBindingDraft:
+    """The base ``MIXED`` component's own prose binding, on its own chunk."""
+    return ProseBindingDraft(
+        component_key=MIXED_KEY,
+        record_key=CREATURE_KEY,
+        chunk_id=f"{prefix}{MIXED_PROSE_CHUNK}",
+        irreducibility_reason_code="open_ended_effect",
+    )
+
+
 def _classification(package_uuid: str, release_version: str) -> ClassificationLedger:
     spans = (
         SemanticSpan(
@@ -432,6 +462,22 @@ def _classification(package_uuid: str, release_version: str) -> ClassificationLe
             disposition=SemanticDisposition.SUBSTANTIVE,
             review_state=ReviewState.ACCEPTED,
         ),
+        SemanticSpan(
+            span_id=MIXED_FACT_SPAN,
+            leaf_id=MIXED_FACT_LEAF,
+            char_start=0,
+            char_end=22,
+            disposition=SemanticDisposition.SUBSTANTIVE,
+            review_state=ReviewState.ACCEPTED,
+        ),
+        SemanticSpan(
+            span_id=MIXED_PROSE_SPAN,
+            leaf_id=MIXED_PROSE_LEAF,
+            char_start=0,
+            char_end=28,
+            disposition=SemanticDisposition.SUBSTANTIVE,
+            review_state=ReviewState.ACCEPTED,
+        ),
     )
     return ClassificationLedger(
         package_uuid=package_uuid,
@@ -449,10 +495,16 @@ def _classification(package_uuid: str, release_version: str) -> ClassificationLe
 def _representation(prefix: str = "") -> RepresentationDraft:
     """A spell with structured and prose-bound authority, plus a scoped creature.
 
-    Small on purpose, but not degenerate: two records, three components across
-    two handling dispositions, and two typed facts of different families — which
-    is the minimum that lets a replace, an append, and a disable each be aimed at
-    something distinguishable.
+    Small on purpose, but not degenerate: two records, four components across
+    three handling dispositions (structured, prose-bound, and mixed), and two
+    typed facts of different families — which is the minimum that lets a
+    replace, an append, and a disable each be aimed at something
+    distinguishable. The base ``MIXED`` component (``MIXED_KEY``) reuses
+    ``CHECK_FACT``'s value rather than declaring a third fact family, but
+    still needs its own dedicated leaves/spans/chunks for its fact and its
+    prose binding: a semantic span may carry only one PRIMARY claim, so it
+    cannot share ``CHECK_SPAN`` or ``PROSE_SPAN`` with the components that
+    already claim them.
     """
     return RepresentationDraft(
         records=(
@@ -482,8 +534,15 @@ def _representation(prefix: str = "") -> RepresentationDraft:
                 handling=ComponentHandling.STRUCTURED,
                 facts=(CHECK_FACT,),
             ),
+            ComponentDraft(
+                record_key=CREATURE_KEY,
+                semantic_key=MIXED_KEY,
+                handling=ComponentHandling.MIXED,
+                irreducibility_reason_code="open_ended_effect",
+                facts=(CHECK_FACT,),
+            ),
         ),
-        prose_bindings=(_wish_binding(prefix),),
+        prose_bindings=(_wish_binding(prefix), _mixed_clause_binding(prefix)),
         relationships=(),
         references=(),
         provenance=(
@@ -500,9 +559,21 @@ def _representation(prefix: str = "") -> RepresentationDraft:
                 ProvenanceRole.PRIMARY,
             ),
             ProvenanceClaim(
+                ProvenanceTargetKind.FACT,
+                (CREATURE_KEY, MIXED_KEY, CHECK_FACT_KEY),
+                MIXED_FACT_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
                 ProvenanceTargetKind.PROSE_BINDING,
                 prose_binding_target_key(_wish_binding(prefix)),
                 PROSE_SPAN,
+                ProvenanceRole.PRIMARY,
+            ),
+            ProvenanceClaim(
+                ProvenanceTargetKind.PROSE_BINDING,
+                prose_binding_target_key(_mixed_clause_binding(prefix)),
+                MIXED_PROSE_SPAN,
                 ProvenanceRole.PRIMARY,
             ),
             ProvenanceClaim(
@@ -526,7 +597,7 @@ _OBLIGATIONS = (
         record_key=CREATURE_KEY,
         kind=RecordKind.CREATURE,
         structured_fact_families=frozenset({CHECK_FACT.FAMILY}),
-        prose_bound_components=frozenset(),
+        prose_bound_components=frozenset({MIXED_KEY}),
     ),
 )
 
@@ -724,6 +795,18 @@ PROSE_COMPONENT_TARGET = MechanicalTarget(
     kind=MechanicalTargetKind.COMPONENT,
     record_key=SPELL_KEY,
     component_key=OPEN_ENDED_KEY,
+)
+#: The base MIXED component's own prose and fact targets.
+MIXED_PROSE_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.PROSE,
+    record_key=CREATURE_KEY,
+    component_key=MIXED_KEY,
+)
+MIXED_FACT_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.FACT,
+    record_key=CREATURE_KEY,
+    component_key=MIXED_KEY,
+    fact_key=CHECK_FACT_KEY,
 )
 
 #: A different spell descriptor, used wherever a replacement must be visibly

--- a/tests/services/rules_authority/test_authored_prose_overlay.py
+++ b/tests/services/rules_authority/test_authored_prose_overlay.py
@@ -14,6 +14,14 @@ passage in deterministic order, ``DISABLE`` suppresses it without deleting
 base state, prose operations never touch typed facts, and the whole overlay
 participates in override-set identity and replay exactly like every other
 typed override.
+
+**Effective-content classification (Owner Decision 2026-08-09).**
+``EffectiveComponent.handling`` describes the authority surviving after
+ordered override application, never authority that existed earlier in the
+sequence — a promotion to ``MIXED`` is not sticky. This module's
+STRUCTURED/MIXED-transition tests are the ones that pin that: they assert
+handling *reverts* when prose is suppressed and facts survive, which a
+sticky-promotion implementation gets wrong.
 """
 
 from __future__ import annotations
@@ -344,9 +352,10 @@ def test_disable_prose_suppresses_it_without_deleting_the_component(
     )
     component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
     assert component.governing_prose == ()
-    # Suppression does not demote the base handling, and it does not delete
-    # the component: it stays PROSE_BOUND, visible with no prose, rather than
-    # being reclassified or dropped from the view.
+    # No facts survive either, so PROSE_BOUND is still the only honest
+    # category (Owner Decision 2026-08-09's named exception) — not because
+    # suppression is exempt from recomputing handling, but because recomputing
+    # it here lands on the same value: no facts, no prose.
     assert component.handling is ComponentHandling.PROSE_BOUND
     assert component.facts == ()
 
@@ -358,9 +367,8 @@ def test_disabling_prose_does_not_suppress_the_components_facts(
 
     Exercised on a component that actually holds both: an earlier APPEND
     promotes DESCRIPTOR_KEY to effective MIXED, then a later DISABLE removes
-    only the prose. If DISABLE touched facts, or if it silently demoted the
-    handling back because the component "looks" structured again, either
-    assertion below would fail.
+    only the prose. The facts must survive untouched regardless of what the
+    disable does to handling (covered separately below).
     """
     author_override(
         runtime.session,
@@ -381,10 +389,320 @@ def test_disabling_prose_does_not_suppress_the_components_facts(
     component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
     assert component.governing_prose == ()
     assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
-    # DISABLE does not demote the promotion an earlier APPEND already made:
-    # the component is effectively MIXED (it once carried authored prose),
-    # not silently reclassified back to STRUCTURED because it shows none now.
+
+
+def test_append_then_disable_prose_returns_a_promoted_component_to_structured(
+    runtime: RuntimeFixture,
+) -> None:
+    """Owner Decision 2026-08-09: effective-content classification, not sticky.
+
+    ``handling`` describes the authority surviving after ordered override
+    application, never authority that existed earlier in the sequence. An
+    earlier promotion to MIXED is not remembered once its only prose is gone:
+    facts survive, prose does not, so the component reads STRUCTURED again —
+    exactly what a sticky "once MIXED, always MIXED" implementation gets
+    wrong.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-append-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("a house-rule clarification"),
+        precedence=10,
+    )
+    # Confirm the promotion actually happened before disabling it, so the
+    # transition this test pins is real rather than a no-op.
+    promoted = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert promoted.handling is ComponentHandling.MIXED
+
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.governing_prose == ()
+    assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
+    assert component.handling is ComponentHandling.STRUCTURED
+    assert component.irreducibility_reason_code is None
+
+
+def test_replace_then_disable_prose_returns_a_promoted_component_to_structured(
+    runtime: RuntimeFixture,
+) -> None:
+    """The REPLACE path to promotion demotes the same way APPEND does."""
+    author_override(
+        runtime.session,
+        override_id="ov-replace-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("an authored replacement"),
+        precedence=10,
+    )
+    promoted = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert promoted.handling is ComponentHandling.MIXED
+
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.governing_prose == ()
+    assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
+    assert component.handling is ComponentHandling.STRUCTURED
+    assert component.irreducibility_reason_code is None
+
+
+def test_a_mixed_component_becomes_effectively_structured_when_prose_is_suppressed(
+    runtime: RuntimeFixture,
+) -> None:
+    """A component that is MIXED going in demotes the same way a promoted one
+    does: suppressing its only prose while its facts survive leaves STRUCTURED,
+    never a handling that remembers the MIXED it used to be.
+    """
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-become-mixed",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact)],
+                "authored_prose": "mixed from the start",
+            },
+        },
+        precedence=10,
+    )
+    mixed = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert mixed.handling is ComponentHandling.MIXED
+    assert mixed.facts != ()
+
+    author_override(
+        runtime.session,
+        override_id="ov-suppress-its-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.governing_prose == ()
+    assert component.facts != ()
+    assert component.handling is ComponentHandling.STRUCTURED
+    assert component.irreducibility_reason_code is None
+
+
+def test_disable_prose_stops_later_processing_of_the_same_prose_target(
+    runtime: RuntimeFixture,
+) -> None:
+    """Unchanged precedence: a DISABLE still stops later processing of the
+    *exact same target* — a later APPEND aimed at the same prose target does
+    not resurrect it. #137/ADR-005d Decision 10's "first winning disable wins"
+    rule, already established for record/component/fact targets, applies to
+    prose exactly the same way; this remediation does not loosen it.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-append-after-disable",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("should never apply"),
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.governing_prose == ()
+    assert component.handling is ComponentHandling.STRUCTURED
+    result = service(runtime).typed_view(whole(runtime))
+    assert result.typed_view is not None
+    applied = {a.override_id: a for a in result.typed_view.applied_overrides}
+    assert applied["ov-disable-prose"].applied is True
+    assert applied["ov-append-after-disable"].applied is False
+
+
+def test_a_whole_component_replace_after_prose_suppression_promotes_again(
+    runtime: RuntimeFixture,
+) -> None:
+    """ "Later higher-precedence prose introduced after suppression must
+    promote the effective view again" (Owner Decision 2026-08-09) — reached
+    through a whole-component REPLACE, a different target kind that a prior
+    PROSE-target DISABLE does not suppress. The stale suppression against the
+    old component's prose target must not hold back the replacement's own
+    prose.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    suppressed = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert suppressed.governing_prose == ()
+    assert suppressed.handling is ComponentHandling.STRUCTURED
+
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-replace-whole-component",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact)],
+                "authored_prose": "the replacement's own prose",
+            },
+        },
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
     assert component.handling is ComponentHandling.MIXED
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "the replacement's own prose"
+
+
+def test_replace_component_clears_prose_suppression_so_a_later_append_applies(
+    runtime: RuntimeFixture,
+) -> None:
+    """The most literal reading of "promote again": a whole-component REPLACE
+    clears the stale PROSE-target suppression (existing ``disabled_prose``
+    clearing, unchanged by this remediation), so a *subsequent* prose APPEND
+    on the same target — which would have been suppressed had the REPLACE not
+    intervened — now applies.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-replace-whole-component",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "structured",
+                "facts": [fact_payload(check_fact)],
+            },
+        },
+        precedence=20,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-append-after-replace",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("now applies"),
+        precedence=30,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "now applies"
+    result = service(runtime).typed_view(whole(runtime))
+    assert result.typed_view is not None
+    applied = {a.override_id: a for a in result.typed_view.applied_overrides}
+    assert applied["ov-append-after-replace"].applied is True
+
+
+def test_a_fact_disable_after_prose_promotion_revises_handling_to_prose_bound(
+    runtime: RuntimeFixture,
+) -> None:
+    """A later, unrelated FACT ``DISABLE`` on the same component resolves
+    *after* an earlier prose promotion in ordering. Handling must reflect what
+    survives at the very end, not only what the prose operation itself saw:
+    losing the last fact after a MIXED promotion leaves prose without facts,
+    which Owner Decision 2026-08-09's third bullet makes ``PROSE_BOUND`` — not
+    a handling that keeps claiming facts it no longer has.
+    """
+    from tests.services.rules_authority.conftest import DESCRIPTOR_FACT_TARGET
+
+    author_override(
+        runtime.session,
+        override_id="ov-append-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("a house-rule clarification"),
+        precedence=10,
+    )
+    promoted = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert promoted.handling is ComponentHandling.MIXED
+    before = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert before.binding is not None
+
+    author_override(
+        runtime.session,
+        override_id="ov-disable-the-only-fact",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.facts == ()
+    assert component.governing_prose != ()
+    assert component.handling is ComponentHandling.PROSE_BOUND
+
+    # Re-derivation at final assembly must not lose either override's own
+    # provenance, and must not touch the immutable base projection identity —
+    # both overrides still resolved and applied against their real targets.
+    after = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert after.binding is not None
+    assert (
+        after.binding.mechanical_projection_uuid
+        == before.binding.mechanical_projection_uuid
+    )
+    result = service(runtime).typed_view(whole(runtime))
+    assert result.typed_view is not None
+    applied = {a.override_id: a for a in result.typed_view.applied_overrides}
+    assert applied["ov-append-prose"].applied is True
+    assert applied["ov-disable-the-only-fact"].applied is True
 
 
 # ---------------------------------------------------------------------------
@@ -676,6 +994,64 @@ def test_replay_reconstructs_authored_prose_after_the_current_row_is_deleted(
     replayed = service(runtime).replay(recorded)
     assert replayed.applied_overrides == original.applied_overrides
     assert replayed.records == original.records
+
+
+def test_replay_reconstructs_the_demoted_handling_after_current_rows_change(
+    runtime: RuntimeFixture,
+) -> None:
+    """Effective-content classification is recorded evidence, not a live query.
+
+    The recorded binding names an override-set version whose derived handling
+    (STRUCTURED, after a promotion was disabled) must reconstruct exactly, even
+    after the current override rows that produced it are edited or deleted —
+    the same replay guarantee every other applied change gets.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-append-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("a house-rule clarification"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    recorded = resolution.binding
+    assert recorded is not None
+    original = service(runtime).replay(recorded)
+    (original_record,) = [r for r in original.records if r.semantic_key == SPELL_KEY]
+    (original_component,) = [
+        c for c in original_record.components if c.semantic_key == DESCRIPTOR_KEY
+    ]
+    assert original_component.handling is ComponentHandling.STRUCTURED
+
+    disable_row = runtime.session.get(MechanicalOverrideORM, "ov-disable-prose")
+    assert disable_row is not None
+    runtime.session.delete(disable_row)
+    append_row = runtime.session.get(MechanicalOverrideORM, "ov-append-prose")
+    assert append_row is not None
+    append_row.payload = append_prose_payload("current state is now unsuppressed")
+    runtime.session.flush()
+
+    # Current state, unlike the replayed one, would resolve MIXED again — the
+    # point is that replay ignores this and reconstructs the original STRUCTURED.
+    current = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert current.handling is ComponentHandling.MIXED
+
+    replayed = service(runtime).replay(recorded)
+    (record,) = [r for r in replayed.records if r.semantic_key == SPELL_KEY]
+    (component,) = [c for c in record.components if c.semantic_key == DESCRIPTOR_KEY]
+    assert component.handling is ComponentHandling.STRUCTURED
+    assert component.governing_prose == ()
+    assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/rules_authority/test_authored_prose_overlay.py
+++ b/tests/services/rules_authority/test_authored_prose_overlay.py
@@ -34,6 +34,7 @@ from afterworlds.ingestion.mechanical.representation import (
     AbilityCheckFact,
     AbilityScore,
     DcKind,
+    fact_key,
     fact_payload,
 )
 from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
@@ -703,6 +704,349 @@ def test_a_fact_disable_after_prose_promotion_revises_handling_to_prose_bound(
     applied = {a.override_id: a for a in result.typed_view.applied_overrides}
     assert applied["ov-append-prose"].applied is True
     assert applied["ov-disable-the-only-fact"].applied is True
+
+
+# ---------------------------------------------------------------------------
+# Path-independent final-effective-handling derivation (Owner Decision
+# 2026-08-09, generalized): the same facts+prose -> handling invariant holds
+# regardless of which override family declared the authority, or whether a
+# prose operation was ever involved at all.
+# ---------------------------------------------------------------------------
+
+
+def test_component_replace_declaring_mixed_then_fact_disable_finishes_prose_bound(
+    runtime: RuntimeFixture,
+) -> None:
+    """The exact regression from the path-dependent residue: a whole-component
+    ``REPLACE`` that declares ``MIXED`` directly (never processed by a prose
+    entry) must still demote to ``PROSE_BOUND`` when a later ``FACT``
+    ``DISABLE`` strips its only fact, with its authored prose intact.
+    """
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-declare-mixed",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact)],
+                "authored_prose": "declared mixed directly",
+            },
+        },
+        precedence=10,
+    )
+    mixed = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert mixed.handling is ComponentHandling.MIXED
+    before = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert before.binding is not None
+
+    author_override(
+        runtime.session,
+        override_id="ov-disable-the-declared-fact",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.FACT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+            fact_key=fact_key(check_fact),
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.facts == ()
+    assert component.governing_prose != ()
+    assert component.handling is ComponentHandling.PROSE_BOUND
+
+    after = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert after.binding is not None
+    assert (
+        after.binding.mechanical_projection_uuid
+        == before.binding.mechanical_projection_uuid
+    )
+    result = service(runtime).typed_view(whole(runtime))
+    assert result.typed_view is not None
+    applied = {a.override_id: a for a in result.typed_view.applied_overrides}
+    assert applied["ov-declare-mixed"].applied is True
+    assert applied["ov-disable-the-declared-fact"].applied is True
+
+    replayed = service(runtime).replay(after.binding)
+    (record,) = [r for r in replayed.records if r.semantic_key == SPELL_KEY]
+    (replayed_component,) = [
+        c for c in record.components if c.semantic_key == DESCRIPTOR_KEY
+    ]
+    assert replayed_component.handling is ComponentHandling.PROSE_BOUND
+    assert replayed_component.facts == ()
+    assert replayed_component.governing_prose != ()
+
+
+def test_record_replace_declaring_mixed_then_fact_disable_finishes_prose_bound(
+    runtime: RuntimeFixture,
+) -> None:
+    """The same invariant through a whole-record ``REPLACE`` containing an
+    authored-prose ``MIXED`` component — a different override family from
+    both the prose path and the whole-component-``REPLACE`` path above.
+    """
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-replace-record",
+        target=MechanicalTarget(kind=MechanicalTargetKind.RECORD, record_key=SPELL_KEY),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_record",
+            "record_kind": "spell",
+            "components": [
+                {
+                    "semantic_key": DESCRIPTOR_KEY,
+                    "handling": "mixed",
+                    "facts": [fact_payload(check_fact)],
+                    "authored_prose": "record-replaced mixed component",
+                }
+            ],
+        },
+        precedence=10,
+    )
+    mixed = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert mixed.handling is ComponentHandling.MIXED
+
+    author_override(
+        runtime.session,
+        override_id="ov-disable-the-record-replaced-fact",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.FACT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+            fact_key=fact_key(check_fact),
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.facts == ()
+    assert component.governing_prose != ()
+    assert component.handling is ComponentHandling.PROSE_BOUND
+
+
+def test_component_append_declaring_mixed_then_fact_disable_finishes_prose_bound(
+    runtime: RuntimeFixture,
+) -> None:
+    """The same invariant for a newly ``APPEND``-ed component declaring
+    ``MIXED`` directly — a fourth distinct override family exercising the
+    same final derivation.
+    """
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    new_component_key = "house-rider"
+    author_override(
+        runtime.session,
+        override_id="ov-append-mixed-component",
+        target=MechanicalTarget(kind=MechanicalTargetKind.RECORD, record_key=SPELL_KEY),
+        operation=OverrideOperationEnum.APPEND,
+        payload={
+            "patch": "append_component",
+            "component": {
+                "semantic_key": new_component_key,
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact)],
+                "authored_prose": "appended mixed component",
+            },
+        },
+        precedence=10,
+    )
+    mixed = typed_component(runtime, SPELL_KEY, new_component_key)
+    assert mixed.handling is ComponentHandling.MIXED
+
+    author_override(
+        runtime.session,
+        override_id="ov-disable-the-appended-fact",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.FACT,
+            record_key=SPELL_KEY,
+            component_key=new_component_key,
+            fact_key=fact_key(check_fact),
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, new_component_key)
+    assert component.facts == ()
+    assert component.governing_prose != ()
+    assert component.handling is ComponentHandling.PROSE_BOUND
+
+
+def test_reusing_a_semantic_key_after_a_prose_operation_does_not_inherit_stale_state(
+    runtime: RuntimeFixture,
+) -> None:
+    """A semantic key a prose operation touched, later reincarnated by a
+    whole-component ``REPLACE`` that declares fresh authority with no prose,
+    must reflect only its own final facts/prose — nothing carried over from
+    the earlier prose operation against the same key. There is no tracking
+    set this could leak from (final handling is derived from each component's
+    own current fields, not from any operation-keyed record of what happened
+    to that key before), but the observable behavior is what matters.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-promote-via-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("a house-rule clarification"),
+        precedence=10,
+    )
+    promoted = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert promoted.handling is ComponentHandling.MIXED
+
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-reincarnate-the-key",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "structured",
+                "facts": [fact_payload(check_fact)],
+            },
+        },
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.handling is ComponentHandling.STRUCTURED
+    assert component.governing_prose == ()
+    assert [f.fact_key for f in component.facts] == [fact_key(check_fact)]
+
+
+def test_all_empty_fallback_does_not_depend_on_fact_vs_prose_disable_order(
+    runtime: RuntimeFixture,
+) -> None:
+    """The all-authority-empty fallback (declared handling, untouched) must
+    not depend on operation order: two component REPLACE/APPEND declarations
+    that both declare ``MIXED`` and both end up with facts=()/prose=() report
+    the same handling whether their prose or their fact was disabled first.
+    Before ``_apply_prose_entry`` stopped mutating ``handling`` mid-loop,
+    reversing this order changed the answer (``STRUCTURED`` vs
+    ``PROSE_BOUND``) even though the final surviving authority — nothing — was
+    identical either way.
+    """
+    check_fact_a = AbilityCheckFact(
+        ability=AbilityScore.WISDOM, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-declare-mixed-a",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact_a)],
+                "authored_prose": "will be fully suppressed, prose disabled first",
+            },
+        },
+        precedence=0,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose-a",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-fact-a",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.FACT,
+            record_key=SPELL_KEY,
+            component_key=DESCRIPTOR_KEY,
+            fact_key=fact_key(check_fact_a),
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+
+    check_fact_b = AbilityCheckFact(
+        ability=AbilityScore.STRENGTH, dc_kind=DcKind.FIXED, dc_value=15
+    )
+    second_key = "house-rider"
+    author_override(
+        runtime.session,
+        override_id="ov-declare-mixed-b",
+        target=MechanicalTarget(kind=MechanicalTargetKind.RECORD, record_key=SPELL_KEY),
+        operation=OverrideOperationEnum.APPEND,
+        payload={
+            "patch": "append_component",
+            "component": {
+                "semantic_key": second_key,
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact_b)],
+                "authored_prose": "will be fully suppressed, fact disabled first",
+            },
+        },
+        precedence=0,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-fact-b",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.FACT,
+            record_key=SPELL_KEY,
+            component_key=second_key,
+            fact_key=fact_key(check_fact_b),
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose-b",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.PROSE,
+            record_key=SPELL_KEY,
+            component_key=second_key,
+        ),
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+
+    component_a = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    component_b = typed_component(runtime, SPELL_KEY, second_key)
+    assert component_a.facts == ()
+    assert component_a.governing_prose == ()
+    assert component_b.facts == ()
+    assert component_b.governing_prose == ()
+    assert component_a.handling is component_b.handling is ComponentHandling.MIXED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/rules_authority/test_authored_prose_overlay.py
+++ b/tests/services/rules_authority/test_authored_prose_overlay.py
@@ -1,0 +1,910 @@
+"""The authored-authority prose overlay — Owner Decision 2026-08-08.
+
+ADR-005d Decisions 3, 6, 9, and 10 (amended) and #137 contracts 3 and 6
+(amended) narrow the blanket prohibition on a second prose store to the
+invariant that there is no duplicated store for what the SRD source says. A
+distinct authored-authority prose overlay is a first-class runtime authority
+layer: it targets a dedicated ``PROSE`` grain scoped by stable record and
+component identity, never a raw chunk, and it never claims 5c chunk identity,
+span provenance, or an irreducibility reason copied from base authority.
+
+This module proves the effective behavior contract 6 defines: ``REPLACE``
+replaces effective governing prose, ``APPEND`` preserves it and adds one more
+passage in deterministic order, ``DISABLE`` suppresses it without deleting
+base state, prose operations never touch typed facts, and the whole overlay
+participates in override-set identity and replay exactly like every other
+typed override.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    DcKind,
+    fact_payload,
+)
+from afterworlds.models.enums import OverrideOperationEnum, OverrideOriginEnum
+from afterworlds.models.rules_package import RuleSliceRequest
+from afterworlds.persistence.orm.rules_authority import MechanicalOverrideORM
+from afterworlds.persistence.orm.rules_package import RuleOverrideORM
+from afterworlds.services.rules_authority import (
+    AuthorityOutcome,
+    MechanicalTarget,
+    MechanicalTargetKind,
+    RulesAuthorityService,
+    collect_current_override_state,
+)
+from afterworlds.services.rules_authority.application import AuthoredProse, SourceProse
+from tests.services.rules_authority.conftest import (
+    DESCRIPTOR_FACT_KEY,
+    DESCRIPTOR_KEY,
+    DISABLE_PAYLOAD,
+    NOW,
+    OPEN_ENDED_KEY,
+    PACKAGE_UUID,
+    PROSE_TEXT,
+    RELEASE_VERSION,
+    SPELL_KEY,
+    WISH_CHUNK,
+    RuntimeFixture,
+    append_fact_payload,
+    author_override,
+)
+
+#: The prose-bound component's prose authority: source-only until an override
+#: replaces, appends to, or disables it.
+PROSE_BOUND_PROSE_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.PROSE, record_key=SPELL_KEY, component_key=OPEN_ENDED_KEY
+)
+#: A purely structured component's (previously prose-free) prose authority —
+#: attaching prose here is the STRUCTURED -> MIXED promotion case.
+STRUCTURED_PROSE_TARGET = MechanicalTarget(
+    kind=MechanicalTargetKind.PROSE, record_key=SPELL_KEY, component_key=DESCRIPTOR_KEY
+)
+
+
+def replace_prose_payload(text: str = "authored replacement text") -> dict[str, object]:
+    return {"patch": "replace_prose", "text": text}
+
+
+def append_prose_payload(text: str = "authored addendum text") -> dict[str, object]:
+    return {"patch": "append_prose", "text": text}
+
+
+def service(runtime: RuntimeFixture) -> RulesAuthorityService:
+    return RulesAuthorityService(runtime.session, now=NOW)
+
+
+def whole(runtime: RuntimeFixture) -> RuleSliceRequest:
+    return RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+
+
+def identity(runtime: RuntimeFixture) -> str:
+    return collect_current_override_state(
+        runtime.session, PACKAGE_UUID, RELEASE_VERSION
+    ).override_set_uuid
+
+
+def typed_component(runtime: RuntimeFixture, record_key: str, component_key: str):  # type: ignore[no-untyped-def]
+    result = service(runtime).typed_view(whole(runtime))
+    assert result.outcome is AuthorityOutcome.RESOLVED, result.detail
+    view = result.typed_view
+    assert view is not None
+    (record,) = [r for r in view.records if r.semantic_key == record_key]
+    (component,) = [c for c in record.components if c.semantic_key == component_key]
+    return component
+
+
+def refusal(runtime: RuntimeFixture):  # type: ignore[no-untyped-def]
+    return service(runtime).typed_view(whole(runtime))
+
+
+def gm_component(runtime: RuntimeFixture, component_key: str):  # type: ignore[no-untyped-def]
+    result = service(runtime).gamemaster_view(whole(runtime))
+    assert result.outcome is AuthorityOutcome.RESOLVED, result.detail
+    view = result.gamemaster_view
+    assert view is not None
+    (component,) = [c for c in view.components if c.component_key == component_key]
+    return component
+
+
+# ---------------------------------------------------------------------------
+# Override-set identity
+# ---------------------------------------------------------------------------
+
+
+def test_authored_text_change_moves_the_override_set_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    """#137 acceptance criterion 25: changing authored text moves the identity."""
+    author_override(
+        runtime.session,
+        override_id="ov-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("first authored text"),
+    )
+    before = identity(runtime)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-prose")
+    assert row is not None
+    row.payload = replace_prose_payload("a different authored text")
+    runtime.session.flush()
+
+    assert identity(runtime) != before
+
+
+def test_two_replace_component_patches_differing_only_in_prose_are_distinct(
+    runtime: RuntimeFixture,
+) -> None:
+    """Regression: ``_component_body_payload`` must not drop authored_prose.
+
+    Two whole-component REPLACE patches identical except for authored text
+    must not canonicalize to the same bytes and share an identity.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-component-prose",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=OPEN_ENDED_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "prose_bound",
+                "facts": [],
+                "authored_prose": "text one",
+            },
+        },
+    )
+    first = identity(runtime)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-component-prose")
+    assert row is not None
+    row.payload = {
+        "patch": "replace_component",
+        "component": {
+            "handling": "prose_bound",
+            "facts": [],
+            "authored_prose": "text two",
+        },
+    }
+    runtime.session.flush()
+
+    assert identity(runtime) != first
+
+
+def test_prose_target_change_moves_the_override_set_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload(),
+    )
+    before = identity(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-prose")
+    assert row is not None
+    row.target_component_key = DESCRIPTOR_KEY
+    runtime.session.flush()
+    assert identity(runtime) != before
+
+
+def test_prose_origin_change_moves_the_override_set_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload(),
+        origin=OverrideOriginEnum.HOUSE_RULE,
+    )
+    before = identity(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-prose")
+    assert row is not None
+    row.override_origin = OverrideOriginEnum.PACKAGE_PATCH.value
+    runtime.session.flush()
+    assert identity(runtime) != before
+
+
+def test_prose_operation_change_moves_the_override_set_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("same text"),
+    )
+    before = identity(runtime)
+    row = runtime.session.get(MechanicalOverrideORM, "ov-prose")
+    assert row is not None
+    row.override_operation = OverrideOperationEnum.REPLACE.value
+    row.payload = replace_prose_payload("same text")
+    runtime.session.flush()
+    assert identity(runtime) != before
+
+
+def test_reordering_two_prose_overrides_moves_the_identity(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-a",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("first"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-b",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("second"),
+        precedence=20,
+    )
+    before = identity(runtime)
+    first = runtime.session.get(MechanicalOverrideORM, "ov-a")
+    second = runtime.session.get(MechanicalOverrideORM, "ov-b")
+    assert first is not None and second is not None
+    first.precedence, second.precedence = 20, 10
+    runtime.session.flush()
+    assert identity(runtime) != before
+
+
+def test_base_projection_identity_is_unaffected_by_authored_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    before = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert before.binding is not None
+    author_override(
+        runtime.session,
+        override_id="ov-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload(),
+    )
+    after = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert after.binding is not None
+    assert (
+        after.binding.mechanical_projection_uuid
+        == before.binding.mechanical_projection_uuid
+    )
+    assert after.binding.override_set_uuid != before.binding.override_set_uuid
+
+
+# ---------------------------------------------------------------------------
+# REPLACE / APPEND / DISABLE over PROSE_BOUND
+# ---------------------------------------------------------------------------
+
+
+def test_replace_prose_on_prose_bound_replaces_source_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-replace",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("the authored replacement"),
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert component.handling is ComponentHandling.PROSE_BOUND
+    assert component.facts == ()
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "the authored replacement"
+    assert entry.supplied_by_override_id == "ov-replace"
+    assert entry.supplied_by_origin is OverrideOriginEnum.HOUSE_RULE
+
+
+def test_append_prose_on_prose_bound_preserves_source_and_adds_authored(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-append",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("an authored addendum"),
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert component.handling is ComponentHandling.PROSE_BOUND
+    source, authored = component.governing_prose
+    assert isinstance(source, SourceProse)
+    assert source.chunk_id == WISH_CHUNK
+    assert isinstance(authored, AuthoredProse)
+    assert authored.text == "an authored addendum"
+    assert authored.supplied_by_override_id == "ov-append"
+
+
+def test_disable_prose_suppresses_it_without_deleting_the_component(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert component.governing_prose == ()
+    # Suppression does not demote the base handling, and it does not delete
+    # the component: it stays PROSE_BOUND, visible with no prose, rather than
+    # being reclassified or dropped from the view.
+    assert component.handling is ComponentHandling.PROSE_BOUND
+    assert component.facts == ()
+
+
+def test_disabling_prose_does_not_suppress_the_components_facts(
+    runtime: RuntimeFixture,
+) -> None:
+    """Prose and facts are siblings: disabling one leaves the other alone.
+
+    Exercised on a component that actually holds both: an earlier APPEND
+    promotes DESCRIPTOR_KEY to effective MIXED, then a later DISABLE removes
+    only the prose. If DISABLE touched facts, or if it silently demoted the
+    handling back because the component "looks" structured again, either
+    assertion below would fail.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-append-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("a house-rule clarification"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-prose",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.governing_prose == ()
+    assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
+    # DISABLE does not demote the promotion an earlier APPEND already made:
+    # the component is effectively MIXED (it once carried authored prose),
+    # not silently reclassified back to STRUCTURED because it shows none now.
+    assert component.handling is ComponentHandling.MIXED
+
+
+# ---------------------------------------------------------------------------
+# STRUCTURED -> effective MIXED promotion, and MIXED-safety
+# ---------------------------------------------------------------------------
+
+
+def test_authored_prose_on_a_structured_component_promotes_effective_handling(
+    runtime: RuntimeFixture,
+) -> None:
+    """An honest effective view, not prose smuggled into a typed fact."""
+    author_override(
+        runtime.session,
+        override_id="ov-promote",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("a house-rule clarification"),
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.handling is ComponentHandling.MIXED
+    assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "a house-rule clarification"
+
+
+def test_promotion_to_mixed_does_not_remint_the_base_projection(
+    runtime: RuntimeFixture,
+) -> None:
+    before = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert before.binding is not None
+    author_override(
+        runtime.session,
+        override_id="ov-promote",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload(),
+    )
+    after = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert after.binding is not None
+    assert (
+        after.binding.mechanical_projection_uuid
+        == before.binding.mechanical_projection_uuid
+    )
+
+
+def test_mixed_component_prose_operations_do_not_alter_typed_facts(
+    runtime: RuntimeFixture,
+) -> None:
+    """On a MIXED component, prose ops leave the facts array untouched."""
+    author_override(
+        runtime.session,
+        override_id="ov-promote",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("first"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-append-again",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("second"),
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert component.handling is ComponentHandling.MIXED
+    assert [f.fact_key for f in component.facts] == [DESCRIPTOR_FACT_KEY]
+    assert len(component.governing_prose) == 2
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_append_append_replace_the_later_replace_wins(
+    runtime: RuntimeFixture,
+) -> None:
+    """A REPLACE resolved after two APPENDs wipes them, not just the source."""
+    author_override(
+        runtime.session,
+        override_id="ov-append-1",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("first addendum"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-append-2",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("second addendum"),
+        precedence=20,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-replace",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("the only surviving text"),
+        precedence=30,
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "the only surviving text"
+    assert entry.supplied_by_override_id == "ov-replace"
+
+
+def test_replace_then_append_preserves_only_the_replacement_and_the_append(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-replace",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("replacement text"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-append",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("appended after replacement"),
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert [e.text for e in component.governing_prose] == [
+        "replacement text",
+        "appended after replacement",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# GameMaster view: exact ordered source/authored authority and provenance
+# ---------------------------------------------------------------------------
+
+
+def test_the_gamemaster_view_returns_ordered_source_then_authored_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-append",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("an authored addendum"),
+    )
+    component = gm_component(runtime, OPEN_ENDED_KEY)
+    source, authored = component.governing_prose
+    assert isinstance(source, SourceProse)
+    assert source.chunk_id == WISH_CHUNK
+    assert source.text == PROSE_TEXT
+    assert isinstance(authored, AuthoredProse)
+    assert authored.text == "an authored addendum"
+    assert authored.supplied_by_override_id == "ov-append"
+    assert authored.supplied_by_origin is OverrideOriginEnum.HOUSE_RULE
+
+
+def test_typed_and_gamemaster_views_report_the_same_prose_provenance(
+    runtime: RuntimeFixture,
+) -> None:
+    """Same entries, same order, same provenance — only source text differs.
+
+    Uses APPEND so both a SourceProse and an AuthoredProse entry are present:
+    a REPLACE here would leave only the authored entry, which passes through
+    both views unresolved and would make this pass without exercising the
+    typed view's "no text lookup" contract at all.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-append",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("shared authored text"),
+    )
+    typed = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    gm = gm_component(runtime, OPEN_ENDED_KEY)
+
+    typed_source, typed_authored = typed.governing_prose
+    gm_source, gm_authored = gm.governing_prose
+    assert isinstance(typed_source, SourceProse) and isinstance(gm_source, SourceProse)
+    assert typed_source.chunk_id == gm_source.chunk_id == WISH_CHUNK
+    # The typed (deterministic-consumer) view never resolves source text; only
+    # the GameMaster view does, by reading the bound package's RuleChunk rows.
+    assert typed_source.text is None
+    assert gm_source.text == PROSE_TEXT
+    assert typed_authored == gm_authored
+    assert isinstance(typed_authored, AuthoredProse)
+    assert typed_authored.text == "shared authored text"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic consumers are unaffected by authored prose
+# ---------------------------------------------------------------------------
+
+
+def test_the_fact_bearing_surface_is_identical_with_and_without_prose_overlay(
+    runtime: RuntimeFixture,
+) -> None:
+    """Not a tautology: proves the *facts* consumers execute against, not just
+    that a prose field exists, are byte-identical whether or not authored
+    prose is attached — a deterministic consumer reading only ``facts`` can
+    never observe the overlay at all.
+    """
+    without = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    author_override(
+        runtime.session,
+        override_id="ov-prose-only",
+        target=STRUCTURED_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("purely informational to a deterministic reader"),
+    )
+    with_prose = typed_component(runtime, SPELL_KEY, DESCRIPTOR_KEY)
+    assert with_prose.facts == without.facts
+    assert with_prose.record_key == without.record_key
+    assert with_prose.semantic_key == without.semantic_key
+    # Only the honestly-promoted handling and the added prose differ.
+    assert with_prose.handling != without.handling
+    assert with_prose.governing_prose != without.governing_prose
+
+
+# ---------------------------------------------------------------------------
+# Replay
+# ---------------------------------------------------------------------------
+
+
+def test_replay_reconstructs_authored_prose_after_the_current_row_is_edited(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-historic-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("the original authored text"),
+        precedence=10,
+        origin=OverrideOriginEnum.HOUSE_RULE,
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    recorded = resolution.binding
+    assert recorded is not None
+    original = service(runtime).replay(recorded)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-historic-prose")
+    assert row is not None
+    row.payload = replace_prose_payload("a completely different current text")
+    row.is_enabled = False
+    row.precedence = 999
+    row.override_origin = OverrideOriginEnum.PACKAGE_PATCH.value
+    runtime.session.flush()
+
+    replayed = service(runtime).replay(recorded)
+    assert replayed.applied_overrides == original.applied_overrides
+    (record,) = [r for r in replayed.records if r.semantic_key == SPELL_KEY]
+    (component,) = [c for c in record.components if c.semantic_key == OPEN_ENDED_KEY]
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "the original authored text"
+
+
+def test_replay_reconstructs_authored_prose_after_the_current_row_is_deleted(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-historic-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_prose_payload("the original addendum"),
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    recorded = resolution.binding
+    assert recorded is not None
+    original = service(runtime).replay(recorded)
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-historic-prose")
+    assert row is not None
+    runtime.session.delete(row)
+    runtime.session.flush()
+
+    replayed = service(runtime).replay(recorded)
+    assert replayed.applied_overrides == original.applied_overrides
+    assert replayed.records == original.records
+
+
+# ---------------------------------------------------------------------------
+# Invalid, blank, malformed, and cross-release prose overrides fail closed
+# ---------------------------------------------------------------------------
+
+
+def test_blank_authored_prose_text_is_refused(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-blank",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload={"patch": "replace_prose", "text": "   "},
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "non-blank" in result.detail
+
+
+def test_missing_text_field_is_refused(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-missing-text",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload={"patch": "append_prose"},
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "missing" in result.detail
+
+
+def test_a_prose_override_naming_no_such_component_is_refused(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-missing-target",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.PROSE,
+            record_key=SPELL_KEY,
+            component_key="no-such-component",
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload(),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "names no component" in result.detail
+
+
+def test_a_cross_release_prose_override_is_refused(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-cross-release",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload(),
+        release_version="5.2.1-some-other-release",
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "authored against release" in resolution.detail
+
+
+def test_appending_prose_onto_a_fact_target_is_type_incompatible(
+    runtime: RuntimeFixture,
+) -> None:
+    """A prose patch aimed at a fact target is outside the closed pairing."""
+    from tests.services.rules_authority.conftest import DESCRIPTOR_FACT_TARGET
+
+    author_override(
+        runtime.session,
+        override_id="ov-wrong-kind",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload={"patch": "append_prose", "text": "should never apply"},
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+
+
+def test_append_onto_a_fact_target_remains_unpermitted_alongside_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    """APPEND has no honest family for a fact target — unchanged by this PR.
+
+    Adding the ``prose`` target kind and its two new families must not loosen
+    the existing rule that a fact has no multiplicity to append into.
+    """
+    from tests.services.rules_authority.conftest import DESCRIPTOR_FACT_TARGET
+
+    author_override(
+        runtime.session,
+        override_id="ov-append-fact-family-mismatch",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(),
+    )
+    result = refusal(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
+    assert "no multiplicity" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Whole-component authored prose (REPLACE_COMPONENT / APPEND_COMPONENT)
+# ---------------------------------------------------------------------------
+
+
+def test_replace_component_may_declare_prose_bound_with_authored_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-whole-component-prose",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.COMPONENT,
+            record_key=SPELL_KEY,
+            component_key=OPEN_ENDED_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={
+            "patch": "replace_component",
+            "component": {
+                "handling": "prose_bound",
+                "facts": [],
+                "authored_prose": "a completely authored component",
+            },
+        },
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert component.handling is ComponentHandling.PROSE_BOUND
+    assert component.irreducibility_reason_code is None
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "a completely authored component"
+
+
+def test_append_component_may_declare_mixed_with_facts_and_authored_prose(
+    runtime: RuntimeFixture,
+) -> None:
+    check_fact = AbilityCheckFact(
+        ability=AbilityScore.STRENGTH, dc_kind=DcKind.FIXED, dc_value=12
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-whole-mixed-add",
+        target=MechanicalTarget(kind=MechanicalTargetKind.RECORD, record_key=SPELL_KEY),
+        operation=OverrideOperationEnum.APPEND,
+        payload={
+            "patch": "append_component",
+            "component": {
+                "semantic_key": "house-mixed-rider",
+                "handling": "mixed",
+                "facts": [fact_payload(check_fact)],
+                "authored_prose": "context for the added mixed component",
+            },
+        },
+    )
+    component = typed_component(runtime, SPELL_KEY, "house-mixed-rider")
+    assert component.handling is ComponentHandling.MIXED
+    assert len(component.facts) == 1
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "context for the added mixed component"
+
+
+# ---------------------------------------------------------------------------
+# Legacy chunk-targeting overrides never alter the new views
+# ---------------------------------------------------------------------------
+
+
+def test_a_legacy_chunk_override_does_not_alter_the_new_authority_views(
+    runtime: RuntimeFixture,
+) -> None:
+    """The service never reads ``rp_overrides`` (docstring guarantee, pinned)."""
+    typed_before = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    gm_before = gm_component(runtime, OPEN_ENDED_KEY)
+
+    runtime.session.add(
+        RuleOverrideORM(
+            override_id="legacy-chunk-override",
+            rules_package_id=str(runtime.package_uuid),
+            target_chunk_id=WISH_CHUNK,
+            target_entity_id=None,
+            override_origin="house_rule",
+            override_operation="replace",
+            override_payload='{"content": "a legacy chunk edit"}',
+            precedence=1,
+            is_enabled=True,
+            created_at=NOW,
+        )
+    )
+    runtime.session.flush()
+
+    typed_after = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    gm_after = gm_component(runtime, OPEN_ENDED_KEY)
+    assert typed_after == typed_before
+    assert gm_after == gm_before
+    (source,) = gm_after.governing_prose
+    assert isinstance(source, SourceProse)
+    assert source.text == PROSE_TEXT
+
+
+# ---------------------------------------------------------------------------
+# house_rules is never silently promoted to trusted mechanical authority
+# ---------------------------------------------------------------------------
+
+
+def test_house_rules_is_never_referenced_by_the_typed_override_system(
+    tmp_path: Path,
+) -> None:
+    """Owner Decision 2026-08-08: no implicit promotion path.
+
+    The free-form session ``house_rules`` string is a wholly different model
+    (``models/session.py``); this pins that the typed override system never
+    reads it, so no future edit can wire it in without this test noticing.
+    """
+    package_dir = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "afterworlds"
+        / ("services/rules_authority")
+    )
+    assert package_dir.is_dir()
+    offenders = [
+        path
+        for path in package_dir.glob("*.py")
+        if re.search(r"house_rules", path.read_text(encoding="utf-8"))
+    ]
+    assert offenders == []

--- a/tests/services/rules_authority/test_authored_prose_overlay.py
+++ b/tests/services/rules_authority/test_authored_prose_overlay.py
@@ -50,9 +50,13 @@ from afterworlds.services.rules_authority import (
 )
 from afterworlds.services.rules_authority.application import AuthoredProse, SourceProse
 from tests.services.rules_authority.conftest import (
+    CHECK_FACT_KEY,
+    CREATURE_KEY,
     DESCRIPTOR_FACT_KEY,
     DESCRIPTOR_KEY,
     DISABLE_PAYLOAD,
+    MIXED_KEY,
+    MIXED_PROSE_TARGET,
     NOW,
     OPEN_ENDED_KEY,
     PACKAGE_UUID,
@@ -304,6 +308,13 @@ def test_base_projection_identity_is_unaffected_by_authored_prose(
 def test_replace_prose_on_prose_bound_replaces_source_prose(
     runtime: RuntimeFixture,
 ) -> None:
+    """PROSE REPLACE removes all source prose *and* the source-derived
+    irreducibility reason it justified: what remains is authored-only
+    authority, and a reason claiming the discarded source prose's
+    irreducibility no longer honestly describes it (ADR-005d Decision 10).
+    Checked in both views — they must agree, the same way they agree on
+    governing prose itself.
+    """
     author_override(
         runtime.session,
         override_id="ov-replace",
@@ -314,16 +325,23 @@ def test_replace_prose_on_prose_bound_replaces_source_prose(
     component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
     assert component.handling is ComponentHandling.PROSE_BOUND
     assert component.facts == ()
+    assert component.irreducibility_reason_code is None
     (entry,) = component.governing_prose
     assert isinstance(entry, AuthoredProse)
     assert entry.text == "the authored replacement"
     assert entry.supplied_by_override_id == "ov-replace"
     assert entry.supplied_by_origin is OverrideOriginEnum.HOUSE_RULE
 
+    gm = gm_component(runtime, OPEN_ENDED_KEY)
+    assert gm.irreducibility_reason_code is None
+
 
 def test_append_prose_on_prose_bound_preserves_source_and_adds_authored(
     runtime: RuntimeFixture,
 ) -> None:
+    """APPEND only adds to existing governing prose — the source prose (and
+    the reason that justifies it) remains effective, unlike REPLACE.
+    """
     author_override(
         runtime.session,
         override_id="ov-append",
@@ -333,12 +351,175 @@ def test_append_prose_on_prose_bound_preserves_source_and_adds_authored(
     )
     component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
     assert component.handling is ComponentHandling.PROSE_BOUND
+    assert component.irreducibility_reason_code == "open_ended_effect"
     source, authored = component.governing_prose
     assert isinstance(source, SourceProse)
     assert source.chunk_id == WISH_CHUNK
     assert isinstance(authored, AuthoredProse)
     assert authored.text == "an authored addendum"
     assert authored.supplied_by_override_id == "ov-append"
+
+    gm = gm_component(runtime, OPEN_ENDED_KEY)
+    assert gm.irreducibility_reason_code == "open_ended_effect"
+
+
+def test_replace_prose_on_a_base_mixed_component_clears_only_the_reason(
+    runtime: RuntimeFixture,
+) -> None:
+    """A base ``MIXED`` component (facts and source prose both declared at
+    build time) keeps its facts and its effective ``MIXED`` handling when its
+    source prose is replaced by authored-only prose — only the now-obsolete
+    source-derived reason is cleared, nothing else.
+    """
+    before = typed_component(runtime, CREATURE_KEY, MIXED_KEY)
+    assert before.handling is ComponentHandling.MIXED
+    assert before.irreducibility_reason_code == "open_ended_effect"
+    assert [f.fact_key for f in before.facts] == [CHECK_FACT_KEY]
+    (before_source,) = before.governing_prose
+    assert isinstance(before_source, SourceProse)
+
+    author_override(
+        runtime.session,
+        override_id="ov-replace-mixed-prose",
+        target=MIXED_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("the authored replacement for the mixed clause"),
+    )
+    component = typed_component(runtime, CREATURE_KEY, MIXED_KEY)
+    assert component.handling is ComponentHandling.MIXED
+    assert [f.fact_key for f in component.facts] == [CHECK_FACT_KEY]
+    assert component.irreducibility_reason_code is None
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "the authored replacement for the mixed clause"
+
+    gm = gm_component(runtime, MIXED_KEY)
+    assert gm.irreducibility_reason_code is None
+
+
+def test_replace_then_disable_leaves_the_reason_cleared(
+    runtime: RuntimeFixture,
+) -> None:
+    """``REPLACE`` -> ``DISABLE`` (ascending precedence 10, 20) on a
+    ``PROSE_BOUND`` component (no facts, so nothing here rides on the
+    settled handling-driven demotion): ``REPLACE`` applies and clears the
+    reason; the later ``DISABLE`` only empties ``governing_prose`` further
+    and leaves the already-cleared reason alone. Final reason: ``None``.
+    Paired with the suppressed-``REPLACE`` case below to pin that clearing
+    depends on whether ``REPLACE`` itself applies, not on a value read
+    mid-resolution.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-replace-then-disable",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("replaced before the disable"),
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-after-replace",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert component.governing_prose == ()
+    assert component.irreducibility_reason_code is None
+
+
+def test_disable_then_suppressed_replace_leaves_the_reason_untouched(
+    runtime: RuntimeFixture,
+) -> None:
+    """``DISABLE`` -> ``REPLACE`` (10, 20) on the *same* ``PROSE_BOUND``
+    target: ``DISABLE`` applies first and suppresses the target; the
+    unchanged precedence rule then refuses the later ``REPLACE`` on that same
+    target (``_suppressed_by``), so it never applies and never clears
+    anything. Final reason: the base ``"open_ended_effect"``, unchanged —
+    the already-settled ``PROSE_BOUND``-with-suppressed-prose exception, not
+    a new effect of this remediation. The suppressed entry's own ``applied``
+    flag is asserted so the reason for the divergence from the sibling test
+    above is visible here, not just inferred.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-disable-then-replace-disable",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.DISABLE,
+        payload=DISABLE_PAYLOAD,
+        precedence=10,
+    )
+    author_override(
+        runtime.session,
+        override_id="ov-disable-then-replace-replace",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("should never apply"),
+        precedence=20,
+    )
+    component = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert component.governing_prose == ()
+    assert component.irreducibility_reason_code == "open_ended_effect"
+    result = service(runtime).typed_view(whole(runtime))
+    assert result.typed_view is not None
+    applied = {a.override_id: a for a in result.typed_view.applied_overrides}
+    assert applied["ov-disable-then-replace-disable"].applied is True
+    assert applied["ov-disable-then-replace-replace"].applied is False
+
+
+def test_replay_reconstructs_the_cleared_reason_after_current_rows_change(
+    runtime: RuntimeFixture,
+) -> None:
+    """The recorded binding names an override-set version whose cleared
+    reason must reconstruct exactly, even after the current override row that
+    produced it is edited or deleted — the same replay guarantee every other
+    applied change gets.
+    """
+    author_override(
+        runtime.session,
+        override_id="ov-replace-prose",
+        target=PROSE_BOUND_PROSE_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_prose_payload("the first authored replacement"),
+    )
+    resolution = service(runtime).resolve(package_uuid=runtime.package_uuid)
+    assert resolution.outcome is AuthorityOutcome.RESOLVED
+    recorded = resolution.binding
+    assert recorded is not None
+    original = service(runtime).replay(recorded)
+    (original_record,) = [r for r in original.records if r.semantic_key == SPELL_KEY]
+    (original_component,) = [
+        c for c in original_record.components if c.semantic_key == OPEN_ENDED_KEY
+    ]
+    assert original_component.irreducibility_reason_code is None
+    assert original_component.handling is ComponentHandling.PROSE_BOUND
+
+    row = runtime.session.get(MechanicalOverrideORM, "ov-replace-prose")
+    assert row is not None
+    row.is_enabled = False
+    runtime.session.flush()
+
+    # Current state, unlike the replayed one, resolves back to the base
+    # source prose and its reason once REPLACE is disabled — the point is
+    # that replay ignores this and reconstructs the original cleared reason.
+    current_after_edit = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert current_after_edit.irreducibility_reason_code == "open_ended_effect"
+
+    runtime.session.delete(row)
+    runtime.session.flush()
+
+    current_after_delete = typed_component(runtime, SPELL_KEY, OPEN_ENDED_KEY)
+    assert current_after_delete.irreducibility_reason_code == "open_ended_effect"
+
+    replayed = service(runtime).replay(recorded)
+    (record,) = [r for r in replayed.records if r.semantic_key == SPELL_KEY]
+    (component,) = [c for c in record.components if c.semantic_key == OPEN_ENDED_KEY]
+    assert component.irreducibility_reason_code is None
+    (entry,) = component.governing_prose
+    assert isinstance(entry, AuthoredProse)
+    assert entry.text == "the first authored replacement"
 
 
 def test_disable_prose_suppresses_it_without_deleting_the_component(

--- a/tests/services/rules_authority/test_base_projection_unchanged.py
+++ b/tests/services/rules_authority/test_base_projection_unchanged.py
@@ -26,6 +26,8 @@ from afterworlds.persistence.orm.mechanical import (
 )
 from afterworlds.services.rules_authority import (
     AuthorityOutcome,
+    MechanicalTarget,
+    MechanicalTargetKind,
     RulesAuthorityService,
 )
 from tests.services.rules_authority.conftest import (
@@ -34,6 +36,8 @@ from tests.services.rules_authority.conftest import (
     DESCRIPTOR_FACT_TARGET,
     DISABLE_PAYLOAD,
     NOW,
+    OPEN_ENDED_KEY,
+    SPELL_KEY,
     RuntimeFixture,
     author_override,
     replace_component_payload,
@@ -179,3 +183,56 @@ def _header_snapshot(runtime: RuntimeFixture) -> tuple[object, ...]:
         header.evidence_report_hash,
         header.oracle_identity,
     )
+
+
+def test_a_prose_replace_clearing_the_effective_reason_leaves_the_base_row_untouched(
+    runtime: RuntimeFixture,
+) -> None:
+    """A PROSE REPLACE clears the source-derived irreducibility reason from
+    the *effective* view (application.py's ``_apply_prose_entry``). This must
+    never reach the persisted base row: ``MechanicalComponentORM`` is written
+    once at publication and is not a place override application writes to.
+    """
+    persisted_before = runtime.session.execute(
+        select(MechanicalComponentORM).where(
+            MechanicalComponentORM.projection_uuid == str(runtime.projection_uuid),
+            MechanicalComponentORM.record_key == SPELL_KEY,
+            MechanicalComponentORM.semantic_key == OPEN_ENDED_KEY,
+        )
+    ).scalar_one()
+    assert persisted_before.irreducibility_reason_code == "open_ended_effect"
+    rows_before = _rows(runtime)
+
+    service = RulesAuthorityService(runtime.session, now=NOW)
+    author_override(
+        runtime.session,
+        override_id="ov-replace-prose",
+        target=MechanicalTarget(
+            kind=MechanicalTargetKind.PROSE,
+            record_key=SPELL_KEY,
+            component_key=OPEN_ENDED_KEY,
+        ),
+        operation=OverrideOperationEnum.REPLACE,
+        payload={"patch": "replace_prose", "text": "the authored replacement"},
+    )
+    result = service.typed_view(
+        RuleSliceRequest(package_id=runtime.package_uuid, whole_package=True)
+    )
+    assert result.outcome is AuthorityOutcome.RESOLVED
+    assert result.typed_view is not None
+    (record,) = [r for r in result.typed_view.records if r.semantic_key == SPELL_KEY]
+    (component,) = [c for c in record.components if c.semantic_key == OPEN_ENDED_KEY]
+    assert component.irreducibility_reason_code is None
+    assert result.binding is not None
+    assert result.binding.mechanical_projection_uuid == runtime.projection_uuid
+
+    persisted_after = runtime.session.execute(
+        select(MechanicalComponentORM).where(
+            MechanicalComponentORM.projection_uuid == str(runtime.projection_uuid),
+            MechanicalComponentORM.record_key == SPELL_KEY,
+            MechanicalComponentORM.semantic_key == OPEN_ENDED_KEY,
+        )
+    ).scalar_one()
+    assert persisted_after.irreducibility_reason_code == "open_ended_effect"
+    assert persisted_after.handling == persisted_before.handling
+    assert _rows(runtime) == rows_before

--- a/tests/services/rules_authority/test_typed_overrides.py
+++ b/tests/services/rules_authority/test_typed_overrides.py
@@ -426,10 +426,18 @@ def test_a_mistyped_fact_field_is_refused(runtime: RuntimeFixture) -> None:
     assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
 
 
-def test_a_prose_bound_override_component_is_refused(
+def test_a_prose_bound_override_component_with_no_authored_prose_is_refused(
     runtime: RuntimeFixture,
 ) -> None:
-    """Runtime patches cannot author governing prose (#137 contract 3)."""
+    """A whole-component replacement declaring PROSE_BOUND still needs prose.
+
+    Owner Decision 2026-08-08 lets an override-supplied component declare
+    ``PROSE_BOUND``/``MIXED`` and carry authored prose (see
+    ``test_authored_prose_overlay.py``), which narrows what was previously a
+    blanket refusal here (#137 contract 3, as amended). This control pins the
+    surviving refusal: declaring prose-bound handling without supplying the
+    authored text it requires is still a malformed patch.
+    """
     author_override(
         runtime.session,
         override_id="ov-prose",
@@ -442,7 +450,7 @@ def test_a_prose_bound_override_component_is_refused(
     )
     result = refusal(runtime)
     assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE
-    assert "must be structured" in result.detail
+    assert "no authored prose" in result.detail
 
 
 def test_an_override_targeting_a_missing_record_is_refused(


### PR DESCRIPTION
CRD Issue 5d (#137) — Owner Decision 2026-08-08: runtime prose-bound overrides use a first-class
authored prose overlay.

**This is a bounded infrastructure PR, not completed CRD Issue 5d.** It is not the production-corpus
authoring PR and not the final activation/legacy-retirement PR. No production mechanical projection is
published, no accepted content is added, and no projection becomes active by merging this.

Based on `main` at `9c80639` (PR #149's runtime-authority infrastructure), extending it rather than
integrating through the legacy `rp_overrides` chunk-targeting path.

## Authority reconciliation

Amended in this PR:

- **ADR-005d** — Decisions 3, 6, 9, and 10, plus Consequences and Rejected Alternatives (14, 15).
- **Issue #137** (live GitHub issue) — the header amendment note, scope (In scope), **contracts 3 and
  6**, Acceptance Criteria (new #25), and Boundary Stop.

The Owner's instruction named contract 6 for amendment; contract 3 also states the "second prose store"
prohibition verbatim ("Exact governing prose resolves through the authoritative 5c `RuleChunk` source
rather than creating a second prose store") and was amended alongside it so the same drift isn't left
live in one contract while narrowed in the other. Flagged explicitly rather than silently expanding
scope.

The amendment replaces ADR-005d's blanket prohibition on a second prose store with the narrower
invariant: there is no duplicated store for what the SRD source says. 5c source prose remains immutable,
resolves only from its exact `RuleChunk`, and is never copied and relabeled as source authority. A
separately identified authored-authority overlay — carrying its own distinct provenance and never
claiming 5c provenance — is now intentional.

## What was built

**A fourth typed target grain: `PROSE`** (`targets.py`)
- `MechanicalTargetKind.PROSE`, scoped by stable record + component identity (same shape rule as
  `COMPONENT`), never a raw chunk, JSON path, or unscoped selector.
- Distinct from `COMPONENT`: a `COMPONENT`-kind `DISABLE` already means "remove the whole component," so
  prose needed its own addressable grain to be suppressible/replaceable/extensible without touching that
  component's typed facts.

**Two new closed patch families** (`patches.py`)
- `ProseReplacementPatch(text)` for `(REPLACE, PROSE)`, `ProseAdditionPatch(text)` for `(APPEND, PROSE)`.
  `DisablePatch` is reused for `(DISABLE, PROSE)` — no new class needed.
- `ComponentBody` gains `authored_prose: str | None`, enforced by the same facts/prose honesty invariant
  the build-time projection validator applies to the base corpus: `STRUCTURED` → facts, no prose;
  `PROSE_BOUND` → prose, no facts; `MIXED` → both. An override-supplied component's
  `irreducibility_reason_code` stays `None` always — that catalog is 5c's own build-time judgment, never
  copied or re-authored at runtime.
- `authored_prose` participates in `_component_body_payload`'s canonical identity payload (a bug in an
  earlier draft that would have silently collided two component patches differing only in authored text
  — caught in review and covered by a dedicated regression test).
- `patch_payload` is now an exhaustive explicit-branch match over all eight families (no bare fallthrough).

**No schema or migration change.** `rp_mech_overrides.target_kind` and `rp_override_set_entries.target_kind`
are unconstrained `String(16)` columns (no CHECK constraint), and `payload` is already generic JSON on
both tables. `"prose"` is a new valid string value on an existing column; retention (`retention.py`) and
identity derivation (`override_set.py`) are fully generic over target kind already and needed zero
changes. This is the lowest-complexity repository-native representation available.

**Effective governing prose as a closed discriminated form** (`application.py`)
- `EffectiveComponent.prose_chunk_ids: tuple[str, ...]` → `governing_prose: tuple[SourceProse |
  AuthoredProse, ...]`, ordered.
  - `SourceProse(chunk_id, text)` — exact 5c chunk identity; `text` resolved later by the GameMaster view.
  - `AuthoredProse(text, supplied_by_override_id, supplied_by_origin)` — exact authored text, already
    resolved from the override's own validated payload; the type has no field for a fabricated `chunk_id`,
    5c span provenance, or an irreducibility reason, so an *entry* can never carry one.
- `REPLACE` on prose replaces the complete effective governing prose (source + any prior authored
  passages) with the one authored passage, and clears the *component's* `irreducibility_reason_code` along
  with it (fixed by the second remediation below — the entry-level guarantee above was never the whole
  story, since the reason lives on the component, not the prose entry); `APPEND` preserves existing
  effective prose, its reason, and adds one more passage in ascending `(precedence, override_id)` order;
  `DISABLE` suppresses prose only, leaving typed facts untouched (prose and facts are siblings under a
  component, not nested).
- **Final effective-state classification, promotion and demotion alike** (corrected by the two 2026-08-09
  remediation rounds below): `handling` is a classification of each component's own final `facts`/
  `governing_prose`, computed once at final assembly for every component alike — never remembered as a
  sticky flag, and never dependent on which override family supplied the authority or which operation
  resolved last. Authored prose landing on a `STRUCTURED` component makes its *effective* `handling`
  `MIXED`; a later `DISABLE` that removes all effective prose while facts survive reverts it to
  `STRUCTURED`; a component with prose and no facts is `PROSE_BOUND`, including when its sole prose is
  suppressed (empty prose surface, still `PROSE_BOUND` — no other category honestly describes it). The base
  projection's own classification and identity are untouched either way; only the runtime effective view
  changes.
- Suppression inheritance extended: record/component-level `DISABLE` still suppresses prose beneath it;
  record/component `REPLACE` clears stale prose-suppression state for reused semantic keys, mirroring the
  existing fact/component clearing.

**Views and service** (`views.py`, `service.py`)
- `GameMasterComponent.governing_prose` now carries the same ordered `SourceProse | AuthoredProse` entries,
  with `SourceProse.text` resolved from the bound package's `RuleChunk` rows; `AuthoredProse` passes through
  unresolved (it already has exact text). Both views report identical ordered prose+provenance.
- `_prose_for` collects chunk ids to resolve only from `SourceProse` entries.

## Tests

`tests/services/rules_authority/test_authored_prose_overlay.py` (48 tests — 31 original plus 17 added or
corrected across the 2026-08-09 remediations below), plus one existing test updated to the narrowed rule
and one new test in `test_base_projection_unchanged.py`. All required controls proved:

- override-set UUID changes on authored-text, target, origin, operation, and order change; base
  `mechanical_projection_uuid` unaffected in every case; a dedicated regression pins the
  `_component_body_payload` identity-collision fix.
- `REPLACE`/`APPEND`/`DISABLE` over `PROSE_BOUND`, `MIXED`, and the `STRUCTURED`→effective-`MIXED`
  promotion case; `APPEND, APPEND, REPLACE` ordering pinned (the later `REPLACE` wipes both appends, not
  just source); `DISABLE` leaves a prose-only `PROSE_BOUND` component's handling at `PROSE_BOUND` (the one
  case where final-state classification and the old sticky reading agree).
- Final effective-state classification (Owner Decision 2026-08-09, see the dedicated section below): a
  `STRUCTURED`→`MIXED` promotion by `REPLACE` or `APPEND` reverts to `STRUCTURED` when its prose is later
  disabled; a base `MIXED` component reverts to `STRUCTURED` the same way; a `DISABLE` on one target does
  not suppress a later override on a *different* target, and a whole-component `REPLACE` clears a stale
  suppression so prose can promote again; a fact `DISABLE` resolving *after* the last prose operation on a
  component, or after a component/record `REPLACE`/`APPEND` that declared `MIXED` directly with no prose
  operation involved at all, still revises `handling` at final assembly the same way in every case; a
  reincarnated semantic key inherits nothing from an earlier prose operation against that key; the
  all-empty fallback is proved order-independent between a fact `DISABLE` and a prose `DISABLE`.
- GameMaster view returns exact ordered source/authored authority and provenance; typed and GameMaster
  views report identical prose+provenance for the same request.
- Deterministic-consumer non-inference: the typed component's `facts` tuple is byte-identical with and
  without an authored prose overlay attached — not merely that a prose field exists, but that a
  fact-only reader can never observe the overlay at all.
- Replay reconstructs exact authored prose after the current override row is edited (payload, enablement,
  precedence, origin all changed) or deleted, including a dedicated case where replaying an original
  binding still reconstructs its demoted `STRUCTURED` handling exactly, even after the current rows have
  since changed enough to resolve `MIXED` again.
- Invalid/blank/missing-target/cross-release/type-incompatible prose patches fail closed as
  `INVALID_OVERRIDE`; `APPEND` onto a `FACT` target remains unpermitted (unchanged by this PR).
- A legacy `rp_overrides` chunk-targeting row does not alter the new typed or GameMaster views (the
  service's existing "never reads it" guarantee, pinned against this new overlay).
- Whole-component authored prose: `REPLACE_COMPONENT`/`APPEND_COMPONENT` may declare `PROSE_BOUND`/`MIXED`
  handling with authored prose, subject to the same facts/prose honesty invariant.
- `house_rules` (the free-form session field) is never referenced anywhere under
  `services/rules_authority` — a static regression so a future edit can't wire it in silently.

## Remediation — Owner Decision 2026-08-09 (effective-content classification, generalized)

Two rounds. Both are implementation residue against the same Owner Decision, not new decisions.

**Round 1 — sticky promotion.** `handling` promotion to `MIXED` was sticky: a `STRUCTURED` component
promoted to `MIXED` by authored prose stayed `MIXED` after a later, higher-precedence `DISABLE` removed all
its effective prose, even though its facts alone should read `STRUCTURED` again. First fix: re-derive
`handling` at the end of every prose operation, plus a second pass at final assembly (tracked via a
`prose_touched` set) for components whose facts changed *after* their last prose operation.

**Round 2 — still path-dependent.** Round 1's fix only re-derived `handling` for components a prose
operation had actually reached. A whole-component or whole-record `REPLACE`/`APPEND` that declares `MIXED`
directly (facts and authored prose validated together in one patch, never processed by `_apply_prose_entry`)
was never re-derived: disabling its last fact left `handling=MIXED` with `facts=()` — the exact stale shape
the fix exists to prevent, reached through a different override family. The `prose_touched` set also risked
stale membership if a semantic key were later reincarnated by a replacement.

**Final implementation** (`application.py`):
- `_finalize_component`, called from `apply_override_set`'s final assembly, is now the *only* place
  `handling` is derived, for *every* surviving component, unconditionally — immutable base components,
  prose-touched components, and components a component/record `REPLACE`/`APPEND` declared directly, alike.
  It classifies each component's own final `facts`/`governing_prose`: facts+prose → `MIXED`; facts only →
  `STRUCTURED`; prose only → `PROSE_BOUND`. There is no tracking set, so there is nothing whose membership
  can go stale when a semantic key is reincarnated by a later replacement.
- `_apply_prose_entry` no longer touches `handling`/`irreducibility_reason_code` at all — only
  `governing_prose` — for any of `DISABLE`/`REPLACE`/`APPEND`. `_derive_prose_driven_handling` and the
  `prose_touched` set from round 1 are removed as dead weight now that final assembly is the single seam.
  This also fixes a latent side effect of round 1: `_apply_entry`'s `FactAdditionPatch` branch refuses to
  append a typed fact to a component that `component.handling is PROSE_BOUND` *at that point in
  resolution* — round 1's mid-loop mutation could make that check see a value a prose operation computed
  moments earlier rather than the component's actual declared/published handling, which is what that
  check's own pre-existing comment says it means to guard. Leaving `handling` alone until final assembly
  restores that.
- A component with neither surviving facts nor surviving prose is not content-bearing; this remediation
  does not invent a policy for that state (unchanged instruction from round 1) — `_finalize_component`
  leaves `handling` exactly as declared (base projection, or whichever `REPLACE`/`APPEND` most recently
  (re)created that component version). Because nothing mid-resolution mutates a component's declared
  `handling` anymore, that fallback is itself order-independent between a fact `DISABLE` and a prose
  `DISABLE` racing to empty the same component out — proved by a dedicated test (below) that failed under
  round 1's mid-loop mutation.
- Clearing `irreducibility_reason_code` to `None` when the final handling is `STRUCTURED` still rides along,
  same justification as round 1: a `STRUCTURED` component carrying a leftover irreducibility reason from a
  demoted `MIXED`/`PROSE_BOUND` state would violate the same honesty invariant the build-time validator
  enforces on the base corpus.

**Transition and sibling-path tests added/corrected** (`test_authored_prose_overlay.py`, 44 total):
1. `STRUCTURED` promoted by `REPLACE`/`APPEND` reverts to `STRUCTURED` when its prose is later disabled; a
   base `MIXED` component reverts the same way.
2. A `PROSE_BOUND` component (no facts) stays `PROSE_BOUND` with an empty prose surface when its sole prose
   is suppressed — the one case old and new rules agree on, kept as a regression.
3. The unchanged precedence rule: `DISABLE` still stops later processing of the *exact same* target; a
   whole-component `REPLACE` clears a stale suppression so a later prose op on that (new) target applies.
4. **Four sibling paths reaching the same final invariant independently of the prose overlay**, each
   proving `facts=()` + prose-intact → `PROSE_BOUND` after a fact `DISABLE`: a whole-component `REPLACE`
   declaring `MIXED` directly (the round-2 regression), a whole-record `REPLACE` containing a `MIXED`
   component, a newly `APPEND`-ed component declaring `MIXED`, and the original prose-operation path from
   round 1 — each with its own applied-provenance and base-projection-identity assertions, and the
   component-REPLACE case additionally through replay.
5. Reusing a semantic key via a fresh `REPLACE` after an earlier prose operation touched that key reflects
   only the replacement's own declared authority — nothing inherited from the earlier operation.
6. The all-empty fallback is order-independent: two `MIXED`-declared components, one with prose disabled
   before its fact and one with its fact disabled before its prose, report identical final `handling`.
7. Replay of a retained binding reconstructs its original demoted `handling` exactly, unaffected by later
   changes to the current override rows; base projection identity, typed facts, and applied-override
   provenance are asserted unchanged throughout every new test above.

**Documentation reconciled:** ADR-005d Decision 10's 2026-08-09 sub-amendment is rewritten in place (not a
new dated amendment — same Owner Decision, corrected implementation) from "derived fresh... each time a
prose operation resolves" to a final classification computed once at final assembly for every component
alike, regardless of override family or operation order, with the order-independence of the all-empty
fallback stated explicitly. Issue #137 contract 6 was rechecked and still contains no equivalent claim — no
amendment needed there.

**Not done, per the boundary this remediation was given:** no new handling status, availability flag,
persistence column, migration, or provenance mechanism; no change to prose target grain or override
precedence; the authored-prose overlay itself is not redesigned. No residue remains from round 1.

## Second remediation — irreducibility-reason leakage across a PROSE REPLACE (separate defect family)

Merge-blocking, but a different family from the handling-derivation remediation above: provenance/
semantic-evidence leakage, not effective-state derivation. No Owner Decision was needed — settled
implementation work against ADR-005d's existing, unchanged rule that authored prose never carries an
irreducibility claim copied from base source authority.

**Defect:** a dedicated PROSE-target `REPLACE` correctly removed all source governing prose (leaving only
`AuthoredProse`) but left `component.irreducibility_reason_code` untouched. `EffectiveComponent` and
`GameMasterComponent` therefore exposed a source-derived accepted irreducibility claim — the base corpus's
judgement that a specific piece of *5c source prose* could not be reduced to facts — beside authority that
was, after the `REPLACE`, entirely newly authored text with no relationship to that source prose at all.

**Fix** (`application.py`, `_apply_prose_entry`): the `ProseReplacementPatch` branch now clears
`irreducibility_reason_code` to `None` in the same `replace()` call that installs the sole authored
`governing_prose` entry. `APPEND` and `DISABLE` are untouched — `APPEND` only adds to existing governing
prose, so any source prose the reason describes remains effective; `DISABLE`'s reason-preserving behavior
on a now-empty `PROSE_BOUND` component is the already-settled exception from the handling-derivation
remediation, not something this fix touches. Clearing is conditional on `REPLACE` itself having applied —
a `REPLACE` the unchanged suppression rule refuses (a later override on an already-`DISABLE`d exact target)
never runs and therefore never clears anything; a dedicated pair of tests pins both orderings so this reads
as REPLACE's own effect, not a reintroduction of the order-dependent mid-loop mutation the prior remediation
removed.

**Tests** (5, matching the required list): (1) base `PROSE_BOUND` with a reason → `REPLACE` → authored-only
authority, reason `None` in both typed and GameMaster views; (2) base `MIXED` with source prose and a
reason → `REPLACE` preserves facts and effective `MIXED` handling, clears only the obsolete reason; (3)
`APPEND` preserves `SourceProse` and its existing reason (both views); (4) replay reconstructs the cleared
reason exactly after the producing override row is disabled, then deleted; (5) `REPLACE`→`DISABLE` clears
the reason, `DISABLE`→`REPLACE` on the same target leaves it untouched because the `REPLACE` is suppressed
— plus a dedicated test in `test_base_projection_unchanged.py` proving the persisted base
`MechanicalComponentORM` row and the full base-projection row snapshot are byte-identical before and after.

**Fixture change, same commit:** the test corpus had no base `MIXED` component (facts + source prose + a
declared reason together), which required tests 2 and 5 need honestly rather than constructing one through
an override (override-supplied components always carry `irreducibility_reason_code=None` by existing
design, which would prove nothing). Added one — `MIXED_KEY` under the existing `CREATURE_KEY` record, with
its own dedicated leaves/spans/chunks (a semantic span may carry only one PRIMARY provenance claim, so it
could not share `CHECK_SPAN`/`PROSE_SPAN` with the components that already claim them). `_representation`'s
docstring and `_OBLIGATIONS` are updated accordingly; blast radius is the 208 tests already run in the
focused `rules_authority` suite.

**Documentation reconciled:** ADR-005d Decision 10's `REPLACE` bullet (added in the 2026-08-08 amendment)
described only the prose-replacement behavior, not the reason it now also clears; one clause added, citing
the existing "never … an irreducibility claim copied from the base source" sentence rather than restating
it. Issue #137 contract 6 makes the same "never a copied irreducibility claim" statement about `AuthoredProse`
already and needed no change.

**Not done:** component provenance is not redesigned; the reason code did not move into prose entries or
gain a new field; no schema or migration change; `PROSE` target grain, precedence, and `DISABLE` semantics
are unchanged; no production-corpus authoring, activation, or legacy retirement.

## Gates (run on this branch head, after all remediation above)

- `black --check`, `ruff check`, `mypy` (strict) — clean across `src/` and `tests/`.
- `pytest -q`, full repository suite — 3321 passed, 10 skipped, 0 failed. Coverage gate (80% minimum):
  93.46% total, reached.
- `pip-audit` — unchanged from the original PR run below; this remediation adds no dependency.
  17 findings across 10 packages, all pre-existing on `main` (`chromadb`, `click`, `cryptography`, `idna`,
  `mako`, `msgpack`, `pip`, `pydantic-settings`, `setuptools`, `urllib3`). None are in a package this PR
  adds, upgrades, or touches; `pyproject.toml`/`requirements*` are unchanged by this diff.

## Per-PR report (#137 delivery requirements)

- Exact 5c release used for production-corpus verification: unchanged — this PR touches no 5c/5d
  production-corpus data, only the runtime override/authority layer.
- Meaning-bearing inputs or identities changed: `override_set_uuid` payload shape extended (new `PROSE`
  target kind, two new patch families, `authored_prose` on `ComponentBody`); `mechanical_projection_uuid`
  and the base projection's own identity derivation are untouched.
- Persisted reconstruction/publication behavior affected: none. No migration, no schema change (see below),
  no change to the Decision 8 publication lifecycle.
- Completeness obligations and negative controls exercised: see Tests above.
- Legacy paths removed or still pending: none removed here; `rp_overrides`/`MechanicalEntity` remain
  scheduled for the final cutover PR, pinned by a regression test that they cannot alter the new views.
- Downstream seams touched: `EffectiveComponent.prose_chunk_ids: tuple[str, ...]` →
  `governing_prose: tuple[SourceProse | AuthoredProse, ...]` — a shape change on a type exported from
  `afterworlds.services.rules_authority`. No in-repo caller referenced the old name (grepped); no other
  package (2b/15c's future consumers) reads this type yet, and `RulesPackageBinding` itself is unchanged.
- Deviation from ADR-005d or this issue: see Architecture Notes below.

## Legacy path and subsequent-PR boundary

- Legacy chunk-targeting `rp_overrides` and `MechanicalEntity` are untouched and remain scheduled for
  removal at final cutover, not here — pinned by a regression test in this PR.
- Not done here, deliberately: production-corpus authoring/acceptance, partial-projection activation,
  `MechanicalEntity`/legacy-runtime-path removal, downstream adjudicated-effect mutation (owned by Issue
  15c), model interpretation/executable prose/a rules DSL, or retrieval-selected authority.
- `house_rules` remains a free-form, untrusted session field; no conversion path exists yet, and none is
  added by this PR.

## Architecture Notes

Deviation from the Owner's instruction: amended Issue #137 contract 3 in addition to the named contract 6,
because contract 3 states the same "second prose store" prohibition this decision narrows, and leaving it
unamended would be a quiet contradiction between two contracts in the same issue. No other deviation from
ADR-005d or CRD Issue 5d.

**2026-08-09 remediation (two rounds):** the sticky `MIXED`-promotion defect described above was a drift
between this PR's implementation/ADR text and the effective-content classification the Owner had actually
decided — surfaced and corrected in this same PR rather than left live. Round 1's fix was itself still
path-dependent (re-derivation was gated to components a prose operation had touched, via a `prose_touched`
set that also risked stale membership on semantic-key reuse); a second review round surfaced that as
implementation residue against the same Owner Decision, not a new one, and it is corrected here too. No
drift remains: ADR-005d Decision 10 now states the final rule — `handling` is a classification of each
component's own final facts and prose, computed once at final assembly, for every component alike,
regardless of which override family supplied its authority or which operation resolved last. The
implementation matches (`_finalize_component` is the single derivation seam; nothing upstream mutates
`handling` mid-resolution). Issue #137 needed no change in either round (its contract 6 wording never made
the sticky or path-dependent claim).

**Second remediation (irreducibility-reason leakage):** a separate, unrelated defect in the same
`_apply_prose_entry` seam — a PROSE `REPLACE` left the base corpus's source-derived
`irreducibility_reason_code` on a component whose source prose it had just fully discarded, which ADR-005d
already forbade (its "never a copied irreducibility reason" rule) without needing a new decision. Fixed by
clearing it in the same `replace()` call that installs the sole authored `governing_prose` entry, and by
adding a base `MIXED` component to the shared test fixture so the reason-preserving-facts case could be
proved honestly rather than through an override (which always declares `irreducibility_reason_code=None`).
No drift remains: ADR-005d Decision 10's `REPLACE` bullet now states the reason-clearing explicitly. Issue
#137 needed no change (contract 6 already states the same rule about `AuthoredProse`, correctly).

Do not merge without owner review. Does not complete CRD Issue 5d.

