### PR TITLE
feat(mechanical): production-authoring workflow and evidence-backed schema expansion (#137)

### DIFF
--- a/alembic/versions/0025_prose_binding_accepted_span.py
+++ b/alembic/versions/0025_prose_binding_accepted_span.py
@@ -1,0 +1,60 @@
+"""Exact governing spans on mechanical prose bindings.
+
+CRD Issue 5d (#137), production-authoring PR. #137 contract 3 requires a
+prose-bound component to resolve its *accepted governing span*, not the whole
+passage that happens to contain it. A binding therefore names the accepted
+classification span it governs, plus that span's half-open offsets into the
+bound ``RuleChunk``'s own text, so runtime resolution slices exactly the
+governing clause without re-reading the 5c projection relation.
+
+The authoritative text still comes from the immutable 5c ``RuleChunk``. Nothing
+here copies source prose into a second store, and no 5c table is touched.
+
+Additive only, and additive to an empty table in every environment: no accepted
+production oracle exists yet, so no mechanical projection has ever been
+published and ``rp_mech_prose_bindings`` carries no rows outside a test
+database. The columns are created ``NOT NULL`` with a server default so a
+development row set survives the upgrade; the default is inert afterwards
+because every writer supplies all three values.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-08-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0025"
+down_revision: str | None = "0024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "rp_mech_prose_bindings"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE,
+        sa.Column("span_id", sa.String(64), nullable=False, server_default=""),
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("chunk_char_start", sa.Integer, nullable=False, server_default="0"),
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("chunk_char_end", sa.Integer, nullable=False, server_default="0"),
+    )
+    op.create_index(f"ix_{_TABLE}_span_id", _TABLE, ["span_id"])
+
+
+def downgrade() -> None:
+    op.drop_index(f"ix_{_TABLE}_span_id", table_name=_TABLE)
+    for column in ("chunk_char_end", "chunk_char_start", "span_id"):
+        op.drop_column(_TABLE, column)

--- a/alembic/versions/0026_batch_proposal_identity.py
+++ b/alembic/versions/0026_batch_proposal_identity.py
@@ -1,0 +1,75 @@
+"""Reviewed-proposal identity on retained batch-acceptance evidence.
+
+CRD Issue 5d (#137), PR #151 review remediation. A batch's scope and semantic
+diff record which spans were accepted and what their disposition became. They
+say nothing about the records, components, facts, prose bindings, relationships,
+references, or provenance that acceptance also draws into the projection — two
+proposals can agree on every span and state entirely different mechanical
+authority. Each batch therefore also retains the content-derived identity of the
+exact complete proposal that was reviewed, so the evidence can establish that the
+accepted representation is one somebody actually looked at.
+
+Retained evidence, never identity: this column is covered by the persisted-state
+digest and is deliberately absent from the projection and oracle identity
+payloads, so re-reviewing an unchanged classification still cannot remint a
+projection.
+
+**No identity is ever fabricated for a legacy row.** There is nothing honest to
+put in this column for a batch recorded before the evidence existed — inventing
+one would assert a review that cannot be shown to have happened, which is the
+precise failure this column exists to prevent. The upgrade therefore refuses to
+run against a table that already holds rows, under ADR-005c's pre-release
+clean-baseline authority: no accepted production oracle exists, so no mechanical
+projection has ever been published, and any such rows are development state to be
+rebuilt rather than migrated. SQLite cannot add a ``NOT NULL`` column without a
+default, so an empty-string default satisfies the dialect; the guard above means
+it can never be written, and both the strict loader and acceptance validation
+reject a blank identity if it somehow were.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-08-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0026"
+down_revision: str | None = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "rp_mech_acceptance_batches"
+
+
+class LegacyAcceptanceEvidenceError(RuntimeError):
+    """Raised when existing batch rows carry no reviewed-proposal identity."""
+
+
+def upgrade() -> None:
+    existing = op.get_bind().execute(
+        sa.text(f"SELECT COUNT(*) FROM {_TABLE}")  # noqa: S608 - fixed identifier
+    ).scalar_one()
+    if existing:
+        raise LegacyAcceptanceEvidenceError(
+            f"{_TABLE} holds {existing} batch row(s) recorded before "
+            "reviewed-proposal identity was retained. There is no honest value "
+            "for this column on those rows, and fabricating one would assert a "
+            "review that cannot be shown to have happened. No mechanical "
+            "projection has ever been published, so rebuild this development "
+            "state under the pre-release clean baseline rather than migrating it."
+        )
+
+    op.add_column(
+        _TABLE,
+        sa.Column("proposal_identity", sa.String(64), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(_TABLE, "proposal_identity")

--- a/docs/architecture/known_unknowns.md
+++ b/docs/architecture/known_unknowns.md
@@ -255,6 +255,31 @@ CRD Issue 5d (structured mechanical authority and deterministic rule binding), C
 character-state completeness for deterministic adjudication), and CRD Issue 15c (bounded d20 adapter
 production reachability).
 
+**In progress — typed Rules Package authority (CRD Issue 5d, #137).** CRD Issue 5d is under
+construction and is **not complete**. Landed so far: span-exact semantic accounting, the closed typed
+representation, the persistence → reconstruction → digest → gate → publication lifecycle and its exact
+completeness gate; the runtime four-component `RulesPackageBinding`, typed override application,
+retained provenance-exact override-set versions, and the authored-authority prose overlay; and the
+production-authoring workflow with the evidence-backed expansion of the closed typed-fact union — dice,
+attacks, damage, healing, creature defence/speed/challenge and saving-throw modifiers, spell
+descriptors, action economy, conditions, spell-slot progression, class spell-list membership, resource
+and recharge cadence, equipment descriptors, advantage/disadvantage, and stated scaling.
+
+Still outstanding inside CRD Issue 5d: **no production accepted authority has been reviewed or
+committed**, so the production SRD 5.2.1 mechanical projection remains unpublished and inactive; and the
+obsolete `MechanicalEntity` path and the legacy chunk-targeting prose override path both remain in place
+pending the final activation/legacy-retirement PR. Contract 3's remaining named family groups —
+targeting restrictions, contests, critical changes, explicit probability, random-table selection,
+eligibility, choices, and sequencing — are added by batch-driven accounting as the corpus surfaces them,
+and are due no later than full-corpus closure.
+
+**This does not move CRD Issue 15c's boundary.** Publishing a mechanical projection proves complete
+*representation*, never adapter capability. The bounded-d20 adapter's capability manifest, certified
+executable coverage, adjudication failure behaviour, and any typed application path for a
+GameMaster-selected effect remain owned by CRD Issue 15c (ADR-005d Decisions 1 and 11). No 5d fact
+family is admitted or withheld on the basis of what the adapter can execute, and neither authority view
+carries an executability claim.
+
 **Surfaced during:** CRD Issue 15b Phase 2 implementation on frozen PR #129 (`D20RulesSystemAdapter.
 _verify_dc` unconditionally returns `None`; Rules Package entities carry no `dc`/`difficulty_class` field
 and store dice/damage data as unstructured prose). The ADR-005c investigation also found the committed

--- a/src/afterworlds/ingestion/mechanical/acceptance.py
+++ b/src/afterworlds/ingestion/mechanical/acceptance.py
@@ -1,0 +1,245 @@
+"""The explicit acceptance action — CRD Issue 5d, contract 2.
+
+One function, because acceptance is one thing: a named reviewer, at a named
+time, accepting an exact scope of proposed claims, with the full semantic diff
+of what that changed retained as evidence.
+
+    machine proposal  →  human semantic review  →  explicit acceptance
+
+:mod:`proposal` owns the first arrow's output. This module owns the third, and
+what it produces — an :class:`~.oracle.AcceptedInputs` — is the committed
+artifact a reviewer commits and the build consumes.
+
+Three properties this is built to keep:
+
+* **Silence is not acceptance.** Only span ids named in ``resolved_scope`` are
+  accepted. A proposed span the reviewer did not name is dropped, not carried
+  forward as "probably fine". The resulting artifact then fails the publication
+  gate's population check until every represented leaf is covered, which is the
+  honest state rather than an optimistic one.
+* **The evidence is the diff, not a digest of it.** The batch retains every
+  :class:`~.models.SemanticDiffEntry` in full, and its hash identifies that diff
+  rather than substituting for it (see :mod:`accounting`).
+* **Evidence never becomes identity.** Reviewer, timestamp, batch grouping, and
+  rule wording travel with the ledger and are excluded from
+  :func:`~.oracle.oracle_payload`, so re-reviewing an unchanged classification
+  cannot remint a projection.
+
+Accepting over a prior artifact is a merge, not a replacement: prior accepted
+spans survive unless this scope re-accepts them, and prior batches stay in the
+record. That is what lets full-corpus review proceed in reviewable content
+batches without any batch quietly discarding an earlier one's work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from afterworlds.ingestion.mechanical.accounting import batch_diff_hash
+from afterworlds.ingestion.mechanical.models import (
+    AcceptanceBatch,
+    AcceptanceRecord,
+    ReviewState,
+    SemanticDiffEntry,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.oracle import (
+    AcceptedInputs,
+    AcceptedOracle,
+    derive_obligations,
+)
+from afterworlds.ingestion.mechanical.proposal import MechanicalProposal
+from afterworlds.ingestion.mechanical.representation import RepresentationDraft
+
+__all__ = ["AcceptanceError", "accept_proposal"]
+
+
+class AcceptanceError(ValueError):
+    """Raised when an acceptance action cannot be recorded as stated.
+
+    Raised rather than reported: a half-recorded acceptance is worse than none,
+    because the artifact would claim review that did not happen.
+    """
+
+
+def _merge_representation(
+    prior: RepresentationDraft | None, proposed: RepresentationDraft
+) -> RepresentationDraft:
+    """Combine a prior accepted representation with a newly accepted one.
+
+    Concatenation, with one guard: a record or component semantic key that
+    appears in both must appear *identically*. A batch that redefines an earlier
+    batch's record under the same key is not a merge, it is a silent
+    replacement of authority somebody already accepted, and the reviewer of the
+    second batch never saw the first.
+
+    Every other collection concatenates freely — a duplicated fact, relationship,
+    reference, or provenance edge is already a violation :mod:`validation`
+    reports by name, and re-checking it here would be a second opinion about
+    what "the same element" means.
+    """
+    if prior is None:
+        return proposed
+
+    for label, prior_items, new_items, key in (
+        (
+            "record",
+            prior.records,
+            proposed.records,
+            lambda r: (r.semantic_key,),
+        ),
+        (
+            "component",
+            prior.components,
+            proposed.components,
+            lambda c: (c.record_key, c.semantic_key),
+        ),
+    ):
+        existing = {key(item): item for item in prior_items}
+        for item in new_items:
+            clash = existing.get(key(item))
+            if clash is not None and clash != item:
+                raise AcceptanceError(
+                    f"{label} {list(key(item))}: this acceptance redefines a "
+                    "record already accepted under the same semantic key"
+                )
+
+    return RepresentationDraft(
+        records=prior.records + proposed.records,
+        components=prior.components + proposed.components,
+        prose_bindings=prior.prose_bindings + proposed.prose_bindings,
+        relationships=prior.relationships + proposed.relationships,
+        references=prior.references + proposed.references,
+        provenance=prior.provenance + proposed.provenance,
+    )
+
+
+def accept_proposal(
+    proposal: MechanicalProposal,
+    *,
+    batch_id: str,
+    rule: str,
+    resolved_scope: tuple[str, ...],
+    reviewer: str,
+    accepted_at: str,
+    prior: AcceptedInputs | None = None,
+) -> AcceptedInputs:
+    """Record one explicit acceptance of *resolved_scope* from *proposal*.
+
+    ``rule`` is how the reviewer selected the scope. It is retained as evidence
+    and is **never re-run**: re-evaluating a selector against changed inputs
+    would resolve to a different set than the reviewer actually saw, which is
+    why ``resolved_scope`` carries the exact span ids alongside it.
+    """
+    if not resolved_scope:
+        raise AcceptanceError("an acceptance action must name at least one span")
+    if not reviewer.strip():
+        raise AcceptanceError("an acceptance action must name its reviewer")
+    if not rule.strip():
+        raise AcceptanceError("an acceptance action must record its selection rule")
+
+    proposed_by_id = {p.span.span_id: p.span for p in proposal.proposed_spans}
+    if duplicates := sorted({s for s in resolved_scope if resolved_scope.count(s) > 1}):
+        raise AcceptanceError(f"resolved scope repeats spans {duplicates}")
+    if unknown := sorted(set(resolved_scope) - proposed_by_id.keys()):
+        raise AcceptanceError(
+            f"resolved scope names spans this proposal did not propose: {unknown}"
+        )
+
+    if prior is not None and prior.oracle.binding != proposal.binding:
+        raise AcceptanceError(
+            "this proposal binds a different 5c release than the prior accepted "
+            "authority it would extend"
+        )
+    if prior is not None and (
+        prior.oracle.policy_version,
+        prior.oracle.policy_hash,
+    ) != (proposal.policy_version, proposal.policy_hash):
+        raise AcceptanceError(
+            "this proposal declares a different semantic policy than the prior "
+            "accepted authority it would extend"
+        )
+
+    prior_spans = {s.span_id: s for s in (prior.oracle.spans if prior else ())}
+    if batch_id in {b.batch_id for b in (prior.batches if prior else ())}:
+        raise AcceptanceError(f"batch {batch_id!r} is already recorded")
+
+    accepted_spans = tuple(
+        replace(proposed_by_id[span_id], review_state=ReviewState.ACCEPTED)
+        for span_id in resolved_scope
+    )
+    diff = tuple(
+        SemanticDiffEntry(
+            span_id=span.span_id,
+            prior_disposition=(
+                prior_spans[span.span_id].disposition
+                if span.span_id in prior_spans
+                else None
+            ),
+            prior_reason_code=(
+                prior_spans[span.span_id].non_mechanical_reason_code
+                if span.span_id in prior_spans
+                else None
+            ),
+            accepted_disposition=span.disposition,
+            accepted_reason_code=span.non_mechanical_reason_code,
+        )
+        for span in accepted_spans
+    )
+    batch = AcceptanceBatch(
+        batch_id=batch_id,
+        rule=rule,
+        resolved_scope=tuple(resolved_scope),
+        diff=diff,
+        semantic_diff_hash="",
+    )
+    batch = replace(batch, semantic_diff_hash=batch_diff_hash(batch))
+
+    re_accepted = set(resolved_scope)
+    spans = (
+        tuple(
+            s
+            for s in (prior.oracle.spans if prior else ())
+            if s.span_id not in re_accepted
+        )
+        + accepted_spans
+    )
+    acceptances = tuple(
+        a for a in (prior.acceptances if prior else ()) if a.span_id not in re_accepted
+    ) + tuple(
+        AcceptanceRecord(
+            span_id=span_id,
+            batch_id=batch_id,
+            reviewer=reviewer,
+            accepted_at=accepted_at,
+        )
+        for span_id in resolved_scope
+    )
+
+    representation = _merge_representation(
+        prior.oracle.representation if prior else None,
+        proposal.proposed_representation,
+    )
+    return AcceptedInputs(
+        oracle=AcceptedOracle(
+            binding=proposal.binding,
+            policy_version=proposal.policy_version,
+            policy_hash=proposal.policy_hash,
+            spans=_ordered(spans),
+            representation=representation,
+            obligations=derive_obligations(representation),
+        ),
+        batches=tuple(prior.batches if prior else ()) + (batch,),
+        acceptances=acceptances,
+    )
+
+
+def _ordered(spans: tuple[SemanticSpan, ...]) -> tuple[SemanticSpan, ...]:
+    """Spans in a deterministic order, so two equal acceptances write one file.
+
+    Ordered by content — leaf then offsets — rather than by acceptance sequence,
+    because the order review happened in is evidence, not part of the accepted
+    result, and letting it into the file would make the artifact depend on which
+    batch ran first.
+    """
+    return tuple(sorted(spans, key=lambda s: (s.leaf_id, s.char_start, s.char_end)))

--- a/src/afterworlds/ingestion/mechanical/acceptance.py
+++ b/src/afterworlds/ingestion/mechanical/acceptance.py
@@ -20,20 +20,37 @@ Three properties this is built to keep:
 * **The evidence is the diff, not a digest of it.** The batch retains every
   :class:`~.models.SemanticDiffEntry` in full, and its hash identifies that diff
   rather than substituting for it (see :mod:`accounting`).
-* **Evidence never becomes identity.** Reviewer, timestamp, batch grouping, and
-  rule wording travel with the ledger and are excluded from
-  :func:`~.oracle.oracle_payload`, so re-reviewing an unchanged classification
-  cannot remint a projection.
+* **Evidence never becomes identity.** Reviewer, timestamp, batch grouping,
+  rule wording, and the reviewed proposal's identity travel with the ledger and
+  are excluded from :func:`~.oracle.oracle_payload`, so re-reviewing an
+  unchanged classification cannot remint a projection.
+* **The evidence names the representation, not only the spans.** A batch's
+  scope and diff say which spans were accepted and what their disposition
+  became; they say nothing about records, facts, or prose bindings. Two
+  proposals can agree on every span and disagree on all the mechanical
+  authority. So each batch also records
+  :func:`~.proposal.proposal_identity` — the content-derived identity of the
+  exact complete proposal reviewed. ``resolved_scope`` scopes *classification*
+  acceptance; ``proposal_identity`` identifies the complete proposed
+  *representation* that acceptance drew from.
 
-Accepting over a prior artifact is a merge, not a replacement: prior accepted
-spans survive unless this scope re-accepts them, and prior batches stay in the
-record. That is what lets full-corpus review proceed in reviewable content
-batches without any batch quietly discarding an earlier one's work.
+Accepting over a prior artifact extends it. Batch scopes accumulate and must
+stay **disjoint**: a span already accepted cannot be re-accepted here, because
+re-acceptance would strand the earlier batch's evidence — its scope member would
+name a different batch than the one that recorded it, and the ledger would fail
+its own acceptance validation. Correcting an earlier acceptance therefore needs
+a history model with supersession semantics, which this module deliberately does
+not have and this PR does not add. What it does support is the workflow
+full-corpus review actually needs: one complete proposal reviewed across several
+disjoint span batches, whose representations merge as a keyed union rather than
+piling up duplicates.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
+from typing import Any
 
 from afterworlds.ingestion.mechanical.accounting import batch_diff_hash
 from afterworlds.ingestion.mechanical.models import (
@@ -48,8 +65,19 @@ from afterworlds.ingestion.mechanical.oracle import (
     AcceptedOracle,
     derive_obligations,
 )
-from afterworlds.ingestion.mechanical.proposal import MechanicalProposal
-from afterworlds.ingestion.mechanical.representation import RepresentationDraft
+from afterworlds.ingestion.mechanical.proposal import (
+    MechanicalProposal,
+    proposal_identity,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ProvenanceClaim,
+    RepresentationDraft,
+    component_target_key,
+    prose_binding_target_key,
+    record_target_key,
+    reference_target_key,
+    relationship_target_key,
+)
 
 __all__ = ["AcceptanceError", "accept_proposal"]
 
@@ -62,55 +90,94 @@ class AcceptanceError(ValueError):
     """
 
 
+def _provenance_key(claim: ProvenanceClaim) -> tuple[str, ...]:
+    """Stable identity of one provenance edge.
+
+    The same tuple :mod:`validation` uses to detect a duplicate edge, so "the
+    same edge" means one thing in this repository rather than two.
+    """
+    return (claim.target_kind.value, *claim.target_key, claim.span_id, claim.role.value)
+
+
+#: How each representation collection is keyed for the merge below, reusing the
+#: repository's canonical target-key definitions rather than restating them.
+#:
+#: Three of these keys are strictly narrower than their element's content, so
+#: the same key can carry conflicting content and the merge has to say so:
+#: a record's kind and parent, a component's handling, reason, and facts, and a
+#: prose binding's chunk extent all live outside their keys. The other three —
+#: relationships, references, provenance — have keys that already span every
+#: field, so under those a key collision *is* content equality and only
+#: duplication is possible. Both cases are handled by the same code; the
+#: difference is only which failure it can reach.
+_COLLECTIONS: tuple[tuple[str, str, Callable[[Any], tuple[str, ...]]], ...] = (
+    ("record", "records", record_target_key),
+    ("component", "components", component_target_key),
+    ("prose binding", "prose_bindings", prose_binding_target_key),
+    ("relationship", "relationships", relationship_target_key),
+    ("reference", "references", reference_target_key),
+    ("provenance edge", "provenance", _provenance_key),
+)
+
+
+def _merged_collection(
+    label: str,
+    key_of: Callable[[Any], tuple[str, ...]],
+    prior_items: tuple[Any, ...],
+    new_items: tuple[Any, ...],
+) -> tuple[Any, ...]:
+    """Keyed union of one collection: retain once, append new, reject conflicts."""
+    merged: list[Any] = []
+    seen: dict[tuple[str, ...], Any] = {}
+    for item in (*prior_items, *new_items):
+        key = key_of(item)
+        existing = seen.get(key)
+        if existing is None:
+            seen[key] = item
+            merged.append(item)
+            continue
+        if existing != item:
+            raise AcceptanceError(
+                f"{label} {list(key)}: this acceptance states different content "
+                "under a semantic key already accepted. Nothing here can choose "
+                "between them — the earlier reviewer never saw this version."
+            )
+    return tuple(merged)
+
+
 def _merge_representation(
     prior: RepresentationDraft | None, proposed: RepresentationDraft
 ) -> RepresentationDraft:
     """Combine a prior accepted representation with a newly accepted one.
 
-    Concatenation, with one guard: a record or component semantic key that
-    appears in both must appear *identically*. A batch that redefines an earlier
-    batch's record under the same key is not a merge, it is a silent
-    replacement of authority somebody already accepted, and the reviewer of the
-    second batch never saw the first.
+    A **keyed union**, not concatenation. Reviewing one complete proposal across
+    several disjoint span batches supplies the same complete representation each
+    time; concatenating it would duplicate every record and component, and the
+    finished artifact could never publish — :mod:`validation` would report
+    duplicate semantic keys and persistence would collide on projection-scoped
+    identities.
 
-    Every other collection concatenates freely — a duplicated fact, relationship,
-    reference, or provenance edge is already a violation :mod:`validation`
-    reports by name, and re-checking it here would be a second opinion about
-    what "the same element" means.
+    So an element whose key was already accepted is retained once, a genuinely
+    new element is appended in first-seen order, and an element that reuses an
+    accepted key while stating *different* content fails closed. That last case
+    is not a merge conflict to resolve: it is one reviewer's authority silently
+    replacing another's, and the earlier reviewer never saw the replacement.
+
+    First-seen order rather than sorted, because the accepted result is
+    canonicalized downstream anyway (:func:`~.projection.representation_payload`
+    orders every collection), so imposing a second ordering here would add a
+    rule without adding a guarantee.
     """
     if prior is None:
         return proposed
 
-    for label, prior_items, new_items, key in (
-        (
-            "record",
-            prior.records,
-            proposed.records,
-            lambda r: (r.semantic_key,),
-        ),
-        (
-            "component",
-            prior.components,
-            proposed.components,
-            lambda c: (c.record_key, c.semantic_key),
-        ),
-    ):
-        existing = {key(item): item for item in prior_items}
-        for item in new_items:
-            clash = existing.get(key(item))
-            if clash is not None and clash != item:
-                raise AcceptanceError(
-                    f"{label} {list(key(item))}: this acceptance redefines a "
-                    "record already accepted under the same semantic key"
-                )
-
     return RepresentationDraft(
-        records=prior.records + proposed.records,
-        components=prior.components + proposed.components,
-        prose_bindings=prior.prose_bindings + proposed.prose_bindings,
-        relationships=prior.relationships + proposed.relationships,
-        references=prior.references + proposed.references,
-        provenance=prior.provenance + proposed.provenance,
+        **{
+            field: _merged_collection(
+                label, key_of, getattr(prior, field), getattr(proposed, field)
+            )
+            for label, field, key_of in _COLLECTIONS
+        }
     )
 
 
@@ -130,6 +197,14 @@ def accept_proposal(
     and is **never re-run**: re-evaluating a selector against changed inputs
     would resolve to a different set than the reviewer actually saw, which is
     why ``resolved_scope`` carries the exact span ids alongside it.
+
+    ``resolved_scope`` scopes *classification* acceptance — which spans, and
+    what their disposition became. The batch separately records the identity of
+    the complete proposal reviewed, which is what ties the accepted
+    *representation* to something a human looked at.
+
+    Extending *prior* requires a disjoint scope: a span it already accepted
+    cannot be re-accepted here.
     """
     if not resolved_scope:
         raise AcceptanceError("an acceptance action must name at least one span")
@@ -160,27 +235,35 @@ def accept_proposal(
             "accepted authority it would extend"
         )
 
-    prior_spans = {s.span_id: s for s in (prior.oracle.spans if prior else ())}
     if batch_id in {b.batch_id for b in (prior.batches if prior else ())}:
         raise AcceptanceError(f"batch {batch_id!r} is already recorded")
+
+    # Accumulating batch scopes stay disjoint. Re-accepting a span would leave
+    # the earlier batch's retained evidence stranded — its scope member would
+    # name a different batch than the record that accepted it — and the ledger
+    # would fail its own acceptance validation from then on. Refused here,
+    # before an artifact exists, rather than producing one that cannot load.
+    if prior is not None:
+        already = {a.span_id for a in prior.acceptances}
+        if overlap := sorted(already.intersection(resolved_scope)):
+            raise AcceptanceError(
+                f"resolved scope re-accepts spans already accepted: {overlap}. "
+                "Batch scopes must be disjoint; correcting an earlier acceptance "
+                "needs supersession semantics this module does not have."
+            )
 
     accepted_spans = tuple(
         replace(proposed_by_id[span_id], review_state=ReviewState.ACCEPTED)
         for span_id in resolved_scope
     )
+    # Every span in a disjoint scope is newly accepted, so there is no prior
+    # disposition to record. The fields stay because the diff shape is shared
+    # with a future history model that will have one.
     diff = tuple(
         SemanticDiffEntry(
             span_id=span.span_id,
-            prior_disposition=(
-                prior_spans[span.span_id].disposition
-                if span.span_id in prior_spans
-                else None
-            ),
-            prior_reason_code=(
-                prior_spans[span.span_id].non_mechanical_reason_code
-                if span.span_id in prior_spans
-                else None
-            ),
+            prior_disposition=None,
+            prior_reason_code=None,
             accepted_disposition=span.disposition,
             accepted_reason_code=span.non_mechanical_reason_code,
         )
@@ -192,21 +275,12 @@ def accept_proposal(
         resolved_scope=tuple(resolved_scope),
         diff=diff,
         semantic_diff_hash="",
+        proposal_identity=proposal_identity(proposal),
     )
     batch = replace(batch, semantic_diff_hash=batch_diff_hash(batch))
 
-    re_accepted = set(resolved_scope)
-    spans = (
-        tuple(
-            s
-            for s in (prior.oracle.spans if prior else ())
-            if s.span_id not in re_accepted
-        )
-        + accepted_spans
-    )
-    acceptances = tuple(
-        a for a in (prior.acceptances if prior else ()) if a.span_id not in re_accepted
-    ) + tuple(
+    spans = tuple(prior.oracle.spans if prior else ()) + accepted_spans
+    acceptances = tuple(prior.acceptances if prior else ()) + tuple(
         AcceptanceRecord(
             span_id=span_id,
             batch_id=batch_id,

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -208,6 +208,10 @@ def _validate_batch(
         findings.append(f"{tag}: no resolved scope recorded")
     if not batch.diff:
         findings.append(f"{tag}: no semantic diff retained")
+    # Without this, the batch attests only that spans were accepted, and the
+    # accepted representation could be authority nobody reviewed.
+    if not batch.proposal_identity.strip():
+        findings.append(f"{tag}: no reviewed proposal identity recorded")
 
     scope = set(batch.resolved_scope)
     if len(scope) != len(batch.resolved_scope):
@@ -420,6 +424,12 @@ def acceptance_evidence_payload(ledger: ClassificationLedger) -> dict[str, objec
                 "resolved_scope": list(b.resolved_scope),
                 "diff": batch_diff_payload(b),
                 "semantic_diff_hash": b.semantic_diff_hash,
+                # Which complete proposal was reviewed. Present here — and so
+                # covered by the persisted-state digest — because evidence that
+                # can be rewritten without detection is not evidence, and this
+                # is the one field attesting that the accepted *representation*
+                # was the one in front of the reviewer.
+                "proposal_identity": b.proposal_identity,
             }
             for b in ledger.batches
         ),

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -31,6 +31,8 @@ acceptance history.
 
 from __future__ import annotations
 
+import re
+
 from afterworlds.ingestion.corpus.hashing import content_id, hash_obj
 from afterworlds.ingestion.mechanical.canonical import canonical_order
 from afterworlds.ingestion.mechanical.models import (
@@ -186,6 +188,32 @@ def batch_diff_hash(batch: AcceptanceBatch) -> str:
     return hash_obj(batch_diff_payload(batch))
 
 
+#: Exactly what :func:`~afterworlds.ingestion.corpus.hashing.hash_obj` returns:
+#: ``hashlib.sha256(...).hexdigest()`` — 64 lowercase hex characters, always.
+_CANONICAL_DIGEST = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
+def _is_canonical_digest(value: str) -> bool:
+    """Could *value* have been produced by this repository's hashing function?
+
+    The two retained hashes are checked differently, and the asymmetry is the
+    point. ``semantic_diff_hash`` is *recomputed* from the diff the batch
+    retains, so its shape never needs asserting — a wrong value fails the
+    comparison whatever it looks like. ``proposal_identity`` names a proposal
+    that no longer exists anywhere in the accepted artifact, so there is nothing
+    to recompute it against; the strongest available check is that it is the
+    shape this repository's hashing function can actually emit.
+
+    That is deliberately a *shape* check and not a claim of authenticity. It
+    cannot prove the digest names the proposal that was reviewed. What it does
+    rule out is evidence that could not have come from a real proposal at all —
+    a placeholder, a truncated paste, an uppercase transcription, or a
+    hand-typed word — which is the difference between weak evidence and evidence
+    that was never generated.
+    """
+    return bool(_CANONICAL_DIGEST.fullmatch(value))
+
+
 def _validate_batch(
     batch: AcceptanceBatch,
     spans_by_id: dict[str, SemanticSpan],
@@ -210,8 +238,11 @@ def _validate_batch(
         findings.append(f"{tag}: no semantic diff retained")
     # Without this, the batch attests only that spans were accepted, and the
     # accepted representation could be authority nobody reviewed.
-    if not batch.proposal_identity.strip():
-        findings.append(f"{tag}: no reviewed proposal identity recorded")
+    if not _is_canonical_digest(batch.proposal_identity):
+        findings.append(
+            f"{tag}: reviewed proposal identity {batch.proposal_identity!r} is not a "
+            "canonical SHA-256 digest"
+        )
 
     scope = set(batch.resolved_scope)
     if len(scope) != len(batch.resolved_scope):

--- a/src/afterworlds/ingestion/mechanical/accounting.py
+++ b/src/afterworlds/ingestion/mechanical/accounting.py
@@ -204,12 +204,23 @@ def _is_canonical_digest(value: str) -> bool:
     to recompute it against; the strongest available check is that it is the
     shape this repository's hashing function can actually emit.
 
-    That is deliberately a *shape* check and not a claim of authenticity. It
-    cannot prove the digest names the proposal that was reviewed. What it does
-    rule out is evidence that could not have come from a real proposal at all —
-    a placeholder, a truncated paste, an uppercase transcription, or a
-    hand-typed word — which is the difference between weak evidence and evidence
-    that was never generated.
+    **What this proves, exactly.** Only that the value *could* be a digest this
+    repository generated. It proves nothing about which proposal that digest
+    names, and nothing about human review: a hand-authored artifact can carry
+    any 64-character lowercase hex string, and this check will accept it. What
+    it rules out is a value that could not have been generated at all — a
+    placeholder, a truncated paste, an uppercase transcription, a typed word.
+
+    **What proves the rest, and where.** ``proposal_identity`` is an audit
+    reference computed by :func:`~.acceptance.accept_proposal`, not a
+    cryptographic attestation of human review. The independently reviewed
+    authority is the committed ``AcceptedInputs`` artifact itself, and Git
+    review is the trust boundary that establishes a human accepted it. The
+    persisted-state digest is a third, separate thing again: it detects later
+    mutation of stored evidence. None of the three establishes reviewer
+    authenticity, and #137 does not require self-authenticating proposal
+    history — retaining proposal payloads beside an editable digest would
+    establish internal consistency, not authenticity.
     """
     return bool(_CANONICAL_DIGEST.fullmatch(value))
 

--- a/src/afterworlds/ingestion/mechanical/bound_corpus.py
+++ b/src/afterworlds/ingestion/mechanical/bound_corpus.py
@@ -132,6 +132,41 @@ class BoundCorpusSnapshot:
                 return True
         return False
 
+    def chunk_relative_range(
+        self, chunk_id: str, leaf_id: str, char_start: int, char_end: int
+    ) -> tuple[int, int] | None:
+        """Translate a leaf subspan into offsets in *chunk_id*'s own text.
+
+        A prose binding names a chunk, but the accepted span is expressed in
+        leaf coordinates. Exact prose resolution has to slice the chunk, so the
+        two coordinate systems have to be related — and they only can be when
+        this release's projection makes the relation unambiguous.
+
+        Returns ``None`` — fail closed, never a guess — unless the chunk covers
+        this leaf as **one** run *and* covers no other leaf. Both conditions
+        matter: a chunk assembled from several leaves has an unknown prefix
+        length before this leaf's text, and a chunk covering one leaf in two
+        runs has an unknown gap inside it. In either case the offset cannot be
+        derived, and inventing one would silently return the wrong sentence as
+        governing authority.
+
+        The production SRD 5.2.1 release satisfies both conditions everywhere —
+        chunk and leaf are in strict bijection and every projection edge covers
+        its whole leaf — but this does not assume that. It checks, per binding.
+        """
+        if not self.covers_span(chunk_id, leaf_id, char_start, char_end):
+            return None
+        covered_leaves = {
+            edge.leaf_id for edge in self.chunk_coverage if edge.chunk_id == chunk_id
+        }
+        if len(covered_leaves) != 1:
+            return None
+        runs = self._covered_runs.get((chunk_id, leaf_id), ())
+        if len(runs) != 1:
+            return None
+        run_start = runs[0][0]
+        return char_start - run_start, char_end - run_start
+
 
 def bound_corpus_from_operational(
     snapshot: OperationalCorpusSnapshot,

--- a/src/afterworlds/ingestion/mechanical/models.py
+++ b/src/afterworlds/ingestion/mechanical/models.py
@@ -132,6 +132,24 @@ class AcceptanceBatch:
     * ``diff`` is the canonical semantic diff itself, retained in full.
     * ``semantic_diff_hash`` identifies and verifies that diff; it never
       substitutes for it.
+    * ``proposal_identity`` is the content-derived identity of the exact
+      :class:`~afterworlds.ingestion.mechanical.proposal.MechanicalProposal`
+      that was reviewed.
+
+    **Scope and proposal identity answer different questions, and both are
+    needed.** ``resolved_scope`` and ``diff`` scope the *classification*
+    acceptance — which spans, and what their disposition and reason became.
+    They say nothing about records, components, facts, prose bindings,
+    relationships, references, or provenance, because two proposals can state
+    identical span dispositions while stating completely different mechanical
+    authority. ``proposal_identity`` closes exactly that gap: it identifies the
+    complete proposed representation the reviewer had in front of them, so the
+    retained evidence establishes that the accepted authority is the authority
+    somebody actually reviewed — not merely that some spans were accepted.
+
+    All five fields are retained audit evidence. None reaches projection or
+    oracle identity — see ``accounting.classification_payload`` — so
+    re-reviewing an unchanged classification cannot remint a projection.
     """
 
     batch_id: str
@@ -139,6 +157,7 @@ class AcceptanceBatch:
     resolved_scope: tuple[str, ...]
     diff: tuple[SemanticDiffEntry, ...]
     semantic_diff_hash: str
+    proposal_identity: str
 
 
 @dataclass(frozen=True)

--- a/src/afterworlds/ingestion/mechanical/oracle.py
+++ b/src/afterworlds/ingestion/mechanical/oracle.py
@@ -1,18 +1,25 @@
-"""The accepted completeness oracle — CRD Issue 5d, Decision 5.
+"""Committed accepted authority — CRD Issue 5d, Decisions 4 and 5.
 
-The publication gate compares reconstructed persisted state against *this*, and
-the only property that makes the comparison worth anything is independence: an
-oracle derived from the projection it checks proves nothing but that the code
-is self-consistent.
+This module owns both halves of what a reviewer commits: the accepted
+**oracle** the publication gate judges persisted state against, and the
+accepted **inputs** the production build consumes, which are the oracle plus the
+review evidence that accepted it (:class:`AcceptedInputs`).
+
+The only property that makes the gate's comparison worth anything is
+independence: an oracle derived from the projection it checks proves nothing but
+that the code is self-consistent.
 
 Independence is structural here, not a convention:
 
 * this module imports no session, no ORM, and nothing from
   :mod:`persistence`, :mod:`raw_state`, or :mod:`gate`. There is no code path,
   public or private, that builds an ``AcceptedOracle`` from a persisted
-  projection or from a :class:`ProjectionCandidate`;
-* :func:`load_oracle` reads a committed JSON file and nothing else. Its whole
-  input is bytes on disk that a reviewer accepted and a commit records; and
+  projection or from a :class:`ProjectionCandidate`.
+  :func:`candidate_from_accepted_inputs` runs the *other* way — committed bytes
+  become a candidate — and the oracle those bytes also carry is what later judges
+  it;
+* :func:`load_accepted_inputs` reads a committed JSON file and nothing else. Its
+  whole input is bytes on disk that a reviewer accepted and a commit records; and
 * the declared semantic policy comes from the *file*, never from the current
   :mod:`policy` constants. Reading current code here would let a policy change
   silently re-bless an oracle nobody re-reviewed — the exact self-attestation
@@ -26,10 +33,11 @@ independent accepted authority with its own publication proof. Re-declaring
 28,109 leaf ids in a committed file would add a second place to drift from 5c
 without adding a second opinion.
 
-**What is committed today.** ``oracles/`` holds no production SRD oracle, so
-the production 5c release resolves to no accepted authority and its projection
-cannot be published. Later inactive-content PRs commit the accepted full-corpus
-oracle; this PR builds the machinery that will judge it.
+**What is committed today.** ``oracles/`` holds no production SRD authority, so
+the production 5c release resolves to nothing and its projection cannot be
+published. Later content PRs commit accepted full-corpus authority through the
+propose → review → accept workflow (:mod:`proposal`, :mod:`acceptance`); the
+machinery that judges it lives here.
 """
 
 from __future__ import annotations

--- a/src/afterworlds/ingestion/mechanical/oracle.py
+++ b/src/afterworlds/ingestion/mechanical/oracle.py
@@ -698,7 +698,14 @@ def _acceptance(
         at = f"{where}.batches[{i}]"
         b = _require(
             raw,
-            ("batch_id", "rule", "resolved_scope", "diff", "semantic_diff_hash"),
+            (
+                "batch_id",
+                "rule",
+                "resolved_scope",
+                "diff",
+                "semantic_diff_hash",
+                "proposal_identity",
+            ),
             at,
         )
         diff = []
@@ -745,6 +752,9 @@ def _acceptance(
                 diff=tuple(diff),
                 semantic_diff_hash=_string(
                     b["semantic_diff_hash"], f"{at}.semantic_diff_hash"
+                ),
+                proposal_identity=_string(
+                    b["proposal_identity"], f"{at}.proposal_identity"
                 ),
             )
         )

--- a/src/afterworlds/ingestion/mechanical/oracle.py
+++ b/src/afterworlds/ingestion/mechanical/oracle.py
@@ -41,15 +41,24 @@ from pathlib import Path
 from typing import Any
 
 from afterworlds.ingestion.corpus.hashing import hash_obj
-from afterworlds.ingestion.mechanical.accounting import span_payload
+from afterworlds.ingestion.mechanical.accounting import (
+    acceptance_evidence_payload,
+    span_payload,
+    validate_acceptance,
+)
 from afterworlds.ingestion.mechanical.canonical import canonical_order
 from afterworlds.ingestion.mechanical.models import (
+    AcceptanceBatch,
+    AcceptanceRecord,
+    ClassificationLedger,
     ComponentHandling,
     ReviewState,
+    SemanticDiffEntry,
     SemanticDisposition,
     SemanticSpan,
 )
 from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
     ReleaseBinding,
     representation_payload,
 )
@@ -72,20 +81,32 @@ from afterworlds.ingestion.mechanical.representation import (
 )
 
 __all__ = [
+    "ACCEPTED_ARTIFACT_KIND",
     "COMMITTED_ORACLE_DIR",
+    "AcceptedInputs",
     "AcceptedOracle",
     "OracleLoadError",
     "RecordObligation",
+    "accepted_inputs_payload",
+    "candidate_from_accepted_inputs",
+    "committed_inputs_for",
     "committed_oracle_for",
     "derive_obligations",
+    "load_accepted_inputs",
     "load_oracle",
     "obligation_payload",
     "oracle_identity",
     "oracle_payload",
 ]
 
-#: Committed accepted oracles, one JSON file per published 5c release.
+#: Committed accepted authority, one JSON file per published 5c release.
 COMMITTED_ORACLE_DIR = Path(__file__).resolve().parent / "oracles"
+
+#: The discriminator a committed accepted-inputs artifact must declare. A
+#: machine proposal declares something else and has a different shape besides
+#: (:mod:`afterworlds.ingestion.mechanical.proposal`), so it cannot be loaded as
+#: accepted authority by renaming it, moving it, or editing one field.
+ACCEPTED_ARTIFACT_KIND = "accepted_authority"
 
 
 class OracleLoadError(ValueError):
@@ -140,6 +161,39 @@ class AcceptedOracle:
     spans: tuple[SemanticSpan, ...]
     representation: RepresentationDraft
     obligations: tuple[RecordObligation, ...]
+
+
+@dataclass(frozen=True)
+class AcceptedInputs:
+    """One committed artifact: the accepted result *and* the review evidence.
+
+    The two halves are deliberately separable. :attr:`oracle` is the accepted
+    semantics the publication gate judges against, and it excludes evidence
+    because review process is not identity-bearing. :attr:`batches` and
+    :attr:`acceptances` are the auditable record of the explicit acceptance
+    action — exact scope, full semantic diff, who accepted it and when — which
+    the build carries into persistence so the gate can see that every span was
+    actually acted on.
+
+    Keeping them in one file means they cannot drift apart; keeping them in
+    separate fields means the evidence cannot leak into identity.
+    """
+
+    oracle: AcceptedOracle
+    batches: tuple[AcceptanceBatch, ...]
+    acceptances: tuple[AcceptanceRecord, ...]
+
+    def classification(self) -> ClassificationLedger:
+        """The complete accepted ledger, result and evidence together."""
+        return ClassificationLedger(
+            package_uuid=self.oracle.binding.package_uuid,
+            release_version=self.oracle.binding.release_version,
+            policy_version=self.oracle.policy_version,
+            policy_hash=self.oracle.policy_hash,
+            spans=self.oracle.spans,
+            batches=self.batches,
+            acceptances=self.acceptances,
+        )
 
 
 #: Handlings whose accepted meaning is carried, wholly or partly, by governing
@@ -452,7 +506,15 @@ def _representation(payload: object) -> RepresentationDraft:
         where = f"representation.prose_bindings[{i}]"
         b = _require(
             raw,
-            ("record_key", "component_key", "chunk_id", "irreducibility_reason_code"),
+            (
+                "record_key",
+                "component_key",
+                "chunk_id",
+                "span_id",
+                "chunk_char_start",
+                "chunk_char_end",
+                "irreducibility_reason_code",
+            ),
             where,
         )
         prose_bindings.append(
@@ -460,6 +522,11 @@ def _representation(payload: object) -> RepresentationDraft:
                 record_key=_string(b["record_key"], f"{where}.record_key"),
                 component_key=_string(b["component_key"], f"{where}.component_key"),
                 chunk_id=_string(b["chunk_id"], f"{where}.chunk_id"),
+                span_id=_string(b["span_id"], f"{where}.span_id"),
+                chunk_char_start=_offset(
+                    b["chunk_char_start"], f"{where}.chunk_char_start"
+                ),
+                chunk_char_end=_offset(b["chunk_char_end"], f"{where}.chunk_char_end"),
                 irreducibility_reason_code=_string(
                     b["irreducibility_reason_code"],
                     f"{where}.irreducibility_reason_code",
@@ -592,24 +659,137 @@ def _check_obligations_closed(
         )
 
 
-def load_oracle(path: Path) -> AcceptedOracle:
-    """Load one committed accepted oracle from JSON.
+# ---------------------------------------------------------------------------
+# Acceptance evidence and the committed accepted-inputs artifact
+# ---------------------------------------------------------------------------
+#
+# **Why one artifact and not two.** #137 contract 4 names five committed
+# meaning-bearing inputs the production build consumes; the oracle carries four
+# of them but deliberately omits the fifth, acceptance evidence, because review
+# process is not identity-bearing (:mod:`accounting`). Something still has to
+# supply that evidence to the build, or the gate reports UNREVIEWED_RESIDUE
+# against reconstructed state that no committed input could have filled in.
+#
+# Two files — build inputs and oracle — would need a third mechanism to prove
+# they still describe the same accepted semantics. One file cannot disagree with
+# itself, so the drift check has nothing to check and the whole class of
+# input/oracle skew stops existing. The independence that actually matters is
+# untouched: this is committed bytes a reviewer accepted, never something
+# derived from a candidate or from persisted output, and the oracle projected
+# out of it drops the evidence before identity is computed.
+
+
+def _acceptance(
+    payload: object, where: str
+) -> tuple[tuple[AcceptanceBatch, ...], tuple[AcceptanceRecord, ...]]:
+    """Load the review evidence half of a committed accepted-inputs file."""
+    p = _require(payload, ("batches", "records"), where)
+
+    batches = []
+    for i, raw in enumerate(_object_list(p["batches"], f"{where}.batches")):
+        at = f"{where}.batches[{i}]"
+        b = _require(
+            raw,
+            ("batch_id", "rule", "resolved_scope", "diff", "semantic_diff_hash"),
+            at,
+        )
+        diff = []
+        for j, raw_entry in enumerate(_object_list(b["diff"], f"{at}.diff")):
+            entry_at = f"{at}.diff[{j}]"
+            d = _require(
+                raw_entry,
+                (
+                    "span_id",
+                    "prior_disposition",
+                    "prior_reason_code",
+                    "accepted_disposition",
+                    "accepted_reason_code",
+                ),
+                entry_at,
+            )
+            prior = d["prior_disposition"]
+            diff.append(
+                SemanticDiffEntry(
+                    span_id=_string(d["span_id"], f"{entry_at}.span_id"),
+                    prior_disposition=(
+                        None
+                        if prior is None
+                        else _enum(SemanticDisposition, prior, entry_at)
+                    ),
+                    prior_reason_code=_optional_string(
+                        d["prior_reason_code"], f"{entry_at}.prior_reason_code"
+                    ),
+                    accepted_disposition=_enum(
+                        SemanticDisposition, d["accepted_disposition"], entry_at
+                    ),
+                    accepted_reason_code=_optional_string(
+                        d["accepted_reason_code"], f"{entry_at}.accepted_reason_code"
+                    ),
+                )
+            )
+        batches.append(
+            AcceptanceBatch(
+                batch_id=_string(b["batch_id"], f"{at}.batch_id"),
+                rule=_string(b["rule"], f"{at}.rule"),
+                resolved_scope=tuple(
+                    _string_list(b["resolved_scope"], f"{at}.resolved_scope")
+                ),
+                diff=tuple(diff),
+                semantic_diff_hash=_string(
+                    b["semantic_diff_hash"], f"{at}.semantic_diff_hash"
+                ),
+            )
+        )
+
+    records = []
+    for i, raw in enumerate(_object_list(p["records"], f"{where}.records")):
+        at = f"{where}.records[{i}]"
+        r = _require(raw, ("span_id", "batch_id", "reviewer", "accepted_at"), at)
+        records.append(
+            AcceptanceRecord(
+                span_id=_string(r["span_id"], f"{at}.span_id"),
+                batch_id=_optional_string(r["batch_id"], f"{at}.batch_id"),
+                reviewer=_string(r["reviewer"], f"{at}.reviewer"),
+                accepted_at=_string(r["accepted_at"], f"{at}.accepted_at"),
+            )
+        )
+    return tuple(batches), tuple(records)
+
+
+def load_accepted_inputs(path: Path) -> AcceptedInputs:
+    """Load one committed accepted-inputs artifact from JSON.
 
     The whole input is the file. Nothing is read from the database, from a
     candidate, or from the current semantic policy.
+
+    ``artifact_kind`` is checked first and must be exactly
+    :data:`ACCEPTED_ARTIFACT_KIND`. That check is a fast, legible rejection of a
+    machine proposal — but it is not what makes a proposal unloadable. A
+    proposal has a different key set at every level (see
+    :mod:`afterworlds.ingestion.mechanical.proposal`), so it fails ``_require``
+    in several places even if someone edits its ``artifact_kind`` to lie.
+    Structural incompatibility, not a flag and not a directory.
     """
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise OracleLoadError(f"{path.name}: {exc}") from exc
 
+    if isinstance(raw, dict) and raw.get("artifact_kind") != ACCEPTED_ARTIFACT_KIND:
+        raise OracleLoadError(
+            f"{path.name}: artifact_kind {raw.get('artifact_kind')!r} is not "
+            f"{ACCEPTED_ARTIFACT_KIND!r}; this file is not accepted authority"
+        )
+
     p = _require(
         raw,
         (
+            "artifact_kind",
             "release_binding",
             "semantic_policy_version",
             "semantic_policy_hash",
             "spans",
+            "acceptance",
             "representation",
             "obligations",
         ),
@@ -630,17 +810,62 @@ def load_oracle(path: Path) -> AcceptedOracle:
         for i, o in enumerate(_object_list(p["obligations"], "obligations"))
     )
     _check_obligations_closed(representation, obligations, path.name)
-    return AcceptedOracle(
+    spans = tuple(_span(s, i) for i, s in enumerate(_object_list(p["spans"], "spans")))
+    batches, acceptances = _acceptance(p["acceptance"], "acceptance")
+
+    oracle = AcceptedOracle(
         binding=ReleaseBinding(
             **{k: _string(binding[k], f"release_binding.{k}") for k in binding_fields}
         ),
         policy_version=_string(p["semantic_policy_version"], "semantic_policy_version"),
         policy_hash=_string(p["semantic_policy_hash"], "semantic_policy_hash"),
-        spans=tuple(
-            _span(s, i) for i, s in enumerate(_object_list(p["spans"], "spans"))
-        ),
+        spans=spans,
         representation=representation,
         obligations=obligations,
+    )
+    inputs = AcceptedInputs(oracle=oracle, batches=batches, acceptances=acceptances)
+
+    # Evidence is validated as strictly as the result it justifies. A file whose
+    # batch retains a digest but not the diff it names, or that accepts a span
+    # nobody acted on, is not a weaker acceptance — it is a claim of acceptance
+    # with the acceptance missing.
+    if violations := validate_acceptance(inputs.classification()):
+        raise OracleLoadError(
+            f"{path.name}: acceptance evidence is not complete: "
+            f"{'; '.join(violations)}"
+        )
+    return inputs
+
+
+def load_oracle(path: Path) -> AcceptedOracle:
+    """Load one committed accepted oracle from JSON.
+
+    The oracle is the accepted-inputs artifact with its review evidence dropped:
+    two files that reviewed their way to the same accepted classification are
+    the same authority, so reviewer, timestamp, batch grouping, and diff never
+    reach projection identity (#137 acceptance criterion 11).
+    """
+    return load_accepted_inputs(path).oracle
+
+
+def candidate_from_accepted_inputs(inputs: AcceptedInputs) -> ProjectionCandidate:
+    """The build candidate one committed accepted-inputs artifact states.
+
+    This is the *input* direction: committed bytes a reviewer accepted become
+    the candidate that is persisted, reconstructed, and then judged. It is not
+    the forbidden direction — nothing here derives accepted authority from a
+    candidate or from persisted output, and :func:`load_oracle` reads the same
+    committed bytes rather than anything this function produced.
+
+    Unlike the oracle, the candidate *does* carry the acceptance evidence: the
+    publication gate requires an explicit acceptance record for every span in
+    reconstructed persisted state, and that evidence has to reach persistence
+    from a committed input or no build could ever satisfy it.
+    """
+    return ProjectionCandidate(
+        binding=inputs.oracle.binding,
+        classification=inputs.classification(),
+        representation=inputs.oracle.representation,
     )
 
 
@@ -660,24 +885,40 @@ def committed_oracle_for(
     an empty oracle: an empty oracle would compare equal to an empty projection
     and publish nothing as if it were everything.
     """
-    return _resolve_committed_oracle(
+    inputs = _resolve_committed_inputs(
+        package_uuid, release_version, COMMITTED_ORACLE_DIR
+    )
+    return None if inputs is None else inputs.oracle
+
+
+def committed_inputs_for(
+    package_uuid: str, release_version: str
+) -> AcceptedInputs | None:
+    """Return the committed accepted inputs for one 5c release, or ``None``.
+
+    Same resolution and same directory as :func:`committed_oracle_for`; this is
+    the build-side view, which additionally carries the acceptance evidence.
+    """
+    return _resolve_committed_inputs(
         package_uuid, release_version, COMMITTED_ORACLE_DIR
     )
 
 
-def _resolve_committed_oracle(
+def _resolve_committed_inputs(
     package_uuid: str, release_version: str, directory: Path
-) -> AcceptedOracle | None:
+) -> AcceptedInputs | None:
     """Resolution semantics, parameterized by directory for tests only.
 
-    Two committed oracles for one release is a rejection, not a choice. Picking
-    one would make publication depend on filesystem ordering.
+    Two committed artifacts for one release is a rejection, not a choice.
+    Picking one would make publication depend on filesystem ordering.
     """
     matches = [
-        oracle
-        for oracle in (load_oracle(p) for p in sorted(directory.glob("*.json")))
-        if oracle.binding.package_uuid == package_uuid
-        and oracle.binding.release_version == release_version
+        inputs
+        for inputs in (
+            load_accepted_inputs(p) for p in sorted(directory.glob("*.json"))
+        )
+        if inputs.oracle.binding.package_uuid == package_uuid
+        and inputs.oracle.binding.release_version == release_version
     ]
     if len(matches) > 1:
         raise OracleLoadError(
@@ -685,3 +926,34 @@ def _resolve_committed_oracle(
             f"{package_uuid}/{release_version}"
         )
     return matches[0] if matches else None
+
+
+def _resolve_committed_oracle(
+    package_uuid: str, release_version: str, directory: Path
+) -> AcceptedOracle | None:
+    """Directory-parameterized oracle resolution, for tests only."""
+    inputs = _resolve_committed_inputs(package_uuid, release_version, directory)
+    return None if inputs is None else inputs.oracle
+
+
+# ---------------------------------------------------------------------------
+# Writing committed artifacts
+# ---------------------------------------------------------------------------
+
+
+def accepted_inputs_payload(inputs: AcceptedInputs) -> dict[str, object]:
+    """Canonical JSON payload of one accepted-inputs artifact.
+
+    Reuses :func:`oracle_payload` for the accepted result and
+    :func:`accounting.acceptance_evidence_payload` for the evidence, so the file
+    a reviewer commits is written in the same canonical form the loader expects
+    and the identity functions already agree on.
+    """
+    payload: dict[str, object] = {"artifact_kind": ACCEPTED_ARTIFACT_KIND}
+    payload.update(oracle_payload(inputs.oracle))
+    evidence = acceptance_evidence_payload(inputs.classification())
+    payload["acceptance"] = {
+        "batches": evidence["batches"],
+        "records": evidence["acceptances"],
+    }
+    return payload

--- a/src/afterworlds/ingestion/mechanical/oracles/README.md
+++ b/src/afterworlds/ingestion/mechanical/oracles/README.md
@@ -1,22 +1,68 @@
-# Committed accepted oracles — CRD Issue 5d
+# Committed accepted authority — CRD Issue 5d
 
 One JSON file per published CRD Issue 5c release, holding the accepted
-meaning-bearing authority the publication gate judges a persisted projection
-against: the exact release binding, the declared semantic policy, the accepted
-span classification, the accepted record/component/fact/prose-binding/
-relationship/reference/provenance inventory, and the accepted per-record
-obligations.
+meaning-bearing inputs the production build consumes and the publication gate
+judges against: the exact release binding, the declared semantic policy, the
+accepted span classification, the review evidence that accepted it, the accepted
+record/component/fact/prose-binding/relationship/reference/provenance inventory,
+and the accepted per-record obligations.
 
-The schema is whatever `oracle.load_oracle` accepts; it rejects a missing key,
-an extra key, and an undeclared enum value rather than defaulting any of them.
+The schema is whatever `oracle.load_accepted_inputs` accepts; it rejects a
+missing key, an extra key, and an undeclared enum value rather than defaulting
+any of them.
 
 **This directory is deliberately empty of production content.** No accepted
-oracle exists for the SRD 5.2.1 release yet, so that release resolves to no
-accepted authority and its mechanical projection cannot be published — which
-is the honest state until the accepted full-corpus authority is reviewed and
-committed by a later CRD Issue 5d content PR.
+authority exists for the SRD 5.2.1 release yet, so that release resolves to
+nothing and its mechanical projection cannot be published — which is the honest
+state until the accepted full-corpus authority is reviewed and committed by a
+later CRD Issue 5d content PR.
 
 Files here are review artifacts, not build output. Nothing in `src/` writes to
-this directory, and no oracle may be generated from a candidate or from
-persisted projection state: an oracle derived from the thing it checks proves
-only that the code agrees with itself.
+this directory, and no accepted artifact may be generated from a candidate or
+from persisted projection state: an oracle derived from the thing it checks
+proves only that the code agrees with itself.
+
+## The workflow
+
+```text
+machine proposal  →  human semantic review  →  explicit acceptance  →  commit
+```
+
+**Propose.** A tool builds a `MechanicalProposal`
+(`afterworlds.ingestion.mechanical.proposal`) and writes `proposal_payload` to a
+working path — never to this directory. A proposal is a *different shape* from
+accepted authority at every level: a different `artifact_kind`, spans under
+`proposed_spans` carrying a per-span origin and rationale, representation under
+`proposed_representation`, and no `acceptance` or `obligations` blocks at all.
+It therefore cannot be loaded as accepted authority by renaming it, moving it
+into this directory, or editing one field.
+
+**Review.** A human reads the proposal and decides the exact scope to accept.
+The rationale on each proposed span is what makes that reviewable.
+
+**Accept.** `acceptance.accept_proposal` records the action: the exact resolved
+scope, the full semantic diff of what it changed, the selection rule as
+evidence, and who accepted it when. Only spans named in the scope are accepted —
+silence is never acceptance. Accepting over a prior artifact merges rather than
+replaces, so a later content batch cannot silently discard an earlier one's
+reviewed work.
+
+**Commit.** `oracle.accepted_inputs_payload` writes the artifact; the reviewer
+commits it here. That commit *is* the acceptance action of record.
+
+## One artifact, two halves
+
+The file carries both the accepted result and the review evidence, and the
+loader keeps them separate:
+
+* `AcceptedInputs.oracle` is what the publication gate judges against. It
+  excludes reviewer, timestamp, batch grouping, and diff, because review process
+  is not identity-bearing — re-reviewing an unchanged classification must not
+  remint a projection (#137 acceptance criterion 11).
+* `AcceptedInputs.batches` / `.acceptances` are the auditable evidence. The
+  build carries them into persistence, because the gate requires an explicit
+  acceptance record for every span in reconstructed state.
+
+They live in one file so they cannot drift apart. The independence that matters
+is untouched: this is committed bytes a reviewer accepted, never anything
+derived from a candidate or from persisted output.

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -176,6 +176,7 @@ def persist_draft(
                 batch_id=batch.batch_id,
                 rule=batch.rule,
                 semantic_diff_hash=batch.semantic_diff_hash,
+                proposal_identity=batch.proposal_identity,
             )
         )
         # Scope order is retained: it is the reviewer's recorded scope, not a
@@ -388,6 +389,7 @@ def reconstruct_candidate(
         AcceptanceBatch(
             batch_id=b.batch_id,
             rule=b.rule,
+            proposal_identity=b.proposal_identity,
             resolved_scope=tuple(
                 s.span_id
                 for s in sorted(
@@ -556,9 +558,9 @@ def compute_persisted_state_digest(session: Session, projection_uuid: str) -> st
     * the **persisted derived IDs** — a corrupted ``record_id`` leaves every
       semantic value intact and would otherwise pass; and
     * the **retained acceptance evidence** — reviewer, timestamp, batch rule,
-      ordered scope, diff, and review state are deliberately outside semantic
-      identity, so without this layer they could be rewritten after the digest
-      was recorded and nothing would notice.
+      ordered scope, diff, reviewed-proposal identity, and review state are
+      deliberately outside semantic identity, so without this layer they could
+      be rewritten after the digest was recorded and nothing would notice.
 
     The last layer is why this digest and the projection UUID are different
     things. The UUID answers "is this the same authority"; the digest answers

--- a/src/afterworlds/ingestion/mechanical/persistence.py
+++ b/src/afterworlds/ingestion/mechanical/persistence.py
@@ -263,6 +263,9 @@ def persist_draft(
                 record_key=binding.record_key,
                 component_key=binding.component_key,
                 chunk_id=binding.chunk_id,
+                span_id=binding.span_id,
+                chunk_char_start=binding.chunk_char_start,
+                chunk_char_end=binding.chunk_char_end,
                 irreducibility_reason_code=binding.irreducibility_reason_code,
             )
         )
@@ -472,6 +475,9 @@ def reconstruct_candidate(
                 component_key=p.component_key,
                 record_key=p.record_key,
                 chunk_id=p.chunk_id,
+                span_id=p.span_id,
+                chunk_char_start=p.chunk_char_start,
+                chunk_char_end=p.chunk_char_end,
                 irreducibility_reason_code=p.irreducibility_reason_code,
             )
             for p in raw.prose_bindings

--- a/src/afterworlds/ingestion/mechanical/projection.py
+++ b/src/afterworlds/ingestion/mechanical/projection.py
@@ -133,6 +133,13 @@ def representation_payload(draft: RepresentationDraft) -> dict[str, object]:
                 "record_key": b.record_key,
                 "component_key": b.component_key,
                 "chunk_id": b.chunk_id,
+                # The accepted span and its extent are meaning-bearing. A
+                # binding moved to a different clause of the same chunk governs
+                # different text, so it is a different projection — the same
+                # reason the chunk itself has always been in this payload.
+                "span_id": b.span_id,
+                "chunk_char_start": b.chunk_char_start,
+                "chunk_char_end": b.chunk_char_end,
                 "irreducibility_reason_code": b.irreducibility_reason_code,
             }
             for b in draft.prose_bindings

--- a/src/afterworlds/ingestion/mechanical/proposal.py
+++ b/src/afterworlds/ingestion/mechanical/proposal.py
@@ -1,0 +1,153 @@
+"""Machine proposals — CRD Issue 5d, the authoring side of contract 2.
+
+A tool may *propose* semantic classification and representation. Nothing a tool
+emits is authority until a human explicitly accepts it, and "silence is not
+acceptance" only means something if an unaccepted proposal physically cannot be
+loaded as accepted authority.
+
+**Structural incompatibility, not a flag and not a directory.** Placing
+proposals in a different folder is a convention a mistake can defeat; a single
+``accepted: false`` field is one edit away from a lie. So a proposal is a
+different *shape* at every level:
+
+===========================  ==================================================
+Accepted artifact            Proposal artifact
+===========================  ==================================================
+``artifact_kind``            ``accepted_authority``   vs ``machine_proposal``
+spans under                  ``spans``                vs ``proposed_spans``
+each span carries            no ``review_state``      vs ``proposal_origin`` and
+                             (accepted by                ``rationale`` per span
+                             construction)
+representation under         ``representation``       vs ``proposed_representation``
+review evidence              ``acceptance`` (required)   absent entirely
+per-record obligations       ``obligations`` (required)  absent entirely
+===========================  ==================================================
+
+:func:`~afterworlds.ingestion.mechanical.oracle.load_accepted_inputs` rejects a
+proposal on ``artifact_kind`` first, for a legible error — but that check is not
+what protects the boundary. Even with ``artifact_kind`` edited to lie, a
+proposal is missing ``spans``, ``acceptance``, ``obligations``, and
+``representation`` while carrying four keys the accepted loader does not
+declare, and its strict ``_require`` rejects both halves of that. There is no
+edit short of *rewriting the file into the accepted shape* — which is what
+acceptance is — that turns one into the other.
+
+The reverse direction is equally closed: this module never reads
+``oracles/``, never writes anywhere, and produces no accepted type. It emits a
+payload; a reviewer decides what happens next.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from afterworlds.ingestion.corpus.hashing import hash_obj
+from afterworlds.ingestion.mechanical.accounting import span_payload
+from afterworlds.ingestion.mechanical.canonical import canonical_order
+from afterworlds.ingestion.mechanical.models import SemanticSpan
+from afterworlds.ingestion.mechanical.projection import (
+    ReleaseBinding,
+    representation_payload,
+)
+from afterworlds.ingestion.mechanical.representation import RepresentationDraft
+
+__all__ = [
+    "PROPOSAL_ARTIFACT_KIND",
+    "PROPOSAL_SCHEMA_VERSION",
+    "MechanicalProposal",
+    "ProposedSpan",
+    "proposal_identity",
+    "proposal_payload",
+]
+
+#: The discriminator every proposal declares. Deliberately not the accepted
+#: artifact's kind, and deliberately not something an accepted loader accepts.
+PROPOSAL_ARTIFACT_KIND = "machine_proposal"
+
+#: Bumped when the proposal shape changes. Proposals are disposable review
+#: material, so this version has no relationship to semantic policy identity and
+#: never reaches a projection.
+PROPOSAL_SCHEMA_VERSION = "5d-proposal-1"
+
+
+@dataclass(frozen=True)
+class ProposedSpan:
+    """One span a tool suggests, with why it suggested it.
+
+    ``rationale`` and ``origin`` exist for the reviewer, and they are the point:
+    a reviewer accepting a batch is accepting *claims*, and a claim with no
+    stated basis is not reviewable. They also make the proposal shape
+    permanently distinct from an accepted span, which carries neither.
+    """
+
+    span: SemanticSpan
+    origin: str
+    rationale: str
+
+
+@dataclass(frozen=True)
+class MechanicalProposal:
+    """One tool's complete suggestion for one bound 5c release.
+
+    Carries no obligations and no acceptance evidence — neither exists until a
+    human acts. Carrying an empty version of either would be the proposal
+    claiming a shape it has not earned.
+    """
+
+    binding: ReleaseBinding
+    policy_version: str
+    policy_hash: str
+    proposed_spans: tuple[ProposedSpan, ...]
+    proposed_representation: RepresentationDraft
+    #: What produced this proposal — a tool name and version, a reviewer's
+    #: manual draft, whatever the authoring path was. Audit metadata for the
+    #: human reading it, never authority.
+    proposal_origin: str
+
+
+def proposal_payload(proposal: MechanicalProposal) -> dict[str, object]:
+    """Canonical JSON payload of one machine proposal.
+
+    Reuses the span and representation payload builders so a reviewer diffs the
+    same canonical form the accepted artifact uses — the *content* is comparable
+    even though the *envelope* is not interchangeable, which is exactly what
+    makes a semantic diff meaningful at acceptance time.
+    """
+    by_span = {p.span.span_id: p for p in proposal.proposed_spans}
+    return {
+        "artifact_kind": PROPOSAL_ARTIFACT_KIND,
+        "proposal_schema_version": PROPOSAL_SCHEMA_VERSION,
+        "proposal_origin": proposal.proposal_origin,
+        "release_binding": {
+            "package_uuid": proposal.binding.package_uuid,
+            "release_version": proposal.binding.release_version,
+            "authoritative_source_hash": proposal.binding.authoritative_source_hash,
+            "transform_config_hash": proposal.binding.transform_config_hash,
+            "bundle_root_hash": proposal.binding.bundle_root_hash,
+            "persisted_corpus_digest": proposal.binding.persisted_corpus_digest,
+        },
+        "semantic_policy_version": proposal.policy_version,
+        "semantic_policy_hash": proposal.policy_hash,
+        "proposed_spans": canonical_order(
+            {
+                **payload,
+                "proposal_origin": by_span[str(payload["span_id"])].origin,
+                "rationale": by_span[str(payload["span_id"])].rationale,
+            }
+            for payload in span_payload(tuple(p.span for p in proposal.proposed_spans))
+        ),
+        "proposed_representation": representation_payload(
+            proposal.proposed_representation
+        ),
+    }
+
+
+def proposal_identity(proposal: MechanicalProposal) -> str:
+    """Content-derived identity of one proposal.
+
+    Lets a review note name the exact proposal it reviewed, and lets acceptance
+    record what it accepted *from*. It is not a projection identity and never
+    becomes one — a proposal that is never accepted leaves no trace in any
+    published authority.
+    """
+    return hash_obj(proposal_payload(proposal))

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -14,18 +14,42 @@ reduced faithfully into a declared family, the honest answer is to bind exact
 governing prose under a closed irreducibility reason, not to widen the union
 into something that can hold anything.
 
-The union is deliberately small. Each family below is justified by a required
-real-corpus canary in #137, which is the source discovery available today:
+Each family is justified by authority observed in the production SRD 5.2.1
+release. The first four came from the required real-corpus canaries in #137:
 
 * ``ability_check`` — the illusion canary's typed check/DC-source authority;
 * ``creature_ability_score`` — the composite-creature canary's ability grid;
 * ``spell_descriptor`` — the Wish and spell-scoped-creature canaries; and
 * ``progression_entry`` — the class-progression-table canary.
 
-That is not a claim of corpus completeness. Full-corpus accounting has not run
-yet, and when it surfaces a substantive family this union cannot represent, the
-family is added explicitly here or the affected component is classified honestly
-as prose-bound.
+The rest were added by the CRD Issue 5d production-authoring checkpoint, which
+measured the full release and found substantive authority those four cannot
+carry: creature defence, speed, and challenge; attack and damage lines; healing;
+damage responses and conditions; action economy; resource and recharge cadence;
+equipment descriptors; advantage/disadvantage; spell-slot progression; class
+spell-list qualifiers; and stated scaling. Each family names the corpus shape
+that justifies it.
+
+Two rules bound that growth, and neither is negotiable:
+
+* **Closed, always.** No generic dictionary, no expression string, no numeric
+  key-value bag. A structure outside the declared families is rejected. When a
+  component's meaning cannot be reduced faithfully, the honest answer is exact
+  governing prose under a closed irreducibility reason.
+* **Declarative, never executable.** :class:`ScalingFact` records *what the
+  source says scales*; it is not a formula anything evaluates, and nothing here
+  defines an adjudication parameter. The typed parameter contract for spell-slot
+  upcasting and variable-resource recovery remains the recorded Known Unknown
+  owned by an ADR-015b amendment.
+
+This is still not a claim of corpus completeness. Full-corpus accounting has not
+run, and #137 contract 3 names family groups — targeting restrictions, contests,
+critical changes, explicit probability, random-table selection, eligibility,
+choices, and sequencing — that no observed shape has yet forced. Each is added
+explicitly here when accounting surfaces it, or the affected component is
+classified honestly as prose-bound. That obligation is met no later than
+full-corpus closure; it is never met by widening the union into something that
+can hold anything.
 """
 
 from __future__ import annotations
@@ -39,33 +63,79 @@ from afterworlds.ingestion.corpus.hashing import canonical_bytes, sha256_hex
 from afterworlds.ingestion.mechanical.models import ComponentHandling
 
 __all__ = [
-    "AbilityCheckFact",
+    # Vocabularies
     "AbilityScore",
-    "ComponentDraft",
-    "CreatureAbilityScoreFact",
+    "ActionCost",
+    "AdvantageState",
+    "AttackKind",
+    "ConditionEffectKind",
+    "ConditionKind",
+    "Currency",
+    "DamageResponseKind",
+    "DamageType",
     "DcKind",
+    "DieSize",
+    "DurationKind",
     "FactFamily",
-    "MechanicalFact",
-    "ProgressionEntryFact",
-    "ProseBindingDraft",
-    "ProvenanceClaim",
+    "MovementMode",
     "ProvenanceRole",
     "ProvenanceTargetKind",
-    "RecordDraft",
+    "RangeKind",
     "RecordKind",
+    "RecoveryTrigger",
+    "RelationshipKind",
+    "RollContext",
+    "ScalingBasis",
+    "ScalingEffect",
+    "SpellSchool",
+    "TimeUnit",
+    "WeaponProperty",
+    # Shared typed value objects
+    "DiceExpression",
+    "Money",
+    "Rational",
+    "SpellCastingTime",
+    "SpellComponents",
+    "SpellDuration",
+    "SpellRange",
+    # Typed fact families
+    "AbilityCheckFact",
+    "ActionEconomyFact",
+    "AdvantageFact",
+    "AttackRollFact",
+    "ConditionEffectFact",
+    "CreatureAbilityScoreFact",
+    "CreatureChallengeFact",
+    "CreatureDefenseFact",
+    "CreatureSpeedFact",
+    "DamageFact",
+    "DamageResponseFact",
+    "EquipmentDescriptorFact",
+    "HealingFact",
+    "MechanicalFact",
+    "ProgressionEntryFact",
+    "ResourceRecoveryFact",
+    "ScalingFact",
+    "SpellDescriptorFact",
+    "SpellListQualifierFact",
+    "SpellSlotProgressionFact",
+    "WeaponPropertyFact",
+    # Keyed drafts
+    "ComponentDraft",
+    "ProseBindingDraft",
+    "ProvenanceClaim",
+    "RecordDraft",
     "ReferenceDraft",
     "RelationshipDraft",
-    "RelationshipKind",
     "RepresentationDraft",
-    "SpellDescriptorFact",
-    "SpellSchool",
+    # Errors and helpers
     "MalformedFactPayloadError",
     "UnknownFactFamilyError",
     "fact_from_payload",
     "fact_invariant_violations",
-    "prose_bindings_by_target_key",
     "fact_key",
     "fact_payload",
+    "prose_bindings_by_target_key",
 ]
 
 
@@ -104,6 +174,13 @@ class RelationshipKind(StrEnum):
     GRANTS = "grants"
     #: One record is required before another applies.
     PREREQUISITE = "prerequisite"
+    #: A spell belongs to a class's spell list. Distinct from ``GRANTS``: a
+    #: class spell list states *eligibility to prepare or know*, which is a
+    #: membership classification, while ``GRANTS`` is a level-indexed
+    #: entitlement the character actually receives. The production release
+    #: carries 73 ``Spell | School | Special`` tables, all inside Classes, and
+    #: neither of the other kinds says what they say.
+    SPELL_LIST_MEMBER = "spell_list_member"
 
 
 class ProvenanceTargetKind(StrEnum):
@@ -163,13 +240,334 @@ class DcKind(StrEnum):
     GAMEMASTER_SET = "gamemaster_set"
 
 
+class DieSize(StrEnum):
+    """The closed set of dice the source rolls.
+
+    A die is named, never a bare integer: ``d100`` and ``d10`` are different
+    dice, and an open integer field would admit a ``d7`` the rules do not have.
+    """
+
+    D4 = "d4"
+    D6 = "d6"
+    D8 = "d8"
+    D10 = "d10"
+    D12 = "d12"
+    D20 = "d20"
+    D100 = "d100"
+
+
+class DamageType(StrEnum):
+    """The closed SRD damage-type vocabulary."""
+
+    ACID = "acid"
+    BLUDGEONING = "bludgeoning"
+    COLD = "cold"
+    FIRE = "fire"
+    FORCE = "force"
+    LIGHTNING = "lightning"
+    NECROTIC = "necrotic"
+    PIERCING = "piercing"
+    POISON = "poison"
+    PSYCHIC = "psychic"
+    RADIANT = "radiant"
+    SLASHING = "slashing"
+    THUNDER = "thunder"
+
+
+class DamageResponseKind(StrEnum):
+    """How a creature or effect responds to a damage type."""
+
+    RESISTANCE = "resistance"
+    IMMUNITY = "immunity"
+    VULNERABILITY = "vulnerability"
+
+
+class AttackKind(StrEnum):
+    """What kind of attack roll the source declares."""
+
+    MELEE_WEAPON = "melee_weapon"
+    RANGED_WEAPON = "ranged_weapon"
+    MELEE_SPELL = "melee_spell"
+    RANGED_SPELL = "ranged_spell"
+
+
+class ActionCost(StrEnum):
+    """The action-economy slot an effect consumes."""
+
+    ACTION = "action"
+    BONUS_ACTION = "bonus_action"
+    REACTION = "reaction"
+    LEGENDARY_ACTION = "legendary_action"
+    #: Costs no part of the actor's economy — e.g. an ongoing trait.
+    NONE = "none"
+    #: The source states a cost its own vocabulary does not name. Never a
+    #: stand-in for "we did not look": a component using this still carries the
+    #: exact governing prose that says what actually happens.
+    SPECIAL = "special"
+
+
+class TimeUnit(StrEnum):
+    """The closed time vocabulary for durations and casting times."""
+
+    ROUND = "round"
+    TURN = "turn"
+    MINUTE = "minute"
+    HOUR = "hour"
+    DAY = "day"
+
+
+class DurationKind(StrEnum):
+    """How long an effect lasts, as the source states it."""
+
+    INSTANTANEOUS = "instantaneous"
+    TIMED = "timed"
+    UNTIL_DISPELLED = "until_dispelled"
+    SPECIAL = "special"
+
+
+class RangeKind(StrEnum):
+    """Where an effect can reach, as the source states it."""
+
+    SELF = "self"
+    TOUCH = "touch"
+    RANGED = "ranged"
+    SIGHT = "sight"
+    UNLIMITED = "unlimited"
+    SPECIAL = "special"
+
+
+class MovementMode(StrEnum):
+    """A creature's movement modes."""
+
+    WALK = "walk"
+    BURROW = "burrow"
+    CLIMB = "climb"
+    FLY = "fly"
+    SWIM = "swim"
+
+
+class ConditionKind(StrEnum):
+    """The closed SRD condition vocabulary."""
+
+    BLINDED = "blinded"
+    CHARMED = "charmed"
+    DEAFENED = "deafened"
+    EXHAUSTION = "exhaustion"
+    FRIGHTENED = "frightened"
+    GRAPPLED = "grappled"
+    INCAPACITATED = "incapacitated"
+    INVISIBLE = "invisible"
+    PARALYZED = "paralyzed"
+    PETRIFIED = "petrified"
+    POISONED = "poisoned"
+    PRONE = "prone"
+    RESTRAINED = "restrained"
+    STUNNED = "stunned"
+    UNCONSCIOUS = "unconscious"
+
+
+class ConditionEffectKind(StrEnum):
+    """What a component does with a condition."""
+
+    #: The effect imposes the condition.
+    APPLIES = "applies"
+    #: The subject cannot receive the condition.
+    IMMUNITY = "immunity"
+    #: The effect removes the condition.
+    REMOVES = "removes"
+
+
+class RecoveryTrigger(StrEnum):
+    """When a limited resource comes back."""
+
+    SHORT_REST = "short_rest"
+    LONG_REST = "long_rest"
+    DAWN = "dawn"
+    #: Recovered by rolling at least a stated minimum on a stated die.
+    RECHARGE_ROLL = "recharge_roll"
+
+
+class AdvantageState(StrEnum):
+    """Whether a stated effect confers advantage or disadvantage."""
+
+    ADVANTAGE = "advantage"
+    DISADVANTAGE = "disadvantage"
+
+
+class RollContext(StrEnum):
+    """Which roll an advantage state applies to."""
+
+    ATTACK_ROLL = "attack_roll"
+    ABILITY_CHECK = "ability_check"
+    SAVING_THROW = "saving_throw"
+    INITIATIVE = "initiative"
+
+
+class Currency(StrEnum):
+    """The closed SRD coin vocabulary."""
+
+    CP = "cp"
+    SP = "sp"
+    EP = "ep"
+    GP = "gp"
+    PP = "pp"
+
+
+class WeaponProperty(StrEnum):
+    """The closed SRD weapon-property vocabulary.
+
+    Each of these is also a rule record in its own right in the production
+    release (``Ammunition``, ``Finesse``, ``Heavy``, ``Light``, … on p89). This
+    enum is how a *weapon* cites one; the rule text itself lives in that record.
+    """
+
+    AMMUNITION = "ammunition"
+    FINESSE = "finesse"
+    HEAVY = "heavy"
+    LIGHT = "light"
+    LOADING = "loading"
+    REACH = "reach"
+    THROWN = "thrown"
+    TWO_HANDED = "two_handed"
+    VERSATILE = "versatile"
+
+
+class ScalingBasis(StrEnum):
+    """What a stated increase scales with."""
+
+    HIGHER_LEVEL_SPELL_SLOT = "higher_level_spell_slot"
+    CHARACTER_LEVEL = "character_level"
+    CLASS_LEVEL = "class_level"
+
+
+class ScalingEffect(StrEnum):
+    """Which part of an effect a stated increase applies to."""
+
+    DAMAGE = "damage"
+    HEALING = "healing"
+    TARGETS = "targets"
+    DURATION = "duration"
+    AREA = "area"
+    #: "Use the spell slot's level for the spell's level in the stat block."
+    EFFECTIVE_SPELL_LEVEL = "effective_spell_level"
+
+
 class FactFamily(StrEnum):
     """The closed typed-fact union's discriminator."""
 
     ABILITY_CHECK = "ability_check"
+    ACTION_ECONOMY = "action_economy"
+    ADVANTAGE = "advantage"
+    ATTACK_ROLL = "attack_roll"
+    CONDITION_EFFECT = "condition_effect"
     CREATURE_ABILITY_SCORE = "creature_ability_score"
-    SPELL_DESCRIPTOR = "spell_descriptor"
+    CREATURE_CHALLENGE = "creature_challenge"
+    CREATURE_DEFENSE = "creature_defense"
+    CREATURE_SPEED = "creature_speed"
+    DAMAGE = "damage"
+    DAMAGE_RESPONSE = "damage_response"
+    EQUIPMENT_DESCRIPTOR = "equipment_descriptor"
+    HEALING = "healing"
     PROGRESSION_ENTRY = "progression_entry"
+    RESOURCE_RECOVERY = "resource_recovery"
+    SCALING = "scaling"
+    SPELL_DESCRIPTOR = "spell_descriptor"
+    SPELL_LIST_QUALIFIER = "spell_list_qualifier"
+    SPELL_SLOT_PROGRESSION = "spell_slot_progression"
+    WEAPON_PROPERTY = "weapon_property"
+
+
+# ---------------------------------------------------------------------------
+# Shared typed value objects
+# ---------------------------------------------------------------------------
+#
+# Families compose these rather than each flattening the same shape into its own
+# fields. One definition of "a dice expression" means damage, healing, hit
+# points, and recharge cannot drift into four incompatible spellings of it.
+#
+# They are frozen dataclasses, not dicts: a value object is as closed as a
+# family, with its own builder and its own invariants.
+
+
+@dataclass(frozen=True)
+class DiceExpression:
+    """``count`` dice of one size, plus a signed flat modifier.
+
+    ``2d6 + 3`` is ``DiceExpression(2, DieSize.D6, 3)``. A modifier of 0 is a
+    stated absence of one, not a missing value.
+    """
+
+    count: int
+    die: DieSize
+    modifier: int = 0
+
+
+@dataclass(frozen=True)
+class Rational:
+    """An exact fraction — never a float.
+
+    Challenge Rating 1/2 and a weight of 1/4 lb are exact source values.
+    Rounding them into a float would make identity depend on binary
+    representation and would quietly invent precision the source never stated.
+    """
+
+    numerator: int
+    denominator: int
+
+
+@dataclass(frozen=True)
+class Money:
+    """A stated price in one coin denomination."""
+
+    amount: int
+    currency: Currency
+
+
+@dataclass(frozen=True)
+class SpellCastingTime:
+    """A spell's stated casting time.
+
+    Either an action-economy cost (``Casting Time: Action``) or an elapsed time
+    (``Casting Time: 1 Minute``) — the invariant below requires exactly one.
+    """
+
+    cost: ActionCost | None = None
+    amount: int | None = None
+    unit: TimeUnit | None = None
+
+
+@dataclass(frozen=True)
+class SpellRange:
+    """A spell's stated range. ``feet`` is set exactly for ``RANGED``."""
+
+    kind: RangeKind
+    feet: int | None = None
+
+
+@dataclass(frozen=True)
+class SpellComponents:
+    """A spell's stated components.
+
+    The material *description* is governing prose, not a typed field: reducing
+    "a diamond worth 300+ GP, which the spell consumes" to a boolean would lose
+    the requirement. ``material_consumed`` is recorded because the source states
+    it as a distinct mechanical fact.
+    """
+
+    verbal: bool
+    somatic: bool
+    material: bool
+    material_consumed: bool = False
+
+
+@dataclass(frozen=True)
+class SpellDuration:
+    """A spell's stated duration. ``amount``/``unit`` are set for ``TIMED``."""
+
+    kind: DurationKind
+    amount: int | None = None
+    unit: TimeUnit | None = None
+    concentration: bool = False
 
 
 @dataclass(frozen=True)
@@ -185,23 +583,38 @@ class AbilityCheckFact:
 
 @dataclass(frozen=True)
 class CreatureAbilityScoreFact:
-    """One cell of a creature's ability grid."""
+    """One row of a creature's ability grid.
+
+    The production release prints **three** columns per ability, and they do not
+    always agree with each other by derivation — the Mummy's Wisdom row is
+    ``12 / +1 / +3``, where the save bonus reflects proficiency the score alone
+    does not state. All three are recorded, and the two printed bonuses stay
+    optional because a stat block that prints only a score has not stated them.
+    """
 
     FAMILY: ClassVar[FactFamily] = FactFamily.CREATURE_ABILITY_SCORE
 
     ability: AbilityScore
     score: int
+    #: The printed ability modifier column, when the source prints one.
+    modifier: int | None = None
+    #: The printed saving-throw column, when the source prints one.
+    save_modifier: int | None = None
 
 
 @dataclass(frozen=True)
 class SpellDescriptorFact:
-    """The typed descriptors a spell record carries.
+    """The typed descriptor line a spell record carries.
 
-    Casting time, range, and duration are deliberately absent: representing
-    them faithfully needs their own typed families, and holding them as free
-    text here would be the untyped escape hatch this union exists to prevent.
-    Until those families are justified by accounting, that authority is
-    prose-bound.
+    One fact rather than five, because the source prints one line —
+    ``Level 9 Conjuration (Sorcerer, Wizard) Casting Time: Action Range: Self
+    Components: V Duration: Instantaneous`` — and a component may claim a span
+    primarily only once. Splitting it into five families would force the
+    accepted classification to cut that line into five sub-spans purely to
+    satisfy the provenance rule, which is a representation artefact rather than
+    a distinction the source makes.
+
+    The material *description* remains prose-bound: see :class:`SpellComponents`.
     """
 
     FAMILY: ClassVar[FactFamily] = FactFamily.SPELL_DESCRIPTOR
@@ -210,11 +623,22 @@ class SpellDescriptorFact:
     school: SpellSchool
     ritual: bool
     concentration: bool
+    casting_time: SpellCastingTime | None = None
+    spell_range: SpellRange | None = None
+    components: SpellComponents | None = None
+    duration: SpellDuration | None = None
 
 
 @dataclass(frozen=True)
 class ProgressionEntryFact:
-    """One level-indexed entitlement from a progression table."""
+    """One level-indexed entitlement from a progression table.
+
+    ``entitlement_key`` names *what* is granted. It is a semantic key, never a
+    place to smuggle a second dimension: spell slots are indexed by slot level
+    as well as character level, and they get their own family
+    (:class:`SpellSlotProgressionFact`) precisely so nobody writes
+    ``entitlement_key="slots_level_3"``.
+    """
 
     FAMILY: ClassVar[FactFamily] = FactFamily.PROGRESSION_ENTRY
 
@@ -223,18 +647,296 @@ class ProgressionEntryFact:
     quantity: int | None = None
 
 
+@dataclass(frozen=True)
+class SpellSlotProgressionFact:
+    """One cell of a class table's spell-slot grid.
+
+    Two typed indices, because the source's grid has two: the class table at
+    p31 is ``Level | Class Features | Cantrips | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+    9``, where the row is the character level and each numbered column is a slot
+    level. Encoding the slot level into a string key would be exactly the
+    stringly escape hatch ADR-005d Decision 4 forbids.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.SPELL_SLOT_PROGRESSION
+
+    character_level: int
+    slot_level: int
+    slots: int
+
+
+@dataclass(frozen=True)
+class SpellListQualifierFact:
+    """A stated qualifier on one entry of a class spell list.
+
+    Membership itself is a :attr:`RelationshipKind.SPELL_LIST_MEMBER` edge; this
+    carries what the ``Special`` column of the 73 ``Spell | School | Special``
+    tables says *about* that membership. A qualifier fact without its
+    membership edge is rejected by :mod:`validation` — the two are one claim.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.SPELL_LIST_QUALIFIER
+
+    spell_record_key: str
+    always_prepared: bool = False
+    minimum_class_level: int | None = None
+
+
+@dataclass(frozen=True)
+class AttackRollFact:
+    """One stated attack roll.
+
+    ``Melee Attack Roll: +5, reach 5 ft.`` — the reach and the two range bands
+    are separate optional fields because a melee attack states reach, a ranged
+    attack states a normal and a long range, and inventing the absent one would
+    be inventing authority.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.ATTACK_ROLL
+
+    attack_kind: AttackKind
+    to_hit_bonus: int
+    reach_feet: int | None = None
+    range_normal_feet: int | None = None
+    range_long_feet: int | None = None
+
+
+@dataclass(frozen=True)
+class DamageFact:
+    """One stated damage amount of one type.
+
+    ``Hit: 10 (2d6 + 3) Bludgeoning damage`` carries both the rolled expression
+    and the printed average, and both are retained: the average is what a stat
+    block uses when the GameMaster does not roll, so dropping it would lose a
+    stated mechanical value.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.DAMAGE
+
+    damage_type: DamageType
+    dice: DiceExpression | None = None
+    flat_amount: int | None = None
+    stated_average: int | None = None
+
+
+@dataclass(frozen=True)
+class HealingFact:
+    """One stated restoration of hit points.
+
+    ``restores_all_hit_points`` is Wish's *Instant Health* — "regain all Hit
+    Points" is a stated effect with no amount, not an amount nobody recorded.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.HEALING
+
+    dice: DiceExpression | None = None
+    flat_amount: int | None = None
+    restores_all_hit_points: bool = False
+
+
+@dataclass(frozen=True)
+class DamageResponseFact:
+    """One resistance, immunity, or vulnerability to a damage type.
+
+    The Mummy prints ``Vulnerabilities Fire`` and ``Immunities Necrotic,
+    Poison`` — three facts, not one list, so each carries its own provenance.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.DAMAGE_RESPONSE
+
+    damage_type: DamageType
+    response: DamageResponseKind
+
+
+@dataclass(frozen=True)
+class ConditionEffectFact:
+    """One condition a component applies, removes, or is immune to."""
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.CONDITION_EFFECT
+
+    condition: ConditionKind
+    effect: ConditionEffectKind
+
+
+@dataclass(frozen=True)
+class CreatureDefenseFact:
+    """A creature's stated Armor Class and Hit Points.
+
+    ``AC 11`` … ``HP 58 (9d8 + 18)`` — the average and the expression are both
+    printed, and both are recorded for the same reason as :class:`DamageFact`.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.CREATURE_DEFENSE
+
+    armor_class: int
+    hit_points: int
+    hit_point_dice: DiceExpression | None = None
+
+
+@dataclass(frozen=True)
+class CreatureSpeedFact:
+    """One of a creature's movement speeds. ``Speed 20 ft.``"""
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.CREATURE_SPEED
+
+    mode: MovementMode
+    feet: int
+
+
+@dataclass(frozen=True)
+class CreatureChallengeFact:
+    """A creature's stated Challenge Rating and proficiency bonus.
+
+    CR is a :class:`Rational` because ``CR 1/2`` is an exact source value.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.CREATURE_CHALLENGE
+
+    challenge_rating: Rational
+    proficiency_bonus: int | None = None
+
+
+@dataclass(frozen=True)
+class ActionEconomyFact:
+    """What action-economy slot a component's effect consumes."""
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.ACTION_ECONOMY
+
+    cost: ActionCost
+
+
+@dataclass(frozen=True)
+class ResourceRecoveryFact:
+    """A limited resource and when the source says it comes back.
+
+    ``recharge_die``/``recharge_minimum`` carry ``Recharge 5–6``; they are set
+    exactly for :attr:`RecoveryTrigger.RECHARGE_ROLL`.
+
+    This records *cadence*, not an adjudication parameter. How a variable
+    recovery amount is chosen at play time remains the ADR-015b Known Unknown.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.RESOURCE_RECOVERY
+
+    resource_key: str
+    recovers_on: RecoveryTrigger
+    uses: int | None = None
+    recharge_die: DieSize | None = None
+    recharge_minimum: int | None = None
+
+
+@dataclass(frozen=True)
+class AdvantageFact:
+    """A stated advantage or disadvantage on a named kind of roll.
+
+    ``You have Disadvantage on attack rolls with a Heavy weapon if …`` — the
+    *condition* under which it applies is governing prose; that it is
+    disadvantage on attack rolls is this fact.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.ADVANTAGE
+
+    state: AdvantageState
+    context: RollContext
+
+
+@dataclass(frozen=True)
+class ScalingFact:
+    """What the source says increases, and with what.
+
+    ``The damage increases by 1d10 for each spell slot level above 4`` is
+    ``ScalingFact(HIGHER_LEVEL_SPELL_SLOT, 4, DAMAGE, dice_increase=1d10)``.
+
+    **Declarative only.** This records a stated increase; it is not evaluated,
+    and it defines no adjudication parameter. Choosing a slot level at play time
+    — the ``chosen_slot_level`` shape — is the recorded Known Unknown owned by
+    an ADR-015b amendment, and nothing in this family supplies it.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.SCALING
+
+    basis: ScalingBasis
+    #: The level above which the increase begins to apply.
+    threshold: int
+    effect: ScalingEffect
+    dice_increase: DiceExpression | None = None
+    amount_increase: int | None = None
+
+
+@dataclass(frozen=True)
+class EquipmentDescriptorFact:
+    """An item's stated price and weight.
+
+    ``weight_pounds`` is a :class:`Rational` so ``1/4 lb`` stays exact.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.EQUIPMENT_DESCRIPTOR
+
+    cost: Money | None = None
+    weight_pounds: Rational | None = None
+
+
+@dataclass(frozen=True)
+class WeaponPropertyFact:
+    """One weapon property a weapon carries.
+
+    ``versatile_damage`` is set exactly for :attr:`WeaponProperty.VERSATILE`,
+    and ``thrown_range`` exactly for :attr:`WeaponProperty.THROWN`, because
+    those are the two properties the source parameterizes.
+    """
+
+    FAMILY: ClassVar[FactFamily] = FactFamily.WEAPON_PROPERTY
+
+    weapon_property: WeaponProperty
+    versatile_damage: DiceExpression | None = None
+    thrown_range_normal_feet: int | None = None
+    thrown_range_long_feet: int | None = None
+
+
 MechanicalFact = (
     AbilityCheckFact
+    | ActionEconomyFact
+    | AdvantageFact
+    | AttackRollFact
+    | ConditionEffectFact
     | CreatureAbilityScoreFact
-    | SpellDescriptorFact
+    | CreatureChallengeFact
+    | CreatureDefenseFact
+    | CreatureSpeedFact
+    | DamageFact
+    | DamageResponseFact
+    | EquipmentDescriptorFact
+    | HealingFact
     | ProgressionEntryFact
+    | ResourceRecoveryFact
+    | ScalingFact
+    | SpellDescriptorFact
+    | SpellListQualifierFact
+    | SpellSlotProgressionFact
+    | WeaponPropertyFact
 )
 
 _FACT_TYPES: dict[FactFamily, type] = {
     FactFamily.ABILITY_CHECK: AbilityCheckFact,
+    FactFamily.ACTION_ECONOMY: ActionEconomyFact,
+    FactFamily.ADVANTAGE: AdvantageFact,
+    FactFamily.ATTACK_ROLL: AttackRollFact,
+    FactFamily.CONDITION_EFFECT: ConditionEffectFact,
     FactFamily.CREATURE_ABILITY_SCORE: CreatureAbilityScoreFact,
-    FactFamily.SPELL_DESCRIPTOR: SpellDescriptorFact,
+    FactFamily.CREATURE_CHALLENGE: CreatureChallengeFact,
+    FactFamily.CREATURE_DEFENSE: CreatureDefenseFact,
+    FactFamily.CREATURE_SPEED: CreatureSpeedFact,
+    FactFamily.DAMAGE: DamageFact,
+    FactFamily.DAMAGE_RESPONSE: DamageResponseFact,
+    FactFamily.EQUIPMENT_DESCRIPTOR: EquipmentDescriptorFact,
+    FactFamily.HEALING: HealingFact,
     FactFamily.PROGRESSION_ENTRY: ProgressionEntryFact,
+    FactFamily.RESOURCE_RECOVERY: ResourceRecoveryFact,
+    FactFamily.SCALING: ScalingFact,
+    FactFamily.SPELL_DESCRIPTOR: SpellDescriptorFact,
+    FactFamily.SPELL_LIST_QUALIFIER: SpellListQualifierFact,
+    FactFamily.SPELL_SLOT_PROGRESSION: SpellSlotProgressionFact,
+    FactFamily.WEAPON_PROPERTY: WeaponPropertyFact,
 }
 
 
@@ -339,6 +1041,8 @@ def _check_creature_ability_score(fact: CreatureAbilityScoreFact) -> list[str]:
     findings = [
         *_enum_field(fact.ability, AbilityScore, "ability"),
         *_int_field(fact.score, "score"),
+        *_optional_int_field(fact.modifier, "modifier"),
+        *_optional_int_field(fact.save_modifier, "save_modifier"),
     ]
     if findings:
         return findings
@@ -353,11 +1057,35 @@ def _check_spell_descriptor(fact: SpellDescriptorFact) -> list[str]:
         *_enum_field(fact.school, SpellSchool, "school"),
         *_bool_field(fact.ritual, "ritual"),
         *_bool_field(fact.concentration, "concentration"),
+        *(
+            []
+            if fact.casting_time is None
+            else _check_casting_time(fact.casting_time, "casting_time")
+        ),
+        *(
+            []
+            if fact.spell_range is None
+            else _check_spell_range(fact.spell_range, "spell_range")
+        ),
+        *(
+            []
+            if fact.components is None
+            else _check_components(fact.components, "components")
+        ),
+        *([] if fact.duration is None else _check_duration(fact.duration, "duration")),
     ]
     if findings:
         return findings
     if fact.level < 0:
         findings.append(f"negative spell level {fact.level}")
+    # The descriptor's own ``concentration`` flag and the duration's are one
+    # claim printed once. Two spellings that disagree is a contradiction, not a
+    # value to pick between.
+    if fact.duration is not None and fact.duration.concentration != fact.concentration:
+        findings.append(
+            f"concentration {fact.concentration} disagrees with duration's "
+            f"{fact.duration.concentration}"
+        )
     return findings
 
 
@@ -378,11 +1106,474 @@ def _check_progression_entry(fact: ProgressionEntryFact) -> list[str]:
     return findings
 
 
+# -- Value-object invariants ------------------------------------------------
+#
+# A value object is as closed as a family and gets the same treatment: the exact
+# declared type, then its own contract. Checking them here rather than inside
+# each family means damage, healing, and hit points cannot disagree about what
+# makes a dice expression valid.
+
+
+def _optional_enum_field(
+    value: object, enum_cls: type[StrEnum], field: str
+) -> list[str]:
+    if value is None:
+        return []
+    return _enum_field(value, enum_cls, field)
+
+
+def _vo_field(value: object, cls: type, field: str) -> list[str]:
+    """The field must hold that exact value-object type, or nothing."""
+    if type(value) is not cls:
+        return [f"{field} must be {cls.__name__}, got {type(value).__name__} {value!r}"]
+    return []
+
+
+def _check_dice(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, DiceExpression, field):
+        return findings
+    dice = cast(DiceExpression, value)
+    findings = [
+        *_int_field(dice.count, f"{field}.count"),
+        *_enum_field(dice.die, DieSize, f"{field}.die"),
+        *_int_field(dice.modifier, f"{field}.modifier"),
+    ]
+    if findings:
+        return findings
+    if dice.count < 1:
+        findings.append(f"{field}.count {dice.count} rolls no dice")
+    return findings
+
+
+def _check_optional_dice(value: object, field: str) -> list[str]:
+    return [] if value is None else _check_dice(value, field)
+
+
+def _check_rational(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, Rational, field):
+        return findings
+    r = cast(Rational, value)
+    findings = [
+        *_int_field(r.numerator, f"{field}.numerator"),
+        *_int_field(r.denominator, f"{field}.denominator"),
+    ]
+    if findings:
+        return findings
+    if r.denominator <= 0:
+        findings.append(f"{field}.denominator {r.denominator} is not positive")
+    if r.numerator < 0:
+        findings.append(f"{field}.numerator {r.numerator} is negative")
+    return findings
+
+
+def _check_optional_rational(value: object, field: str) -> list[str]:
+    return [] if value is None else _check_rational(value, field)
+
+
+def _check_money(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, Money, field):
+        return findings
+    money = cast(Money, value)
+    findings = [
+        *_int_field(money.amount, f"{field}.amount"),
+        *_enum_field(money.currency, Currency, f"{field}.currency"),
+    ]
+    if findings:
+        return findings
+    if money.amount < 0:
+        findings.append(f"{field}.amount {money.amount} is negative")
+    return findings
+
+
+def _check_casting_time(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, SpellCastingTime, field):
+        return findings
+    ct = cast(SpellCastingTime, value)
+    findings = [
+        *_optional_enum_field(ct.cost, ActionCost, f"{field}.cost"),
+        *_optional_int_field(ct.amount, f"{field}.amount"),
+        *_optional_enum_field(ct.unit, TimeUnit, f"{field}.unit"),
+    ]
+    if findings:
+        return findings
+    elapsed = ct.amount is not None or ct.unit is not None
+    if (ct.cost is None) == (not elapsed):
+        findings.append(
+            f"{field}: state exactly one of an action cost or an elapsed time"
+        )
+    if elapsed and (ct.amount is None or ct.unit is None):
+        findings.append(f"{field}: an elapsed casting time needs both amount and unit")
+    if ct.amount is not None and ct.amount < 1:
+        findings.append(f"{field}.amount {ct.amount} is not a duration")
+    return findings
+
+
+def _check_spell_range(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, SpellRange, field):
+        return findings
+    rng = cast(SpellRange, value)
+    findings = [
+        *_enum_field(rng.kind, RangeKind, f"{field}.kind"),
+        *_optional_int_field(rng.feet, f"{field}.feet"),
+    ]
+    if findings:
+        return findings
+    if rng.kind is RangeKind.RANGED:
+        if rng.feet is None:
+            findings.append(f"{field}: a ranged spell states a distance")
+        elif rng.feet < 1:
+            findings.append(f"{field}.feet {rng.feet} is not a distance")
+    elif rng.feet is not None:
+        findings.append(
+            f"{field}: {rng.kind.value} range carries feet {rng.feet}; the "
+            "distance comes from the named kind, not from the fact"
+        )
+    return findings
+
+
+def _check_components(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, SpellComponents, field):
+        return findings
+    c = cast(SpellComponents, value)
+    findings = [
+        *_bool_field(c.verbal, f"{field}.verbal"),
+        *_bool_field(c.somatic, f"{field}.somatic"),
+        *_bool_field(c.material, f"{field}.material"),
+        *_bool_field(c.material_consumed, f"{field}.material_consumed"),
+    ]
+    if findings:
+        return findings
+    if c.material_consumed and not c.material:
+        findings.append(f"{field}: consumes a material component it does not have")
+    return findings
+
+
+def _check_duration(value: object, field: str) -> list[str]:
+    if findings := _vo_field(value, SpellDuration, field):
+        return findings
+    d = cast(SpellDuration, value)
+    findings = [
+        *_enum_field(d.kind, DurationKind, f"{field}.kind"),
+        *_optional_int_field(d.amount, f"{field}.amount"),
+        *_optional_enum_field(d.unit, TimeUnit, f"{field}.unit"),
+        *_bool_field(d.concentration, f"{field}.concentration"),
+    ]
+    if findings:
+        return findings
+    if d.kind is DurationKind.TIMED:
+        if d.amount is None or d.unit is None:
+            findings.append(f"{field}: a timed duration needs both amount and unit")
+        elif d.amount < 1:
+            findings.append(f"{field}.amount {d.amount} is not a duration")
+    elif d.amount is not None or d.unit is not None:
+        findings.append(
+            f"{field}: {d.kind.value} duration carries an amount; the length "
+            "comes from the named kind, not from the fact"
+        )
+    return findings
+
+
+# -- Family invariants ------------------------------------------------------
+
+
+def _check_spell_slot_progression(fact: SpellSlotProgressionFact) -> list[str]:
+    findings = [
+        *_int_field(fact.character_level, "character_level"),
+        *_int_field(fact.slot_level, "slot_level"),
+        *_int_field(fact.slots, "slots"),
+    ]
+    if findings:
+        return findings
+    if fact.character_level < 1:
+        findings.append(f"character_level {fact.character_level} is not a level")
+    if fact.slot_level < 1:
+        findings.append(f"slot_level {fact.slot_level} is not a slot level")
+    if fact.slots < 1:
+        findings.append(f"slots {fact.slots} grants nothing")
+    return findings
+
+
+def _check_spell_list_qualifier(fact: SpellListQualifierFact) -> list[str]:
+    findings = [
+        *_str_field(fact.spell_record_key, "spell_record_key"),
+        *_bool_field(fact.always_prepared, "always_prepared"),
+        *_optional_int_field(fact.minimum_class_level, "minimum_class_level"),
+    ]
+    if findings:
+        return findings
+    if not fact.spell_record_key.strip():
+        findings.append("spell_list qualifier without a spell record key")
+    if fact.minimum_class_level is not None and fact.minimum_class_level < 1:
+        findings.append(
+            f"minimum_class_level {fact.minimum_class_level} is not a level"
+        )
+    if not fact.always_prepared and fact.minimum_class_level is None:
+        findings.append("spell_list qualifier states no qualifier")
+    return findings
+
+
+def _check_attack_roll(fact: AttackRollFact) -> list[str]:
+    findings = [
+        *_enum_field(fact.attack_kind, AttackKind, "attack_kind"),
+        *_int_field(fact.to_hit_bonus, "to_hit_bonus"),
+        *_optional_int_field(fact.reach_feet, "reach_feet"),
+        *_optional_int_field(fact.range_normal_feet, "range_normal_feet"),
+        *_optional_int_field(fact.range_long_feet, "range_long_feet"),
+    ]
+    if findings:
+        return findings
+    for name, value in (
+        ("reach_feet", fact.reach_feet),
+        ("range_normal_feet", fact.range_normal_feet),
+        ("range_long_feet", fact.range_long_feet),
+    ):
+        if value is not None and value < 1:
+            findings.append(f"{name} {value} is not a distance")
+    if (
+        fact.range_long_feet is not None
+        and fact.range_normal_feet is not None
+        and fact.range_long_feet < fact.range_normal_feet
+    ):
+        findings.append(
+            f"range_long_feet {fact.range_long_feet} is shorter than "
+            f"range_normal_feet {fact.range_normal_feet}"
+        )
+    if fact.range_long_feet is not None and fact.range_normal_feet is None:
+        findings.append("range_long_feet without a normal range")
+    return findings
+
+
+def _check_damage(fact: DamageFact) -> list[str]:
+    findings = [
+        *_enum_field(fact.damage_type, DamageType, "damage_type"),
+        *_check_optional_dice(fact.dice, "dice"),
+        *_optional_int_field(fact.flat_amount, "flat_amount"),
+        *_optional_int_field(fact.stated_average, "stated_average"),
+    ]
+    if findings:
+        return findings
+    if (fact.dice is None) == (fact.flat_amount is None):
+        findings.append(
+            "damage states exactly one of a dice expression or a flat amount"
+        )
+    if fact.flat_amount is not None and fact.flat_amount < 1:
+        findings.append(f"flat_amount {fact.flat_amount} deals no damage")
+    if fact.stated_average is not None and fact.stated_average < 1:
+        findings.append(f"stated_average {fact.stated_average} deals no damage")
+    return findings
+
+
+def _check_healing(fact: HealingFact) -> list[str]:
+    findings = [
+        *_check_optional_dice(fact.dice, "dice"),
+        *_optional_int_field(fact.flat_amount, "flat_amount"),
+        *_bool_field(fact.restores_all_hit_points, "restores_all_hit_points"),
+    ]
+    if findings:
+        return findings
+    stated = [
+        fact.dice is not None,
+        fact.flat_amount is not None,
+        fact.restores_all_hit_points,
+    ]
+    if sum(stated) != 1:
+        findings.append(
+            "healing states exactly one of a dice expression, a flat amount, or "
+            "full restoration"
+        )
+    if fact.flat_amount is not None and fact.flat_amount < 1:
+        findings.append(f"flat_amount {fact.flat_amount} restores nothing")
+    return findings
+
+
+def _check_damage_response(fact: DamageResponseFact) -> list[str]:
+    return [
+        *_enum_field(fact.damage_type, DamageType, "damage_type"),
+        *_enum_field(fact.response, DamageResponseKind, "response"),
+    ]
+
+
+def _check_condition_effect(fact: ConditionEffectFact) -> list[str]:
+    return [
+        *_enum_field(fact.condition, ConditionKind, "condition"),
+        *_enum_field(fact.effect, ConditionEffectKind, "effect"),
+    ]
+
+
+def _check_creature_defense(fact: CreatureDefenseFact) -> list[str]:
+    findings = [
+        *_int_field(fact.armor_class, "armor_class"),
+        *_int_field(fact.hit_points, "hit_points"),
+        *_check_optional_dice(fact.hit_point_dice, "hit_point_dice"),
+    ]
+    if findings:
+        return findings
+    if fact.armor_class < 0:
+        findings.append(f"negative armor_class {fact.armor_class}")
+    if fact.hit_points < 1:
+        findings.append(f"hit_points {fact.hit_points} is not a living creature")
+    return findings
+
+
+def _check_creature_speed(fact: CreatureSpeedFact) -> list[str]:
+    findings = [
+        *_enum_field(fact.mode, MovementMode, "mode"),
+        *_int_field(fact.feet, "feet"),
+    ]
+    if findings:
+        return findings
+    if fact.feet < 0:
+        findings.append(f"negative speed {fact.feet}")
+    return findings
+
+
+def _check_creature_challenge(fact: CreatureChallengeFact) -> list[str]:
+    return [
+        *_check_rational(fact.challenge_rating, "challenge_rating"),
+        *_optional_int_field(fact.proficiency_bonus, "proficiency_bonus"),
+    ]
+
+
+def _check_action_economy(fact: ActionEconomyFact) -> list[str]:
+    return _enum_field(fact.cost, ActionCost, "cost")
+
+
+def _check_resource_recovery(fact: ResourceRecoveryFact) -> list[str]:
+    findings = [
+        *_str_field(fact.resource_key, "resource_key"),
+        *_enum_field(fact.recovers_on, RecoveryTrigger, "recovers_on"),
+        *_optional_int_field(fact.uses, "uses"),
+        *_optional_enum_field(fact.recharge_die, DieSize, "recharge_die"),
+        *_optional_int_field(fact.recharge_minimum, "recharge_minimum"),
+    ]
+    if findings:
+        return findings
+    if not fact.resource_key.strip():
+        findings.append("resource recovery without a resource key")
+    if fact.uses is not None and fact.uses < 1:
+        findings.append(f"uses {fact.uses} grants nothing")
+    recharge = fact.recharge_die is not None or fact.recharge_minimum is not None
+    if fact.recovers_on is RecoveryTrigger.RECHARGE_ROLL:
+        if fact.recharge_die is None or fact.recharge_minimum is None:
+            findings.append(
+                "recharge_roll recovery needs both a die and a minimum roll"
+            )
+        elif fact.recharge_minimum < 1:
+            findings.append(f"recharge_minimum {fact.recharge_minimum} always succeeds")
+    elif recharge:
+        findings.append(
+            f"{fact.recovers_on.value} recovery carries recharge terms; the "
+            "cadence comes from the named trigger, not from the fact"
+        )
+    return findings
+
+
+def _check_advantage(fact: AdvantageFact) -> list[str]:
+    return [
+        *_enum_field(fact.state, AdvantageState, "state"),
+        *_enum_field(fact.context, RollContext, "context"),
+    ]
+
+
+def _check_scaling(fact: ScalingFact) -> list[str]:
+    findings = [
+        *_enum_field(fact.basis, ScalingBasis, "basis"),
+        *_int_field(fact.threshold, "threshold"),
+        *_enum_field(fact.effect, ScalingEffect, "effect"),
+        *_check_optional_dice(fact.dice_increase, "dice_increase"),
+        *_optional_int_field(fact.amount_increase, "amount_increase"),
+    ]
+    if findings:
+        return findings
+    if fact.threshold < 0:
+        findings.append(f"negative scaling threshold {fact.threshold}")
+    stated = (fact.dice_increase is not None) + (fact.amount_increase is not None)
+    if fact.effect is ScalingEffect.EFFECTIVE_SPELL_LEVEL:
+        # "Use the spell slot's level for the spell's level in the stat block"
+        # states no increment of its own — the slot level *is* the value.
+        if stated:
+            findings.append(
+                "effective_spell_level scaling carries an increment; the value "
+                "comes from the slot level itself"
+            )
+    elif stated != 1:
+        findings.append(
+            "scaling states exactly one of a dice increase or an amount increase"
+        )
+    if fact.amount_increase is not None and fact.amount_increase < 1:
+        findings.append(f"amount_increase {fact.amount_increase} increases nothing")
+    return findings
+
+
+def _check_equipment_descriptor(fact: EquipmentDescriptorFact) -> list[str]:
+    findings = [
+        *([] if fact.cost is None else _check_money(fact.cost, "cost")),
+        *_check_optional_rational(fact.weight_pounds, "weight_pounds"),
+    ]
+    if findings:
+        return findings
+    if fact.cost is None and fact.weight_pounds is None:
+        findings.append("equipment descriptor states neither a cost nor a weight")
+    return findings
+
+
+def _check_weapon_property(fact: WeaponPropertyFact) -> list[str]:
+    findings = [
+        *_enum_field(fact.weapon_property, WeaponProperty, "weapon_property"),
+        *_check_optional_dice(fact.versatile_damage, "versatile_damage"),
+        *_optional_int_field(fact.thrown_range_normal_feet, "thrown_range_normal_feet"),
+        *_optional_int_field(fact.thrown_range_long_feet, "thrown_range_long_feet"),
+    ]
+    if findings:
+        return findings
+    thrown = (
+        fact.thrown_range_normal_feet is not None
+        or fact.thrown_range_long_feet is not None
+    )
+    if fact.weapon_property is not WeaponProperty.VERSATILE:
+        if fact.versatile_damage is not None:
+            findings.append(
+                f"{fact.weapon_property.value} property carries versatile damage"
+            )
+    elif fact.versatile_damage is None:
+        findings.append("versatile property without its two-handed damage")
+    if fact.weapon_property is not WeaponProperty.THROWN:
+        if thrown:
+            findings.append(
+                f"{fact.weapon_property.value} property carries a thrown range"
+            )
+    elif fact.thrown_range_normal_feet is None:
+        findings.append("thrown property without a normal range")
+    for name, value in (
+        ("thrown_range_normal_feet", fact.thrown_range_normal_feet),
+        ("thrown_range_long_feet", fact.thrown_range_long_feet),
+    ):
+        if value is not None and value < 1:
+            findings.append(f"{name} {value} is not a distance")
+    return findings
+
+
 _FACT_INVARIANTS: dict[FactFamily, Callable[[Any], list[str]]] = {
     FactFamily.ABILITY_CHECK: _check_ability_check,
+    FactFamily.ACTION_ECONOMY: _check_action_economy,
+    FactFamily.ADVANTAGE: _check_advantage,
+    FactFamily.ATTACK_ROLL: _check_attack_roll,
+    FactFamily.CONDITION_EFFECT: _check_condition_effect,
     FactFamily.CREATURE_ABILITY_SCORE: _check_creature_ability_score,
-    FactFamily.SPELL_DESCRIPTOR: _check_spell_descriptor,
+    FactFamily.CREATURE_CHALLENGE: _check_creature_challenge,
+    FactFamily.CREATURE_DEFENSE: _check_creature_defense,
+    FactFamily.CREATURE_SPEED: _check_creature_speed,
+    FactFamily.DAMAGE: _check_damage,
+    FactFamily.DAMAGE_RESPONSE: _check_damage_response,
+    FactFamily.EQUIPMENT_DESCRIPTOR: _check_equipment_descriptor,
+    FactFamily.HEALING: _check_healing,
     FactFamily.PROGRESSION_ENTRY: _check_progression_entry,
+    FactFamily.RESOURCE_RECOVERY: _check_resource_recovery,
+    FactFamily.SCALING: _check_scaling,
+    FactFamily.SPELL_DESCRIPTOR: _check_spell_descriptor,
+    FactFamily.SPELL_LIST_QUALIFIER: _check_spell_list_qualifier,
+    FactFamily.SPELL_SLOT_PROGRESSION: _check_spell_slot_progression,
+    FactFamily.WEAPON_PROPERTY: _check_weapon_property,
 }
 
 
@@ -421,6 +1612,15 @@ def _json_enum(value: object, enum_cls: type[StrEnum], field: str) -> list[str]:
     return []
 
 
+def _optional_json_enum(
+    value: object, enum_cls: type[StrEnum], field: str
+) -> list[str]:
+    """A declared member or ``null``, for a stored ``Enum | None`` field."""
+    if value is None:
+        return []
+    return _json_enum(value, enum_cls, field)
+
+
 def _reject(family: FactFamily, findings: list[str]) -> None:
     if findings:
         raise MalformedFactPayloadError(
@@ -450,10 +1650,148 @@ def _build_creature_ability_score(p: Mapping[str, Any]) -> CreatureAbilityScoreF
         [
             *_json_enum(p["ability"], AbilityScore, "ability"),
             *_int_field(p["score"], "score"),
+            *_optional_int_field(p["modifier"], "modifier"),
+            *_optional_int_field(p["save_modifier"], "save_modifier"),
         ],
     )
     return CreatureAbilityScoreFact(
-        ability=AbilityScore(p["ability"]), score=p["score"]
+        ability=AbilityScore(p["ability"]),
+        score=p["score"],
+        modifier=p["modifier"],
+        save_modifier=p["save_modifier"],
+    )
+
+
+# -- Value-object builders --------------------------------------------------
+#
+# Same strictness as a family: the exact declared key set, no coercion, no
+# defaulting. A nested object is not a free-form dict that happens to live
+# inside a typed fact.
+
+
+def _json_object(value: object, keys: tuple[str, ...], where: str) -> Mapping[str, Any]:
+    if type(value) is not dict:
+        raise MalformedFactPayloadError(
+            f"{where} must be an object, got {type(value).__name__} {value!r}"
+        )
+    supplied = set(value)
+    if missing := sorted(set(keys) - supplied):
+        raise MalformedFactPayloadError(f"{where} is missing {missing}")
+    if extra := sorted(supplied - set(keys)):
+        raise MalformedFactPayloadError(f"{where} carries extra {extra}")
+    return value
+
+
+def _reject_at(where: str, findings: list[str]) -> None:
+    if findings:
+        raise MalformedFactPayloadError(f"{where}: {'; '.join(findings)}")
+
+
+def _build_dice(value: object, where: str) -> DiceExpression:
+    p = _json_object(value, ("count", "die", "modifier"), where)
+    _reject_at(
+        where,
+        [
+            *_int_field(p["count"], "count"),
+            *_json_enum(p["die"], DieSize, "die"),
+            *_int_field(p["modifier"], "modifier"),
+        ],
+    )
+    return DiceExpression(
+        count=p["count"], die=DieSize(p["die"]), modifier=p["modifier"]
+    )
+
+
+def _build_rational(value: object, where: str) -> Rational:
+    p = _json_object(value, ("numerator", "denominator"), where)
+    _reject_at(
+        where,
+        [
+            *_int_field(p["numerator"], "numerator"),
+            *_int_field(p["denominator"], "denominator"),
+        ],
+    )
+    return Rational(numerator=p["numerator"], denominator=p["denominator"])
+
+
+def _build_money(value: object, where: str) -> Money:
+    p = _json_object(value, ("amount", "currency"), where)
+    _reject_at(
+        where,
+        [
+            *_int_field(p["amount"], "amount"),
+            *_json_enum(p["currency"], Currency, "currency"),
+        ],
+    )
+    return Money(amount=p["amount"], currency=Currency(p["currency"]))
+
+
+def _build_casting_time(value: object, where: str) -> SpellCastingTime:
+    p = _json_object(value, ("cost", "amount", "unit"), where)
+    _reject_at(
+        where,
+        [
+            *_optional_json_enum(p["cost"], ActionCost, "cost"),
+            *_optional_int_field(p["amount"], "amount"),
+            *_optional_json_enum(p["unit"], TimeUnit, "unit"),
+        ],
+    )
+    return SpellCastingTime(
+        cost=None if p["cost"] is None else ActionCost(p["cost"]),
+        amount=p["amount"],
+        unit=None if p["unit"] is None else TimeUnit(p["unit"]),
+    )
+
+
+def _build_spell_range(value: object, where: str) -> SpellRange:
+    p = _json_object(value, ("kind", "feet"), where)
+    _reject_at(
+        where,
+        [
+            *_json_enum(p["kind"], RangeKind, "kind"),
+            *_optional_int_field(p["feet"], "feet"),
+        ],
+    )
+    return SpellRange(kind=RangeKind(p["kind"]), feet=p["feet"])
+
+
+def _build_components(value: object, where: str) -> SpellComponents:
+    p = _json_object(
+        value, ("verbal", "somatic", "material", "material_consumed"), where
+    )
+    _reject_at(
+        where,
+        [
+            *_bool_field(p["verbal"], "verbal"),
+            *_bool_field(p["somatic"], "somatic"),
+            *_bool_field(p["material"], "material"),
+            *_bool_field(p["material_consumed"], "material_consumed"),
+        ],
+    )
+    return SpellComponents(
+        verbal=p["verbal"],
+        somatic=p["somatic"],
+        material=p["material"],
+        material_consumed=p["material_consumed"],
+    )
+
+
+def _build_duration(value: object, where: str) -> SpellDuration:
+    p = _json_object(value, ("kind", "amount", "unit", "concentration"), where)
+    _reject_at(
+        where,
+        [
+            *_json_enum(p["kind"], DurationKind, "kind"),
+            *_optional_int_field(p["amount"], "amount"),
+            *_optional_json_enum(p["unit"], TimeUnit, "unit"),
+            *_bool_field(p["concentration"], "concentration"),
+        ],
+    )
+    return SpellDuration(
+        kind=DurationKind(p["kind"]),
+        amount=p["amount"],
+        unit=None if p["unit"] is None else TimeUnit(p["unit"]),
+        concentration=p["concentration"],
     )
 
 
@@ -472,6 +1810,276 @@ def _build_spell_descriptor(p: Mapping[str, Any]) -> SpellDescriptorFact:
         school=SpellSchool(p["school"]),
         ritual=p["ritual"],
         concentration=p["concentration"],
+        casting_time=(
+            None
+            if p["casting_time"] is None
+            else _build_casting_time(p["casting_time"], "casting_time")
+        ),
+        spell_range=(
+            None
+            if p["spell_range"] is None
+            else _build_spell_range(p["spell_range"], "spell_range")
+        ),
+        components=(
+            None
+            if p["components"] is None
+            else _build_components(p["components"], "components")
+        ),
+        duration=(
+            None
+            if p["duration"] is None
+            else _build_duration(p["duration"], "duration")
+        ),
+    )
+
+
+def _build_spell_slot_progression(p: Mapping[str, Any]) -> SpellSlotProgressionFact:
+    _reject(
+        FactFamily.SPELL_SLOT_PROGRESSION,
+        [
+            *_int_field(p["character_level"], "character_level"),
+            *_int_field(p["slot_level"], "slot_level"),
+            *_int_field(p["slots"], "slots"),
+        ],
+    )
+    return SpellSlotProgressionFact(
+        character_level=p["character_level"],
+        slot_level=p["slot_level"],
+        slots=p["slots"],
+    )
+
+
+def _build_spell_list_qualifier(p: Mapping[str, Any]) -> SpellListQualifierFact:
+    _reject(
+        FactFamily.SPELL_LIST_QUALIFIER,
+        [
+            *_str_field(p["spell_record_key"], "spell_record_key"),
+            *_bool_field(p["always_prepared"], "always_prepared"),
+            *_optional_int_field(p["minimum_class_level"], "minimum_class_level"),
+        ],
+    )
+    return SpellListQualifierFact(
+        spell_record_key=p["spell_record_key"],
+        always_prepared=p["always_prepared"],
+        minimum_class_level=p["minimum_class_level"],
+    )
+
+
+def _build_attack_roll(p: Mapping[str, Any]) -> AttackRollFact:
+    _reject(
+        FactFamily.ATTACK_ROLL,
+        [
+            *_json_enum(p["attack_kind"], AttackKind, "attack_kind"),
+            *_int_field(p["to_hit_bonus"], "to_hit_bonus"),
+            *_optional_int_field(p["reach_feet"], "reach_feet"),
+            *_optional_int_field(p["range_normal_feet"], "range_normal_feet"),
+            *_optional_int_field(p["range_long_feet"], "range_long_feet"),
+        ],
+    )
+    return AttackRollFact(
+        attack_kind=AttackKind(p["attack_kind"]),
+        to_hit_bonus=p["to_hit_bonus"],
+        reach_feet=p["reach_feet"],
+        range_normal_feet=p["range_normal_feet"],
+        range_long_feet=p["range_long_feet"],
+    )
+
+
+def _build_damage(p: Mapping[str, Any]) -> DamageFact:
+    _reject(
+        FactFamily.DAMAGE,
+        [
+            *_json_enum(p["damage_type"], DamageType, "damage_type"),
+            *_optional_int_field(p["flat_amount"], "flat_amount"),
+            *_optional_int_field(p["stated_average"], "stated_average"),
+        ],
+    )
+    return DamageFact(
+        damage_type=DamageType(p["damage_type"]),
+        dice=None if p["dice"] is None else _build_dice(p["dice"], "dice"),
+        flat_amount=p["flat_amount"],
+        stated_average=p["stated_average"],
+    )
+
+
+def _build_healing(p: Mapping[str, Any]) -> HealingFact:
+    _reject(
+        FactFamily.HEALING,
+        [
+            *_optional_int_field(p["flat_amount"], "flat_amount"),
+            *_bool_field(p["restores_all_hit_points"], "restores_all_hit_points"),
+        ],
+    )
+    return HealingFact(
+        dice=None if p["dice"] is None else _build_dice(p["dice"], "dice"),
+        flat_amount=p["flat_amount"],
+        restores_all_hit_points=p["restores_all_hit_points"],
+    )
+
+
+def _build_damage_response(p: Mapping[str, Any]) -> DamageResponseFact:
+    _reject(
+        FactFamily.DAMAGE_RESPONSE,
+        [
+            *_json_enum(p["damage_type"], DamageType, "damage_type"),
+            *_json_enum(p["response"], DamageResponseKind, "response"),
+        ],
+    )
+    return DamageResponseFact(
+        damage_type=DamageType(p["damage_type"]),
+        response=DamageResponseKind(p["response"]),
+    )
+
+
+def _build_condition_effect(p: Mapping[str, Any]) -> ConditionEffectFact:
+    _reject(
+        FactFamily.CONDITION_EFFECT,
+        [
+            *_json_enum(p["condition"], ConditionKind, "condition"),
+            *_json_enum(p["effect"], ConditionEffectKind, "effect"),
+        ],
+    )
+    return ConditionEffectFact(
+        condition=ConditionKind(p["condition"]),
+        effect=ConditionEffectKind(p["effect"]),
+    )
+
+
+def _build_creature_defense(p: Mapping[str, Any]) -> CreatureDefenseFact:
+    _reject(
+        FactFamily.CREATURE_DEFENSE,
+        [
+            *_int_field(p["armor_class"], "armor_class"),
+            *_int_field(p["hit_points"], "hit_points"),
+        ],
+    )
+    return CreatureDefenseFact(
+        armor_class=p["armor_class"],
+        hit_points=p["hit_points"],
+        hit_point_dice=(
+            None
+            if p["hit_point_dice"] is None
+            else _build_dice(p["hit_point_dice"], "hit_point_dice")
+        ),
+    )
+
+
+def _build_creature_speed(p: Mapping[str, Any]) -> CreatureSpeedFact:
+    _reject(
+        FactFamily.CREATURE_SPEED,
+        [
+            *_json_enum(p["mode"], MovementMode, "mode"),
+            *_int_field(p["feet"], "feet"),
+        ],
+    )
+    return CreatureSpeedFact(mode=MovementMode(p["mode"]), feet=p["feet"])
+
+
+def _build_creature_challenge(p: Mapping[str, Any]) -> CreatureChallengeFact:
+    _reject(
+        FactFamily.CREATURE_CHALLENGE,
+        _optional_int_field(p["proficiency_bonus"], "proficiency_bonus"),
+    )
+    return CreatureChallengeFact(
+        challenge_rating=_build_rational(p["challenge_rating"], "challenge_rating"),
+        proficiency_bonus=p["proficiency_bonus"],
+    )
+
+
+def _build_action_economy(p: Mapping[str, Any]) -> ActionEconomyFact:
+    _reject(FactFamily.ACTION_ECONOMY, _json_enum(p["cost"], ActionCost, "cost"))
+    return ActionEconomyFact(cost=ActionCost(p["cost"]))
+
+
+def _build_resource_recovery(p: Mapping[str, Any]) -> ResourceRecoveryFact:
+    _reject(
+        FactFamily.RESOURCE_RECOVERY,
+        [
+            *_str_field(p["resource_key"], "resource_key"),
+            *_json_enum(p["recovers_on"], RecoveryTrigger, "recovers_on"),
+            *_optional_int_field(p["uses"], "uses"),
+            *_optional_json_enum(p["recharge_die"], DieSize, "recharge_die"),
+            *_optional_int_field(p["recharge_minimum"], "recharge_minimum"),
+        ],
+    )
+    return ResourceRecoveryFact(
+        resource_key=p["resource_key"],
+        recovers_on=RecoveryTrigger(p["recovers_on"]),
+        uses=p["uses"],
+        recharge_die=(
+            None if p["recharge_die"] is None else DieSize(p["recharge_die"])
+        ),
+        recharge_minimum=p["recharge_minimum"],
+    )
+
+
+def _build_advantage(p: Mapping[str, Any]) -> AdvantageFact:
+    _reject(
+        FactFamily.ADVANTAGE,
+        [
+            *_json_enum(p["state"], AdvantageState, "state"),
+            *_json_enum(p["context"], RollContext, "context"),
+        ],
+    )
+    return AdvantageFact(
+        state=AdvantageState(p["state"]), context=RollContext(p["context"])
+    )
+
+
+def _build_scaling(p: Mapping[str, Any]) -> ScalingFact:
+    _reject(
+        FactFamily.SCALING,
+        [
+            *_json_enum(p["basis"], ScalingBasis, "basis"),
+            *_int_field(p["threshold"], "threshold"),
+            *_json_enum(p["effect"], ScalingEffect, "effect"),
+            *_optional_int_field(p["amount_increase"], "amount_increase"),
+        ],
+    )
+    return ScalingFact(
+        basis=ScalingBasis(p["basis"]),
+        threshold=p["threshold"],
+        effect=ScalingEffect(p["effect"]),
+        dice_increase=(
+            None
+            if p["dice_increase"] is None
+            else _build_dice(p["dice_increase"], "dice_increase")
+        ),
+        amount_increase=p["amount_increase"],
+    )
+
+
+def _build_equipment_descriptor(p: Mapping[str, Any]) -> EquipmentDescriptorFact:
+    return EquipmentDescriptorFact(
+        cost=None if p["cost"] is None else _build_money(p["cost"], "cost"),
+        weight_pounds=(
+            None
+            if p["weight_pounds"] is None
+            else _build_rational(p["weight_pounds"], "weight_pounds")
+        ),
+    )
+
+
+def _build_weapon_property(p: Mapping[str, Any]) -> WeaponPropertyFact:
+    _reject(
+        FactFamily.WEAPON_PROPERTY,
+        [
+            *_json_enum(p["weapon_property"], WeaponProperty, "weapon_property"),
+            *_optional_int_field(
+                p["thrown_range_normal_feet"], "thrown_range_normal_feet"
+            ),
+            *_optional_int_field(p["thrown_range_long_feet"], "thrown_range_long_feet"),
+        ],
+    )
+    return WeaponPropertyFact(
+        weapon_property=WeaponProperty(p["weapon_property"]),
+        versatile_damage=(
+            None
+            if p["versatile_damage"] is None
+            else _build_dice(p["versatile_damage"], "versatile_damage")
+        ),
+        thrown_range_normal_feet=p["thrown_range_normal_feet"],
+        thrown_range_long_feet=p["thrown_range_long_feet"],
     )
 
 
@@ -493,10 +2101,34 @@ def _build_progression_entry(p: Mapping[str, Any]) -> ProgressionEntryFact:
 
 _FACT_BUILDERS: dict[FactFamily, Callable[[Mapping[str, Any]], MechanicalFact]] = {
     FactFamily.ABILITY_CHECK: _build_ability_check,
+    FactFamily.ACTION_ECONOMY: _build_action_economy,
+    FactFamily.ADVANTAGE: _build_advantage,
+    FactFamily.ATTACK_ROLL: _build_attack_roll,
+    FactFamily.CONDITION_EFFECT: _build_condition_effect,
     FactFamily.CREATURE_ABILITY_SCORE: _build_creature_ability_score,
-    FactFamily.SPELL_DESCRIPTOR: _build_spell_descriptor,
+    FactFamily.CREATURE_CHALLENGE: _build_creature_challenge,
+    FactFamily.CREATURE_DEFENSE: _build_creature_defense,
+    FactFamily.CREATURE_SPEED: _build_creature_speed,
+    FactFamily.DAMAGE: _build_damage,
+    FactFamily.DAMAGE_RESPONSE: _build_damage_response,
+    FactFamily.EQUIPMENT_DESCRIPTOR: _build_equipment_descriptor,
+    FactFamily.HEALING: _build_healing,
     FactFamily.PROGRESSION_ENTRY: _build_progression_entry,
+    FactFamily.RESOURCE_RECOVERY: _build_resource_recovery,
+    FactFamily.SCALING: _build_scaling,
+    FactFamily.SPELL_DESCRIPTOR: _build_spell_descriptor,
+    FactFamily.SPELL_LIST_QUALIFIER: _build_spell_list_qualifier,
+    FactFamily.SPELL_SLOT_PROGRESSION: _build_spell_slot_progression,
+    FactFamily.WEAPON_PROPERTY: _build_weapon_property,
 }
+
+#: Every family must declare a builder and an invariant checker. A family added
+#: to the union with neither is a family nothing validates and nothing can
+#: reconstruct — a silent hole rather than a visible omission, which is exactly
+#: what this module's per-family structure exists to prevent.
+assert (
+    set(_FACT_TYPES) == set(_FACT_BUILDERS) == set(_FACT_INVARIANTS) == set(FactFamily)
+), "every FactFamily needs a type, a builder, and an invariant checker"
 
 
 def fact_from_payload(
@@ -575,8 +2207,28 @@ def fact_payload(fact: object) -> dict[str, object]:
     # frozen dataclasses, which is what asdict needs.
     payload: dict[str, object] = {"family": family.value}
     for key, value in sorted(asdict(cast(Any, fact)).items()):
-        payload[key] = value.value if isinstance(value, StrEnum) else value
+        payload[key] = _canonical_value(value)
     return payload
+
+
+def _canonical_value(value: object) -> object:
+    """Canonical JSON form of one field value, however deeply nested.
+
+    ``asdict`` already turns a nested value object into a dict, but it leaves
+    ``StrEnum`` members as enum instances. They *are* strings, so a serializer
+    would accept them — and then a payload rebuilt from storage would hold a
+    plain ``str`` where the freshly built one holds an enum, and the two would
+    be the same bytes but different objects. Normalizing here means the
+    canonical form is the *stored* form, so a round trip is a fixed point
+    rather than something that merely happens to hash the same.
+    """
+    if isinstance(value, StrEnum):
+        return value.value
+    if isinstance(value, dict):
+        return {k: _canonical_value(v) for k, v in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_canonical_value(v) for v in value]
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -611,16 +2263,39 @@ class ComponentDraft:
 
 @dataclass(frozen=True)
 class ProseBindingDraft:
-    """Exact governing prose for a component, bound to the 5c chunk that holds it.
+    """Exact governing prose for a component: one accepted span of one chunk.
 
-    Resolution goes through the authoritative ``RuleChunk`` rather than copying
-    text into a second prose store, so there is exactly one authority for what
-    the source says.
+    Two halves, and #137 contract 3 requires both:
+
+    * **the text comes from 5c.** ``chunk_id`` names the authoritative
+      ``RuleChunk``, so nothing here copies source text into a second prose
+      store; and
+    * **the authority is the accepted span, not the whole passage.**
+      ``span_id`` names one accepted classification span, and
+      ``chunk_char_start``/``chunk_char_end`` are that span's offsets *into the
+      chunk's own text*. A component governed by one clause of a paragraph
+      resolves to that clause — the rest of the paragraph is other components'
+      authority, or none.
+
+    The offsets are redundant with the span, deliberately and checkably: they
+    let runtime resolution slice the chunk without re-reading the 5c projection
+    relation, and :mod:`validation` recomputes them from the bound release and
+    rejects a binding whose declared offsets do not match. Redundancy that is
+    verified on every build cannot drift; redundancy that is trusted can.
+
+    A component may bind several passages; each is a separate binding, and the
+    provenance key below keeps them distinct.
     """
 
     component_key: str
     record_key: str
     chunk_id: str
+    #: The accepted span this binding governs. Governing prose is accepted
+    #: authority, so it resolves through the classification, not around it.
+    span_id: str
+    #: Half-open offsets into ``chunk_id``'s own text.
+    chunk_char_start: int
+    chunk_char_end: int
     irreducibility_reason_code: str
 
 
@@ -709,13 +2384,16 @@ def prose_binding_target_key(binding: ProseBindingDraft) -> tuple[str, ...]:
     """Provenance key of one prose binding.
 
     ``(record_key, component_key)`` alone cannot address a component that binds
-    more than one passage, so the bound chunk and the reason it is bound are
-    part of the identity.
+    more than one passage, so the bound chunk, the accepted span within it, and
+    the reason it is bound are all part of the identity. The span is what keeps
+    two clauses of the *same* chunk distinct — without it, a component binding
+    two sentences of one paragraph would collapse to one key.
     """
     return (
         binding.record_key,
         binding.component_key,
         binding.chunk_id,
+        binding.span_id,
         binding.irreducibility_reason_code,
     )
 

--- a/src/afterworlds/ingestion/mechanical/representation.py
+++ b/src/afterworlds/ingestion/mechanical/representation.py
@@ -255,6 +255,15 @@ class DieSize(StrEnum):
     D20 = "d20"
     D100 = "d100"
 
+    @property
+    def faces(self) -> int:
+        """The highest number this die can roll.
+
+        Derived from the member's own name rather than kept in a parallel
+        table, so a die added to this union cannot arrive without its range.
+        """
+        return int(self.value[1:])
+
 
 class DamageType(StrEnum):
     """The closed SRD damage-type vocabulary."""
@@ -1460,6 +1469,16 @@ def _check_resource_recovery(fact: ResourceRecoveryFact) -> list[str]:
             )
         elif fact.recharge_minimum < 1:
             findings.append(f"recharge_minimum {fact.recharge_minimum} always succeeds")
+        elif fact.recharge_minimum > fact.recharge_die.faces:
+            # The mirror of the check above, and it matters more: a threshold
+            # the die cannot reach is a resource that never recharges, which
+            # would persist and publish as typed authority for a feature that
+            # can never come back. ``Recharge 6`` on a d6 is real and must pass,
+            # so the bound is inclusive.
+            findings.append(
+                f"recharge_minimum {fact.recharge_minimum} is unreachable on "
+                f"{fact.recharge_die.value}; the resource could never recharge"
+            )
     elif recharge:
         findings.append(
             f"{fact.recovers_on.value} recovery carries recharge terms; the "

--- a/src/afterworlds/ingestion/mechanical/validation.py
+++ b/src/afterworlds/ingestion/mechanical/validation.py
@@ -40,6 +40,7 @@ from afterworlds.ingestion.mechanical.representation import (
     ProseBindingDraft,
     ProvenanceRole,
     ProvenanceTargetKind,
+    RecordKind,
     RelationshipKind,
     RepresentationDraft,
     declared_provenance_targets,
@@ -302,13 +303,47 @@ def _validate_spell_list_membership(
     qualifier without its edge would be a claim about a membership the
     projection never declares, and it would silently vanish from any consumer
     that reads the relationship graph.
+
+    ``SPELL_LIST_MEMBER`` also carries a domain claim the other relationship
+    kinds do not, so its endpoints are constrained: it means *this class's spell
+    list includes this spell*, and a consumer reading it as eligibility to
+    prepare or know would be misled by any other pair. A creature or an item on
+    either end is not a weaker version of that statement; it is a different one.
+
+    ``SCOPED_WITHIN``, ``GRANTS``, and ``PREREQUISITE`` stay deliberately
+    polymorphic — a spell scopes a creature, a level grants a feature, a feat
+    requires a species — so nothing here invents endpoint rules for them.
+
+    A membership edge with no qualifier is normal and stays valid: most rows of
+    a ``Spell | School | Special`` table say nothing in the ``Special`` column,
+    and requiring a qualifier would force one to be invented.
     """
     findings: list[str] = []
-    members = {
-        (rel.source_record_key, rel.target_record_key)
-        for rel in draft.relationships
-        if rel.kind is RelationshipKind.SPELL_LIST_MEMBER
-    }
+    kinds = {r.semantic_key: r.kind for r in draft.records}
+    members: set[tuple[str, str]] = set()
+
+    for rel in draft.relationships:
+        if rel.kind is not RelationshipKind.SPELL_LIST_MEMBER:
+            continue
+        members.add((rel.source_record_key, rel.target_record_key))
+        tag = (
+            f"spell-list membership {rel.source_record_key} -> {rel.target_record_key}"
+        )
+        source_kind = kinds.get(rel.source_record_key)
+        target_kind = kinds.get(rel.target_record_key)
+        # A missing endpoint is already reported as an unknown record by the
+        # relationship checks above; repeating it here would say it twice.
+        if source_kind is not None and source_kind is not RecordKind.CLASS:
+            findings.append(
+                f"{tag}: source is a {source_kind.value} record; a spell list "
+                "belongs to a class"
+            )
+        if target_kind is not None and target_kind is not RecordKind.SPELL:
+            findings.append(
+                f"{tag}: target is a {target_kind.value} record; only a spell "
+                "can be on a spell list"
+            )
+
     for component in draft.components:
         for fact in component.facts:
             if getattr(fact, "FAMILY", None) is not FactFamily.SPELL_LIST_QUALIFIER:
@@ -318,9 +353,23 @@ def _validate_spell_list_membership(
                 f"spell-list qualifier {component.record_key}/"
                 f"{component.semantic_key} -> {target}"
             )
+            owner_kind = kinds.get(component.record_key)
+            if owner_kind is not None and owner_kind is not RecordKind.CLASS:
+                # The Special column is a column of the *class's* table, so the
+                # qualifier belongs to the class component that states the list.
+                findings.append(
+                    f"{tag}: qualifier sits on a {owner_kind.value} record; the "
+                    "Special column belongs to the class stating the list"
+                )
             if target not in record_keys:
                 findings.append(f"{tag}: unknown spell record")
-            elif (component.record_key, target) not in members:
+                continue
+            if kinds.get(target) is not RecordKind.SPELL:
+                findings.append(
+                    f"{tag}: qualifies a {kinds[target].value} record; a "
+                    "spell-list qualifier names a spell"
+                )
+            if (component.record_key, target) not in members:
                 findings.append(
                     f"{tag}: qualifies a membership the projection does not "
                     "declare as a spell_list_member relationship"

--- a/src/afterworlds/ingestion/mechanical/validation.py
+++ b/src/afterworlds/ingestion/mechanical/validation.py
@@ -31,12 +31,16 @@ from afterworlds.ingestion.mechanical.models import (
     ClassificationLedger,
     ComponentHandling,
     SemanticDisposition,
+    SemanticSpan,
 )
 from afterworlds.ingestion.mechanical.policy import irreducibility_reason_for
 from afterworlds.ingestion.mechanical.representation import (
     PROVENANCE_REQUIRED_KINDS,
+    FactFamily,
+    ProseBindingDraft,
     ProvenanceRole,
     ProvenanceTargetKind,
+    RelationshipKind,
     RepresentationDraft,
     declared_provenance_targets,
     fact_invariant_violations,
@@ -45,6 +49,13 @@ from afterworlds.ingestion.mechanical.representation import (
 )
 
 __all__ = ["validate_representation"]
+
+#: Dispositions whose text may serve as a component's governing prose. A
+#: non-mechanical or unresolved span states no mechanic, so binding authority to
+#: it would reintroduce as authority exactly what the accounting set aside.
+_PROSE_BEARING_DISPOSITIONS = frozenset(
+    {SemanticDisposition.SUBSTANTIVE, SemanticDisposition.SUPPORTING_AUTHORITY}
+)
 
 
 def _validate_records(draft: RepresentationDraft) -> list[str]:
@@ -149,11 +160,61 @@ def _validate_components(draft: RepresentationDraft) -> list[str]:
     return findings
 
 
+def _validate_prose_extent(
+    binding: ProseBindingDraft,
+    spans_by_id: dict[str, SemanticSpan],
+    corpus: BoundCorpusSnapshot,
+    tag: str,
+) -> list[str]:
+    """Check that a binding governs exactly the accepted span it names.
+
+    Governing prose is *accepted* authority, so it resolves through the
+    classification rather than around it, and the chunk-relative offsets the
+    binding carries for runtime resolution are recomputed here from the bound
+    release. A binding whose declared extent disagrees with the span it names is
+    rejected: the whole point of carrying offsets is that runtime need not
+    re-derive them, which is only safe if the build proved them.
+    """
+    findings: list[str] = []
+    span = spans_by_id.get(binding.span_id)
+    if span is None:
+        return [f"{tag}: unknown accepted span {binding.span_id!r}"]
+
+    # Governing prose must be text the accounting accepted as saying something.
+    # Binding a component's authority to licensing, navigation, or flavour text
+    # would let material the classification excluded back in as authority.
+    if span.disposition not in _PROSE_BEARING_DISPOSITIONS:
+        findings.append(
+            f"{tag}: span {binding.span_id} is {span.disposition.value}; governing "
+            "prose resolves only to substantive or supporting authority"
+        )
+
+    extent = corpus.chunk_relative_range(
+        binding.chunk_id, span.leaf_id, span.char_start, span.char_end
+    )
+    if extent is None:
+        findings.append(
+            f"{tag}: chunk {binding.chunk_id} does not unambiguously contain span "
+            f"{binding.span_id} [{span.char_start},{span.char_end}) of leaf "
+            f"{span.leaf_id}"
+        )
+    elif (binding.chunk_char_start, binding.chunk_char_end) != extent:
+        findings.append(
+            f"{tag}: declared chunk extent "
+            f"[{binding.chunk_char_start},{binding.chunk_char_end}) is not the "
+            f"bound span's extent {list(extent)}"
+        )
+    return findings
+
+
 def _validate_prose_bindings(
-    draft: RepresentationDraft, corpus: BoundCorpusSnapshot
+    draft: RepresentationDraft,
+    ledger: ClassificationLedger,
+    corpus: BoundCorpusSnapshot,
 ) -> list[str]:
     findings: list[str] = []
     components = {(c.record_key, c.semantic_key): c for c in draft.components}
+    spans_by_id = {s.span_id: s for s in ledger.spans}
     for binding in draft.prose_bindings:
         tag = f"prose binding {binding.record_key}/{binding.component_key}"
         component = components.get((binding.record_key, binding.component_key))
@@ -169,6 +230,8 @@ def _validate_prose_bindings(
                 f"{tag}: chunk {binding.chunk_id!r} is not authoritative prose of "
                 f"release {corpus.package_uuid}/{corpus.release_version}"
             )
+        else:
+            findings.extend(_validate_prose_extent(binding, spans_by_id, corpus, tag))
 
         code = binding.irreducibility_reason_code
         if irreducibility_reason_for(code) is None:
@@ -222,6 +285,46 @@ def _validate_relationships_and_references(draft: RepresentationDraft) -> list[s
                 f"reference {scope}:{text!r}: ambiguous — resolves to "
                 f"{sorted(targets)}"
             )
+
+    findings.extend(_validate_spell_list_membership(draft, record_keys))
+    return findings
+
+
+def _validate_spell_list_membership(
+    draft: RepresentationDraft, record_keys: set[str]
+) -> list[str]:
+    """A spell-list qualifier and its membership edge are one claim.
+
+    The ``Special`` column of a class spell-list table qualifies a membership
+    the same table states. Splitting that across a fact and a relationship is
+    the right typing — the edge is the classification, the fact is what the
+    source says about it — but only if neither half can exist alone. A
+    qualifier without its edge would be a claim about a membership the
+    projection never declares, and it would silently vanish from any consumer
+    that reads the relationship graph.
+    """
+    findings: list[str] = []
+    members = {
+        (rel.source_record_key, rel.target_record_key)
+        for rel in draft.relationships
+        if rel.kind is RelationshipKind.SPELL_LIST_MEMBER
+    }
+    for component in draft.components:
+        for fact in component.facts:
+            if getattr(fact, "FAMILY", None) is not FactFamily.SPELL_LIST_QUALIFIER:
+                continue
+            target = getattr(fact, "spell_record_key", "")
+            tag = (
+                f"spell-list qualifier {component.record_key}/"
+                f"{component.semantic_key} -> {target}"
+            )
+            if target not in record_keys:
+                findings.append(f"{tag}: unknown spell record")
+            elif (component.record_key, target) not in members:
+                findings.append(
+                    f"{tag}: qualifies a membership the projection does not "
+                    "declare as a spell_list_member relationship"
+                )
     return findings
 
 
@@ -377,7 +480,7 @@ def validate_representation(
     findings: list[str] = []
     findings.extend(_validate_records(draft))
     findings.extend(_validate_components(draft))
-    findings.extend(_validate_prose_bindings(draft, corpus))
+    findings.extend(_validate_prose_bindings(draft, ledger, corpus))
     findings.extend(_validate_relationships_and_references(draft))
     findings.extend(_validate_provenance(draft, ledger, corpus))
     return tuple(findings)

--- a/src/afterworlds/persistence/orm/mechanical.py
+++ b/src/afterworlds/persistence/orm/mechanical.py
@@ -250,7 +250,15 @@ class MechanicalFactORM(_ProjectionScoped):
 
 
 class MechanicalProseBindingORM(_ProjectionScoped):
-    """Exact governing prose bound to the authoritative 5c chunk."""
+    """One accepted governing span of one authoritative 5c chunk.
+
+    ``span_id`` is the accepted classification span this binding governs, and
+    ``chunk_char_start``/``chunk_char_end`` are that span's half-open offsets
+    into the chunk's own text — so runtime resolution slices exactly the
+    governing clause instead of returning the whole passage that contains it.
+    The build proves those offsets against the bound 5c release before they are
+    written (:mod:`afterworlds.ingestion.mechanical.validation`).
+    """
 
     __tablename__ = "rp_mech_prose_bindings"
 
@@ -258,6 +266,9 @@ class MechanicalProseBindingORM(_ProjectionScoped):
     record_key: Mapped[str] = mapped_column(sa.String(255), nullable=False, index=True)
     component_key: Mapped[str] = mapped_column(sa.String(255), nullable=False)
     chunk_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    span_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
+    chunk_char_start: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    chunk_char_end: Mapped[int] = mapped_column(sa.Integer, nullable=False)
     irreducibility_reason_code: Mapped[str] = mapped_column(
         sa.String(64), nullable=False
     )

--- a/src/afterworlds/persistence/orm/mechanical.py
+++ b/src/afterworlds/persistence/orm/mechanical.py
@@ -167,6 +167,10 @@ class MechanicalAcceptanceBatchORM(_ProjectionScoped):
     batch_id: Mapped[str] = mapped_column(sa.String(64), nullable=False, index=True)
     rule: Mapped[str] = mapped_column(sa.Text, nullable=False)
     semantic_diff_hash: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    #: Content-derived identity of the complete proposal that was reviewed.
+    #: Retained evidence, never identity: it says the accepted representation is
+    #: one a human actually saw, which the scope and diff cannot say on their own.
+    proposal_identity: Mapped[str] = mapped_column(sa.String(64), nullable=False)
 
 
 class MechanicalBatchScopeORM(_ProjectionScoped):

--- a/src/afterworlds/services/rules_authority/application.py
+++ b/src/afterworlds/services/rules_authority/application.py
@@ -107,16 +107,27 @@ class EffectiveFact:
 
 @dataclass(frozen=True)
 class SourceProse:
-    """One passage of exact 5c source prose, identified by its chunk.
+    """One accepted governing span of exact 5c source prose.
 
     ``text`` is resolved later, by the GameMaster view, from the authoritative
     ``RuleChunk`` the service reads by this exact ``chunk_id``; it is ``None``
     here because this type is built before that resolution happens. It is
-    never anything but an exact 5c chunk — never a fabricated id, never a
+    never anything but exact 5c text — never a fabricated id, never a
     stand-in for authored text.
+
+    ``char_start``/``char_end`` are the accepted span's half-open offsets into
+    that chunk, recorded by the build-time prose binding and proved against the
+    bound release there. Resolution slices them, so a component governed by one
+    clause of a paragraph returns that clause: the rest of the paragraph is
+    other components' authority, or none, and returning it would overstate what
+    governs this component. ``span_id`` names the accepted span itself, so a
+    reader can tie the passage back to the classification that accepted it.
     """
 
     chunk_id: str
+    span_id: str
+    char_start: int
+    char_end: int
     text: str | None = None
 
 
@@ -238,10 +249,21 @@ def _base_records(candidate: ProjectionCandidate) -> dict[str, EffectiveRecord]:
     """Assemble the immutable base projection as an effective view."""
     draft = candidate.representation
     spans = _provenance_index(candidate)
-    prose: dict[tuple[str, str], list[str]] = {}
-    for binding in draft.prose_bindings:
+    # Ordered by the binding's own content rather than by row order, so two
+    # reconstructions of the same projection present a component's governing
+    # passages in the same order.
+    prose: dict[tuple[str, str], list[SourceProse]] = {}
+    for binding in sorted(
+        draft.prose_bindings,
+        key=lambda b: (b.chunk_id, b.chunk_char_start, b.chunk_char_end, b.span_id),
+    ):
         prose.setdefault((binding.record_key, binding.component_key), []).append(
-            binding.chunk_id
+            SourceProse(
+                chunk_id=binding.chunk_id,
+                span_id=binding.span_id,
+                char_start=binding.chunk_char_start,
+                char_end=binding.chunk_char_end,
+            )
         )
 
     components: dict[str, list[EffectiveComponent]] = {}
@@ -268,10 +290,7 @@ def _base_records(candidate: ProjectionCandidate) -> dict[str, EffectiveRecord]:
                 irreducibility_reason_code=component.irreducibility_reason_code,
                 facts=facts,
                 governing_prose=tuple(
-                    SourceProse(chunk_id=chunk_id)
-                    for chunk_id in sorted(
-                        prose.get((component.record_key, component.semantic_key), ())
-                    )
+                    prose.get((component.record_key, component.semantic_key), ())
                 ),
                 span_ids=spans.get(
                     (

--- a/src/afterworlds/services/rules_authority/views.py
+++ b/src/afterworlds/services/rules_authority/views.py
@@ -130,13 +130,28 @@ def _resolve_prose(
     """Resolve one prose entry's text for the GameMaster view.
 
     A :class:`SourceProse` entry is resolved by its exact ``chunk_id`` against
-    *prose*. An :class:`AuthoredProse` entry already carries exact text — it
-    came from the override's own validated payload, not from a lookup — so it
-    passes through unchanged.
+    *prose* and then **sliced to its accepted governing span**. The whole chunk
+    is what the source stores; the span is what the projection accepted as this
+    component's authority, and returning the surrounding sentences would
+    overstate what governs it (#137 contract 3).
+
+    The slice is bounds-checked rather than trusted. Python would silently
+    return a short string — or an empty one — for offsets past the end of the
+    text, and a truncated passage presented as exact governing authority is
+    worse than an absent one. A chunk whose stored text no longer contains the
+    recorded extent therefore resolves to ``None``: the same "absent passage"
+    the caller already handles, reported rather than papered over.
+
+    An :class:`AuthoredProse` entry already carries exact text — it came from
+    the override's own validated payload, not from a lookup — so it passes
+    through unchanged.
     """
-    if isinstance(entry, SourceProse):
-        return replace(entry, text=prose.get(entry.chunk_id))
-    return entry
+    if not isinstance(entry, SourceProse):
+        return entry
+    text = prose.get(entry.chunk_id)
+    if text is None or entry.char_end > len(text):
+        return replace(entry, text=None)
+    return replace(entry, text=text[entry.char_start : entry.char_end])
 
 
 def _gamemaster_component(

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -21,6 +21,7 @@ committed file can be checked for drift in one place with a clear message.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -124,6 +125,14 @@ from afterworlds.persistence.orm.rules_package import RulesPackageORM
 NOW = "2026-07-31T00:00:00Z"
 DATA_DIR = Path(__file__).resolve().parent / "data"
 BOUNDED_ORACLE_PATH = DATA_DIR / "bounded_oracle.json"
+
+#: The reviewed proposal this fixture's acceptance evidence names. A fixed
+#: content-derived identity rather than one recomputed from a proposal object,
+#: because the committed artifact records what a reviewer saw and a fixture that
+#: re-derived it would prove only that the code agrees with itself.
+REVIEWED_PROPOSAL_IDENTITY = (
+    "f1e2d3c4b5a6978869788796a5b4c3d2e1f00112233445566778899aabbccddee"
+)
 
 SPELL_LEAF = "leaf-spell"
 PROSE_LEAF = "leaf-prose"
@@ -410,14 +419,9 @@ def batch_accepted_ledger() -> ClassificationLedger:
         resolved_scope=tuple(s.span_id for s in base.spans),
         diff=diff,
         semantic_diff_hash="",
+        proposal_identity=REVIEWED_PROPOSAL_IDENTITY,
     )
-    batch = AcceptanceBatch(
-        batch_id=unhashed.batch_id,
-        rule=unhashed.rule,
-        resolved_scope=unhashed.resolved_scope,
-        diff=unhashed.diff,
-        semantic_diff_hash=batch_diff_hash(unhashed),
-    )
+    batch = replace(unhashed, semantic_diff_hash=batch_diff_hash(unhashed))
     return ClassificationLedger(
         package_uuid=base.package_uuid,
         release_version=base.release_version,

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -436,8 +436,44 @@ WISH_BINDING = ProseBindingDraft(
     component_key=OPEN_ENDED_KEY,
     record_key=SPELL_KEY,
     chunk_id=WISH_CHUNK,
+    span_id=PROSE_SPAN,
+    # The prose leaf is 30 characters and ``WISH_CHUNK`` covers all of it from
+    # offset 0, so this accepted span's chunk-relative extent is the whole
+    # chunk. ``test_prose_extent.py`` covers the sub-leaf case, where exactly
+    # this arithmetic is what excludes the neighbouring clause.
+    chunk_char_start=0,
+    chunk_char_end=30,
     irreducibility_reason_code="open_ended_effect",
 )
+
+
+def prose_binding(
+    chunk_id: str = WISH_CHUNK,
+    reason: str = "open_ended_effect",
+    *,
+    component_key: str = OPEN_ENDED_KEY,
+    record_key: str = SPELL_KEY,
+    span_id: str = PROSE_SPAN,
+    chunk_char_start: int = 0,
+    chunk_char_end: int = 30,
+) -> ProseBindingDraft:
+    """A prose binding over the fixture's prose leaf.
+
+    The default extent is the whole 30-character prose leaf, which every chunk
+    in ``DEFAULT_COVERAGE`` covers from offset 0. Tests that care about the
+    binding's *extent* pass their own; tests that care about anything else get
+    a consistent one without restating four fields.
+    """
+    return ProseBindingDraft(
+        component_key=component_key,
+        record_key=record_key,
+        chunk_id=chunk_id,
+        span_id=span_id,
+        chunk_char_start=chunk_char_start,
+        chunk_char_end=chunk_char_end,
+        irreducibility_reason_code=reason,
+    )
+
 
 SCOPED_WITHIN = RelationshipDraft(
     source_record_key=CREATURE_KEY,

--- a/tests/ingestion/mechanical/conftest.py
+++ b/tests/ingestion/mechanical/conftest.py
@@ -127,11 +127,16 @@ DATA_DIR = Path(__file__).resolve().parent / "data"
 BOUNDED_ORACLE_PATH = DATA_DIR / "bounded_oracle.json"
 
 #: The reviewed proposal this fixture's acceptance evidence names. A fixed
-#: content-derived identity rather than one recomputed from a proposal object,
-#: because the committed artifact records what a reviewer saw and a fixture that
-#: re-derived it would prove only that the code agrees with itself.
+#: literal rather than one recomputed from a proposal object, because the
+#: committed artifact records what a reviewer saw and a fixture that re-derived
+#: it would prove only that the code agrees with itself.
+#:
+#: It is a real ``sha256(b"bounded fixture reviewed proposal")`` digest, not a
+#: readable placeholder: acceptance validation requires the canonical 64-lowercase-
+#: hex shape ``hash_obj`` emits, and an invented-looking value would fail it. The
+#: first draft of this constant was 65 characters and did exactly that.
 REVIEWED_PROPOSAL_IDENTITY = (
-    "f1e2d3c4b5a6978869788796a5b4c3d2e1f00112233445566778899aabbccddee"
+    "aae73b3d1cb9b87b0da2ee35565e6664d43be68732bdbc4e3b0e158a1e02f5e9"
 )
 
 SPELL_LEAF = "leaf-spell"

--- a/tests/ingestion/mechanical/data/bounded_oracle.json
+++ b/tests/ingestion/mechanical/data/bounded_oracle.json
@@ -70,7 +70,7 @@
           }
         ],
         "semantic_diff_hash": "6b6513a81284ab14856f2300113ae4bcea68f62978daf31deb9c61bd6e876808",
-        "proposal_identity": "f1e2d3c4b5a6978869788796a5b4c3d2e1f00112233445566778899aabbccddee"
+        "proposal_identity": "aae73b3d1cb9b87b0da2ee35565e6664d43be68732bdbc4e3b0e158a1e02f5e9"
       }
     ],
     "records": [

--- a/tests/ingestion/mechanical/data/bounded_oracle.json
+++ b/tests/ingestion/mechanical/data/bounded_oracle.json
@@ -69,7 +69,8 @@
             "accepted_reason_code": null
           }
         ],
-        "semantic_diff_hash": "6b6513a81284ab14856f2300113ae4bcea68f62978daf31deb9c61bd6e876808"
+        "semantic_diff_hash": "6b6513a81284ab14856f2300113ae4bcea68f62978daf31deb9c61bd6e876808",
+        "proposal_identity": "f1e2d3c4b5a6978869788796a5b4c3d2e1f00112233445566778899aabbccddee"
       }
     ],
     "records": [

--- a/tests/ingestion/mechanical/data/bounded_oracle.json
+++ b/tests/ingestion/mechanical/data/bounded_oracle.json
@@ -1,4 +1,5 @@
 {
+  "artifact_kind": "accepted_authority",
   "release_binding": {
     "package_uuid": "pkg-5c",
     "release_version": "rel-5c",
@@ -35,6 +36,63 @@
       "non_mechanical_reason_code": null
     }
   ],
+  "acceptance": {
+    "batches": [
+      {
+        "batch_id": "batch-wish",
+        "rule": "every span of the Wish authority reviewed together",
+        "resolved_scope": [
+          "47d4cc94-8b98-5c55-a6bc-603b83d78766",
+          "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
+          "bd7c3ee9-737e-5a61-b75e-66d8c15f9f24"
+        ],
+        "diff": [
+          {
+            "span_id": "47d4cc94-8b98-5c55-a6bc-603b83d78766",
+            "prior_disposition": null,
+            "prior_reason_code": null,
+            "accepted_disposition": "substantive",
+            "accepted_reason_code": null
+          },
+          {
+            "span_id": "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
+            "prior_disposition": null,
+            "prior_reason_code": null,
+            "accepted_disposition": "substantive",
+            "accepted_reason_code": null
+          },
+          {
+            "span_id": "bd7c3ee9-737e-5a61-b75e-66d8c15f9f24",
+            "prior_disposition": null,
+            "prior_reason_code": null,
+            "accepted_disposition": "supporting_authority",
+            "accepted_reason_code": null
+          }
+        ],
+        "semantic_diff_hash": "6b6513a81284ab14856f2300113ae4bcea68f62978daf31deb9c61bd6e876808"
+      }
+    ],
+    "records": [
+      {
+        "span_id": "47d4cc94-8b98-5c55-a6bc-603b83d78766",
+        "batch_id": "batch-wish",
+        "reviewer": "owner",
+        "accepted_at": "2026-07-31T00:00:00Z"
+      },
+      {
+        "span_id": "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
+        "batch_id": "batch-wish",
+        "reviewer": "owner",
+        "accepted_at": "2026-07-31T00:00:00Z"
+      },
+      {
+        "span_id": "bd7c3ee9-737e-5a61-b75e-66d8c15f9f24",
+        "batch_id": "batch-wish",
+        "reviewer": "owner",
+        "accepted_at": "2026-07-31T00:00:00Z"
+      }
+    ]
+  },
   "representation": {
     "records": [
       {
@@ -60,7 +118,11 @@
             "concentration": false,
             "level": 9,
             "ritual": false,
-            "school": "conjuration"
+            "school": "conjuration",
+            "casting_time": null,
+            "spell_range": null,
+            "components": null,
+            "duration": null
           }
         ]
       },
@@ -77,6 +139,9 @@
         "record_key": "spell:wish",
         "component_key": "open-ended-clause",
         "chunk_id": "chunk-wish-0001",
+        "span_id": "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
+        "chunk_char_start": 0,
+        "chunk_char_end": 30,
         "irreducibility_reason_code": "open_ended_effect"
       }
     ],
@@ -94,7 +159,7 @@
         "target_key": [
           "spell:wish",
           "descriptor",
-          "79b28acf072dd442"
+          "31875ef3eacb7104"
         ],
         "span_id": "47d4cc94-8b98-5c55-a6bc-603b83d78766",
         "role": "primary"
@@ -105,6 +170,7 @@
           "spell:wish",
           "open-ended-clause",
           "chunk-wish-0001",
+          "78377f22-9d54-510d-b2ae-b8ba6f5c5857",
           "open_ended_effect"
         ],
         "span_id": "78377f22-9d54-510d-b2ae-b8ba6f5c5857",

--- a/tests/ingestion/mechanical/test_accepted_inputs.py
+++ b/tests/ingestion/mechanical/test_accepted_inputs.py
@@ -16,14 +16,20 @@ fields means the evidence cannot leak into identity. These tests hold both ends.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.mechanical.acceptance import AcceptanceError, accept_proposal
+from afterworlds.ingestion.mechanical.accounting import validate_acceptance
+from afterworlds.ingestion.mechanical.models import ComponentHandling
 from afterworlds.ingestion.mechanical.oracle import (
     COMMITTED_ORACLE_DIR,
+    OracleLoadError,
     accepted_inputs_payload,
     candidate_from_accepted_inputs,
     committed_inputs_for,
@@ -34,23 +40,41 @@ from afterworlds.ingestion.mechanical.oracle import (
 from afterworlds.ingestion.mechanical.persistence import (
     persist_draft,
     reconstruct_candidate,
+    record_persisted_state_digest,
+    verify_persisted_state,
 )
 from afterworlds.ingestion.mechanical.policy import (
     SEMANTIC_POLICY_VERSION,
     semantic_policy_hash,
 )
 from afterworlds.ingestion.mechanical.projection import identify_projection
-from afterworlds.ingestion.mechanical.proposal import MechanicalProposal, ProposedSpan
+from afterworlds.ingestion.mechanical.proposal import (
+    MechanicalProposal,
+    ProposedSpan,
+    proposal_identity,
+)
 from afterworlds.ingestion.mechanical.publication import (
     PublicationOutcome,
     publish_from_committed_oracle,
     resolve_active_projection,
 )
+from afterworlds.ingestion.mechanical.representation import (
+    ComponentDraft,
+    RecordDraft,
+    RecordKind,
+    SpellDescriptorFact,
+    SpellSchool,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from afterworlds.persistence.orm.mechanical import MechanicalAcceptanceBatchORM
 from tests.ingestion.mechanical.conftest import (
     BOUNDED_ORACLE_PATH,
+    DESCRIPTOR_KEY,
     NOW,
     PACKAGE_UUID,
     RELEASE_BINDING,
+    SPELL_KEY,
+    bound_corpus,
     build_ledger,
     build_representation,
 )
@@ -253,3 +277,369 @@ def test_the_production_release_cannot_publish_or_activate(session: Session) -> 
         active = resolve_active_projection(session, package)
         assert active.outcome is PublicationOutcome.UNPUBLISHED
         assert active.projection_uuid is None
+
+
+# ---------------------------------------------------------------------------
+# PR #151 review remediation — evidence binding, keyed merge, disjoint scopes
+# ---------------------------------------------------------------------------
+#
+# Three findings, one function, one invariant: a batch's retained evidence has
+# to describe the authority acceptance actually draws in, and accumulating
+# batches have to compose into a ledger that still loads.
+
+
+def _two_batch_scopes() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """One complete proposal's spans, split into two disjoint review batches."""
+    span_ids = [p.span.span_id for p in _proposal().proposed_spans]
+    return (span_ids[0],), tuple(span_ids[1:])
+
+
+def _accept_in_two_batches() -> Any:
+    """The workflow full-corpus review needs: one proposal, two disjoint batches."""
+    proposal = _proposal()
+    first_scope, second_scope = _two_batch_scopes()
+    first = accept_proposal(
+        proposal,
+        batch_id="batch-1",
+        rule="the first reviewed span",
+        resolved_scope=first_scope,
+        reviewer="owner",
+        accepted_at="2026-08-09T00:00:00Z",
+    )
+    return accept_proposal(
+        proposal,
+        batch_id="batch-2",
+        rule="the remaining spans",
+        resolved_scope=second_scope,
+        reviewer="owner",
+        accepted_at="2026-08-10T00:00:00Z",
+        prior=first,
+    )
+
+
+# -- 1. evidence names the representation, not only the spans -----------------
+
+
+def test_identical_span_acceptance_over_different_representations_differs() -> None:
+    """The defect this closes: same spans, same diff, different authority.
+
+    A batch that records only span transitions cannot distinguish these two
+    acceptances, so its evidence could not establish that the reviewer saw the
+    representation about to be published. The recorded proposal identity can.
+    """
+    baseline = _proposal()
+    restated = _proposal(
+        proposed_representation=build_representation(
+            components=(
+                ComponentDraft(
+                    record_key=SPELL_KEY,
+                    semantic_key=DESCRIPTOR_KEY,
+                    handling=ComponentHandling.STRUCTURED,
+                    # Level 8, not 9. Not one span disposition differs.
+                    facts=(
+                        SpellDescriptorFact(
+                            level=8,
+                            school=SpellSchool.CONJURATION,
+                            ritual=False,
+                            concentration=False,
+                        ),
+                    ),
+                ),
+                build_representation().components[1],
+            )
+        )
+    )
+    scope = tuple(p.span.span_id for p in baseline.proposed_spans)
+    kwargs = dict(
+        batch_id="batch-1",
+        rule="every span, reviewed together",
+        resolved_scope=scope,
+        reviewer="owner",
+        accepted_at="2026-08-09T00:00:00Z",
+    )
+    first = accept_proposal(baseline, **kwargs)  # type: ignore[arg-type]
+    second = accept_proposal(restated, **kwargs)  # type: ignore[arg-type]
+
+    # The classification evidence is genuinely identical...
+    assert first.batches[0].resolved_scope == second.batches[0].resolved_scope
+    assert first.batches[0].diff == second.batches[0].diff
+    assert first.batches[0].semantic_diff_hash == second.batches[0].semantic_diff_hash
+    # ...and the representation evidence is not.
+    assert first.batches[0].proposal_identity == proposal_identity(baseline)
+    assert second.batches[0].proposal_identity == proposal_identity(restated)
+    assert first.batches[0].proposal_identity != second.batches[0].proposal_identity
+
+
+def test_the_reviewed_proposal_identity_round_trips(tmp_path: Path) -> None:
+    inputs = _accept()
+    path = tmp_path / "accepted.json"
+    path.write_text(json.dumps(accepted_inputs_payload(inputs)), encoding="utf-8")
+    reloaded = load_accepted_inputs(path)
+    assert reloaded.batches[0].proposal_identity == inputs.batches[0].proposal_identity
+
+
+def test_the_reviewed_proposal_identity_is_evidence_not_identity() -> None:
+    """Audit metadata, exactly like reviewer and timestamp.
+
+    Two acceptances that reached the same accepted result from differently
+    *identified* proposals are still the same authority, so neither the oracle
+    identity nor the projection UUID may move.
+    """
+    inputs = _accept()
+    restamped = replace(
+        inputs,
+        batches=(replace(inputs.batches[0], proposal_identity="b" * 64),),
+    )
+    assert restamped.batches[0].proposal_identity != inputs.batches[0].proposal_identity
+    assert oracle_identity(restamped.oracle) == oracle_identity(inputs.oracle)
+    assert (
+        identify_projection(candidate_from_accepted_inputs(restamped)).projection_uuid
+        == identify_projection(candidate_from_accepted_inputs(inputs)).projection_uuid
+    )
+
+
+# -- 2. one complete proposal, two batches, one copy of everything ------------
+
+
+def test_two_disjoint_batches_of_one_proposal_do_not_duplicate_authority(
+    session: Session,
+) -> None:
+    """The keyed union, end to end.
+
+    Each batch supplies the *same complete* representation, because that is what
+    reviewing one proposal in two sittings means. Concatenating it would
+    duplicate every record and component, and the finished artifact could never
+    publish.
+    """
+    merged = _accept_in_two_batches()
+    expected = build_representation()
+    actual = merged.oracle.representation
+
+    for field in (
+        "records",
+        "components",
+        "prose_bindings",
+        "relationships",
+        "references",
+        "provenance",
+    ):
+        got = getattr(actual, field)
+        assert list(got) == list(getattr(expected, field)), field
+        assert len(got) == len(set(got)), f"{field} carries a duplicate"
+
+    # Both batches are recorded, every span is accepted exactly once, and the
+    # ledger validates as internally honest review evidence.
+    assert [b.batch_id for b in merged.batches] == ["batch-1", "batch-2"]
+    assert len(merged.acceptances) == len(merged.oracle.spans)
+    assert validate_acceptance(merged.classification()) == ()
+    assert (
+        validate_representation(actual, merged.classification(), bound_corpus()) == ()
+    )
+
+
+def test_the_merged_artifact_survives_persistence_and_reconstruction(
+    session: Session,
+) -> None:
+    merged = _accept_in_two_batches()
+    identified = identify_projection(candidate_from_accepted_inputs(merged))
+    persist_draft(session, identified, now=NOW)
+    session.flush()
+
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert rebuilt.representation == merged.oracle.representation
+    assert {
+        b.batch_id: b.proposal_identity for b in rebuilt.classification.batches
+    } == {b.batch_id: b.proposal_identity for b in merged.batches}
+    assert identify_projection(rebuilt).projection_uuid == identified.projection_uuid
+
+
+def test_a_merged_artifact_round_trips_through_its_committed_form(
+    tmp_path: Path,
+) -> None:
+    merged = _accept_in_two_batches()
+    path = tmp_path / "merged.json"
+    path.write_text(json.dumps(accepted_inputs_payload(merged)), encoding="utf-8")
+    reloaded = load_accepted_inputs(path)
+    assert oracle_identity(reloaded.oracle) == oracle_identity(merged.oracle)
+    assert reloaded.batches == merged.batches
+
+
+# -- 3. a conflicting element under an accepted key fails closed --------------
+
+
+@pytest.mark.parametrize(
+    ("mutation", "label"),
+    [
+        (
+            lambda base: {
+                "records": (
+                    RecordDraft(semantic_key=SPELL_KEY, kind=RecordKind.CONDITION),
+                    base.records[1],
+                )
+            },
+            "record",
+        ),
+        (
+            lambda base: {
+                "components": (
+                    replace(base.components[0], handling=ComponentHandling.MIXED),
+                    base.components[1],
+                )
+            },
+            "component",
+        ),
+        (
+            lambda base: {
+                "prose_bindings": (replace(base.prose_bindings[0], chunk_char_end=17),)
+            },
+            "prose binding",
+        ),
+    ],
+    ids=["record-kind-changed", "component-handling-changed", "prose-extent-changed"],
+)
+def test_a_conflicting_element_under_an_accepted_key_fails_closed(
+    mutation: Any, label: str
+) -> None:
+    """Not a merge conflict to resolve — one reviewer's authority replacing another's.
+
+    These are the three collections whose keys are narrower than their content,
+    so they are the three where a key collision can mean disagreement rather
+    than repetition.
+    """
+    proposal = _proposal()
+    base = proposal.proposed_representation
+    first_scope, second_scope = _two_batch_scopes()
+    first = accept_proposal(
+        proposal,
+        batch_id="batch-1",
+        rule="the first reviewed span",
+        resolved_scope=first_scope,
+        reviewer="owner",
+        accepted_at="2026-08-09T00:00:00Z",
+    )
+    conflicting = _proposal(
+        proposed_representation=build_representation(**mutation(base))
+    )
+    with pytest.raises(AcceptanceError, match="different content") as exc:
+        accept_proposal(
+            conflicting,
+            batch_id="batch-2",
+            rule="the remaining spans",
+            resolved_scope=second_scope,
+            reviewer="owner",
+            accepted_at="2026-08-10T00:00:00Z",
+            prior=first,
+        )
+    assert label in str(exc.value)
+
+
+# -- 4. overlapping re-acceptance is refused ----------------------------------
+
+
+def test_an_overlapping_re_acceptance_is_refused() -> None:
+    """Refused before an artifact exists, rather than producing an unloadable one.
+
+    Re-accepting a span used to strand the earlier batch: its scope member would
+    name the newer batch, so the older batch had no acceptance record naming it
+    and the ledger failed its own validation from then on.
+    """
+    proposal = _proposal()
+    first_scope, _ = _two_batch_scopes()
+    first = accept_proposal(
+        proposal,
+        batch_id="batch-1",
+        rule="the first reviewed span",
+        resolved_scope=first_scope,
+        reviewer="owner",
+        accepted_at="2026-08-09T00:00:00Z",
+    )
+    with pytest.raises(AcceptanceError, match="re-accepts spans already accepted"):
+        accept_proposal(
+            proposal,
+            batch_id="batch-2",
+            rule="reviewing the same span again",
+            resolved_scope=first_scope,
+            reviewer="second-reviewer",
+            accepted_at="2026-08-10T00:00:00Z",
+            prior=first,
+        )
+
+
+def test_every_accumulated_ledger_stays_valid() -> None:
+    """The property the refusal protects, asserted directly.
+
+    Whatever sequence of accepted batches exists, each batch is named by the
+    acceptance records of exactly its own scope — which is what
+    ``validate_acceptance`` requires and what re-acceptance used to break.
+    """
+    merged = _accept_in_two_batches()
+    by_batch: dict[str | None, set[str]] = {}
+    for record in merged.acceptances:
+        by_batch.setdefault(record.batch_id, set()).add(record.span_id)
+    for batch in merged.batches:
+        assert by_batch[batch.batch_id] == set(batch.resolved_scope)
+    assert validate_acceptance(merged.classification()) == ()
+
+
+# -- 5. missing, malformed, and corrupted evidence ----------------------------
+
+
+def test_an_artifact_without_a_reviewed_proposal_identity_is_rejected(
+    tmp_path: Path,
+) -> None:
+    payload = accepted_inputs_payload(_accept())
+    for batch in payload["acceptance"]["batches"]:  # type: ignore[index]
+        del batch["proposal_identity"]
+    path = tmp_path / "missing.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(OracleLoadError, match=r"missing \['proposal_identity'\]"):
+        load_accepted_inputs(path)
+
+
+def test_a_blank_reviewed_proposal_identity_is_rejected(tmp_path: Path) -> None:
+    """Present but empty is not evidence, and is not treated as evidence."""
+    payload = accepted_inputs_payload(_accept())
+    for batch in payload["acceptance"]["batches"]:  # type: ignore[index]
+        batch["proposal_identity"] = "   "
+    path = tmp_path / "blank.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(OracleLoadError, match="no reviewed proposal identity"):
+        load_accepted_inputs(path)
+
+
+def test_a_mistyped_reviewed_proposal_identity_is_rejected(tmp_path: Path) -> None:
+    payload = accepted_inputs_payload(_accept())
+    for batch in payload["acceptance"]["batches"]:  # type: ignore[index]
+        batch["proposal_identity"] = 12345
+    path = tmp_path / "mistyped.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(OracleLoadError, match="expected a string"):
+        load_accepted_inputs(path)
+
+
+def test_the_persisted_state_digest_covers_the_reviewed_proposal_identity(
+    session: Session,
+) -> None:
+    """Rewriting it after the fact is detected, exactly like a rewritten reviewer.
+
+    It sits outside semantic identity by design, so without digest coverage a
+    stored identity could be swapped for one naming a proposal nobody reviewed
+    and every other check would still pass.
+    """
+    inputs = _accept()
+    identified = identify_projection(candidate_from_accepted_inputs(inputs))
+    persist_draft(session, identified, now=NOW)
+    record_persisted_state_digest(session, identified.projection_uuid)
+    session.flush()
+    assert verify_persisted_state(session, identified.projection_uuid) == ()
+
+    row = session.execute(
+        select(MechanicalAcceptanceBatchORM).where(
+            MechanicalAcceptanceBatchORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    row.proposal_identity = "c" * 64
+    session.flush()
+
+    findings = verify_persisted_state(session, identified.projection_uuid)
+    assert any("digest" in f for f in findings), findings

--- a/tests/ingestion/mechanical/test_accepted_inputs.py
+++ b/tests/ingestion/mechanical/test_accepted_inputs.py
@@ -644,12 +644,17 @@ def test_a_non_canonical_reviewed_proposal_identity_is_rejected(
     assert "is not a canonical SHA-256 digest" in message, why
 
 
-def test_a_real_digest_of_the_wrong_shape_family_is_still_accepted() -> None:
-    """The check is shape, and it says so — it cannot prove authenticity.
+def test_a_canonical_digest_naming_another_proposal_is_still_accepted() -> None:
+    """The stated limit of the shape check, asserted so nobody infers more.
 
-    A canonical digest naming some *other* proposal passes, because nothing in
-    the accepted artifact can recompute the reviewed proposal. Asserted so the
-    guarantee is not overstated by a reader of the tests above.
+    A canonical digest naming some *other* proposal passes: nothing in the
+    accepted artifact can recompute the reviewed proposal, so this layer cannot
+    tell the difference — and it is not the layer that should. Reviewer
+    authenticity comes from Git review of the committed artifact, which is the
+    independently reviewed authority; the persisted-state digest separately
+    detects later mutation of stored evidence. Neither this check nor that one
+    attests to human review, and #137 does not require self-authenticating
+    proposal history.
     """
     inputs = _accept()
     other = replace(

--- a/tests/ingestion/mechanical/test_accepted_inputs.py
+++ b/tests/ingestion/mechanical/test_accepted_inputs.py
@@ -26,6 +26,10 @@ from sqlalchemy.orm import Session
 
 from afterworlds.ingestion.mechanical.acceptance import AcceptanceError, accept_proposal
 from afterworlds.ingestion.mechanical.accounting import validate_acceptance
+from afterworlds.ingestion.mechanical.gate import (
+    GateFailureCategory,
+    run_publication_gate,
+)
 from afterworlds.ingestion.mechanical.models import ComponentHandling
 from afterworlds.ingestion.mechanical.oracle import (
     COMMITTED_ORACLE_DIR,
@@ -77,6 +81,7 @@ from tests.ingestion.mechanical.conftest import (
     bound_corpus,
     build_ledger,
     build_representation,
+    mark_release_published,
 )
 
 #: The exact production binding, from the merged CRD Issue 5c release. Stated
@@ -596,15 +601,62 @@ def test_an_artifact_without_a_reviewed_proposal_identity_is_rejected(
         load_accepted_inputs(path)
 
 
-def test_a_blank_reviewed_proposal_identity_is_rejected(tmp_path: Path) -> None:
-    """Present but empty is not evidence, and is not treated as evidence."""
+@pytest.mark.parametrize(
+    ("identity", "why"),
+    [
+        ("   ", "blank"),
+        ("banana", "a readable placeholder"),
+        ("a" * 63, "one character short of a digest"),
+        ("a" * 65, "one character long"),
+        (("a" * 63 + "A"), "uppercase hex the hashing function never emits"),
+        (("z" * 64), "the right length but not hexadecimal"),
+        (("0123456789abcdef" * 3 + "0123456789abcde "), "a digest with a stray space"),
+    ],
+    ids=[
+        "blank",
+        "readable-placeholder",
+        "too-short",
+        "too-long",
+        "uppercase",
+        "non-hex",
+        "trailing-space",
+    ],
+)
+def test_a_non_canonical_reviewed_proposal_identity_is_rejected(
+    tmp_path: Path, identity: str, why: str
+) -> None:
+    """Only what ``hash_obj`` can actually emit counts as this evidence.
+
+    A nonblank string was the previous bar, and it let through every value
+    below. None of them could have been produced by the repository's hashing
+    function, so none of them names a proposal anybody reviewed — the
+    difference between weak evidence and evidence that was never generated.
+    """
     payload = accepted_inputs_payload(_accept())
     for batch in payload["acceptance"]["batches"]:  # type: ignore[index]
-        batch["proposal_identity"] = "   "
-    path = tmp_path / "blank.json"
+        batch["proposal_identity"] = identity
+    path = tmp_path / "non-canonical.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
-    with pytest.raises(OracleLoadError, match="no reviewed proposal identity"):
+    with pytest.raises(OracleLoadError) as exc:
         load_accepted_inputs(path)
+    message = str(exc.value)
+    assert "reviewed proposal identity" in message, why
+    assert "is not a canonical SHA-256 digest" in message, why
+
+
+def test_a_real_digest_of_the_wrong_shape_family_is_still_accepted() -> None:
+    """The check is shape, and it says so — it cannot prove authenticity.
+
+    A canonical digest naming some *other* proposal passes, because nothing in
+    the accepted artifact can recompute the reviewed proposal. Asserted so the
+    guarantee is not overstated by a reader of the tests above.
+    """
+    inputs = _accept()
+    other = replace(
+        inputs,
+        batches=(replace(inputs.batches[0], proposal_identity="0" * 64),),
+    )
+    assert validate_acceptance(other.classification()) == ()
 
 
 def test_a_mistyped_reviewed_proposal_identity_is_rejected(tmp_path: Path) -> None:
@@ -643,3 +695,68 @@ def test_the_persisted_state_digest_covers_the_reviewed_proposal_identity(
 
     findings = verify_persisted_state(session, identified.projection_uuid)
     assert any("digest" in f for f in findings), findings
+
+
+def test_a_corrupted_persisted_proposal_identity_cannot_pass_verification(
+    session: Session,
+) -> None:
+    """Reconstructed evidence is held to the same shape as a committed file.
+
+    The committed artifact is not the only way this evidence reaches a
+    projection: it is persisted, read back, and judged. Editing the stored value
+    to something no hashing function could emit must fail the same check, or the
+    database would be a way around the file loader.
+    """
+    inputs = _accept()
+    identified = identify_projection(candidate_from_accepted_inputs(inputs))
+    persist_draft(session, identified, now=NOW)
+    record_persisted_state_digest(session, identified.projection_uuid)
+    session.flush()
+
+    row = session.execute(
+        select(MechanicalAcceptanceBatchORM).where(
+            MechanicalAcceptanceBatchORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    row.proposal_identity = "not-a-digest"
+    session.flush()
+
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    findings = validate_acceptance(rebuilt.classification)
+    assert any("is not a canonical SHA-256 digest" in f for f in findings), findings
+
+    # And the digest still catches it independently, so the two layers do not
+    # depend on each other.
+    assert any(
+        "digest" in f
+        for f in verify_persisted_state(session, identified.projection_uuid)
+    )
+
+
+def test_a_corrupted_persisted_proposal_identity_fails_the_publication_gate(
+    session: Session,
+) -> None:
+    """The gate runs acceptance validation over reconstructed state, so it refuses.
+
+    Publication is the decision that matters; asserting the finding without
+    asserting the refusal would leave open whether anything acts on it.
+    """
+    inputs = _accept()
+    identified = identify_projection(candidate_from_accepted_inputs(inputs))
+    persist_draft(session, identified, now=NOW)
+    record_persisted_state_digest(session, identified.projection_uuid)
+    mark_release_published(session)
+    session.flush()
+
+    row = session.execute(
+        select(MechanicalAcceptanceBatchORM).where(
+            MechanicalAcceptanceBatchORM.projection_uuid == identified.projection_uuid
+        )
+    ).scalar_one()
+    row.proposal_identity = "0" * 63
+    session.flush()
+
+    result = run_publication_gate(session, identified.projection_uuid, inputs.oracle)
+    assert not result.passed
+    assert GateFailureCategory.SEMANTIC_VALIDATION in result.categories()
+    assert any("is not a canonical SHA-256 digest" in f.detail for f in result.failures)

--- a/tests/ingestion/mechanical/test_accepted_inputs.py
+++ b/tests/ingestion/mechanical/test_accepted_inputs.py
@@ -1,0 +1,255 @@
+"""The committed accepted-inputs artifact — CRD Issue 5d, #137 contract 4.
+
+One file carries both halves of accepted authority, and the split between them
+is load-bearing:
+
+* the **result** — binding, policy, spans, representation, obligations — is what
+  the publication gate judges against and what projection identity is derived
+  from; and
+* the **evidence** — exact scope, full semantic diff, reviewer, timestamp — is
+  retained, persisted, and reconstructable, and reaches no identity.
+
+Keeping them in one file means they cannot drift apart. Keeping them in separate
+fields means the evidence cannot leak into identity. These tests hold both ends.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.acceptance import AcceptanceError, accept_proposal
+from afterworlds.ingestion.mechanical.oracle import (
+    COMMITTED_ORACLE_DIR,
+    accepted_inputs_payload,
+    candidate_from_accepted_inputs,
+    committed_inputs_for,
+    committed_oracle_for,
+    load_accepted_inputs,
+    oracle_identity,
+)
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+    reconstruct_candidate,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    SEMANTIC_POLICY_VERSION,
+    semantic_policy_hash,
+)
+from afterworlds.ingestion.mechanical.projection import identify_projection
+from afterworlds.ingestion.mechanical.proposal import MechanicalProposal, ProposedSpan
+from afterworlds.ingestion.mechanical.publication import (
+    PublicationOutcome,
+    publish_from_committed_oracle,
+    resolve_active_projection,
+)
+from tests.ingestion.mechanical.conftest import (
+    BOUNDED_ORACLE_PATH,
+    NOW,
+    PACKAGE_UUID,
+    RELEASE_BINDING,
+    build_ledger,
+    build_representation,
+)
+
+#: The exact production binding, from the merged CRD Issue 5c release. Stated
+#: here so the "nothing is accepted yet" guard names the real release rather
+#: than trusting that no file happens to exist.
+PRODUCTION_PACKAGE = "4458fa10-4a66-5e0e-9ecc-ea37530ad2b4"
+PRODUCTION_RELEASE = "5.2.1-corpus.36b786d8-fa2"
+
+
+def _proposal(**overrides: object) -> MechanicalProposal:
+    base = dict(
+        binding=RELEASE_BINDING,
+        policy_version=SEMANTIC_POLICY_VERSION,
+        policy_hash=semantic_policy_hash(),
+        proposed_spans=tuple(
+            ProposedSpan(span, "tool:classifier@0", "stated basis")
+            for span in build_ledger().spans
+        ),
+        proposed_representation=build_representation(),
+        proposal_origin="tool:proposer@0",
+    )
+    return MechanicalProposal(**{**base, **overrides})  # type: ignore[arg-type]
+
+
+def _accept(**overrides: object):  # type: ignore[no-untyped-def]
+    proposal = _proposal()
+    base = dict(
+        batch_id="batch-1",
+        rule="every span of the bounded fixture, reviewed together",
+        resolved_scope=tuple(p.span.span_id for p in proposal.proposed_spans),
+        reviewer="owner",
+        accepted_at="2026-08-09T00:00:00Z",
+    )
+    return accept_proposal(proposal, **{**base, **overrides})  # type: ignore[arg-type]
+
+
+# -- the committed fixture carries both halves --------------------------------
+
+
+def test_the_committed_artifact_carries_its_review_evidence() -> None:
+    inputs = load_accepted_inputs(BOUNDED_ORACLE_PATH)
+    assert inputs.acceptances
+    assert {a.span_id for a in inputs.acceptances} == {
+        s.span_id for s in inputs.oracle.spans
+    }
+    assert all(a.reviewer and a.accepted_at for a in inputs.acceptances)
+
+
+def test_a_batch_retains_its_full_diff_not_only_a_digest() -> None:
+    (batch,) = load_accepted_inputs(BOUNDED_ORACLE_PATH).batches
+    assert batch.rule
+    assert batch.resolved_scope
+    assert len(batch.diff) == len(batch.resolved_scope)
+    assert batch.semantic_diff_hash
+
+
+def test_an_artifact_missing_its_acceptance_evidence_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """A claim of acceptance with the acceptance missing is not weaker — it is false."""
+    payload = json.loads(BOUNDED_ORACLE_PATH.read_text(encoding="utf-8"))
+    payload["acceptance"] = {"batches": [], "records": []}
+    path = tmp_path / "hollow.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(Exception, match="acceptance evidence is not complete"):
+        load_accepted_inputs(path)
+
+
+# -- evidence is retained, and reaches no identity ----------------------------
+
+
+def test_evidence_does_not_participate_in_semantic_identity() -> None:
+    """Re-reviewing an unchanged classification must not remint a projection.
+
+    Same accepted result, different reviewer, timestamp, batch id, and selection
+    rule — one authority (#137 acceptance criterion 11).
+    """
+    first = _accept()
+    second = _accept(
+        batch_id="batch-2",
+        rule="re-reviewed after a policy question",
+        reviewer="second-reviewer",
+        accepted_at="2026-09-01T00:00:00Z",
+    )
+    assert first.acceptances != second.acceptances
+    assert oracle_identity(first.oracle) == oracle_identity(second.oracle)
+    assert (
+        identify_projection(candidate_from_accepted_inputs(first)).projection_uuid
+        == identify_projection(candidate_from_accepted_inputs(second)).projection_uuid
+    )
+
+
+def test_evidence_survives_persistence_and_reconstruction(session: Session) -> None:
+    """The gate reads acceptance from reconstructed state, so it has to get there."""
+    inputs = _accept()
+    identified = identify_projection(candidate_from_accepted_inputs(inputs))
+    persist_draft(session, identified, now=NOW)
+    session.flush()
+
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    assert {(a.span_id, a.reviewer) for a in rebuilt.classification.acceptances} == {
+        (a.span_id, a.reviewer) for a in inputs.acceptances
+    }
+    (batch,) = rebuilt.classification.batches
+    assert batch.rule == "every span of the bounded fixture, reviewed together"
+    assert batch.diff == inputs.batches[0].diff
+    # And the round trip did not change what the projection *is*.
+    assert identify_projection(rebuilt).projection_uuid == identified.projection_uuid
+
+
+# -- acceptance is explicit, scoped, and merging ------------------------------
+
+
+def test_only_spans_named_in_the_scope_are_accepted() -> None:
+    proposal = _proposal()
+    chosen = proposal.proposed_spans[0].span.span_id
+    inputs = _accept(resolved_scope=(chosen,))
+    assert {s.span_id for s in inputs.oracle.spans} == {chosen}
+
+
+def test_an_unscoped_or_unattributed_acceptance_is_refused() -> None:
+    for kwargs in (
+        {"resolved_scope": ()},
+        {"reviewer": "  "},
+        {"rule": ""},
+        {"resolved_scope": ("span:not-proposed",)},
+    ):
+        with pytest.raises(AcceptanceError):
+            _accept(**kwargs)
+
+
+def test_a_later_batch_does_not_discard_an_earlier_ones_work() -> None:
+    proposal = _proposal()
+    first_span, *rest = [p.span.span_id for p in proposal.proposed_spans]
+    first = _accept(resolved_scope=(first_span,))
+    second = accept_proposal(
+        proposal,
+        batch_id="batch-2",
+        rule="the remaining spans",
+        resolved_scope=tuple(rest),
+        reviewer="owner",
+        accepted_at="2026-08-10T00:00:00Z",
+        prior=first,
+    )
+    assert {s.span_id for s in second.oracle.spans} == {first_span, *rest}
+    assert [b.batch_id for b in second.batches] == ["batch-1", "batch-2"]
+
+
+def test_reusing_a_batch_id_is_refused() -> None:
+    with pytest.raises(AcceptanceError, match="already recorded"):
+        accept_proposal(
+            _proposal(),
+            batch_id="batch-1",
+            rule="again",
+            resolved_scope=(_proposal().proposed_spans[0].span.span_id,),
+            reviewer="owner",
+            accepted_at="2026-08-10T00:00:00Z",
+            prior=_accept(),
+        )
+
+
+def test_an_accepted_artifact_round_trips_through_its_committed_form(
+    tmp_path: Path,
+) -> None:
+    inputs = _accept()
+    path = tmp_path / "accepted.json"
+    path.write_text(json.dumps(accepted_inputs_payload(inputs)), encoding="utf-8")
+    reloaded = load_accepted_inputs(path)
+    assert oracle_identity(reloaded.oracle) == oracle_identity(inputs.oracle)
+    assert reloaded.acceptances == inputs.acceptances
+    assert reloaded.batches == inputs.batches
+
+
+# -- production is unpublished and inactive -----------------------------------
+
+
+def test_no_production_authority_is_committed() -> None:
+    """This PR builds the workflow; it accepts no production content.
+
+    Stated as a test rather than a claim in a PR description, so the day
+    somebody commits production authority without review, this fails.
+    """
+    assert sorted(p.name for p in COMMITTED_ORACLE_DIR.glob("*.json")) == []
+    assert committed_oracle_for(PRODUCTION_PACKAGE, PRODUCTION_RELEASE) is None
+    assert committed_inputs_for(PRODUCTION_PACKAGE, PRODUCTION_RELEASE) is None
+
+
+def test_the_production_release_cannot_publish_or_activate(session: Session) -> None:
+    """No accepted authority means ABSENT, and nothing becomes active.
+
+    ``publish_from_committed_oracle`` is the production entry point; there is no
+    parameter that would let a caller supply authority of its own.
+    """
+    result = publish_from_committed_oracle(session, "any-projection-uuid", now=NOW)
+    assert result.outcome is PublicationOutcome.ABSENT
+    # Typed absence, never a null that a caller could read as "fine".
+    for package in (PRODUCTION_PACKAGE, PACKAGE_UUID):
+        active = resolve_active_projection(session, package)
+        assert active.outcome is PublicationOutcome.UNPUBLISHED
+        assert active.projection_uuid is None

--- a/tests/ingestion/mechanical/test_accounting.py
+++ b/tests/ingestion/mechanical/test_accounting.py
@@ -12,6 +12,8 @@ identity-bearing, and the review path that reached it is not.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from afterworlds.ingestion.mechanical import accounting
@@ -72,6 +74,7 @@ def _batch(
     scope: tuple[str, ...] | None = None,
     diff: tuple[SemanticDiffEntry, ...] | None = None,
     digest: str | None = None,
+    proposal_identity: str = "a" * 64,
 ) -> AcceptanceBatch:
     """A batch whose retained diff matches *spans* unless overridden."""
     if diff is None:
@@ -91,12 +94,10 @@ def _batch(
         resolved_scope=scope if scope is not None else tuple(s.span_id for s in spans),
         diff=diff,
         semantic_diff_hash="",
+        proposal_identity=proposal_identity,
     )
-    return AcceptanceBatch(
-        batch_id=batch.batch_id,
-        rule=batch.rule,
-        resolved_scope=batch.resolved_scope,
-        diff=batch.diff,
+    return replace(
+        batch,
         semantic_diff_hash=digest if digest is not None else batch_diff_hash(batch),
     )
 
@@ -260,6 +261,7 @@ def test_batch_without_rule_scope_or_diff_is_not_acceptance() -> None:
         resolved_scope=(),
         diff=(),
         semantic_diff_hash="",
+        proposal_identity="  ",
     )
     findings = validate_acceptance(
         _ledger(

--- a/tests/ingestion/mechanical/test_canonical_ordering.py
+++ b/tests/ingestion/mechanical/test_canonical_ordering.py
@@ -47,6 +47,7 @@ from tests.ingestion.mechanical.conftest import (
     build_candidate,
     build_ledger,
     build_representation,
+    prose_binding,
     reference_claim,
 )
 
@@ -164,15 +165,15 @@ def _two_binding_candidates(
 
 
 def test_prose_bindings_on_one_component_differing_in_chunk() -> None:
-    a = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect")
-    b = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect")
+    a = prose_binding(WISH_CHUNK)
+    b = prose_binding(SECOND_CHUNK)
     forward, reverse = _two_binding_candidates(a, b)
     assert forward == reverse
 
 
 def test_prose_bindings_differing_only_in_the_reason() -> None:
-    a = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect")
-    b = ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "subjective_judgment")
+    a = prose_binding(WISH_CHUNK)
+    b = prose_binding(WISH_CHUNK, "subjective_judgment")
     forward, reverse = _two_binding_candidates(a, b)
     assert forward == reverse
 
@@ -198,13 +199,7 @@ def test_relationships_differing_only_in_kind() -> None:
                 ),
             )
         },
-        {
-            "prose_bindings": (
-                ProseBindingDraft(
-                    OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
-                ),
-            )
-        },
+        {"prose_bindings": (prose_binding(SECOND_CHUNK),)},
         {
             "relationships": (
                 RelationshipDraft(

--- a/tests/ingestion/mechanical/test_chunk_locality.py
+++ b/tests/ingestion/mechanical/test_chunk_locality.py
@@ -25,11 +25,9 @@ from afterworlds.ingestion.mechanical.representation import (
 from afterworlds.ingestion.mechanical.validation import validate_representation
 from tests.ingestion.mechanical.conftest import (
     DEFAULT_COVERAGE,
-    OPEN_ENDED_KEY,
     PROSE_LEAF,
     PROSE_SPAN,
     SECOND_CHUNK,
-    SPELL_KEY,
     SPELL_LEAF,
     WISH_CHUNK,
     binding_claim,
@@ -37,6 +35,7 @@ from tests.ingestion.mechanical.conftest import (
     build_ledger,
     build_representation,
     coverage,
+    prose_binding,
 )
 
 OTHER_CHUNK = "chunk-elsewhere"
@@ -52,7 +51,7 @@ def _findings(**overrides: object) -> tuple[str, ...]:
 
 
 def _binding(chunk_id: str) -> ProseBindingDraft:
-    return ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, chunk_id, "open_ended_effect")
+    return prose_binding(chunk_id)
 
 
 def _with_binding(binding: ProseBindingDraft, **kwargs: object) -> tuple[str, ...]:

--- a/tests/ingestion/mechanical/test_fact_families.py
+++ b/tests/ingestion/mechanical/test_fact_families.py
@@ -16,7 +16,8 @@ family cannot be added here without someone stating what in the SRD justifies it
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import fields, replace
+from enum import StrEnum
 from typing import Any
 
 import pytest
@@ -508,3 +509,347 @@ def test_membership_with_its_edge_is_accepted() -> None:
     )
     findings = validate_representation(draft, build_ledger(), bound_corpus())
     assert not [f for f in findings if "spell-list qualifier" in f]
+
+
+# -- the invariant checkers themselves ----------------------------------------
+#
+# Membership of the closed union is not validity: a fact can be a declared
+# family and still contradict its own contract, and such a fact would persist as
+# mechanically unusable authority. The checkers are that safety net, so they are
+# exercised across every family and every field here, rather than only at the
+# handful of contradictions somebody thought to write down.
+
+
+def _wrong_typed(value: Any) -> Any:
+    """A value of the wrong type for the field *value* came from.
+
+    Chosen to be the mistakes that actually slip through: a string where a
+    Boolean belongs (``"false"`` is truthy), a Boolean where an integer belongs
+    (``bool`` is an ``int`` subclass), and a plain string where an enum member
+    belongs (``StrEnum`` members *are* strings).
+    """
+    if isinstance(value, bool):
+        return "false"
+    if isinstance(value, StrEnum):
+        return str(value.value)
+    if isinstance(value, int):
+        return True
+    if isinstance(value, str):
+        return 42
+    return "not-a-value-object"
+
+
+@pytest.mark.parametrize("fact", EXEMPLARS.values(), ids=FAMILY_IDS)
+def test_every_field_of_every_family_is_type_checked(fact: Any) -> None:
+    """Mistyping any declared field is reported, for every family.
+
+    Generic rather than per-family on purpose: a family added with a checker
+    that forgets one of its fields fails here, without anyone having to remember
+    to hand-write that family's negative control.
+    """
+    for spec in fields(type(fact)):
+        original = getattr(fact, spec.name)
+        if original is None:
+            continue  # An unset optional field has no type to get wrong.
+        broken = replace(fact, **{spec.name: _wrong_typed(original)})
+        violations = fact_invariant_violations(broken)
+        assert violations, f"{type(fact).__name__}.{spec.name} accepted a wrong type"
+        assert any(spec.name in v for v in violations), (
+            f"{type(fact).__name__}.{spec.name} was rejected, but no violation "
+            f"named it: {violations}"
+        )
+
+
+#: Which family each shared value object hangs off, so a value-object control
+#: can be written once and checked through a real fact.
+_HOLDERS: dict[type, tuple[FactFamily, str]] = {
+    DiceExpression: (FactFamily.DAMAGE, "dice"),
+    Rational: (FactFamily.CREATURE_CHALLENGE, "challenge_rating"),
+    Money: (FactFamily.EQUIPMENT_DESCRIPTOR, "cost"),
+    SpellCastingTime: (FactFamily.SPELL_DESCRIPTOR, "casting_time"),
+    SpellRange: (FactFamily.SPELL_DESCRIPTOR, "spell_range"),
+    SpellComponents: (FactFamily.SPELL_DESCRIPTOR, "components"),
+    SpellDuration: (FactFamily.SPELL_DESCRIPTOR, "duration"),
+}
+
+
+def _holding(value: Any, value_type: type) -> Any:
+    family, field = _HOLDERS[value_type]
+    return replace(EXEMPLARS[family], **{field: value})
+
+
+@pytest.mark.parametrize(
+    "value_object",
+    [
+        DiceExpression(2, DieSize.D6, 3),
+        Rational(1, 2),
+        Money(5, Currency.GP),
+        SpellCastingTime(cost=ActionCost.ACTION),
+        SpellRange(kind=RangeKind.RANGED, feet=60),
+        SpellComponents(verbal=True, somatic=True, material=False),
+        SpellDuration(kind=DurationKind.TIMED, amount=1, unit=TimeUnit.MINUTE),
+    ],
+    ids=[
+        "dice",
+        "rational",
+        "money",
+        "casting-time",
+        "range",
+        "components",
+        "duration",
+    ],
+)
+def test_a_value_object_replaced_by_a_look_alike_dict_is_rejected(
+    value_object: Any,
+) -> None:
+    """A nested value object is as closed as a family.
+
+    A dict with exactly the right keys is not a :class:`DiceExpression`, and
+    accepting one would reopen the untyped escape hatch through the back door.
+    """
+    as_dict = {
+        f.name: getattr(value_object, f.name) for f in fields(type(value_object))
+    }
+    violations = fact_invariant_violations(_holding(as_dict, type(value_object)))
+    assert any("must be" in v for v in violations), violations
+
+
+@pytest.mark.parametrize(
+    ("value_object", "expected"),
+    [
+        (DiceExpression(0, DieSize.D6), "rolls no dice"),
+        (Rational(-1, 2), "is negative"),
+        (Rational(1, 0), "is not positive"),
+        (Money(-5, Currency.GP), "is negative"),
+        (SpellCastingTime(), "exactly one of an action cost or an elapsed time"),
+        (
+            SpellCastingTime(cost=ActionCost.ACTION, amount=1, unit=TimeUnit.MINUTE),
+            "exactly one of an action cost or an elapsed time",
+        ),
+        (SpellCastingTime(amount=1), "needs both amount and unit"),
+        (SpellRange(kind=RangeKind.RANGED), "a ranged spell states a distance"),
+        (SpellRange(kind=RangeKind.RANGED, feet=0), "is not a distance"),
+        (
+            SpellRange(kind=RangeKind.SELF, feet=30),
+            "the distance comes from the named kind",
+        ),
+        (
+            SpellComponents(
+                verbal=True, somatic=False, material=False, material_consumed=True
+            ),
+            "consumes a material component it does not have",
+        ),
+        (SpellDuration(kind=DurationKind.TIMED), "needs both amount and unit"),
+        (
+            SpellDuration(
+                kind=DurationKind.INSTANTANEOUS, amount=1, unit=TimeUnit.MINUTE
+            ),
+            "the length comes from the named kind",
+        ),
+    ],
+)
+def test_a_value_object_that_contradicts_its_own_contract_is_reported(
+    value_object: Any, expected: str
+) -> None:
+    """ "The value comes from the named kind, not from the fact", held.
+
+    Each of these would otherwise persist as authority stating two incompatible
+    things about one printed value.
+    """
+    violations = fact_invariant_violations(_holding(value_object, type(value_object)))
+    assert any(expected in v for v in violations), violations
+
+
+@pytest.mark.parametrize(
+    ("fact", "expected"),
+    [
+        (
+            replace(EXEMPLARS[FactFamily.ABILITY_CHECK], dc_kind=DcKind.FIXED),
+            "fixed DC without a dc_value",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.ABILITY_CHECK], dc_value=15),
+            "the value comes from the named source",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.CREATURE_ABILITY_SCORE], score=-1),
+            "negative ability score",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SPELL_DESCRIPTOR], level=-1),
+            "negative spell level",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.PROGRESSION_ENTRY], level=-1),
+            "negative progression level",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.PROGRESSION_ENTRY], quantity=0),
+            "grants nothing",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SPELL_SLOT_PROGRESSION], character_level=0),
+            "is not a level",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SPELL_SLOT_PROGRESSION], slot_level=0),
+            "is not a slot level",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SPELL_LIST_QUALIFIER], spell_record_key="  "),
+            "without a spell record key",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.SPELL_LIST_QUALIFIER],
+                always_prepared=False,
+                minimum_class_level=None,
+            ),
+            "states no qualifier",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SPELL_LIST_QUALIFIER], minimum_class_level=0),
+            "is not a level",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.ATTACK_ROLL], reach_feet=0),
+            "reach_feet 0 is not a distance",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.ATTACK_ROLL],
+                reach_feet=None,
+                range_normal_feet=100,
+                range_long_feet=20,
+            ),
+            "is shorter than",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.ATTACK_ROLL], reach_feet=None, range_long_feet=100
+            ),
+            "range_long_feet without a normal range",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.DAMAGE], dice=None, flat_amount=0),
+            "deals no damage",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.DAMAGE], stated_average=0),
+            "stated_average 0 deals no damage",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.HEALING],
+                restores_all_hit_points=False,
+                flat_amount=0,
+            ),
+            "restores nothing",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.CREATURE_DEFENSE], hit_points=0),
+            "is not a living creature",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.CREATURE_DEFENSE], armor_class=-1),
+            "negative armor_class",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.CREATURE_SPEED], feet=-5),
+            "negative speed",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.RESOURCE_RECOVERY], resource_key=" "),
+            "without a resource key",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.RESOURCE_RECOVERY], uses=0),
+            "grants nothing",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+                recovers_on=RecoveryTrigger.RECHARGE_ROLL,
+            ),
+            "needs both a die and a minimum roll",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+                recovers_on=RecoveryTrigger.RECHARGE_ROLL,
+                recharge_die=DieSize.D6,
+                recharge_minimum=0,
+            ),
+            "always succeeds",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SCALING], threshold=-1),
+            "negative scaling threshold",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SCALING], dice_increase=None),
+            "exactly one of a dice increase or an amount increase",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.SCALING],
+                effect=ScalingEffect.EFFECTIVE_SPELL_LEVEL,
+            ),
+            "the value comes from the slot level itself",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.SCALING], dice_increase=None, amount_increase=0
+            ),
+            "increases nothing",
+        ),
+        (EquipmentDescriptorFact(), "states neither a cost nor a weight"),
+        (
+            replace(
+                EXEMPLARS[FactFamily.WEAPON_PROPERTY],
+                weapon_property=WeaponProperty.HEAVY,
+            ),
+            "carries versatile damage",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.WEAPON_PROPERTY],
+                weapon_property=WeaponProperty.THROWN,
+                versatile_damage=None,
+            ),
+            "thrown property without a normal range",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.WEAPON_PROPERTY],
+                versatile_damage=DiceExpression(1, DieSize.D10),
+                thrown_range_normal_feet=20,
+            ),
+            "carries a thrown range",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.WEAPON_PROPERTY],
+                weapon_property=WeaponProperty.THROWN,
+                versatile_damage=None,
+                thrown_range_normal_feet=20,
+                thrown_range_long_feet=0,
+            ),
+            "thrown_range_long_feet 0 is not a distance",
+        ),
+    ],
+)
+def test_each_family_reports_its_own_contract_violation(
+    fact: Any, expected: str
+) -> None:
+    """One control per contract clause, so no clause goes unexercised."""
+    violations = fact_invariant_violations(fact)
+    assert any(expected in v for v in violations), violations
+
+
+def test_a_structure_outside_the_union_has_no_contract_to_check() -> None:
+    """Reported as non-membership, rather than crashing on a missing checker."""
+    violations = fact_invariant_violations(DiceExpression(1, DieSize.D6))
+    assert violations == (
+        "DiceExpression is not a member of the closed typed-fact union",
+    )

--- a/tests/ingestion/mechanical/test_fact_families.py
+++ b/tests/ingestion/mechanical/test_fact_families.py
@@ -1,0 +1,510 @@
+"""The expanded closed typed-fact union — CRD Issue 5d, Decision 4.
+
+The union grew because full-corpus accounting found substantive authority the
+first four families could not carry. Growth is only safe while two properties
+hold, so every family is held to both here:
+
+* **closed** — every family round-trips through its canonical payload without
+  loss, and an unknown family, a missing field, an extra field, or a mistyped
+  value is rejected rather than defaulted; and
+* **not an escape hatch** — a second index gets a second typed field, never a
+  string with a number in it.
+
+One exemplar per family, each taken from real production-corpus text, so a
+family cannot be added here without someone stating what in the SRD justifies it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+import pytest
+from sqlalchemy.orm import Session
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.persistence import (
+    persist_draft,
+    reconstruct_candidate,
+)
+from afterworlds.ingestion.mechanical.projection import (
+    ProjectionCandidate,
+    identify_projection,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    AbilityCheckFact,
+    AbilityScore,
+    ActionCost,
+    ActionEconomyFact,
+    AdvantageFact,
+    AdvantageState,
+    AttackKind,
+    AttackRollFact,
+    ComponentDraft,
+    ConditionEffectFact,
+    ConditionEffectKind,
+    ConditionKind,
+    CreatureAbilityScoreFact,
+    CreatureChallengeFact,
+    CreatureDefenseFact,
+    CreatureSpeedFact,
+    Currency,
+    DamageFact,
+    DamageResponseFact,
+    DamageResponseKind,
+    DamageType,
+    DcKind,
+    DiceExpression,
+    DieSize,
+    DurationKind,
+    EquipmentDescriptorFact,
+    FactFamily,
+    HealingFact,
+    MalformedFactPayloadError,
+    Money,
+    MovementMode,
+    ProgressionEntryFact,
+    RangeKind,
+    Rational,
+    RecoveryTrigger,
+    RelationshipDraft,
+    RelationshipKind,
+    ResourceRecoveryFact,
+    RollContext,
+    ScalingBasis,
+    ScalingEffect,
+    ScalingFact,
+    SpellCastingTime,
+    SpellComponents,
+    SpellDescriptorFact,
+    SpellDuration,
+    SpellListQualifierFact,
+    SpellRange,
+    SpellSchool,
+    SpellSlotProgressionFact,
+    TimeUnit,
+    UnknownFactFamilyError,
+    WeaponProperty,
+    WeaponPropertyFact,
+    fact_from_payload,
+    fact_invariant_violations,
+    fact_key,
+    fact_payload,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from tests.ingestion.mechanical.conftest import (
+    CREATURE_KEY,
+    DESCRIPTOR_KEY,
+    NOW,
+    RELEASE_BINDING,
+    SPELL_KEY,
+    bound_corpus,
+    build_ledger,
+    build_representation,
+)
+
+#: One honest exemplar per family, each annotated with the production-corpus
+#: text it represents. ``EXEMPLARS`` is asserted to cover the whole union below,
+#: so adding a family without an exemplar fails rather than going unnoticed.
+EXEMPLARS: dict[FactFamily, Any] = {
+    # "an Intelligence (Investigation) check against your spell save DC"
+    FactFamily.ABILITY_CHECK: AbilityCheckFact(
+        AbilityScore.INTELLIGENCE, DcKind.SPELL_SAVE_DC
+    ),
+    # Mummy's ability grid: "W IS 12" / "+1" / "+3"
+    FactFamily.CREATURE_ABILITY_SCORE: CreatureAbilityScoreFact(
+        AbilityScore.WISDOM, 12, modifier=1, save_modifier=3
+    ),
+    # Wish: "Level 9 Conjuration … Casting Time: Action Range: Self
+    # Components: V Duration: Instantaneous"
+    FactFamily.SPELL_DESCRIPTOR: SpellDescriptorFact(
+        level=9,
+        school=SpellSchool.CONJURATION,
+        ritual=False,
+        concentration=False,
+        casting_time=SpellCastingTime(cost=ActionCost.ACTION),
+        spell_range=SpellRange(kind=RangeKind.SELF),
+        components=SpellComponents(verbal=True, somatic=False, material=False),
+        duration=SpellDuration(kind=DurationKind.INSTANTANEOUS),
+    ),
+    # A class table's "Class Features" column
+    FactFamily.PROGRESSION_ENTRY: ProgressionEntryFact(
+        level=5, entitlement_key="feature:extra-attack"
+    ),
+    # A class table's numbered slot columns: level 5, third-level slots, 2
+    FactFamily.SPELL_SLOT_PROGRESSION: SpellSlotProgressionFact(
+        character_level=5, slot_level=3, slots=2
+    ),
+    # The "Special" column of a "Spell | School | Special" class spell list
+    FactFamily.SPELL_LIST_QUALIFIER: SpellListQualifierFact(
+        spell_record_key="spell:cure-wounds", always_prepared=True
+    ),
+    # "Slam. Melee Attack Roll: +4, reach 5 ft."
+    FactFamily.ATTACK_ROLL: AttackRollFact(
+        AttackKind.MELEE_WEAPON, to_hit_bonus=4, reach_feet=5
+    ),
+    # "Hit: 10 (2d6 + 3) Bludgeoning damage."
+    FactFamily.DAMAGE: DamageFact(
+        damage_type=DamageType.BLUDGEONING,
+        dice=DiceExpression(2, DieSize.D6, 3),
+        stated_average=10,
+    ),
+    # Wish, Instant Health: "regain all Hit Points"
+    FactFamily.HEALING: HealingFact(restores_all_hit_points=True),
+    # Mummy: "Vulnerabilities Fire"
+    FactFamily.DAMAGE_RESPONSE: DamageResponseFact(
+        DamageType.FIRE, DamageResponseKind.VULNERABILITY
+    ),
+    # Mummy: "Immunities … Charmed"
+    FactFamily.CONDITION_EFFECT: ConditionEffectFact(
+        ConditionKind.CHARMED, ConditionEffectKind.IMMUNITY
+    ),
+    # Mummy: "AC 11" … "HP 58 (9d8 + 18)"
+    FactFamily.CREATURE_DEFENSE: CreatureDefenseFact(
+        armor_class=11, hit_points=58, hit_point_dice=DiceExpression(9, DieSize.D8, 18)
+    ),
+    # Mummy: "Speed 20 ft."
+    FactFamily.CREATURE_SPEED: CreatureSpeedFact(MovementMode.WALK, 20),
+    # "CR 1/2 (XP 100; PB +2)"
+    FactFamily.CREATURE_CHALLENGE: CreatureChallengeFact(
+        challenge_rating=Rational(1, 2), proficiency_bonus=2
+    ),
+    # "Casting Time: Bonus Action"
+    FactFamily.ACTION_ECONOMY: ActionEconomyFact(ActionCost.BONUS_ACTION),
+    # "You can use this feature twice, and you regain all expended uses when you
+    # finish a Long Rest."
+    FactFamily.RESOURCE_RECOVERY: ResourceRecoveryFact(
+        resource_key="feature:channel-divinity",
+        recovers_on=RecoveryTrigger.LONG_REST,
+        uses=2,
+    ),
+    # "You have Disadvantage on attack rolls with a Heavy weapon if …"
+    FactFamily.ADVANTAGE: AdvantageFact(
+        AdvantageState.DISADVANTAGE, RollContext.ATTACK_ROLL
+    ),
+    # "The damage increases by 1d10 for each spell slot level above 4."
+    FactFamily.SCALING: ScalingFact(
+        basis=ScalingBasis.HIGHER_LEVEL_SPELL_SLOT,
+        threshold=4,
+        effect=ScalingEffect.DAMAGE,
+        dice_increase=DiceExpression(1, DieSize.D10),
+    ),
+    # A weapon table row: "5 GP" / "2 lb."
+    FactFamily.EQUIPMENT_DESCRIPTOR: EquipmentDescriptorFact(
+        cost=Money(5, Currency.GP), weight_pounds=Rational(2, 1)
+    ),
+    # "Versatile (1d10)"
+    FactFamily.WEAPON_PROPERTY: WeaponPropertyFact(
+        WeaponProperty.VERSATILE, versatile_damage=DiceExpression(1, DieSize.D10)
+    ),
+}
+
+FAMILY_IDS = [f.value for f in EXEMPLARS]
+
+
+def test_every_declared_family_has_a_corpus_grounded_exemplar() -> None:
+    """A family nobody can name source text for has no business in the union."""
+    assert set(EXEMPLARS) == set(FactFamily)
+
+
+# -- closed: canonical round trip --------------------------------------------
+
+
+@pytest.mark.parametrize("fact", EXEMPLARS.values(), ids=FAMILY_IDS)
+def test_every_family_round_trips_through_its_canonical_payload(fact: Any) -> None:
+    payload = fact_payload(fact)
+    rebuilt = fact_from_payload(payload)
+    assert rebuilt == fact
+    assert fact_payload(rebuilt) == payload
+    assert fact_key(rebuilt) == fact_key(fact)
+    assert fact_invariant_violations(rebuilt) == ()
+
+
+@pytest.mark.parametrize("fact", EXEMPLARS.values(), ids=FAMILY_IDS)
+def test_a_canonical_payload_holds_only_json_primitives(fact: Any) -> None:
+    """Nested value objects serialize as plain data, enums as their values.
+
+    A payload holding a live enum member would hash the same as its string but
+    compare differently after a round trip, so the stored form and the built
+    form would quietly diverge.
+    """
+
+    def plain(value: Any) -> bool:
+        if isinstance(value, dict):
+            return all(isinstance(k, str) and plain(v) for k, v in value.items())
+        if isinstance(value, list):
+            return all(plain(v) for v in value)
+        return value is None or type(value) in (str, int, float, bool)
+
+    assert plain(fact_payload(fact))
+
+
+@pytest.mark.parametrize("fact", EXEMPLARS.values(), ids=FAMILY_IDS)
+def test_a_missing_field_is_rejected_not_defaulted(fact: Any) -> None:
+    payload = fact_payload(fact)
+    for field in [k for k in payload if k != "family"]:
+        without = {k: v for k, v in payload.items() if k != field}
+        with pytest.raises(MalformedFactPayloadError, match="missing"):
+            fact_from_payload(without)
+
+
+@pytest.mark.parametrize("fact", EXEMPLARS.values(), ids=FAMILY_IDS)
+def test_an_extra_field_is_rejected_not_dropped(fact: Any) -> None:
+    with pytest.raises(MalformedFactPayloadError, match="extra"):
+        fact_from_payload({**fact_payload(fact), "smuggled": 1})
+
+
+def test_an_unknown_family_is_rejected() -> None:
+    with pytest.raises(UnknownFactFamilyError):
+        fact_from_payload({"family": "vibes", "amount": 3})
+
+
+# -- closed: nested value objects are as strict as families -------------------
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        (lambda p: {**p, "dice": {"count": 2, "die": "d6"}}, "missing"),
+        (
+            lambda p: {**p, "dice": {"count": 2, "die": "d6", "modifier": 3, "x": 1}},
+            "extra",
+        ),
+        (
+            lambda p: {**p, "dice": {"count": "2", "die": "d6", "modifier": 3}},
+            "integer",
+        ),
+        (lambda p: {**p, "dice": {"count": 2, "die": "d7", "modifier": 3}}, "DieSize"),
+        (lambda p: {**p, "dice": "2d6+3"}, "must be an object"),
+    ],
+    ids=["missing", "extra", "mistyped", "undeclared-die", "flattened-to-a-string"],
+)
+def test_a_malformed_nested_value_object_is_rejected(
+    mutate: Any, expected: str
+) -> None:
+    """``2d6 + 3`` is a typed object, never a string somebody parses later."""
+    payload = fact_payload(EXEMPLARS[FactFamily.DAMAGE])
+    with pytest.raises(MalformedFactPayloadError, match=expected):
+        fact_from_payload(mutate(payload))
+
+
+# -- family contracts, not just field types -----------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fact", "expected"),
+    [
+        (
+            replace(EXEMPLARS[FactFamily.DAMAGE], flat_amount=4),
+            "exactly one of a dice expression or a flat amount",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.HEALING], flat_amount=4),
+            "exactly one of a dice expression, a flat amount, or full restoration",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.CREATURE_SPEED], feet=-5),
+            "negative speed",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.SPELL_SLOT_PROGRESSION], slots=0),
+            "grants nothing",
+        ),
+        (
+            replace(EXEMPLARS[FactFamily.WEAPON_PROPERTY], versatile_damage=None),
+            "versatile property without its two-handed damage",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+                recharge_die=DieSize.D6,
+                recharge_minimum=5,
+            ),
+            "carries recharge terms",
+        ),
+        (
+            replace(
+                EXEMPLARS[FactFamily.CREATURE_CHALLENGE],
+                challenge_rating=Rational(1, 0),
+            ),
+            "denominator 0 is not positive",
+        ),
+    ],
+    ids=[
+        "damage-two-amounts",
+        "healing-two-amounts",
+        "negative-speed",
+        "slot-grants-nothing",
+        "versatile-without-damage",
+        "recharge-terms-on-a-rest",
+        "challenge-rating-over-zero",
+    ],
+)
+def test_a_fact_that_contradicts_its_own_contract_is_reported(
+    fact: Any, expected: str
+) -> None:
+    """Union membership is not validity. Such a fact is unusable authority."""
+    violations = fact_invariant_violations(fact)
+    assert any(expected in v for v in violations), violations
+
+
+def test_a_spell_descriptor_disagreeing_with_its_own_duration_is_rejected() -> None:
+    """One printed claim, spelled twice, must not say two things."""
+    descriptor = EXEMPLARS[FactFamily.SPELL_DESCRIPTOR]
+    contradictory = replace(
+        descriptor,
+        duration=SpellDuration(
+            kind=DurationKind.TIMED, amount=1, unit=TimeUnit.MINUTE, concentration=True
+        ),
+    )
+    assert any(
+        "disagrees with duration" in v for v in fact_invariant_violations(contradictory)
+    )
+
+
+# -- not an escape hatch ------------------------------------------------------
+
+
+def test_spell_slot_progression_indexes_the_slot_level_with_a_typed_field() -> None:
+    """The class table's second dimension is a typed integer, not a string.
+
+    ``entitlement_key="slots_level_3"`` would satisfy the older family and is
+    exactly the stringly escape hatch ADR-005d Decision 4 forbids. It is not
+    representable here: the field is an ``int``, and a string is rejected.
+    """
+    fact = EXEMPLARS[FactFamily.SPELL_SLOT_PROGRESSION]
+    assert isinstance(fact.slot_level, int)
+    payload = fact_payload(fact)
+    assert payload["slot_level"] == 3
+    with pytest.raises(MalformedFactPayloadError, match="integer"):
+        fact_from_payload({**payload, "slot_level": "3"})
+
+
+def test_progression_entry_cannot_carry_a_blank_or_absent_entitlement() -> None:
+    """The remaining string field is a semantic key, and it must actually name one."""
+    assert any(
+        "without an entitlement key" in v
+        for v in fact_invariant_violations(
+            replace(EXEMPLARS[FactFamily.PROGRESSION_ENTRY], entitlement_key="  ")
+        )
+    )
+
+
+def test_challenge_rating_stays_an_exact_fraction() -> None:
+    """``CR 1/2`` is exact source data; a float would invent precision."""
+    payload = fact_payload(EXEMPLARS[FactFamily.CREATURE_CHALLENGE])
+    assert payload["challenge_rating"] == {"numerator": 1, "denominator": 2}
+    with pytest.raises(MalformedFactPayloadError, match="integer"):
+        fact_from_payload(
+            {**payload, "challenge_rating": {"numerator": 0.5, "denominator": 1}}
+        )
+
+
+# -- persistence, reconstruction, and the membership relation -----------------
+
+
+def test_every_family_survives_persistence_and_reconstruction(
+    session: Session,
+) -> None:
+    """A family the store cannot reconstruct is a family the projection cannot keep.
+
+    All twenty at once, on one component, so a family added without a persisted
+    round trip fails here rather than the first time a real corpus carries it.
+    """
+    draft = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=tuple(EXEMPLARS.values()),
+            ),
+            build_representation().components[1],
+        )
+    )
+    identified = identify_projection(
+        ProjectionCandidate(RELEASE_BINDING, build_ledger(), draft)
+    )
+    persist_draft(session, identified, now=NOW)
+    session.flush()
+
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    (component,) = [
+        c for c in rebuilt.representation.components if c.semantic_key == DESCRIPTOR_KEY
+    ]
+    assert set(component.facts) == set(EXEMPLARS.values())
+    assert identify_projection(rebuilt).projection_uuid == identified.projection_uuid
+
+
+def test_a_spell_list_qualifier_needs_its_membership_edge() -> None:
+    """The fact and the relationship are one claim, split by what each can say.
+
+    The edge is the membership classification; the fact is what the ``Special``
+    column says about it. A qualifier alone would describe a membership the
+    projection never declares, and would vanish from any consumer reading the
+    relationship graph.
+    """
+    qualifier = SpellListQualifierFact(
+        spell_record_key=CREATURE_KEY, always_prepared=True
+    )
+    draft = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(qualifier,),
+            ),
+            build_representation().components[1],
+        )
+    )
+    findings = validate_representation(draft, build_ledger(), bound_corpus())
+    assert any("does not declare as a spell_list_member" in f for f in findings)
+
+
+def test_a_spell_list_qualifier_naming_no_record_is_rejected() -> None:
+    qualifier = SpellListQualifierFact(
+        spell_record_key="spell:not-in-this-projection", always_prepared=True
+    )
+    draft = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(qualifier,),
+            ),
+            build_representation().components[1],
+        )
+    )
+    findings = validate_representation(draft, build_ledger(), bound_corpus())
+    assert any("unknown spell record" in f for f in findings)
+
+
+def test_membership_with_its_edge_is_accepted() -> None:
+    """The negative controls above are not "any qualifier fails"."""
+    qualifier = SpellListQualifierFact(
+        spell_record_key=CREATURE_KEY, always_prepared=True
+    )
+    base = build_representation()
+    draft = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(qualifier,),
+            ),
+            base.components[1],
+        ),
+        relationships=base.relationships
+        + (
+            RelationshipDraft(
+                source_record_key=SPELL_KEY,
+                target_record_key=CREATURE_KEY,
+                kind=RelationshipKind.SPELL_LIST_MEMBER,
+            ),
+        ),
+    )
+    findings = validate_representation(draft, build_ledger(), bound_corpus())
+    assert not [f for f in findings if "spell-list qualifier" in f]

--- a/tests/ingestion/mechanical/test_fact_families.py
+++ b/tests/ingestion/mechanical/test_fact_families.py
@@ -67,9 +67,12 @@ from afterworlds.ingestion.mechanical.representation import (
     ProgressionEntryFact,
     RangeKind,
     Rational,
+    RecordDraft,
+    RecordKind,
     RecoveryTrigger,
     RelationshipDraft,
     RelationshipKind,
+    RepresentationDraft,
     ResourceRecoveryFact,
     RollContext,
     ScalingBasis,
@@ -437,6 +440,132 @@ def test_every_family_survives_persistence_and_reconstruction(
     assert identify_projection(rebuilt).projection_uuid == identified.projection_uuid
 
 
+#: A class record and a spell record, so a spell-list claim can be stated with
+#: the endpoints it actually means. The bounded fixture has a spell and a
+#: creature but no class, and a spell list belongs to a class.
+CLASS_KEY = "class:wizard"
+LISTED_SPELL_KEY = "spell:cure-wounds"
+SPELL_LIST_KEY = "spell-list"
+
+
+def _spell_list_draft(
+    *,
+    qualifier: SpellListQualifierFact | None = None,
+    source_key: str = CLASS_KEY,
+    source_kind: RecordKind = RecordKind.CLASS,
+    target_key: str = LISTED_SPELL_KEY,
+    target_kind: RecordKind = RecordKind.SPELL,
+    with_edge: bool = True,
+    qualifier_on: str | None = None,
+) -> RepresentationDraft:
+    """The bounded fixture plus one class spell list, perturbable per control."""
+    base = build_representation()
+    facts = (qualifier,) if qualifier is not None else ()
+    owner = qualifier_on or source_key
+    return build_representation(
+        records=base.records
+        + (
+            RecordDraft(semantic_key=source_key, kind=source_kind),
+            RecordDraft(semantic_key=target_key, kind=target_kind),
+        ),
+        components=base.components
+        + (
+            ComponentDraft(
+                record_key=owner,
+                semantic_key=SPELL_LIST_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=facts or (EXEMPLARS[FactFamily.PROGRESSION_ENTRY],),
+            ),
+        ),
+        relationships=base.relationships
+        + (
+            (
+                RelationshipDraft(
+                    source_record_key=source_key,
+                    target_record_key=target_key,
+                    kind=RelationshipKind.SPELL_LIST_MEMBER,
+                ),
+            )
+            if with_edge
+            else ()
+        ),
+    )
+
+
+def _spell_list_findings(**kwargs: Any) -> list[str]:
+    """Only the spell-list judgements.
+
+    The perturbed draft adds records and a component with no provenance edges,
+    which the provenance validator reports for reasons unrelated to spell lists.
+    Narrowing to the two message families under test stops a positive control
+    from failing — or a negative one from passing — for the wrong reason.
+    """
+    findings = validate_representation(
+        _spell_list_draft(**kwargs), build_ledger(), bound_corpus()
+    )
+    return [
+        f
+        for f in findings
+        if f.startswith("spell-list membership") or f.startswith("spell-list qualifier")
+    ]
+
+
+QUALIFIER = SpellListQualifierFact(
+    spell_record_key=LISTED_SPELL_KEY, always_prepared=True
+)
+
+
+def test_a_class_to_spell_membership_with_a_qualifier_is_accepted() -> None:
+    """The shape the 73 ``Spell | School | Special`` tables actually state."""
+    assert _spell_list_findings(qualifier=QUALIFIER) == []
+
+
+def test_membership_without_a_qualifier_remains_valid() -> None:
+    """Most rows say nothing in the Special column, and must not have to.
+
+    Requiring a qualifier per edge would force one to be invented for every
+    ordinary spell on every class list.
+    """
+    assert _spell_list_findings() == []
+
+
+def test_a_membership_edge_from_a_non_class_record_is_rejected() -> None:
+    """A spell list belongs to a class; any other source states something else."""
+    findings = _spell_list_findings(
+        qualifier=QUALIFIER, source_key=CREATURE_KEY, source_kind=RecordKind.CREATURE
+    )
+    assert any("a spell list belongs to a class" in f for f in findings), findings
+
+
+def test_a_membership_edge_to_a_non_spell_record_is_rejected() -> None:
+    """The case the previous revision accepted: a spell-to-creature edge.
+
+    A consumer reading these edges as spell-list eligibility would have received
+    an arbitrary record as a member.
+    """
+    findings = _spell_list_findings(
+        target_key=CREATURE_KEY, target_kind=RecordKind.CREATURE
+    )
+    assert any("only a spell can be on a spell list" in f for f in findings), findings
+
+
+def test_a_qualifier_naming_a_non_spell_record_is_rejected() -> None:
+    findings = _spell_list_findings(
+        qualifier=SpellListQualifierFact(
+            spell_record_key=CREATURE_KEY, always_prepared=True
+        ),
+        target_key=CREATURE_KEY,
+        target_kind=RecordKind.CREATURE,
+    )
+    assert any("a spell-list qualifier names a spell" in f for f in findings), findings
+
+
+def test_a_qualifier_on_a_non_class_record_is_rejected() -> None:
+    """The Special column is a column of the class's own table."""
+    findings = _spell_list_findings(qualifier=QUALIFIER, qualifier_on=SPELL_KEY)
+    assert any("belongs to the class stating the list" in f for f in findings), findings
+
+
 def test_a_spell_list_qualifier_needs_its_membership_edge() -> None:
     """The fact and the relationship are one claim, split by what each can say.
 
@@ -445,70 +574,17 @@ def test_a_spell_list_qualifier_needs_its_membership_edge() -> None:
     projection never declares, and would vanish from any consumer reading the
     relationship graph.
     """
-    qualifier = SpellListQualifierFact(
-        spell_record_key=CREATURE_KEY, always_prepared=True
-    )
-    draft = build_representation(
-        components=(
-            ComponentDraft(
-                record_key=SPELL_KEY,
-                semantic_key=DESCRIPTOR_KEY,
-                handling=ComponentHandling.STRUCTURED,
-                facts=(qualifier,),
-            ),
-            build_representation().components[1],
-        )
-    )
-    findings = validate_representation(draft, build_ledger(), bound_corpus())
+    findings = _spell_list_findings(qualifier=QUALIFIER, with_edge=False)
     assert any("does not declare as a spell_list_member" in f for f in findings)
 
 
 def test_a_spell_list_qualifier_naming_no_record_is_rejected() -> None:
-    qualifier = SpellListQualifierFact(
-        spell_record_key="spell:not-in-this-projection", always_prepared=True
-    )
-    draft = build_representation(
-        components=(
-            ComponentDraft(
-                record_key=SPELL_KEY,
-                semantic_key=DESCRIPTOR_KEY,
-                handling=ComponentHandling.STRUCTURED,
-                facts=(qualifier,),
-            ),
-            build_representation().components[1],
+    findings = _spell_list_findings(
+        qualifier=SpellListQualifierFact(
+            spell_record_key="spell:not-in-this-projection", always_prepared=True
         )
     )
-    findings = validate_representation(draft, build_ledger(), bound_corpus())
     assert any("unknown spell record" in f for f in findings)
-
-
-def test_membership_with_its_edge_is_accepted() -> None:
-    """The negative controls above are not "any qualifier fails"."""
-    qualifier = SpellListQualifierFact(
-        spell_record_key=CREATURE_KEY, always_prepared=True
-    )
-    base = build_representation()
-    draft = build_representation(
-        components=(
-            ComponentDraft(
-                record_key=SPELL_KEY,
-                semantic_key=DESCRIPTOR_KEY,
-                handling=ComponentHandling.STRUCTURED,
-                facts=(qualifier,),
-            ),
-            base.components[1],
-        ),
-        relationships=base.relationships
-        + (
-            RelationshipDraft(
-                source_record_key=SPELL_KEY,
-                target_record_key=CREATURE_KEY,
-                kind=RelationshipKind.SPELL_LIST_MEMBER,
-            ),
-        ),
-    )
-    findings = validate_representation(draft, build_ledger(), bound_corpus())
-    assert not [f for f in findings if "spell-list qualifier" in f]
 
 
 # -- the invariant checkers themselves ----------------------------------------
@@ -853,3 +929,105 @@ def test_a_structure_outside_the_union_has_no_contract_to_check() -> None:
     assert violations == (
         "DiceExpression is not a member of the closed typed-fact union",
     )
+
+
+# -- recharge thresholds the die can actually reach ---------------------------
+
+
+@pytest.mark.parametrize("die", list(DieSize), ids=[d.value for d in DieSize])
+def test_a_recharge_minimum_equal_to_the_die_maximum_is_attainable(
+    die: DieSize,
+) -> None:
+    """``Recharge 6`` on a d6 is a real stat-block line, so the bound is inclusive."""
+    fact = replace(
+        EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+        recovers_on=RecoveryTrigger.RECHARGE_ROLL,
+        recharge_die=die,
+        recharge_minimum=die.faces,
+    )
+    assert fact_invariant_violations(fact) == ()
+
+
+@pytest.mark.parametrize("die", list(DieSize), ids=[d.value for d in DieSize])
+def test_a_recharge_minimum_above_the_die_maximum_is_rejected(die: DieSize) -> None:
+    """One past the top of the die is a resource that can never come back.
+
+    It would otherwise validate, persist, and publish as typed authority for a
+    feature that never recharges.
+    """
+    fact = replace(
+        EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+        recovers_on=RecoveryTrigger.RECHARGE_ROLL,
+        recharge_die=die,
+        recharge_minimum=die.faces + 1,
+    )
+    violations = fact_invariant_violations(fact)
+    assert any("is unreachable on" in v for v in violations), violations
+
+
+def test_the_die_range_comes_from_the_die_itself() -> None:
+    """No parallel table to fall out of step with the union."""
+    assert [d.faces for d in DieSize] == [4, 6, 8, 10, 12, 20, 100]
+
+
+def test_the_existing_recharge_controls_remain_green() -> None:
+    """The new upper bound did not displace the checks already there."""
+    base = replace(
+        EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+        recovers_on=RecoveryTrigger.RECHARGE_ROLL,
+        recharge_die=DieSize.D6,
+        recharge_minimum=5,
+    )
+    assert fact_invariant_violations(base) == ()
+    assert any(
+        "always succeeds" in v
+        for v in fact_invariant_violations(replace(base, recharge_minimum=0))
+    )
+    assert any(
+        "needs both a die and a minimum roll" in v
+        for v in fact_invariant_violations(replace(base, recharge_minimum=None))
+    )
+    assert any(
+        "carries recharge terms" in v
+        for v in fact_invariant_violations(
+            replace(base, recovers_on=RecoveryTrigger.LONG_REST)
+        )
+    )
+
+
+def test_an_unreachable_recharge_still_fails_after_reconstruction(
+    session: Session,
+) -> None:
+    """The publication path exercises this over reconstructed state, not memory.
+
+    A fact that only failed in-memory validation could be persisted by an
+    authoring path and then published from the database.
+    """
+    unreachable = replace(
+        EXEMPLARS[FactFamily.RESOURCE_RECOVERY],
+        recovers_on=RecoveryTrigger.RECHARGE_ROLL,
+        recharge_die=DieSize.D6,
+        recharge_minimum=7,
+    )
+    draft = build_representation(
+        components=(
+            ComponentDraft(
+                record_key=SPELL_KEY,
+                semantic_key=DESCRIPTOR_KEY,
+                handling=ComponentHandling.STRUCTURED,
+                facts=(unreachable,),
+            ),
+            build_representation().components[1],
+        )
+    )
+    identified = identify_projection(
+        ProjectionCandidate(RELEASE_BINDING, build_ledger(), draft)
+    )
+    persist_draft(session, identified, now=NOW)
+    session.flush()
+
+    rebuilt = reconstruct_candidate(session, identified.projection_uuid)
+    findings = validate_representation(
+        rebuilt.representation, rebuilt.classification, bound_corpus()
+    )
+    assert any("is unreachable on" in f for f in findings), findings

--- a/tests/ingestion/mechanical/test_fact_field_types.py
+++ b/tests/ingestion/mechanical/test_fact_field_types.py
@@ -59,12 +59,21 @@ def _check_payload(family: str, **fields: Any) -> dict[str, Any]:
             "dc_kind": "fixed",
             "dc_value": 15,
         },
-        "creature_ability_score": {"ability": "strength", "score": 12},
+        "creature_ability_score": {
+            "ability": "strength",
+            "score": 12,
+            "modifier": None,
+            "save_modifier": None,
+        },
         "spell_descriptor": {
             "level": 3,
             "school": "illusion",
             "ritual": False,
             "concentration": False,
+            "casting_time": None,
+            "spell_range": None,
+            "components": None,
+            "duration": None,
         },
         "progression_entry": {
             "level": 5,

--- a/tests/ingestion/mechanical/test_invariants_and_binding.py
+++ b/tests/ingestion/mechanical/test_invariants_and_binding.py
@@ -22,7 +22,6 @@ from afterworlds.ingestion.mechanical.representation import (
     CreatureAbilityScoreFact,
     DcKind,
     ProgressionEntryFact,
-    ProseBindingDraft,
     ProvenanceRole,
     ReferenceDraft,
     RelationshipDraft,
@@ -46,6 +45,7 @@ from tests.ingestion.mechanical.conftest import (
     bound_corpus,
     build_ledger,
     build_representation,
+    prose_binding,
 )
 
 NON_FIXED = [DcKind.SPELL_SAVE_DC, DcKind.CONTESTED, DcKind.GAMEMASTER_SET]
@@ -206,11 +206,7 @@ def test_component_reason_outside_the_closed_catalog_is_rejected() -> None:
 
 
 def test_binding_reason_outside_the_closed_catalog_is_rejected() -> None:
-    findings = _findings(
-        prose_bindings=(
-            ProseBindingDraft(OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "too_hard"),
-        )
-    )
+    findings = _findings(prose_bindings=(prose_binding(WISH_CHUNK, "too_hard"),))
     assert any("irreducibility reason 'too_hard' is not closed" in f for f in findings)
 
 
@@ -218,11 +214,7 @@ def test_component_and_binding_reasons_valid_but_unequal_are_rejected() -> None:
     # Both closed, both plausible, and they disagree about *why* this authority
     # is prose-bound. Neither copy wins.
     findings = _findings(
-        prose_bindings=(
-            ProseBindingDraft(
-                OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "subjective_judgment"
-            ),
-        )
+        prose_bindings=(prose_binding(WISH_CHUNK, "subjective_judgment"),)
     )
     assert any("disagrees with its component's" in f for f in findings)
 
@@ -231,12 +223,8 @@ def test_multiple_bindings_sharing_the_component_reason_pass() -> None:
     # Two passages bound by one component: each is a distinct authoritative
     # element with its own provenance, which is why the binding key carries
     # the chunk rather than stopping at the component.
-    first = ProseBindingDraft(
-        OPEN_ENDED_KEY, SPELL_KEY, WISH_CHUNK, "open_ended_effect"
-    )
-    second = ProseBindingDraft(
-        OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
-    )
+    first = prose_binding(WISH_CHUNK)
+    second = prose_binding(SECOND_CHUNK)
     findings = _findings(
         prose_bindings=(first, second),
         provenance=build_representation().provenance
@@ -267,13 +255,7 @@ def test_structured_component_carrying_a_reason_is_rejected() -> None:
 
 
 def test_fabricated_chunk_is_rejected() -> None:
-    findings = _findings(
-        prose_bindings=(
-            ProseBindingDraft(
-                OPEN_ENDED_KEY, SPELL_KEY, "chunk-invented", "open_ended_effect"
-            ),
-        )
-    )
+    findings = _findings(prose_bindings=(prose_binding("chunk-invented"),))
     assert any("is not authoritative prose of release" in f for f in findings)
 
 

--- a/tests/ingestion/mechanical/test_packaging.py
+++ b/tests/ingestion/mechanical/test_packaging.py
@@ -41,11 +41,14 @@ SENTINEL_PACKAGE = "pkg-sentinel-packaging"
 SENTINEL_RELEASE = "rel-sentinel-packaging"
 SENTINEL_FILENAME = "sentinel_packaging_oracle.json"
 
-#: The smallest payload ``load_oracle`` accepts: no spans, no representation, and
-#: therefore no obligations — the derived obligation relation over an empty
-#: record set is empty, so the closed-relation check passes. It exists to be
-#: *found*, not to pass a gate.
+#: The smallest payload ``load_accepted_inputs`` accepts: no spans, no
+#: representation, and therefore no obligations — the derived obligation
+#: relation over an empty record set is empty, so the closed-relation check
+#: passes — plus an empty acceptance block, which is complete evidence for an
+#: empty span set. It exists to be *found*, not to pass a gate.
 SENTINEL_ORACLE: dict[str, object] = {
+    "artifact_kind": "accepted_authority",
+    "acceptance": {"batches": [], "records": []},
     "release_binding": {
         "package_uuid": SENTINEL_PACKAGE,
         "release_version": SENTINEL_RELEASE,

--- a/tests/ingestion/mechanical/test_persisted_evidence.py
+++ b/tests/ingestion/mechanical/test_persisted_evidence.py
@@ -238,6 +238,8 @@ def test_extra_payload_field_is_rejected() -> None:
                 "family": "creature_ability_score",
                 "ability": "strength",
                 "score": 12,
+                "modifier": None,
+                "save_modifier": None,
                 "smuggled": {"dc": 15},
             }
         )
@@ -267,6 +269,8 @@ def test_bad_enum_value_is_rejected() -> None:
                 "family": "creature_ability_score",
                 "ability": "luck",
                 "score": 12,
+                "modifier": None,
+                "save_modifier": None,
             }
         )
 

--- a/tests/ingestion/mechanical/test_projection.py
+++ b/tests/ingestion/mechanical/test_projection.py
@@ -36,13 +36,13 @@ from tests.ingestion.mechanical.conftest import (
     DESCRIPTOR_FACT,
     DESCRIPTOR_KEY,
     LEAF_LENGTHS,
-    OPEN_ENDED_KEY,
     SPELL_KEY,
     SPELL_LEAF,
     bound_corpus,
     build_candidate,
     build_ledger,
     build_representation,
+    prose_binding,
 )
 
 # -- acyclic derivation ------------------------------------------------------
@@ -171,19 +171,22 @@ def test_identity_changes_when_record_assembly_changes() -> None:
 
 
 def test_identity_changes_when_a_prose_binding_changes() -> None:
-    draft = build_representation()
-    rebound = build_representation(
-        prose_bindings=(
-            type(draft.prose_bindings[0])(
-                component_key=OPEN_ENDED_KEY,
-                record_key=SPELL_KEY,
-                chunk_id="chunk-wish-0002",
-                irreducibility_reason_code="open_ended_effect",
-            ),
-        )
-    )
+    rebound = build_representation(prose_bindings=(prose_binding("chunk-wish-0002"),))
     assert projection_uuid(
         ProjectionCandidate(build_candidate().binding, build_ledger(), rebound)
+    ) != projection_uuid(build_candidate())
+
+
+def test_identity_changes_when_a_prose_binding_narrows_its_extent() -> None:
+    """Same component, same chunk, fewer characters — different authority.
+
+    The extent is meaning-bearing. A binding narrowed to half the passage
+    governs different text, and reusing the identity would let that narrowed
+    claim inherit a projection reviewed against the wider one.
+    """
+    narrowed = build_representation(prose_bindings=(prose_binding(chunk_char_end=17),))
+    assert projection_uuid(
+        ProjectionCandidate(build_candidate().binding, build_ledger(), narrowed)
     ) != projection_uuid(build_candidate())
 
 

--- a/tests/ingestion/mechanical/test_proposal_boundary.py
+++ b/tests/ingestion/mechanical/test_proposal_boundary.py
@@ -1,0 +1,201 @@
+"""A machine proposal is not authority — CRD Issue 5d, #137 contract 2.
+
+"Silence is not acceptance" is only enforceable if an unaccepted proposal
+physically cannot be loaded as accepted authority. Convention cannot carry that:
+a folder is a mistake away from being wrong, and a single ``accepted: false``
+field is one edit away from a lie.
+
+So the boundary is structural, and these tests attack it the way a mistake
+would — by renaming the file, by moving it into the committed directory, and by
+editing the discriminator to say what the loader wants to hear.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from afterworlds.ingestion.mechanical.oracle import (
+    ACCEPTED_ARTIFACT_KIND,
+    OracleLoadError,
+    _resolve_committed_inputs,
+    accepted_inputs_payload,
+    load_accepted_inputs,
+    load_oracle,
+)
+from afterworlds.ingestion.mechanical.policy import (
+    SEMANTIC_POLICY_VERSION,
+    semantic_policy_hash,
+)
+from afterworlds.ingestion.mechanical.proposal import (
+    PROPOSAL_ARTIFACT_KIND,
+    MechanicalProposal,
+    ProposedSpan,
+    proposal_identity,
+    proposal_payload,
+)
+from tests.ingestion.mechanical.conftest import (
+    PACKAGE_UUID,
+    RELEASE_BINDING,
+    RELEASE_VERSION,
+    build_ledger,
+    build_representation,
+)
+
+
+def _proposal() -> MechanicalProposal:
+    """A proposal whose *content* is exactly the bounded accepted authority.
+
+    Deliberately identical in substance to the accepted fixture: if the boundary
+    depended on the proposal being somehow deficient, this would slip through.
+    It must be refused for its shape alone.
+    """
+    return MechanicalProposal(
+        binding=RELEASE_BINDING,
+        policy_version=SEMANTIC_POLICY_VERSION,
+        policy_hash=semantic_policy_hash(),
+        proposed_spans=tuple(
+            ProposedSpan(
+                span=span,
+                origin="tool:span-classifier@0",
+                rationale="lexical mechanical signal in the leaf's canonical text",
+            )
+            for span in build_ledger().spans
+        ),
+        proposed_representation=build_representation(),
+        proposal_origin="tool:mechanical-proposer@0",
+    )
+
+
+def _written(tmp_path: Path, payload: dict[str, object], name: str) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# -- the shapes are not interchangeable --------------------------------------
+
+
+def test_a_proposal_declares_its_own_artifact_kind() -> None:
+    payload = proposal_payload(_proposal())
+    assert payload["artifact_kind"] == PROPOSAL_ARTIFACT_KIND
+    assert payload["artifact_kind"] != ACCEPTED_ARTIFACT_KIND
+
+
+def test_a_proposal_carries_no_acceptance_or_obligations() -> None:
+    """Not empty ones — none at all.
+
+    An empty ``acceptance`` block would be the proposal claiming a shape it has
+    not earned, and an empty ``obligations`` list would let it satisfy the
+    accepted loader's key set.
+    """
+    payload = proposal_payload(_proposal())
+    assert "acceptance" not in payload
+    assert "obligations" not in payload
+    assert "spans" not in payload
+    assert "representation" not in payload
+
+
+def test_every_proposed_span_carries_a_reviewable_rationale() -> None:
+    """The reviewer is accepting claims, and a claim needs a stated basis."""
+    payload = proposal_payload(_proposal())
+    spans = payload["proposed_spans"]
+    assert isinstance(spans, list) and spans
+    for span in spans:
+        assert span["rationale"]
+        assert span["proposal_origin"]
+
+
+# -- and the accepted loader refuses every route in ---------------------------
+
+
+def test_a_proposal_file_does_not_load_as_accepted_authority(tmp_path: Path) -> None:
+    path = _written(tmp_path, proposal_payload(_proposal()), "proposal.json")
+    with pytest.raises(OracleLoadError, match="not accepted authority"):
+        load_accepted_inputs(path)
+
+
+def test_renaming_a_proposal_does_not_make_it_accepted(tmp_path: Path) -> None:
+    path = _written(
+        tmp_path,
+        proposal_payload(_proposal()),
+        f"{PACKAGE_UUID}_{RELEASE_VERSION}.json",
+    )
+    with pytest.raises(OracleLoadError):
+        load_oracle(path)
+
+
+def test_forging_the_discriminator_still_fails_on_shape(tmp_path: Path) -> None:
+    """The ``artifact_kind`` check is legibility, not the protection.
+
+    With it edited to lie, the file is still missing every key accepted
+    authority requires and still carrying four the accepted loader does not
+    declare. There is no edit short of rewriting it into the accepted shape —
+    which is what acceptance *is*.
+    """
+    payload = proposal_payload(_proposal())
+    payload["artifact_kind"] = ACCEPTED_ARTIFACT_KIND
+    path = _written(tmp_path, payload, "forged.json")
+    with pytest.raises(OracleLoadError) as exc:
+        load_accepted_inputs(path)
+    message = str(exc.value)
+    assert "missing" in message
+    for required in ("spans", "acceptance", "representation", "obligations"):
+        assert required in message
+
+
+def test_a_proposal_in_the_committed_directory_is_refused(tmp_path: Path) -> None:
+    """Directory placement never confers authority.
+
+    A proposal dropped into the committed directory makes resolution *fail*
+    rather than silently supplying unaccepted authority to the gate.
+    """
+    _written(tmp_path, proposal_payload(_proposal()), "dropped-in.json")
+    with pytest.raises(OracleLoadError):
+        _resolve_committed_inputs(PACKAGE_UUID, RELEASE_VERSION, tmp_path)
+
+
+def test_an_accepted_artifact_still_loads_from_the_same_directory(
+    tmp_path: Path,
+) -> None:
+    """The negative controls above are not just "nothing loads here"."""
+    from afterworlds.ingestion.mechanical.acceptance import accept_proposal
+
+    proposal = _proposal()
+    inputs = accept_proposal(
+        proposal,
+        batch_id="batch-1",
+        rule="every span of the bounded fixture, reviewed together",
+        resolved_scope=tuple(p.span.span_id for p in proposal.proposed_spans),
+        reviewer="owner",
+        accepted_at="2026-08-09T00:00:00Z",
+    )
+    _written(tmp_path, accepted_inputs_payload(inputs), "accepted.json")
+    resolved = _resolve_committed_inputs(PACKAGE_UUID, RELEASE_VERSION, tmp_path)
+    assert resolved is not None
+    assert resolved.oracle.binding == RELEASE_BINDING
+
+
+# -- proposals leave no trace in accepted authority ---------------------------
+
+
+def test_proposal_identity_is_content_derived_and_not_a_projection_identity() -> None:
+    first, second = proposal_identity(_proposal()), proposal_identity(_proposal())
+    assert first == second
+
+    noisier = MechanicalProposal(
+        binding=_proposal().binding,
+        policy_version=_proposal().policy_version,
+        policy_hash=_proposal().policy_hash,
+        proposed_spans=tuple(
+            ProposedSpan(p.span, p.origin, "a different stated reason")
+            for p in _proposal().proposed_spans
+        ),
+        proposed_representation=_proposal().proposed_representation,
+        proposal_origin=_proposal().proposal_origin,
+    )
+    # The rationale is part of what a reviewer reads, so it identifies the
+    # proposal — and none of it reaches any accepted artifact.
+    assert proposal_identity(noisier) != first

--- a/tests/ingestion/mechanical/test_prose_extent.py
+++ b/tests/ingestion/mechanical/test_prose_extent.py
@@ -1,0 +1,178 @@
+"""Exact governing spans on prose bindings — CRD Issue 5d, #137 contract 3.
+
+A prose-bound component resolves *its accepted governing span*, not the whole
+passage that happens to contain it. The text still comes from the immutable 5c
+``RuleChunk``; what narrows is which characters of that chunk this component
+claims authority over.
+
+The redundancy between the named span and the recorded chunk-relative offsets is
+deliberate — runtime slices without re-reading the 5c projection relation — so
+these tests exist to prove the build never lets that redundancy drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from afterworlds.ingestion.mechanical.accounting import derive_span_id
+from afterworlds.ingestion.mechanical.models import (
+    ClassificationLedger,
+    ReviewState,
+    SemanticDisposition,
+    SemanticSpan,
+)
+from afterworlds.ingestion.mechanical.representation import (
+    ProseBindingDraft,
+    ProvenanceClaim,
+    ProvenanceRole,
+    ProvenanceTargetKind,
+)
+from afterworlds.ingestion.mechanical.validation import validate_representation
+from tests.ingestion.mechanical.conftest import (
+    PROSE_LEAF,
+    PROSE_SPAN,
+    SECOND_CHUNK,
+    SPELL_KEY,
+    SPELL_LEAF,
+    SUPPORT_LEAF,
+    WISH_CHUNK,
+    binding_claim,
+    bound_corpus,
+    build_ledger,
+    build_representation,
+    coverage,
+    prose_binding,
+)
+
+
+def _validate(
+    binding: ProseBindingDraft,
+    *,
+    ledger: ClassificationLedger | None = None,
+    extra_claims: tuple[ProvenanceClaim, ...] = (),
+    **corpus_kwargs: Any,
+) -> tuple[str, ...]:
+    """Validate a candidate whose sole prose binding is *binding*."""
+    base = build_representation()
+    claims = tuple(c for c in base.provenance if c.target_kind.value != "prose_binding")
+    draft = build_representation(
+        prose_bindings=(binding,),
+        provenance=claims + (binding_claim(binding, binding.span_id),) + extra_claims,
+    )
+    return validate_representation(
+        draft, ledger or build_ledger(), bound_corpus(**corpus_kwargs)
+    )
+
+
+def _ledger_with(*prose_spans: SemanticSpan) -> ClassificationLedger:
+    """The fixture ledger with the prose leaf's partition replaced."""
+    kept = tuple(s for s in build_ledger().spans if s.leaf_id != PROSE_LEAF)
+    return build_ledger(spans=kept + prose_spans)
+
+
+def _record_context(span_id: str) -> ProvenanceClaim:
+    return ProvenanceClaim(
+        ProvenanceTargetKind.RECORD, (SPELL_KEY,), span_id, ProvenanceRole.CONTEXTUAL
+    )
+
+
+# -- the honest cases --------------------------------------------------------
+
+
+def test_a_binding_whose_extent_matches_its_accepted_span_passes() -> None:
+    assert _validate(prose_binding()) == ()
+
+
+def test_a_binding_may_govern_a_subspan_of_its_chunk() -> None:
+    """Half a leaf is a legitimate governing extent.
+
+    This is the shape the feature exists for: one clause of a paragraph governs
+    one component, and the neighbouring clause governs another or none.
+    """
+    clause = SemanticSpan(
+        span_id=derive_span_id(PROSE_LEAF, 0, 12),
+        leaf_id=PROSE_LEAF,
+        char_start=0,
+        char_end=12,
+        disposition=SemanticDisposition.SUBSTANTIVE,
+        review_state=ReviewState.ACCEPTED,
+    )
+    remainder = SemanticSpan(
+        span_id=derive_span_id(PROSE_LEAF, 12, 30),
+        leaf_id=PROSE_LEAF,
+        char_start=12,
+        char_end=30,
+        disposition=SemanticDisposition.SUPPORTING_AUTHORITY,
+        review_state=ReviewState.ACCEPTED,
+    )
+    findings = _validate(
+        prose_binding(span_id=clause.span_id, chunk_char_start=0, chunk_char_end=12),
+        ledger=_ledger_with(clause, remainder),
+        # The other half of the leaf stays accounted for, as supporting
+        # authority linked to the record it contextualizes.
+        extra_claims=(_record_context(remainder.span_id),),
+    )
+    assert findings == ()
+
+
+# -- the extent must be the span's, proved against the bound release ---------
+
+
+def test_a_declared_extent_that_is_not_the_spans_extent_is_rejected() -> None:
+    """Offsets are recomputed from the release, never trusted.
+
+    A binding that names the whole clause but records offsets for half of it
+    would resolve to half a sentence at runtime while every other check passed.
+    """
+    findings = _validate(prose_binding(chunk_char_end=17))
+    assert any("is not the bound span's extent" in f for f in findings)
+
+
+def test_a_binding_naming_an_unknown_span_is_rejected() -> None:
+    findings = _validate(prose_binding(span_id="span:never-accepted"))
+    assert any("unknown accepted span" in f for f in findings)
+
+
+def test_a_binding_naming_a_span_of_another_leaf_is_rejected() -> None:
+    """The chunk must actually contain the span it claims to govern."""
+    findings = _validate(
+        prose_binding(span_id=derive_span_id(SPELL_LEAF, 0, 40), chunk_char_end=40)
+    )
+    assert any("does not unambiguously contain span" in f for f in findings)
+
+
+def test_a_binding_to_non_mechanical_text_is_rejected() -> None:
+    """Governing prose resolves only to text the accounting found meaningful.
+
+    Otherwise licensing or navigation text the classification deliberately set
+    aside could return as a component's governing authority.
+    """
+    dismissed = SemanticSpan(
+        span_id=PROSE_SPAN,
+        leaf_id=PROSE_LEAF,
+        char_start=0,
+        char_end=30,
+        disposition=SemanticDisposition.NON_MECHANICAL,
+        review_state=ReviewState.ACCEPTED,
+        non_mechanical_reason_code="legal_licensing",
+    )
+    findings = _validate(prose_binding(), ledger=_ledger_with(dismissed))
+    assert any("governing prose resolves only to" in f for f in findings)
+
+
+def test_a_chunk_spanning_two_leaves_cannot_supply_an_extent() -> None:
+    """Fail closed where the coordinate mapping is genuinely unknown.
+
+    A chunk assembled from several leaves has an unknown prefix before this
+    leaf's text, so no offset can be derived. Guessing one would silently return
+    the wrong sentence as governing authority.
+    """
+    findings = _validate(
+        prose_binding(),
+        chunk_coverage=(
+            coverage(WISH_CHUNK, PROSE_LEAF, 0, 30),
+            coverage(WISH_CHUNK, SUPPORT_LEAF, 0, 20),
+            coverage(SECOND_CHUNK, PROSE_LEAF, 0, 30),
+        ),
+    )
+    assert any("does not unambiguously contain span" in f for f in findings)

--- a/tests/ingestion/mechanical/test_provenance_relation.py
+++ b/tests/ingestion/mechanical/test_provenance_relation.py
@@ -19,7 +19,6 @@ from afterworlds.ingestion.mechanical.models import (
 )
 from afterworlds.ingestion.mechanical.representation import (
     ComponentDraft,
-    ProseBindingDraft,
     ProvenanceClaim,
     ProvenanceRole,
     ProvenanceTargetKind,
@@ -50,6 +49,7 @@ from tests.ingestion.mechanical.conftest import (
     bound_corpus,
     build_ledger,
     build_representation,
+    prose_binding,
     reference_claim,
 )
 
@@ -108,9 +108,7 @@ def test_resolved_reference_without_provenance_is_rejected() -> None:
 
 
 def test_one_of_several_bindings_lacking_provenance_is_rejected() -> None:
-    second = ProseBindingDraft(
-        OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
-    )
+    second = prose_binding(SECOND_CHUNK)
     findings = _findings(prose_bindings=(WISH_BINDING, second))
     assert any(SECOND_CHUNK in f and "no provenance" in f for f in findings)
 
@@ -299,9 +297,7 @@ def test_claim_with_a_wrong_shaped_target_key_is_rejected() -> None:
 
 
 def test_binding_key_distinguishes_two_bindings_of_one_component() -> None:
-    second = ProseBindingDraft(
-        OPEN_ENDED_KEY, SPELL_KEY, SECOND_CHUNK, "open_ended_effect"
-    )
+    second = prose_binding(SECOND_CHUNK)
     assert prose_binding_target_key(WISH_BINDING) != prose_binding_target_key(second)
     assert WISH_BINDING.chunk_id == WISH_CHUNK
 

--- a/tests/ingestion/mechanical/test_raw_state_closure.py
+++ b/tests/ingestion/mechanical/test_raw_state_closure.py
@@ -260,6 +260,9 @@ def test_orphan_component_and_binding_rows_are_rejected(session: Session) -> Non
             record_key="record:that-never-existed",
             component_key="component:none",
             chunk_id="chunk-x",
+            span_id="span:that-never-existed",
+            chunk_char_start=0,
+            chunk_char_end=1,
             irreducibility_reason_code="open_ended_effect",
         )
     )

--- a/tests/ingestion/mechanical/test_representation.py
+++ b/tests/ingestion/mechanical/test_representation.py
@@ -13,7 +13,6 @@ from afterworlds.ingestion.mechanical.representation import (
     ComponentDraft,
     DcKind,
     ProgressionEntryFact,
-    ProseBindingDraft,
     ProvenanceClaim,
     ProvenanceRole,
     ProvenanceTargetKind,
@@ -41,6 +40,7 @@ from tests.ingestion.mechanical.conftest import (
     bound_corpus,
     build_ledger,
     build_representation,
+    prose_binding,
 )
 
 
@@ -212,27 +212,12 @@ def test_mixed_component_requires_both() -> None:
 
 
 def test_irreducibility_reason_must_be_closed() -> None:
-    findings = _findings(
-        prose_bindings=(
-            ProseBindingDraft(
-                component_key=OPEN_ENDED_KEY,
-                record_key=SPELL_KEY,
-                chunk_id=WISH_CHUNK,
-                irreducibility_reason_code="too_hard",
-            ),
-        )
-    )
+    findings = _findings(prose_bindings=(prose_binding(WISH_CHUNK, "too_hard"),))
     assert any("is not closed" in f for f in findings)
 
 
 def test_prose_binding_requires_an_authoritative_chunk() -> None:
-    findings = _findings(
-        prose_bindings=(
-            ProseBindingDraft(
-                OPEN_ENDED_KEY, SPELL_KEY, "fabricated", "open_ended_effect"
-            ),
-        )
-    )
+    findings = _findings(prose_bindings=(prose_binding("fabricated"),))
     assert any("is not authoritative prose of release" in f for f in findings)
 
 

--- a/tests/services/rules_authority/conftest.py
+++ b/tests/services/rules_authority/conftest.py
@@ -411,6 +411,11 @@ def _wish_binding(prefix: str = "") -> ProseBindingDraft:
         component_key=OPEN_ENDED_KEY,
         record_key=SPELL_KEY,
         chunk_id=f"{prefix}{WISH_CHUNK}",
+        span_id=PROSE_SPAN,
+        # The prose leaf is 30 characters and the chunk covers all of it from
+        # offset 0, so this binding's chunk-relative extent is the whole chunk.
+        chunk_char_start=0,
+        chunk_char_end=30,
         irreducibility_reason_code="open_ended_effect",
     )
 
@@ -424,6 +429,9 @@ def _mixed_clause_binding(prefix: str = "") -> ProseBindingDraft:
         component_key=MIXED_KEY,
         record_key=CREATURE_KEY,
         chunk_id=f"{prefix}{MIXED_PROSE_CHUNK}",
+        span_id=MIXED_PROSE_SPAN,
+        chunk_char_start=0,
+        chunk_char_end=28,
         irreducibility_reason_code="open_ended_effect",
     )
 

--- a/tests/services/rules_authority/test_exact_prose_resolution.py
+++ b/tests/services/rules_authority/test_exact_prose_resolution.py
@@ -1,0 +1,139 @@
+"""The GameMaster view returns the governing clause, not its paragraph.
+
+CRD Issue 5d, #137 contract 3. A prose-bound component's authority is its
+accepted span. The 5c ``RuleChunk`` remains the only store of what the source
+says — nothing here copies it — but what the view *returns* is sliced to the
+extent the projection accepted, because the surrounding sentences are other
+components' authority or nobody's.
+
+Built directly from an :class:`EffectiveAuthority` rather than through the
+service, so the assertions are about resolution itself and cannot pass by
+accident because a fixture's chunk happens to be one sentence long.
+"""
+
+from __future__ import annotations
+
+from uuid import NAMESPACE_URL, uuid5
+
+from afterworlds.ingestion.mechanical.models import ComponentHandling
+from afterworlds.ingestion.mechanical.representation import RecordKind
+from afterworlds.models.enums import OverrideOriginEnum
+from afterworlds.models.rules_package import RulesPackageBinding
+from afterworlds.services.rules_authority.application import (
+    AuthoredProse,
+    EffectiveAuthority,
+    EffectiveComponent,
+    EffectiveRecord,
+    GoverningProseEntry,
+    SourceProse,
+)
+from afterworlds.services.rules_authority.views import build_gamemaster_view
+
+CHUNK = "chunk-wish-open-ended"
+SPAN = "span-reshape-reality"
+
+#: One chunk, two clauses. The component below governs only the second.
+CHUNK_TEXT = (
+    "You create one object of up to 25,000 GP in value. "
+    "You may wish for something not included in any of the other effects."
+)
+GOVERNING = "You may wish for something not included in any of the other effects."
+NEIGHBOUR = "You create one object of up to 25,000 GP in value."
+
+START = CHUNK_TEXT.index(GOVERNING)
+END = START + len(GOVERNING)
+
+
+def _authority(*prose: GoverningProseEntry) -> EffectiveAuthority:
+    return EffectiveAuthority(
+        binding=RulesPackageBinding(
+            package_uuid=uuid5(NAMESPACE_URL, "pkg-5c"),
+            release_version="rel-5c",
+            mechanical_projection_uuid=uuid5(NAMESPACE_URL, "proj-1"),
+            override_set_uuid=uuid5(NAMESPACE_URL, "ovs-1"),
+        ),
+        records=(
+            EffectiveRecord(
+                semantic_key="spell:wish",
+                kind=RecordKind.SPELL,
+                parent_key=None,
+                components=(
+                    EffectiveComponent(
+                        record_key="spell:wish",
+                        semantic_key="open-ended-clause",
+                        handling=ComponentHandling.PROSE_BOUND,
+                        irreducibility_reason_code="open_ended_effect",
+                        facts=(),
+                        governing_prose=prose,
+                        span_ids=(SPAN,),
+                    ),
+                ),
+            ),
+        ),
+        applied_overrides=(),
+    )
+
+
+def _resolved(
+    *prose: GoverningProseEntry, text: str = CHUNK_TEXT
+) -> tuple[object, ...]:
+    view = build_gamemaster_view(_authority(*prose), {CHUNK: text})
+    return view.components[0].governing_prose
+
+
+def test_resolution_returns_only_the_accepted_span() -> None:
+    (entry,) = _resolved(SourceProse(CHUNK, SPAN, START, END))
+    assert entry.text == GOVERNING
+
+
+def test_resolution_excludes_unrelated_text_from_the_same_chunk() -> None:
+    """The neighbouring clause is in the same chunk and must not come back.
+
+    This is the whole point of the extent: returning the paragraph would
+    overstate what governs this component, and a GameMaster reading it would
+    adjudicate against authority the projection never accepted here.
+    """
+    (entry,) = _resolved(SourceProse(CHUNK, SPAN, START, END))
+    assert NEIGHBOUR not in (entry.text or "")
+    assert entry.text != CHUNK_TEXT
+
+
+def test_resolution_retains_exact_5c_provenance() -> None:
+    """Narrowing the text does not turn source authority into something else.
+
+    The entry stays :class:`SourceProse`, still names the exact chunk and the
+    accepted span, and carries no override identity — a slice is not an authored
+    overlay.
+    """
+    (entry,) = _resolved(SourceProse(CHUNK, SPAN, START, END))
+    assert isinstance(entry, SourceProse)
+    assert (entry.chunk_id, entry.span_id) == (CHUNK, SPAN)
+    assert (entry.char_start, entry.char_end) == (START, END)
+    assert not hasattr(entry, "supplied_by_override_id")
+
+
+def test_an_absent_chunk_is_reported_absent_not_empty() -> None:
+    view = build_gamemaster_view(_authority(SourceProse(CHUNK, SPAN, START, END)), {})
+    assert view.components[0].governing_prose[0].text is None
+
+
+def test_an_extent_past_the_stored_text_resolves_to_absent() -> None:
+    """A short chunk yields no passage rather than a truncated one.
+
+    Python would silently slice to whatever is there. A partial sentence
+    presented as exact governing authority is worse than a reported absence.
+    """
+    (entry,) = _resolved(SourceProse(CHUNK, SPAN, START, END), text=CHUNK_TEXT[:60])
+    assert entry.text is None
+
+
+def test_authored_prose_passes_through_unsliced() -> None:
+    """An authored overlay already carries exact text and is never chunk-bound."""
+    authored = AuthoredProse(
+        text="House rule: the GM may veto any wish that ends the campaign.",
+        supplied_by_override_id="ovr-1",
+        supplied_by_origin=OverrideOriginEnum.HOUSE_RULE,
+    )
+    entries = _resolved(SourceProse(CHUNK, SPAN, START, END), authored)
+    assert entries[0].text == GOVERNING
+    assert entries[1] == authored

--- a/tests/services/rules_authority/test_expanded_families_overrides.py
+++ b/tests/services/rules_authority/test_expanded_families_overrides.py
@@ -1,0 +1,222 @@
+"""Expanded fact families flow through the override path — CRD Issue 5d.
+
+Typed patches rebuild facts through the projection's own
+:func:`fact_from_payload`, so a family added to the closed union is patchable the
+moment it exists and there is no looser runtime door into the same union. That is
+a claim about *this* code, though, not a law of nature — these tests hold it for
+the families the production-authoring work added, and hold the door shut against
+the payloads that would widen it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from afterworlds.ingestion.mechanical.representation import (
+    AttackKind,
+    AttackRollFact,
+    CreatureDefenseFact,
+    DamageFact,
+    DamageType,
+    DiceExpression,
+    DieSize,
+    fact_key,
+    fact_payload,
+)
+from afterworlds.models.enums import OverrideOperationEnum
+from afterworlds.services.rules_authority.outcomes import AuthorityOutcome
+from afterworlds.services.rules_authority.service import RulesAuthorityService
+from tests.services.rules_authority.conftest import (
+    CHECK_COMPONENT_TARGET,
+    CHECK_FACT_KEY,
+    CHECK_KEY,
+    CREATURE_KEY,
+    DESCRIPTOR_FACT_TARGET,
+    DESCRIPTOR_KEY,
+    NOW,
+    SPELL_KEY,
+    RuntimeFixture,
+    append_fact_payload,
+    author_override,
+    replace_fact_payload,
+)
+from tests.services.rules_authority.test_typed_overrides import (
+    component,
+    effective,
+    whole_package,
+)
+
+
+def typed_view(runtime: RuntimeFixture):  # type: ignore[no-untyped-def]
+    """The raw service result, so a refusal is inspectable rather than asserted away."""
+    return RulesAuthorityService(runtime.session, now=NOW).typed_view(
+        whole_package(runtime)
+    )
+
+
+#: "Slam. Melee Attack Roll: +4, reach 5 ft." — a family that did not exist
+#: when the override path was written.
+SLAM = AttackRollFact(AttackKind.MELEE_WEAPON, to_hit_bonus=4, reach_feet=5)
+
+#: "Hit: 10 (2d6 + 3) Bludgeoning damage." — a family carrying a nested value
+#: object, which is the part a payload-shaped override could most easily mangle.
+SLAM_DAMAGE = DamageFact(
+    damage_type=DamageType.BLUDGEONING,
+    dice=DiceExpression(2, DieSize.D6, 3),
+    stated_average=10,
+)
+
+#: "AC 11" / "HP 58 (9d8 + 18)"
+DEFENSE = CreatureDefenseFact(
+    armor_class=11, hit_points=58, hit_point_dice=DiceExpression(9, DieSize.D8, 18)
+)
+
+
+def test_a_new_family_can_be_appended_by_an_override(runtime: RuntimeFixture) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-append-attack",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(SLAM),
+    )
+    view = effective(runtime)
+
+    check = component(view, CREATURE_KEY, CHECK_KEY)
+    assert check is not None
+    added = [f for f in check.facts if f.fact_key == fact_key(SLAM)]
+    assert [f.fact for f in added] == [SLAM]
+    # Override-supplied authority names its override, never 5c spans.
+    assert added[0].supplied_by_override_id == "ov-append-attack"
+    assert added[0].span_ids == ()
+
+
+def test_a_nested_value_object_survives_the_override_path(
+    runtime: RuntimeFixture,
+) -> None:
+    """``2d6 + 3`` comes back as the same typed object, not a look-alike."""
+    author_override(
+        runtime.session,
+        override_id="ov-append-damage",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(SLAM_DAMAGE),
+    )
+    check = component(effective(runtime), CREATURE_KEY, CHECK_KEY)
+    assert check is not None
+    (added,) = [f for f in check.facts if f.fact_key == fact_key(SLAM_DAMAGE)]
+    assert added.fact == SLAM_DAMAGE
+    assert isinstance(added.fact.dice, DiceExpression)
+    assert added.fact.dice.die is DieSize.D6
+
+
+def test_a_new_family_can_replace_a_fact_of_another_family(
+    runtime: RuntimeFixture,
+) -> None:
+    """``REPLACE`` supplies a complete replacement, not a merge of two shapes."""
+    author_override(
+        runtime.session,
+        override_id="ov-replace-with-defense",
+        target=DESCRIPTOR_FACT_TARGET,
+        operation=OverrideOperationEnum.REPLACE,
+        payload=replace_fact_payload(DEFENSE),
+    )
+    descriptor = component(effective(runtime), SPELL_KEY, DESCRIPTOR_KEY)
+    assert descriptor is not None
+    assert [f.fact for f in descriptor.facts] == [DEFENSE]
+
+
+def test_the_typed_view_reports_the_new_family_to_deterministic_consumers(
+    runtime: RuntimeFixture,
+) -> None:
+    author_override(
+        runtime.session,
+        override_id="ov-append-attack-view",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(SLAM),
+    )
+    result = typed_view(runtime)
+    assert result.outcome is AuthorityOutcome.RESOLVED
+    assert result.typed_view is not None
+    facts = [
+        f.fact
+        for record in result.typed_view.records
+        for comp in record.components
+        for f in comp.facts
+    ]
+    assert SLAM in facts
+
+
+# -- and the door stays shut --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "why"),
+    [
+        (
+            {"patch": "append_fact", "fact": {"family": "vibes", "amount": 3}},
+            "a family outside the closed union",
+        ),
+        (
+            {
+                "patch": "append_fact",
+                "fact": {**fact_payload(SLAM), "smuggled": {"dc": 15}},
+            },
+            "an extra field the union does not declare",
+        ),
+        (
+            {
+                "patch": "append_fact",
+                "fact": {
+                    k: v for k, v in fact_payload(SLAM).items() if k != "to_hit_bonus"
+                },
+            },
+            "a missing field that would otherwise default",
+        ),
+        (
+            {
+                "patch": "append_fact",
+                "fact": {**fact_payload(SLAM_DAMAGE), "dice": "2d6+3"},
+            },
+            "a nested value object flattened into a string",
+        ),
+    ],
+    ids=["unknown-family", "extra-field", "missing-field", "stringly-dice"],
+)
+def test_an_override_cannot_widen_the_closed_union(
+    runtime: RuntimeFixture, payload: dict[str, object], why: str
+) -> None:
+    """Every one of these is ``INVALID_OVERRIDE`` — never a skipped override.
+
+    A runtime path that accepted what persistence rejects would be a second,
+    looser definition of the union, and the looser one would win.
+    """
+    author_override(
+        runtime.session,
+        override_id=f"ov-bad-{abs(hash(why))}",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=payload,
+    )
+    result = typed_view(runtime)
+    assert result.outcome is AuthorityOutcome.INVALID_OVERRIDE, why
+
+
+def test_base_authority_is_unchanged_by_any_of_this(runtime: RuntimeFixture) -> None:
+    """Overrides never mutate the immutable base projection."""
+    author_override(
+        runtime.session,
+        override_id="ov-append-attack-base",
+        target=CHECK_COMPONENT_TARGET,
+        operation=OverrideOperationEnum.APPEND,
+        payload=append_fact_payload(SLAM),
+    )
+    effective(runtime)
+
+    from afterworlds.ingestion.mechanical.persistence import reconstruct_candidate
+
+    rebuilt = reconstruct_candidate(runtime.session, str(runtime.projection_uuid))
+    keys = {fact_key(f) for c in rebuilt.representation.components for f in c.facts}
+    assert fact_key(SLAM) not in keys
+    assert CHECK_FACT_KEY in keys


### PR DESCRIPTION
## What was built

The CRD Issue 5d **production-authoring workflow and evidence-backed schema expansion**. Three
interlocking changes the pre-implementation checkpoint found necessary before any production corpus
content can be proposed, reviewed, or accepted.

### 1. The closed typed-fact union grows, from measured corpus evidence

Sixteen new families and two extended ones. Each is justified by authority observed in the production
SRD 5.2.1 release that the previous four families could not carry:

| Approved area | Representation |
|---|---|
| dice | `DiceExpression` shared value object (`count`, `DieSize`, `modifier`) |
| attacks | `AttackRollFact` |
| damage | `DamageFact` |
| creature defence / stat block | `CreatureDefenseFact`, `CreatureSpeedFact`, `CreatureChallengeFact`, `DamageResponseFact` |
| creature save modifiers | `CreatureAbilityScoreFact` extended with `modifier` and `save_modifier` |
| spell descriptors | `SpellDescriptorFact` extended with `SpellCastingTime`, `SpellRange`, `SpellComponents`, `SpellDuration` |
| action economy and timing | `ActionEconomyFact` (+ the casting-time/duration value objects above) |
| conditions and typed state effects | `ConditionEffectFact` |
| spell-slot progression | `SpellSlotProgressionFact` |
| resources and rest/recharge cadence | `ResourceRecoveryFact` |
| equipment descriptors | `EquipmentDescriptorFact`, `WeaponPropertyFact` |
| **healing** | `HealingFact` |
| **advantage/disadvantage** | `AdvantageFact` |
| **class spell-list membership** | `RelationshipKind.SPELL_LIST_MEMBER` + `SpellListQualifierFact` |
| scaling (settled correction 3) | `ScalingFact` |

All three of the additionally-named areas — healing, advantage/disadvantage, and spell-list membership —
are covered **now**. None is deferred.

The union stays closed: per-family intrinsic invariants, per-family strict builders, nested value
objects held to the same strictness as the families that contain them, and a module-level assertion that
no `FactFamily` can exist without both a builder and an invariant checker. `test_fact_families.py`
asserts every declared family has a corpus-grounded exemplar, so a family cannot be added without
someone naming the source text that justifies it.

**Settled correction 2 — spell-slot progression.** `SpellSlotProgressionFact(character_level, slot_level,
slots)`: two typed integer indices, because the class table has two dimensions. The slot level is never
encoded into `entitlement_key`.

**Settled correction 7 — spell-list membership.** Not assumed to fit the existing `RelationshipKind`
union. A new `SPELL_LIST_MEMBER` kind carries the membership classification (distinct from `GRANTS`,
which is a level-indexed entitlement rather than eligibility to prepare or know); `SpellListQualifierFact`
carries what the `Special` column of the 73 `Spell | School | Special` tables says about it. Validation
rejects a qualifier whose membership edge the projection does not declare — the two are one claim.
`RecordKind` was not expanded; no observed shape required a sixteenth kind.

**Settled correction 3 — scaling is declarative.** `ScalingFact` records what the source says increases
(`"The damage increases by 1d10 for each spell slot level above 4"`). Nothing evaluates it, and it
defines no adjudication parameter. The typed `chosen_slot_level` / variable-resource parameter contract
remains the recorded ADR-015b Known Unknown and is untouched.

### 2. Governing prose binds to its exact accepted span (settled correction 1)

`ProseBindingDraft` now names the accepted classification span it governs, plus that span's half-open
offsets into the bound chunk's own text. A component governed by one clause of a paragraph resolves to
that clause; the neighbouring clause is another component's authority or nobody's.

* The authoritative text still comes only from the immutable 5c `RuleChunk`. Nothing is copied into a
  second prose store.
* **No 5c behaviour, segmentation, chunk, identity, or publication path is changed.**
* The offsets are redundant with the span deliberately — runtime slices without re-reading the 5c
  projection relation — and `validation` recomputes them from the bound release on every build and
  rejects a binding whose declared extent disagrees. Redundancy verified on every build cannot drift.
* `BoundCorpusSnapshot.chunk_relative_range` **fails closed** where the coordinate mapping is genuinely
  unknown (a chunk assembled from several leaves, or covering one leaf in several runs). It never guesses
  an offset.
* Governing prose may resolve only to `SUBSTANTIVE` or `SUPPORTING_AUTHORITY` spans, so material the
  accounting set aside cannot return as authority through a binding.
* The extent is meaning-bearing and participates in projection identity: narrowing a binding mints a new
  projection.

### 3. Accepted authority is one committed artifact with two separable halves

The checkpoint surfaced a real gap: `oracle_payload` deliberately omits acceptance evidence (review
process is not identity-bearing), but the gate demands an `AcceptanceRecord` for every span in
reconstructed state. Something had to supply it.

`AcceptedInputs` is one committed file carrying both:

* `oracle` — the accepted result the publication gate judges against, excluding reviewer, timestamp,
  batch grouping, and diff; and
* `batches` / `acceptances` — the auditable evidence the build carries into persistence.

`candidate_from_accepted_inputs` is the build direction (committed bytes → candidate). The oracle comes
from the same committed bytes, never from a candidate or from persisted output, so oracle independence
is unchanged.

**Settled correction 5 — machine proposals are structurally incompatible with accepted authority.**
`proposal.py` emits a different shape at *every* level: a different `artifact_kind`, spans under
`proposed_spans` carrying a per-span origin and rationale, representation under
`proposed_representation`, and no `acceptance` or `obligations` blocks at all. The `artifact_kind` check
is for a legible error, not for protection — with it edited to lie, the file is still missing four
required keys and carrying four undeclared ones. Directory placement confers nothing: a proposal dropped
into `oracles/` makes resolution *fail* rather than silently supplying unaccepted authority.

`acceptance.accept_proposal` is the explicit acceptance action. It retains the exact resolved scope, the
full semantic diff (not a digest of it), the selection rule as evidence that is never re-run, and the
reviewer and timestamp. Only spans named in the scope are accepted — silence is never acceptance — and
accepting over a prior artifact merges rather than replaces, so a later content batch cannot silently
discard an earlier one's reviewed work.

---

## Exact production 5c release used for verification

| | |
|---|---|
| `package_uuid` | `4458fa10-4a66-5e0e-9ecc-ea37530ad2b4` |
| `release_version` | `5.2.1-corpus.36b786d8-fa2` |
| authoritative source SHA-256 | `8974902d109d6e63672d7c490bde9ccf052410503d9cfa768237154fbc5e3d87` |
| transform-config SHA-256 | `77720c2f3b8c9b88363d48050466fb8e3a26f8476b63145d1b5928ff2581ef3e` |
| bundle root hash | `03353dfb79790aee7260b9ed96055b7296cd6f70e3e6f97d6cbe0a2484279685` |
| persisted-corpus digest | `c1f547962b7d9096986f0b8e75624f9f8803dfc281c16033e1c2250cad5a929b` |
| supported corpus contract | `5c-operational-1` |

All values reproduced from a fresh `build_candidate` → `finalize_release` over the committed PDF during
the checkpoint, not read from a constant. `test_accepted_inputs.py` asserts the package/release pair
resolves to no accepted authority.

Corpus measurements the schema rests on (diagnostics, never completeness authority): 28,109 represented
leaves, 2,422 `ENTRY` containers, 683 logical tables; 15,715 word-grain table-cell leaves; chunk↔leaf in
strict bijection with every projection edge covering its whole leaf; 73 `Spell | School | Special` tables,
all in Classes.

---

## Accepted-input topology (settled correction 6)

**One combined artifact.** Two files — build inputs and oracle — would need a third mechanism to prove
they still describe the same accepted semantics. One file cannot disagree with itself, so that whole
class of input/oracle skew stops existing, and it is the lower-complexity repository-native shape.

What the split buys is preserved by keeping the halves as separate *fields*, not separate files:

* acceptance evidence is auditable, persisted, and reconstructable, and reaches no identity —
  `oracle_payload` excludes it and `gate._accepted_identity` already constructs its ledger with empty
  batches and acceptances;
* the publication oracle remains independent of candidate and persisted output — `oracle.py` still
  imports no session, no ORM, and nothing from `persistence`, `raw_state`, or `gate`; and
* clean-checkout reconstruction stays deterministic: `test_evidence_survives_persistence_and_reconstruction`
  round-trips evidence through persistence and re-derives the same projection UUID.

No `scripts/` CLI ships in this PR. Proposal and acceptance are library seams (`proposal.py`,
`acceptance.py`) that a content-batch PR calls; the checkpoint's sketch of a `scripts/` tool is superseded
as engineering discretion, because a *proposal generator* over the real corpus is production-corpus
authoring work this PR must not do.

---

## Schema-pressure dispositions

**Implementation modelling already authorized by Issue 5d** (contract 3 names each family group verbatim;
Decision 4 authorizes adding a typed family): every family and field in the table above, the
`SPELL_LIST_MEMBER` relationship kind, and the shared value objects.

**Deferred to batch-driven accounting, due no later than full-corpus closure:** contract 3's remaining
named family groups that no observed shape has yet forced — targeting restrictions, contests, critical
changes, explicit probability, random-table selection, eligibility, choices, and sequencing. This is
recorded in `representation.py`'s module docstring and in `known_unknowns.md`, with the deadline stated,
so the deferral is bounded rather than open. Random-table selection specifically could not be located:
of 683 table containers, none carries a `dN` column header in its label.

**Known Unknown, untouched:** the typed adjustment-parameter contract for spell-slot upcasting and
variable-resource recovery (ADR-015b amendment required). Representing the `"Using a Higher-Level Spell
Slot"` clause is 5d work and is done; defining the parameter is not.

**Downstream-owned, untouched:** adapter capability, certification, and execution (CRD Issue 15c).
No family was admitted or withheld on the basis of what the bounded-d20 adapter can execute, and neither
authority view carries an executability claim.

`RecordKind` needed no expansion. No non-mechanical or irreducibility catalog entry was added, so
`semantic_policy_hash()` is unchanged.

---

## Test evidence

940 tests pass across `tests/ingestion/mechanical` and `tests/services/rules_authority` before the
production-corpus control; the full default CI run is reported under Gates.

Coverage on the modules this PR changes, measured over those two suites:
`validation.py` 100%, `proposal.py` 100%, `projection.py` 100%, `views.py` 100%,
`bound_corpus.py` 99%, `representation.py` 99%, `oracle.py` 98%, `persistence.py` 98%,
`acceptance.py` 92%.

**New negative controls**

* `test_proposal_boundary.py` — a proposal cannot load as accepted authority when renamed, when dropped
  into the committed directory, or with its `artifact_kind` edited to lie (that case is asserted to fail
  on *shape*, naming all four missing keys). A genuinely accepted artifact resolves from the same
  directory, so the controls are not "nothing loads here".
* `test_prose_extent.py` — a declared extent that is not the bound span's extent, a binding naming an
  unknown span, a span of another leaf, non-mechanical text, and a chunk spanning two leaves are each
  rejected by name. A sub-leaf binding with the rest of the leaf accounted for passes.
* `test_exact_prose_resolution.py` — resolution returns the accepted clause, excludes the neighbouring
  clause of the same chunk, retains exact 5c chunk and span provenance, reports an absent passage rather
  than a truncated one, and leaves authored prose unsliced.
* `test_fact_families.py` — every family round-trips through canonical serialization, persistence, and
  reconstruction; missing field, extra field, unknown family, and a nested value object flattened to a
  string are each rejected; seven family contracts (two amounts, negative speed, zero slots, versatile
  without damage, recharge terms on a rest trigger, CR over zero, descriptor disagreeing with its own
  duration) are reported as violations.
* `test_expanded_families_overrides.py` — new families append, replace, and reach the typed view through
  the override path with override provenance and no 5c spans; four payloads that would widen the union
  are `INVALID_OVERRIDE`; base authority is unchanged.
* `test_accepted_inputs.py` — hollow acceptance evidence is rejected; evidence changes do not change
  semantic identity; evidence survives reconstruction; unscoped, unattributed, unproposed, and
  duplicate-batch acceptances are refused; a later batch does not discard an earlier one's work.
* `test_accepted_inputs.py`, round-1 remediation — two proposals with identical span scope, diff, and
  diff hash but different representations record **different** proposal identities; that identity
  round-trips through the committed form and through persistence, and moving it changes neither the
  oracle identity nor the projection UUID; one complete proposal accepted through two disjoint batches
  yields exactly one copy of every element in all six collections and passes `validate_representation`,
  `validate_acceptance`, persistence, and reconstruction; a conflicting record kind, component handling,
  or prose extent under an already-accepted key fails closed; an overlapping re-acceptance is refused and
  every accumulated ledger keeps each batch named by exactly its own scope; and missing, blank, mistyped,
  or post-hoc-rewritten proposal identity is rejected or detected, the last through the persisted-state
  digest.
* `test_projection.py` — narrowing a prose binding's extent mints a new projection.
* Invariant-checker controls — every declared field of every family is type-checked (generic, so a
  family added with a checker that forgets a field fails without a hand-written control); a dict with
  exactly the right keys standing in for a typed value object is rejected; and one control per contract
  clause covers the "the value comes from the named kind, not from the fact" rule wherever it appears.
  This took `representation.py` from 92% to 99%; the uncovered lines had been concentrated in exactly
  the checkers whose job is refusing unusable authority.

**Production unpublished and inactive**

`test_no_production_authority_is_committed` asserts `oracles/` holds no `*.json` and that the exact
production package/release resolves to no accepted authority.
`test_the_production_release_cannot_publish_or_activate` asserts `publish_from_committed_oracle` reports
`ABSENT` and `resolve_active_projection` reports typed `UNPUBLISHED` with no projection UUID.

**Migration.** `alembic upgrade head` from a clean database (0001 → 0025), then `downgrade -1`, then
`upgrade head` again, all succeeded; the three new columns and the `span_id` index are present at 0025.

---

## Gates

Run in an isolated worktree venv on the exact branch head:

* `black` — clean
* `ruff check src/ tests/` — All checks passed
* `mypy src/` — Success: no issues found in 224 source files
* `pytest` (full default CI configuration, including the coverage gate) — green on branch head
  `0a3af10`, including both production-corpus modules, which build the real SRD 5.2.1 release from the
  committed PDF. GitHub Actions run is linked in the PR conversation.
* `alembic upgrade head` → `downgrade -1` → `upgrade head` on a clean database, through 0026. The 0026
  legacy guard was tested rather than assumed: seeding one pre-existing batch row makes the upgrade exit
  non-zero with a named error.
* `pip-audit` — exit 0. One pre-existing advisory: `chromadb 1.5.9` / `PYSEC-2026-311`, a pinned
  dependency unrelated to this change (the pre-existing checkout's venv reports strictly more).
* `detect-secrets` — exit 0. **Flagged for review:** `scan --baseline .secrets.baseline` rewrites the
  baseline wholesale on unchanged files (filter-name and scanned-path differences, ~1,000 entries across
  `frontend/package-lock.json`, `srd_table_inventory.json`, and other files this PR never touches). That
  is a pre-existing baseline/tooling mismatch, reproducible on `main`, so I restored the committed
  baseline rather than commit an unrelated 7,000-line rewrite. Nothing this PR adds is credential-like:
  the four entries under `bounded_oracle.json` are content-derived hex digests in a test fixture, two of
  which predate this change.

---

## Review remediation — round 1 (Codex, 3 findings)

All three landed on `accept_proposal` and on one invariant, so the sibling gate applied: a batch's
retained evidence must describe the authority acceptance actually draws in, and accumulating batches must
compose into a ledger that still loads.

**P1 — evidence named only the spans.** A batch recorded scope, diff, and diff hash; all three describe
span dispositions. The whole proposed representation was copied into accepted authority alongside them,
so changing a typed fact left every retained field identical and the evidence could not establish that
the reviewer saw the representation about to be published. Each batch now records
`proposal_identity(proposal)` — the content-derived identity of the exact complete proposal reviewed.

**P1 — repeated representations concatenated.** Reviewing one complete proposal across several span
batches supplies the same complete representation each time; concatenation duplicated every record and
component, so `validate_representation` would report duplicate semantic keys, persistence would collide
on projection-scoped identities, and the finished artifact could never publish. The merge is now a keyed
union over all six collections, reusing the repository's canonical target-key definitions.

**P2 — overlapping re-acceptance left an invalid ledger.** Re-accepting a span dropped its acceptance
record while retaining the old batch, so that batch had no record naming it and its scope member pointed
at the new one; the artifact failed `validate_acceptance` permanently. Batch scopes must now be disjoint,
refused before any artifact is constructed. Supersession semantics are what a correcting re-acceptance
needs and are deliberately not invented here.

### Round 2 — canonical shape of the new evidence field (P2)

`proposal_identity` is the SHA-256 hex identity `proposal_identity()` returns, but acceptance validation
required only a nonblank string, so `"banana"`, a 63-character digest, uppercase hex, and a 64-character
non-hex string all loaded and validated as evidence.

The two retained hashes need different checks, which is why this was missed. `semantic_diff_hash` is
recomputed from the diff the batch retains, so its shape never needs asserting. `proposal_identity` names
a proposal that exists nowhere in the accepted artifact, so there is nothing to recompute it against; the
strongest available check is that it is the shape `hash_obj` can emit — exactly 64 lowercase hex
characters.

Enforced in `_validate_batch`, the single choke point `validate_acceptance` already routes through, so
committed-file loading, reconstructed persisted evidence (and therefore the publication gate), and
directly constructed ledgers all get it with **no routing change** to `oracle.py` or `persistence.py`.

It is a shape check and the code says so: it cannot prove the digest names the proposal that was
reviewed. What it rules out is evidence that could not have come from a real proposal at all. A test
asserts that limit, so the guarantee is not overstated.

The bounded fixture's own placeholder was 65 characters and failed the new check immediately — the defect
class in miniature. It is now a real `sha256(b"bounded fixture reviewed proposal")` digest.

### Round 3 — domain constraints on the new vocabulary (2 × P2, 1 × P1 dispositioned)

**`SPELL_LIST_MEMBER` endpoints (P2).** The edge carries a domain claim the other relationship kinds do
not — *this class's spell list includes this spell* — but only its kind and record keys were checked, so a
spell-to-creature edge passed and a consumer reading these edges as eligibility would have received
arbitrary records as members. Now validated as `CLASS -> SPELL`, with a qualifier required to sit on the
class component stating the list and to name a `SPELL` joined by the matching edge. Qualifier-free
membership stays valid: most `Spell | School | Special` rows say nothing in the Special column.

**Recharge upper bound (P2).** `recharge_die=D6, recharge_minimum=7` validated, persisted, and could
publish as typed authority for a resource that can never recharge. The minimum must now lie within the
die's attainable range, inclusive, so `Recharge 6` on a d6 still passes. `DieSize.faces` derives the range
from the member's own name, so a die added later cannot arrive without one. Missing-pair, below-one, and
non-recharge-trigger checks are unchanged.

**Proposal-identity authenticity (P1) — no behavioural or schema change.** The observation is correct and
was accepted in round 2, not overlooked. `proposal_identity` is an audit reference computed by
`accept_proposal()`, not an attestation of human review; the committed `AcceptedInputs` artifact is the
independently reviewed authority and Git review is that trust boundary. Retaining proposal payloads beside
an editable digest would establish internal consistency, not authenticity, and #137 does not require
self-authenticating proposal history. Code and test prose now state the three guarantees separately:
canonical validation proves only that a value could be a repository-generated digest; the persisted-state
digest detects later stored-state mutation; neither proves reviewer authenticity. No payload retention, no
extra hash, no migration change, no identity change.

**Sibling disposition.** `SCOPED_WITHIN`, `GRANTS`, and `PREREQUISITE` stay polymorphic by design — a
spell scopes a creature, a level grants a feature, a feat requires a species — so no endpoint rules were
invented for them; only `SPELL_LIST_MEMBER` carries a consumer-facing domain claim. Other fact-family
cross-field invariants were already covered in round 1 and were not broadened.

### Sibling audit — all six representation collections

**Trigger:** three findings, one function, one invariant. **Structures inspected:** every collection in
`RepresentationDraft`. Three have keys narrower than their content, so under those a key collision can
mean genuine disagreement; three have keys spanning every field, so a collision there is repetition and
nothing else. Both cases go through the same merge; only the reachable failure differs.

| Collection | Canonical key reused | Duplication (pre-fix) | Conflict reachable | Disposition |
|---|---|---|---|---|
| `records` | `record_target_key` | yes | yes — `kind`, `parent_key` outside the key | **patched** |
| `components` | `component_target_key` | yes | yes — `handling`, reason, `facts` outside the key | **patched** |
| `prose_bindings` | `prose_binding_target_key` | yes | yes — chunk extent outside the key | **patched** (previously not even conflict-guarded) |
| `relationships` | `relationship_target_key` | yes | no — key spans every field | **patched** (dedup); conflict unreachable by construction |
| `references` | `reference_target_key` | yes | no — key spans every field | **patched** (dedup); conflict unreachable by construction |
| `provenance` | the edge tuple `validation` already uses for duplicate detection | yes | no — key spans every field | **patched** (dedup); conflict unreachable by construction |

Facts are not a seventh collection: they are part of a component's content, so a differing fact set under
an accepted component key is a component conflict and is caught there.

**Regression coverage:** eight of the new tests fail against the pre-fix `acceptance.py` and pass after,
verified by reverting that module alone. The digest-coverage test was likewise verified against an
`acceptance_evidence_payload` with the new field removed.

**Out of scope, deliberately, and stated rather than silently skipped:** acceptance chronology,
supersession semantics, and any synthesis or pruning of historical batch evidence. A correcting
re-acceptance needs a history model; this PR refuses the operation instead of half-implementing one.

---

## Architecture Notes

**No drift from design principles**, with these choices stated explicitly:

1. **Prose subspans are implemented as `span_id` + verified chunk-relative offsets**, per settled
   correction 1 (which records that #137 contract 3 already requires this and it is not an Owner
   Decision). The offsets are recomputed and re-checked against the bound release on every build, and
   translation fails closed where the 5c projection makes it ambiguous. No 5c segmentation, chunk,
   identity, or publication behaviour changes; `rp_corpus_projections` and `rp_chunks` are read-only here.

2. **One combined accepted-inputs artifact** rather than separate build-input and oracle files
   (engineering discretion under settled correction 6, rationale above). `load_oracle` is retained as the
   projection of `load_accepted_inputs`, so every existing caller and the packaging control are unchanged.

3. **No `scripts/` CLI.** Proposal and acceptance are library seams. The checkpoint sketched a
   `scripts/propose_*` / `scripts/accept_*` pair; a real proposal *generator* over the production corpus
   is authoring work barred from this PR, and a CLI wrapper around two library calls is complexity the
   contract does not require. Named here so its absence is a decision rather than an omission.

4. **`SpellDescriptorFact` is one family carrying four nested value objects**, not five families. The
   source prints one descriptor line, and a component may claim a span primarily only once; five families
   would force the accepted classification to cut that line into five sub-spans purely to satisfy the
   provenance rule — a representation artefact rather than a distinction the source makes.

5. **Migration 0025 adds three `NOT NULL` columns with an inert server default.** Additive to an empty
   table in every environment: no accepted production oracle exists, so no mechanical projection has ever
   been published. The default exists so a development row set survives the upgrade and is never relied
   on by a writer.

6. **Migration 0026 refuses to run against a table that already holds batch rows.** There is no honest
   reviewed-proposal identity for a batch recorded before that evidence existed, and fabricating one
   would assert a review that cannot be shown to have happened — precisely what the column exists to
   prevent. Legacy development state is rebuilt under ADR-005c's pre-release clean baseline rather than
   migrated. Verified: seeding one legacy row makes `alembic upgrade head` exit non-zero with a named
   error.

7. **`proposal_identity` is retained evidence, never identity.** It is covered by the persisted-state
   digest — so it cannot be rewritten after the fact undetected — and absent from
   `classification_payload` and `oracle_payload`, so it never reaches the projection UUID. This is the
   same treatment reviewer, timestamp, and batch rule already receive.

6. **The bounded test fixture was upgraded in place, order-preserving**, rather than regenerated, so the
   diff shows the added fields and the acceptance block rather than a reordering of unchanged content.

**Meaning-bearing inputs or identities changed.** `representation_payload` now includes each prose
binding's `span_id` and chunk extent, and `prose_binding_target_key` includes the span. Projection
identity therefore changes for any projection carrying prose bindings — correct, since the accepted
governing extent is part of what a projection *is*. No production projection exists to be affected.
`semantic_policy_hash()` is unchanged, so no committed oracle is invalidated by a policy change.

**Persisted reconstruction / publication behaviour affected.** `rp_mech_prose_bindings` gains
`span_id`, `chunk_char_start`, `chunk_char_end`; reconstruction reads them; the gate's element-level
comparison covers them through the shared payload builder. The publication lifecycle, the completeness
gate's checks, and every typed failure state are otherwise untouched.

**Legacy paths removed or still pending.** None removed. `MechanicalEntity` and its family, and the
legacy `rp_overrides` chunk-targeting prose path, both remain and are still scheduled for the final
activation/legacy-retirement PR. (A fresh production build writes 0 rows to both tables, so that removal
is a code/migration change, not a data migration.)

**Downstream seams touched.** `RulesPackageBinding`, the rule-slice request path, override precedence and
operation semantics, and override-set identity are all unchanged. `SourceProse` gains `span_id`,
`char_start`, `char_end`; `AuthoredProse` is unchanged and still passes through unsliced. CRD Issue 2b's
four-component binding and CRD Issue 15c's capability boundary are unaffected.

**Deviation from ADR-005d or #137.** None.

---

## Explicit statements

* **No production authority was accepted.** `src/afterworlds/ingestion/mechanical/oracles/` contains no
  JSON file, asserted by test.
* **No partial projection was activated.** The production release resolves to no accepted authority;
  publication reports `ABSENT` and active resolution reports typed `UNPUBLISHED`.
* **CRD Issue 5d remains incomplete.** Accepted content batches, full-corpus closure, activation, and
  legacy retirement all remain outstanding, and `known_unknowns.md` now records exactly that while
  preserving CRD Issue 15c's ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gcmq8yYp96k4dBSNiFjne6
